### PR TITLE
Fix directory traversal in Windows in getFromDirectory / listDirectoryContents

### DIFF
--- a/akka-http-tests/src/test/resources/dirWithLink/linked-dir
+++ b/akka-http-tests/src/test/resources/dirWithLink/linked-dir
@@ -1,0 +1,1 @@
+../subDirectory

--- a/akka-http-tests/src/test/resources/sübdir/sample späce.PDF
+++ b/akka-http-tests/src/test/resources/sübdir/sample späce.PDF
@@ -1,0 +1,1 @@
+This is PDF

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -171,6 +171,15 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
         headers should contain(`Last-Modified`(DateTime(lastModified)))
       }
     }
+    "return the file content with the MediaType matching the file extension (unicode chars in filename)" in {
+      Get("sample%20sp%c3%a4ce.PDF") ~> _getFromDirectory("sübdir") ~> check {
+        mediaType shouldEqual `application/pdf`
+        charsetOption shouldEqual None
+        responseAs[String] shouldEqual "This is PDF"
+        val lastModified = new File(testRoot, "sübdir/sample späce.PDF").lastModified()
+        headers should contain(`Last-Modified`(DateTime(lastModified)))
+      }
+    }
   }
 
   "getFromResource" should {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -183,10 +183,12 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
         headers should contain(`Last-Modified`(DateTime(lastModified)))
       }
     }
-    "follow symbolic links to find a file" in {
+    "not follow symbolic links to find a file" in {
       Get("linked-dir/empty.pdf") ~> _getFromDirectory("dirWithLink") ~> check {
-        mediaType shouldEqual `application/pdf`
+        handled shouldBe false
+        /* TODO: resurrect following links under an option
         responseAs[String] shouldEqual "123"
+        mediaType shouldEqual `application/pdf`*/
       }
     }
   }


### PR DESCRIPTION
@2beaucoup here's a new fix without all your extra changes. AFAICS these should apply also to former versions for which we might have to issue a fix release.

WDYT about containing the changes inside of the new `safeDirectoryChildPath` (old `fileSystemPath`)?

Fixes #346.