### PR TITLE
Add entity directive example

### DIFF
--- a/docs/src/main/paradox/java/http/routing-dsl/directives/marshalling-directives/entity.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/marshalling-directives/entity.md
@@ -24,12 +24,8 @@ are mapped to rejections:
 
 ## Examples
 
-The following example uses `spray-json` to unmarshall a json request into a simple `Person` 
-class.  It utilizes `SprayJsonSupport` via the `PersonJsonSupport` object as the in-scope unmarshaller.
+The following example uses @ref[Json Support via Jackson](../../../common/json-support.md#json-jackson-support-java) to unmarshall a json request into a simple `Person`  
 
-TODO: Add example snippets.
+@@snip [MarshallingDirectivesExamplesTest.java](../../../../../../../test/java/docs/http/javadsl/server/directives/MarshallingDirectivesExamplesTest.java) { #person }
 
-It is also possible to use the `entity` directive to obtain raw `JsValue` ( [spray-json](https://github.com/spray/spray-json) ) objects, by simply using
-`as[JsValue]`, or any other JSON type for which you have marshallers in-scope.
-
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: [write example snippets for Akka HTTP Java DSL #218](https://github.com/akka/akka-http/issues/218).
+@@snip [MarshallingDirectivesExamplesTest.java](../../../../../../../test/java/docs/http/javadsl/server/directives/MarshallingDirectivesExamplesTest.java) { #example-entity-with-json }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MarshallingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MarshallingDirectivesExamplesTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl.server.directives;
+
+import akka.http.javadsl.marshallers.jackson.Jackson;
+import akka.http.javadsl.model.*;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import akka.http.javadsl.unmarshalling.Unmarshaller;
+import org.junit.Test;
+
+public class MarshallingDirectivesExamplesTest extends JUnitRouteTest {
+
+  //#person
+  static public class Person {
+    private final String name;
+    private final int favoriteNumber;
+
+    //default constructor required for Jackson
+    public Person() {
+      this.name = "";
+      this.favoriteNumber = 0;
+    }
+
+    public Person(String name, int favoriteNumber) {
+      this.name = name;
+      this.favoriteNumber = favoriteNumber;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public int getFavoriteNumber() {
+      return favoriteNumber;
+    }
+  }
+  //#person
+
+  @Test
+  public void testEntity() {
+    //#example-entity-with-json
+    final Unmarshaller<HttpEntity, Person> unmarshallar = Jackson.unmarshaller(Person.class);
+
+    final Route route = entity(unmarshallar, person ->
+      complete( "Person:" +  person.getName() + " - favoriteNumber:" + person.getFavoriteNumber() )
+    );
+
+    testRoute(route).run(
+      HttpRequest.POST("/")
+        .withEntity(
+          HttpEntities.create(
+            ContentTypes.APPLICATION_JSON, "{\"name\":\"Jane\",\"favoriteNumber\":42}"
+          )
+        )
+    ).assertEntity("Person:Jane - favoriteNumber:42");
+    //#example-entity-with-json
+  }
+}


### PR DESCRIPTION
Refs #218 entity directive

From entity.md, I removed mentions to spray-json and JsValue, but is that ok? I was assuming currently supported marshalling methods in Java is only via Jackson, as in [marshalling.html](http://doc.akka.io/docs/akka/2.4/java/http/routing-dsl/marshalling.html), but let me know if that is wrong.

![image](https://cloud.githubusercontent.com/assets/7414320/18649744/1aa35110-7efc-11e6-81ba-722e537a39b2.png)
