### PR TITLE
fixed a part of compiler warnings

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -112,7 +112,7 @@ private[http] class HttpRequestRendererFactory(
         case None ⇒ headerPart ++ body
         case Some(future) ⇒
           val barrier = Source.fromFuture(future).drop(1).asInstanceOf[Source[ByteString, Any]]
-          (headerPart ++ barrier ++ body).recoverWith { case HttpResponseParser.OneHundredContinueError ⇒ Source.empty }
+          (headerPart ++ barrier ++ body).recoverWithRetries(-1, { case HttpResponseParser.OneHundredContinueError ⇒ Source.empty })
       }
       RequestRenderingOutput.Streamed(stream)
     }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -402,7 +402,7 @@ class ConnectionPoolSpec extends AkkaSpec("""
     val (serverEndpoint, serverHostName, serverPort) = TestUtils.temporaryServerHostnameAndPort()
 
     def testServerHandler(connNr: Int): HttpRequest ⇒ HttpResponse = {
-      case r: HttpRequest ⇒ HttpResponse(headers = responseHeaders(r, connNr), entity = r.entity)
+      r: HttpRequest ⇒ HttpResponse(headers = responseHeaders(r, connNr), entity = r.entity)
     }
 
     def responseHeaders(r: HttpRequest, connNr: Int) =

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -402,7 +402,7 @@ class ConnectionPoolSpec extends AkkaSpec("""
     val (serverEndpoint, serverHostName, serverPort) = TestUtils.temporaryServerHostnameAndPort()
 
     def testServerHandler(connNr: Int): HttpRequest ⇒ HttpResponse = {
-      r: HttpRequest ⇒ HttpResponse(headers = responseHeaders(r, connNr), entity = r.entity)
+      r ⇒ HttpResponse(headers = responseHeaders(r, connNr), entity = r.entity)
     }
 
     def responseHeaders(r: HttpRequest, connNr: Int) =

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSServerAutobahnTest.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSServerAutobahnTest.scala
@@ -8,7 +8,6 @@ import akka.NotUsed
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
@@ -16,6 +15,8 @@ import akka.http.scaladsl.model.ws.{ Message, UpgradeToWebSocket }
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
+
+import scala.io.StdIn
 
 object WSServerAutobahnTest extends App {
   implicit val system = ActorSystem("WSServerTest")
@@ -40,10 +41,10 @@ object WSServerAutobahnTest extends App {
       port = port)
 
     Await.result(binding, 3.second) // throws if binding fails
-    println(s"Server online at http://${host}:${port}")
+    println(s"Server online at http://$host:$port")
     mode match {
       case "sleep" ⇒ while (true) Thread.sleep(1.minute.toMillis)
-      case "read"  ⇒ Console.readLine("Press RETURN to stop...")
+      case "read"  ⇒ StdIn.readLine("Press RETURN to stop...")
       case _       ⇒ throw new Exception("akka.ws-mode MUST be sleep or read.")
     }
   } finally {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
@@ -14,9 +14,11 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ws._
 import akka.stream._
-import akka.stream.scaladsl.{ Source, Flow }
-import com.typesafe.config.{ ConfigFactory, Config }
+import akka.stream.scaladsl.{ Flow, Source }
+import com.typesafe.config.{ Config, ConfigFactory }
 import HttpMethods._
+
+import scala.io.StdIn
 
 object TestServer extends App {
   val testConf: Config = ConfigFactory.parseString("""
@@ -55,7 +57,7 @@ object TestServer extends App {
     Await.result(binding, 1.second) // throws if binding fails
     println("Server online at http://localhost:9001")
     println("Press RETURN to stop...")
-    Console.readLine()
+    StdIn.readLine()
   } finally {
     system.terminate()
   }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/SettingsEqualitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/SettingsEqualitySpec.scala
@@ -11,17 +11,18 @@ import org.scalatest.WordSpec
 
 class SettingsEqualitySpec extends WordSpec with Matchers {
 
-  val config = ConfigFactory.parseString("""
-    akka.http.routing {
-      verbose-error-messages = off
-      file-get-conditional = on
-      render-vanity-footer = yes
-      range-coalescing-threshold = 80
-      range-count-limit = 16
-      decode-max-bytes-per-chunk = 1m
-      file-io-dispatcher = ${akka.stream.blocking-io-dispatcher}
-    }
-  """).withFallback(ConfigFactory.load).resolve
+  val config = ConfigFactory.parseString(
+    """
+      |    akka.http.routing {
+      |      verbose-error-messages = off
+      |      file-get-conditional = on
+      |      render-vanity-footer = yes
+      |      range-coalescing-threshold = 80
+      |      range-count-limit = 16
+      |      decode-max-bytes-per-chunk = 1m
+      |      file-io-dispatcher = ${akka.stream.blocking-io-dispatcher}
+      |    }
+    """.stripMargin).withFallback(ConfigFactory.load).resolve
 
   "equality" should {
     "hold for ConnectionPoolSettings" in {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/SettingsEqualitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/SettingsEqualitySpec.scala
@@ -11,18 +11,17 @@ import org.scalatest.WordSpec
 
 class SettingsEqualitySpec extends WordSpec with Matchers {
 
-  val config = ConfigFactory.parseString(
-    """
-      |    akka.http.routing {
-      |      verbose-error-messages = off
-      |      file-get-conditional = on
-      |      render-vanity-footer = yes
-      |      range-coalescing-threshold = 80
-      |      range-count-limit = 16
-      |      decode-max-bytes-per-chunk = 1m
-      |      file-io-dispatcher = ${akka.stream.blocking-io-dispatcher}
-      |    }
-    """.stripMargin).withFallback(ConfigFactory.load).resolve
+  val config = ConfigFactory.parseString("""
+    akka.http.routing {
+      verbose-error-messages = off
+      file-get-conditional = on
+      render-vanity-footer = yes
+      range-coalescing-threshold = 80
+      range-count-limit = 16
+      decode-max-bytes-per-chunk = 1m
+      file-io-dispatcher = ${akka.stream.blocking-io-dispatcher}
+    }
+  """).withFallback(ConfigFactory.load).resolve
 
   "equality" should {
     "hold for ConnectionPoolSettings" in {

--- a/akka-http-core/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -3,19 +3,19 @@
  */
 package akka.testkit
 
-import org.scalactic.Constraint
+import org.scalactic.{ CanEqual, TypeCheckedTripleEquals }
 
 import language.postfixOps
-import org.scalatest.{ WordSpecLike, BeforeAndAfterAll }
+import org.scalatest.{ BeforeAndAfterAll, WordSpecLike }
 import org.scalatest.Matchers
 import akka.actor.ActorSystem
 import akka.event.{ Logging, LoggingAdapter }
+
 import scala.concurrent.duration._
 import scala.concurrent.Future
 import com.typesafe.config.{ Config, ConfigFactory }
 import akka.dispatch.Dispatchers
 import akka.testkit.TestEvent._
-import org.scalactic.ConversionCheckedTripleEquals
 import org.scalatest.concurrent.ScalaFutures
 
 object AkkaSpec {
@@ -56,7 +56,7 @@ object AkkaSpec {
 
 abstract class AkkaSpec(_system: ActorSystem)
   extends TestKit(_system) with WordSpecLike with Matchers with BeforeAndAfterAll with WatchedByCoroner
-  with ConversionCheckedTripleEquals with ScalaFutures {
+  with TypeCheckedTripleEquals with ScalaFutures {
 
   implicit val patience = PatienceConfig(testKitSettings.DefaultTimeout.duration)
 
@@ -75,7 +75,7 @@ abstract class AkkaSpec(_system: ActorSystem)
   override val invokeBeforeAllAndAfterAllEvenIfNoTestsAreExpected = true
 
   final override def beforeAll {
-    startCoroner
+    startCoroner()
     atStartup()
   }
 
@@ -106,13 +106,13 @@ abstract class AkkaSpec(_system: ActorSystem)
     }
 
   // for ScalaTest === compare of Class objects
-  implicit def classEqualityConstraint[A, B]: Constraint[Class[A], Class[B]] =
-    new Constraint[Class[A], Class[B]] {
+  implicit def classEqualityConstraint[A, B]: CanEqual[Class[A], Class[B]] =
+    new CanEqual[Class[A], Class[B]] {
       def areEqual(a: Class[A], b: Class[B]) = a == b
     }
 
-  implicit def setEqualityConstraint[A, T <: Set[_ <: A]]: Constraint[Set[A], T] =
-    new Constraint[Set[A], T] {
+  implicit def setEqualityConstraint[A, T <: Set[_ <: A]]: CanEqual[Set[A], T] =
+    new CanEqual[Set[A], T] {
       def areEqual(a: Set[A], b: T) = a == b
     }
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
@@ -14,6 +14,7 @@ import akka.util.Index
 import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.Future
+import scala.io.StdIn
 import scala.util.{ Failure, Success, Try }
 
 object ConnectionTestApp {
@@ -89,9 +90,9 @@ object ConnectionTestApp {
       //sendSingle(uri, i)
     }
 
-    readLine()
+    StdIn.readLine()
     println("===================== \n\n" + system.asInstanceOf[ActorSystemImpl].printTree + "\n\n========================")
-    readLine()
+    StdIn.readLine()
     system.terminate()
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
@@ -36,12 +36,13 @@ object TcpLeakApp extends App {
         .toMat(Sink.head)(Keep.right).run())
     .last
     .onComplete {
-      error ⇒
-        println(s"Error: $error")
+      result ⇒
+        println(s"Result: $result")
         Thread.sleep(10000)
         println("===================== \n\n" + system.asInstanceOf[ActorSystemImpl].printTree + "\n\n========================")
     }
 
-  StdIn.readLine()
+  Thread.sleep(11000)
+  StdIn.readLine("Press Enter to stop the application")
   system.terminate()
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
@@ -12,6 +12,7 @@ import akka.stream.scaladsl._
 import akka.stream.{ ActorAttributes, ActorMaterializer }
 import akka.util.ByteString
 import com.typesafe.config.{ Config, ConfigFactory }
+import scala.io.StdIn
 
 object TcpLeakApp extends App {
   val testConf: Config = ConfigFactory.parseString(
@@ -35,12 +36,12 @@ object TcpLeakApp extends App {
         .toMat(Sink.head)(Keep.right).run())
     .last
     .onComplete {
-      case error ⇒
+      error ⇒
         println(s"Error: $error")
         Thread.sleep(10000)
         println("===================== \n\n" + system.asInstanceOf[ActorSystemImpl].printTree + "\n\n========================")
     }
 
-  readLine()
+  StdIn.readLine()
   system.terminate()
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
@@ -11,7 +11,7 @@ import akka.http.scaladsl.util.FastFuture._
 trait PredefinedToRequestMarshallers {
   private type TRM[T] = ToRequestMarshaller[T] // brevity alias
 
-  implicit val fromRequest: TRM[HttpRequest] = Marshaller.opaque(conforms)
+  implicit val fromRequest: TRM[HttpRequest] = Marshaller.opaque(identity)
 
   implicit def fromUri: TRM[Uri] =
     Marshaller strict { uri ⇒ Marshalling.Opaque(() ⇒ HttpRequest(uri = uri)) }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
@@ -69,7 +69,7 @@ trait BasicDirectives {
    * @group basic
    */
   def mapRouteResultPF(f: PartialFunction[RouteResult, RouteResult]): Directive0 =
-    mapRouteResult(f.applyOrElse(_, conforms[RouteResult]))
+    mapRouteResult(f.applyOrElse(_, identity[RouteResult]))
 
   /**
    * @group basic

--- a/docs/src/test/java/docs/http/javadsl/server/directives/SecurityDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/SecurityDirectivesExamplesTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.Optional;
+import akka.japi.Option;
 
 public class SecurityDirectivesExamplesTest extends JUnitRouteTest {
 
@@ -202,7 +203,7 @@ public class SecurityDirectivesExamplesTest extends JUnitRouteTest {
   @Test
   public void testAuthenticateOrRejectWithChallenge() {
     //#authenticateOrRejectWithChallenge
-    final HttpChallenge challenge = HttpChallenge.create("MyAuth", "MyRealm");
+    final HttpChallenge challenge = HttpChallenge.create("MyAuth", new Option.Some<>("MyRealm"));
 
     // your custom authentication logic:
     final Function<HttpCredentials, Boolean> auth = credentials -> true;

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -104,7 +104,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
     val response1: HttpResponse = ??? // obtained from an HTTP call (see examples below)
 
     val discardingComplete: Future[Done] = response1.entity.dataBytes.runWith(Sink.ignore)
-    discardingComplete.onComplete { case done => println("Entity discarded completely!") }
+    discardingComplete.onComplete(done => println("Entity discarded completely!"))
     //#manual-entity-discard-example-2
   }
 

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -87,7 +87,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
     val response1: HttpResponse = ??? // obtained from an HTTP call (see examples below)
 
     val discarded: DiscardedEntity = response1.discardEntityBytes()
-    discarded.future.onComplete { case done => println("Entity discarded completely!") }
+    discarded.future.onComplete { done => println("Entity discarded completely!") }
 
     //#manual-entity-discard-example-1
   }

--- a/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
@@ -172,7 +172,10 @@ class WebSocketClientExampleSpec extends WordSpec with Matchers with CompileOnly
     implicit val materializer = ActorMaterializer()
     import collection.immutable.Seq
 
-    val flow: Flow[Message, Message, NotUsed] = ???
+    val flow: Flow[Message, Message, NotUsed] =
+      Flow.fromSinkAndSource(
+        Sink.foreach(println),
+        Source.empty)
 
     //#authorized-single-WebSocket-request
     val (upgradeResponse, _) =

--- a/docs/src/test/scala/docs/http/scaladsl/server/BlockingInHttpExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/BlockingInHttpExamplesSpec.scala
@@ -14,7 +14,7 @@ class BlockingInHttpExamplesSpec extends WordSpec with CompileOnlySpec
   with Directives {
 
   compileOnlySpec {
-    val system: ActorSystem = ???
+    val system: ActorSystem = ActorSystem()
 
     //#blocking-example-in-default-dispatcher
     // BAD (due to blocking in Future, on default dispatcher)
@@ -32,7 +32,7 @@ class BlockingInHttpExamplesSpec extends WordSpec with CompileOnlySpec
   }
 
   compileOnlySpec {
-    val system: ActorSystem = ???
+    val system: ActorSystem = ActorSystem()
 
     //#blocking-example-in-dedicated-dispatcher
     // GOOD (the blocking is now isolated onto a dedicated dispatcher):

--- a/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -37,7 +37,7 @@ abstract class HttpsServerExampleSpec extends WordSpec with Matchers
 
     // Manual HTTPS configuration
 
-    val password: Array[Char] = ??? // do not store passwords in code, read them from somewhere safe!
+    val password: Array[Char] = "change me".toCharArray // do not store passwords in code, read them from somewhere safe!
 
     val ks: KeyStore = KeyStore.getInstance("PKCS12")
     val keystore: InputStream = getClass.getClassLoader.getResourceAsStream("server.p12")

--- a/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
@@ -9,6 +9,8 @@ import akka.stream.scaladsl.Sink
 import docs.CompileOnlySpec
 import org.scalatest.{ Matchers, WordSpec }
 
+import scala.io.StdIn
+
 class WebSocketExampleSpec extends WordSpec with Matchers with CompileOnlySpec {
   "core-example" in compileOnlySpec {
     //#websocket-example-using-core
@@ -59,7 +61,7 @@ class WebSocketExampleSpec extends WordSpec with Matchers with CompileOnlySpec {
       Http().bindAndHandleSync(requestHandler, interface = "localhost", port = 8080)
 
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
-    Console.readLine()
+    StdIn.readLine()
 
     import system.dispatcher // for the future transformations
     bindingFuture
@@ -101,7 +103,7 @@ class WebSocketExampleSpec extends WordSpec with Matchers with CompileOnlySpec {
     val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
 
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
-    Console.readLine()
+    StdIn.readLine()
 
     import system.dispatcher // for the future transformations
     bindingFuture


### PR DESCRIPTION
As part of getting familiar with akka-http I went through a part of compiler warnings and fixed them.

Mostly they were related to deprecation, there were few related to dead code.
I have only touched the warnings that are straightforward to fix because I didn't want to break anything

I'm not sure about the warnings related to `parboiled2` - should they be fixed here, or in the https://github.com/sirthias/parboiled2 repository ?

There was no issue related to this PR