### PR TITLE
WIP Add `reverseProxy` directive #240

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ReverseProxyDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ReverseProxyDirectivesSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.server.directives
+
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.model.Uri.{Authority, Host}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.RouteResult.Complete
+import akka.http.scaladsl.server.{CircuitBreakerOpenRejection, RequestContext, Route, RoutingSpec}
+import akka.http.scaladsl.{Http, TestUtils}
+import akka.pattern.CircuitBreaker
+import org.scalatest.Inside
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+class ReverseProxyDirectivesSpec extends RoutingSpec with Inside {
+
+  trait TestWithCircuitBreaker {
+    val breakerResetTimeout = 500.millis
+    val breaker = new CircuitBreaker(system.scheduler, maxFailures = 1, callTimeout = 10.seconds, breakerResetTimeout)
+
+    def openBreaker() = breaker.withCircuitBreaker(Future.failed(new Exception("boom")))
+  }
+
+  def withServer(route: Route)(f: Authority ⇒ Unit) = {
+    val hostAndPort: (InetSocketAddress, String, Int) = TestUtils.temporaryServerHostnameAndPort()
+    val bindingFuture: Future[ServerBinding] = Http().bindAndHandle(route, interface = hostAndPort._2, port = hostAndPort._3)
+    f(Authority(Host(hostAndPort._2), hostAndPort._3))
+    bindingFuture.flatMap(_.unbind())
+  }
+
+  def completeTryResponse(tryHttpResponse: Try[HttpResponse]) = { ctx: RequestContext ⇒
+    tryHttpResponse match {
+      case Success(response) ⇒ Future.successful(Complete(response))
+      case Failure(e)        ⇒ Future.failed(e)
+    }
+  }
+
+  "The 'forwardRequest' directive" should {
+    "use a default configOption if None provided" in {
+      withServer(complete("ok!")) { a: Authority ⇒
+        val route = forwardRequest() { completeTryResponse(_) }
+        Get(Uri(authority = a)) ~> route ~> check {
+          responseAs[String] shouldEqual "ok!"
+        }
+        val route2 = forwardRequest(None) { completeTryResponse(_) }
+        Get(Uri(authority = a)) ~> route2 ~> check {
+          responseAs[String] shouldEqual "ok!"
+        }
+      }
+    }
+    "use the provided request executor" in {
+      val i: AtomicInteger = new AtomicInteger(0)
+      val route = forwardRequest(Some(ReverseProxyConfig(None, x ⇒ { i.incrementAndGet(); Future.successful(Ok.withEntity("executed")) }))) { completeTryResponse(_) }
+      Get() ~> route ~> check {
+        i.get() shouldEqual 1
+        responseAs[String] shouldEqual "executed"
+      }
+      Get() ~> route ~> check {
+        i.get() shouldEqual 2
+        responseAs[String] shouldEqual "executed"
+      }
+    }
+    "respond with 500 Internal Server Error when proxing request fails" in {
+      val route = forwardRequest(Some(ReverseProxyConfig(None, x ⇒ Future.failed(new RuntimeException("ouch!"))))) { completeTryResponse(_) }
+      Get() ~> route ~> check {
+        responseAs[String] shouldEqual "There was an internal server error."
+        response.status.intValue shouldEqual 500
+      }
+    }
+    "respond with proxies error when proxy encounters an error" in {
+      val route = forwardRequest(Some(ReverseProxyConfig(None, _ ⇒ Future.successful(HttpResponse(StatusCodes.InternalServerError, entity = "damn"))))) { completeTryResponse(_) }
+      Get() ~> route ~> check {
+        responseAs[String] shouldEqual "damn"
+        response.status.intValue shouldEqual 500
+      }
+    }
+    "use the circuitBreaker if provided" in new TestWithCircuitBreaker {
+      val route = forwardRequest(Some(ReverseProxyConfig(Some(breaker), _ ⇒ Future.successful(Ok)))) { completeTryResponse(_) }
+      Get() ~> route ~> check {
+        response.status.intValue shouldEqual 200
+      }
+      openBreaker()
+      Get() ~> route ~> check {
+        inside(rejection) {
+          case CircuitBreakerOpenRejection(_) ⇒
+        }
+      }
+      Thread.sleep(breakerResetTimeout.toMillis + 200)
+      Get() ~> route ~> check {
+        response.status.intValue shouldEqual 200
+      }
+    }
+
+  }
+}

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/ReverseProxyDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/ReverseProxyDirectives.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.server.directives
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.Http.{ HostConnectionPool, OutgoingConnection }
+import akka.http.scaladsl.model.Uri.Authority
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.{ HttpResponse, _ }
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.server.directives.BasicDirectives._
+import akka.http.scaladsl.server.directives.FutureDirectives._
+import akka.http.scaladsl.server.directives.RouteDirectives._
+import akka.pattern.CircuitBreaker
+import akka.stream._
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+import scala.util.{ Failure, Success, Try }
+
+trait ReverseProxyDirectives {
+  type RequestExecutor = ((HttpRequest) ⇒ Future[HttpResponse])
+
+  def completeUnmatchedPathWithReverseProxy(authority: Authority, configOption: Option[ReverseProxyConfig] = None): Route = {
+    forward(authority, configOption).tapply(x ⇒ complete(x._1))
+  }
+
+  def forward(authority: Authority, configOption: Option[ReverseProxyConfig] = None): Directive1[Try[HttpResponse]] = {
+    extractUri.flatMap { uri ⇒
+      val forwardUri: Uri = uri.withAuthority(authority)
+      forwardToUri(forwardUri, configOption)
+    }
+  }
+
+  def forwardUnmatchedPath(authority: Authority, configOption: Option[ReverseProxyConfig] = None): Directive1[Try[HttpResponse]] = {
+    extractUnmatchedPath.flatMap { unmatched ⇒
+      extractUri.flatMap { uri ⇒
+        val forwardUri: Uri = uri.withAuthority(authority).withPath(unmatched)
+        forwardToUri(forwardUri, configOption)
+      }
+    }
+  }
+
+  def forwardToUri(uri: Uri, configOption: Option[ReverseProxyConfig] = None): Directive1[Try[HttpResponse]] = {
+    val requestUriInterceptor = ProxyUriRequestInterceptor(uri).andThen(ProxyHeaderRequestInterceptor)
+    mapRequest(requestUriInterceptor).tflatMap { _ ⇒
+      forwardRequest(configOption)
+    }
+  }
+
+  def forwardRequest(configOption: Option[ReverseProxyConfig] = None): Directive1[Try[HttpResponse]] = {
+    extractExecutionContext.flatMap { implicit ec ⇒
+      extractRequest.flatMap { request ⇒
+        getOrCreateDefaultConfig(configOption).flatMap { reverseProxyConfig ⇒
+          val responseFuture: Future[HttpResponse] = reverseProxyConfig.requestExecutor.apply(request)
+          reverseProxyConfig.circuitBreakerOption match {
+            case Some(circuitBreaker) ⇒ onCompleteWithBreaker(circuitBreaker)(responseFuture)
+            case None                 ⇒ onComplete(responseFuture)
+          }
+        }
+      }
+    }
+  }
+
+  private[akka] def getOrCreateDefaultConfig(configOption: Option[ReverseProxyConfig]): Directive1[ReverseProxyConfig] = {
+    configOption match {
+      case Some(config) ⇒ provide(config)
+      case None ⇒ {
+        extractMaterializer.flatMap { mat ⇒
+          extractActorSystem.flatMap { system ⇒
+            provide(ReverseProxyConfig(None, CachedHostConnectionPoolRequestExecutor()(system, mat)))
+          }
+        }
+      }
+    }
+  }
+}
+
+private[akka] case class ProxyUriRequestInterceptor(val uri: Uri) extends ((HttpRequest) ⇒ HttpRequest) {
+  override def apply(httpRequest: HttpRequest): HttpRequest = {
+    httpRequest.withUri(uri)
+  }
+}
+
+private[akka] case object ProxyHeaderRequestInterceptor extends ((HttpRequest) ⇒ HttpRequest) {
+  override def apply(httpRequest: HttpRequest): HttpRequest = {
+    val headers: Seq[HttpHeader] = httpRequest.headers
+    val remoteAddressHeaderOption = headers.collectFirst({ case h: `Remote-Address` ⇒ h })
+
+    val xRealIpPF: PartialFunction[HttpHeader, `X-Real-Ip`] = { case h: `X-Real-Ip` ⇒ h }
+    val xForwardedForPF: PartialFunction[HttpHeader, `X-Forwarded-For`] = { case h: `X-Forwarded-For` ⇒ h }
+
+    val xRealIpHeaderOption = headers.collectFirst(xRealIpPF)
+    val xForwardedForHeaderOption = headers.collectFirst(xForwardedForPF)
+    //TODO: Add `Via` HttpHeader as defined in https://tools.ietf.org/html/rfc2616#section-14.45 in akka.http.scaladsl.model.headers
+    //var viaHeaderOption: Option[HttpHeader] = headers.collectFirst({case h: HttpHeader if "via".equalsIgnoreCase(h.name) => h})
+
+    val remoteAddressOption = remoteAddressHeaderOption.map(_.address)
+    val xRealIpOption = xRealIpHeaderOption.map(_.address)
+
+    val ipOption = xRealIpOption.orElse(xForwardedForHeaderOption.flatMap(_.addresses.headOption).orElse(remoteAddressOption))
+
+    val updatedXRealIpHeaderOption = ipOption.map(`X-Real-Ip`(_))
+    val updatedXForwardedForHeaderOption = remoteAddressOption.map(remoteAddresss ⇒ xForwardedForHeaderOption.fold(`X-Forwarded-For`(remoteAddresss))(h ⇒ `X-Forwarded-For`(h.addresses ++ Seq(remoteAddresss))))
+
+    val updatedHeaders = headers.filterNot((xRealIpPF orElse xForwardedForPF).isDefinedAt(_)) ++ (updatedXRealIpHeaderOption.toSeq ++ updatedXForwardedForHeaderOption.toSeq)
+    httpRequest.withHeaders(updatedHeaders)
+
+    //TODO: This has some security implications: What to do with cookies, authentication data, etc.?
+  }
+}
+
+case class SingleRequestExecutor(implicit val system: ActorSystem, implicit val materializer: Materializer) extends ((HttpRequest) ⇒ Future[HttpResponse]) {
+  override def apply(httpRequest: HttpRequest): Future[HttpResponse] = {
+    Http().singleRequest(httpRequest)
+  }
+}
+
+case class OutgoingRequestExecutor(implicit val system: ActorSystem, implicit val materializer: Materializer) extends ((HttpRequest) ⇒ Future[HttpResponse]) {
+  override def apply(httpRequest: HttpRequest): Future[HttpResponse] = {
+    implicit val executor = system.dispatcher
+    val authority: Authority = httpRequest.uri.authority
+    val source = Source.single(httpRequest)
+
+    val flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = httpRequest.uri.scheme match {
+      case "http" ⇒ Http().outgoingConnection(authority.host.toString, authority.port)
+      case _      ⇒ Http().outgoingConnectionHttps(authority.host.toString, authority.port)
+    }
+    source.via(flow).toMat(Sink.head)(Keep.right).run()
+  }
+}
+
+case class CachedHostConnectionPoolRequestExecutor(implicit val system: ActorSystem, implicit val materializer: Materializer) extends ((HttpRequest) ⇒ Future[HttpResponse]) {
+  override def apply(httpRequest: HttpRequest): Future[HttpResponse] = {
+    implicit val executor = system.dispatcher
+    val authority: Authority = httpRequest.uri.authority
+    val source = Source.single(httpRequest → 1)
+
+    val flow: Flow[(HttpRequest, Int), (Try[HttpResponse], Int), HostConnectionPool] = httpRequest.uri.scheme match {
+      case "http" ⇒ Http().cachedHostConnectionPool[Int](authority.host.toString, authority.port)
+      case _      ⇒ Http().cachedHostConnectionPoolHttps[Int](authority.host.toString, authority.port)
+    }
+    source.via(flow).map(x ⇒ x._1).toMat(Sink.head)(Keep.right).run().flatMap({
+      case Success(res) ⇒ Future.successful(res)
+      case Failure(e)   ⇒ Future.failed(e)
+    })
+  }
+}
+
+case class ReverseProxyConfig(
+  val circuitBreakerOption: Option[CircuitBreaker],
+  val requestExecutor:      (HttpRequest) ⇒ Future[HttpResponse]
+)
+
+/*
+object ReverseProxyConfig extends SettingsCompanion[ReverseProxyConfig]("akka.http"){
+  override def fromSubConfig(root: Config, c: Config): ReverseProxyConfig = ???
+}
+*/ 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Directives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Directives.scala
@@ -37,5 +37,6 @@ trait Directives extends RouteConcatenation
   with SecurityDirectives
   with WebSocketDirectives
   with FramedEntityStreamingDirectives
+  with ReverseProxyDirectives
 
 object Directives extends Directives


### PR DESCRIPTION
Directives to enable proxying of single requests to an (internal) remote backend.
Previous work (before splitting off akka-http) was done in akka/akka#21185 
