### PR TITLE
Add compile dependency to akka-http-testkit on scalatest

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,6 +64,8 @@ object Dependencies {
     val aeronDriver = "io.aeron"                      % "aeron-driver"                 % "1.0.1"       // ApacheV2
     val aeronClient = "io.aeron"                      % "aeron-client"                 % "1.0.1"       // ApacheV2
 
+    val scalatest    = Def.setting { "org.scalatest"  %% "scalatest"  % scalaTestVersion.value } // ApacheV2
+
     object Docs {
       val sprayJson   = "io.spray"                   %%  "spray-json"                  % "1.3.2"             % "test"
       val gson        = "com.google.code.gson"        % "gson"                         % "2.3.1"             % "test"
@@ -143,7 +145,7 @@ object Dependencies {
 
   lazy val httpTestkit = l ++= Seq(
     Test.junit, Test.junitIntf, Compile.junit % "provided", 
-    Test.scalatest.value.copy(configurations = Some("provided; test"))
+    Compile.scalatest.value
   )
 
   lazy val httpTests = l ++= Seq(Test.junit, Test.scalatest.value, Test.junitIntf)


### PR DESCRIPTION
For the first issue in #216. Work in progress as the second issue not fixed yet, or I can create another PR for the issue 2 later.

> 1. Projects using JUnitRouteTest must declare a dependency on scalatest themselves, since it's not a declared compile dependency for akka-testkit (apparently).

This is fixed as in before/after below.

#### Before 

```
<dependency org="org.scalatest" name="scalatest_2.11" rev="3.0.0" conf="provided->default(compile);test->default(compile)"/>
```
    
#### After
    
```
<dependency org="org.scalatest" name="scalatest_2.11" rev="3.0.0" conf="compile->default(compile)"/>   
```

However, I didn't fix the second issue yet.

> 2. All Java test classes now are marked Serializable (since Suite is), triggering compiler warnings by default.

 Actually I didn't see any warning in my sbt, so wondering what the warnining @jypma saw.

> Is the warning for 2 = "Serializable class without serialVersionUID"?


