### PR TITLE
Error logging verbosity is not configurable for routing and used to determine log content of ErrorHandler (#16).

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/settings/RoutingSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/RoutingSettingsImpl.scala
@@ -29,5 +29,4 @@ object RoutingSettingsImpl extends SettingsCompanion[RoutingSettingsImpl]("akka.
     c getBytes "range-coalescing-threshold",
     c getIntBytes "decode-max-bytes-per-chunk",
     c getString "file-io-dispatcher")
-
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/RoutingSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/RoutingSettings.scala
@@ -34,7 +34,6 @@ abstract class RoutingSettings private[akka] () extends akka.http.javadsl.settin
   override def withRangeCoalescingThreshold(rangeCoalescingThreshold: Long): RoutingSettings = self.copy(rangeCoalescingThreshold = rangeCoalescingThreshold)
   override def withDecodeMaxBytesPerChunk(decodeMaxBytesPerChunk: Int): RoutingSettings = self.copy(decodeMaxBytesPerChunk = decodeMaxBytesPerChunk)
   override def withFileIODispatcher(fileIODispatcher: String): RoutingSettings = self.copy(fileIODispatcher = fileIODispatcher)
-
 }
 
 object RoutingSettings extends SettingsCompanion[RoutingSettings] {

--- a/akka-http-core/src/test/resources/reference.conf
+++ b/akka-http-core/src/test/resources/reference.conf
@@ -5,5 +5,5 @@ akka {
     serialize-messages = on
     default-dispatcher.throughput = 1
   }
-  stream.materializer.debug.fuzzing-mode=off
+  stream.materializer.debug.fuzzing-mode = off
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/BasicRouteSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/BasicRouteSpecs.scala
@@ -180,9 +180,12 @@ class BasicRouteSpecs extends RoutingSpec {
     }
   }
 
-  case object MyException extends RuntimeException
+  case object MyException extends RuntimeException("Boom")
   "Route sealing" should {
-    "catch route execution exceptions" in EventFilter[MyException.type](occurrences = 1).intercept {
+    "catch route execution exceptions" in EventFilter.error(
+      occurrences = 1,
+      message = "Error during processing of request: 'Boom'. Completing with 500 Internal Server Error response."
+    ).intercept {
       Get("/abc") ~> Route.seal {
         get { ctx ⇒
           throw MyException
@@ -191,7 +194,10 @@ class BasicRouteSpecs extends RoutingSpec {
         status shouldEqual StatusCodes.InternalServerError
       }
     }
-    "catch route building exceptions" in EventFilter[MyException.type](occurrences = 1).intercept {
+    "catch route building exceptions" in EventFilter.error(
+      occurrences = 1,
+      message = "Error during processing of request: 'Boom'. Completing with 500 Internal Server Error response."
+    ).intercept {
       Get("/abc") ~> Route.seal {
         get {
           throw MyException
@@ -200,7 +206,10 @@ class BasicRouteSpecs extends RoutingSpec {
         status shouldEqual StatusCodes.InternalServerError
       }
     }
-    "convert all rejections to responses" in EventFilter[RuntimeException](occurrences = 1).intercept {
+    "convert all rejections to responses" in EventFilter.error(
+      occurrences = 1,
+      start = "Error during processing of request"
+    ).intercept {
       object MyRejection extends Rejection
       Get("/abc") ~> Route.seal {
         get {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FutureDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FutureDirectivesSpec.scala
@@ -113,7 +113,10 @@ class FutureDirectivesSpec extends RoutingSpec with Inside {
         responseAs[String] shouldEqual "yes"
       }
     }
-    "propagate the exception in the failure case" in EventFilter[Exception](occurrences = 1, message = "XXX").intercept {
+    "propagate the exception in the failure case" in EventFilter.error(
+      occurrences = 1,
+      message = "Error during processing of request: 'XXX'. Completing with 500 Internal Server Error response."
+    ).intercept {
       Get() ~> onSuccess(Future.failed(TestException)) { echoComplete } ~> check {
         status shouldEqual StatusCodes.InternalServerError
       }
@@ -124,7 +127,10 @@ class FutureDirectivesSpec extends RoutingSpec with Inside {
         responseAs[String] shouldEqual s"Oops. akka.http.scaladsl.server.directives.FutureDirectivesSpec$$TestException: EX when ok"
       }
     }
-    "catch an exception in the failure case" in EventFilter[Exception](occurrences = 1, message = "XXX").intercept {
+    "catch an exception in the failure case" in EventFilter.error(
+      occurrences = 1,
+      message = "Error during processing of request: 'XXX'. Completing with 500 Internal Server Error response."
+    ).intercept {
       Get() ~> onSuccess(Future.failed(TestException)) { throwTestException("EX when ") } ~> check {
         status shouldEqual StatusCodes.InternalServerError
         responseAs[String] shouldEqual "There was an internal server error."

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -43,8 +43,11 @@ class RouteDirectivesSpec extends FreeSpec with GenericRoutingSpec {
       "for successful futures and marshalling" in {
         Get() ~> complete(Promise.successful("yes").future) ~> check { responseAs[String] shouldEqual "yes" }
       }
-      "for failed futures and marshalling" in EventFilter[RuntimeException](occurrences = 1).intercept {
-        object TestException extends RuntimeException
+      "for failed futures and marshalling" in EventFilter.error(
+        occurrences = 1,
+        message = "Error during processing of request: 'Boom'. Completing with 500 Internal Server Error response."
+      ).intercept {
+        object TestException extends RuntimeException("Boom")
         Get() ~> complete(Promise.failed[String](TestException).future) ~>
           check {
             status shouldEqual StatusCodes.InternalServerError

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/SecurityDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/SecurityDirectivesSpec.scala
@@ -61,8 +61,11 @@ class SecurityDirectivesSpec extends RoutingSpec {
       } ~> check { responseAs[String] shouldEqual "We are Legion" }
     }
     "properly handle exceptions thrown in its inner route" in {
-      object TestException extends RuntimeException
-      EventFilter[TestException.type](occurrences = 1).intercept {
+      object TestException extends RuntimeException("Boom")
+      EventFilter.error(
+        occurrences = 1,
+        message = "Error during processing of request: 'Boom'. Completing with 500 Internal Server Error response."
+      ).intercept {
         Get() ~> Authorization(BasicHttpCredentials("Alice", "")) ~> {
           Route.seal {
             doBasicAuth { _ ⇒ throw TestException }
@@ -111,8 +114,11 @@ class SecurityDirectivesSpec extends RoutingSpec {
       } ~> check { responseAs[String] shouldEqual "We are Legion" }
     }
     "properly handle exceptions thrown in its inner route" in {
-      object TestException extends RuntimeException
-      EventFilter[TestException.type](occurrences = 1).intercept {
+      object TestException extends RuntimeException("Boom")
+      EventFilter.error(
+        occurrences = 1,
+        message = "Error during processing of request: 'Boom'. Completing with 500 Internal Server Error response."
+      ).intercept {
         Get() ~> Authorization(OAuth2BearerToken("myToken")) ~> {
           Route.seal {
             doOAuth2Auth { _ ⇒ throw TestException }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
  */
-
 package akka.http.scaladsl.server
 
 import scala.util.control.NonFatal
@@ -40,13 +39,11 @@ object ExceptionHandler {
   def default(settings: RoutingSettings): ExceptionHandler =
     apply(knownToBeSealed = true) {
       case IllegalRequestException(info, status) ⇒ ctx ⇒ {
-        ctx.log.warning(
-          "Illegal request {}\n\t{}\n\tCompleting with '{}' response",
-          ctx.request, info.formatPretty, status)
+        ctx.log.warning("Illegal request: '{}'. Completing with {} response.", info.summary, status)
         ctx.complete((status, info.format(settings.verboseErrorMessages)))
       }
       case NonFatal(e) ⇒ ctx ⇒ {
-        ctx.log.error(e, "Error during processing of request {}", ctx.request)
+        ctx.log.error("Error during processing of request: '{}'. Completing with {} response.", e.getMessage, InternalServerError)
         ctx.complete(InternalServerError)
       }
     }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
@@ -126,7 +126,7 @@ class RouteDirectivesExamplesSpec extends RoutingSpec {
     //#redirect-examples
   }
 
-  "failwith-examples" in EventFilter[RuntimeException](start = "Error during processing of request", occurrences = 1).intercept {
+  "failwith-examples" in EventFilter.error(start = "Error during processing of request: 'Oops.'. Completing with 500 Internal Server Error response.", occurrences = 1).intercept {
     //#failwith-examples
     val route =
       path("foo") {


### PR DESCRIPTION
Reused already existing property type. Set to full logging in tests as event filters asserts on that.