### PR TITLE
Update external links to Akka docs and GitHub source code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val docs = project("docs")
     name := "akka-http-docs",
     paradoxTheme := Some(builtinParadoxTheme("generic")),
     paradoxNavigationDepth := 3,
-    paradoxProperties ++= Map(
+    paradoxProperties in Compile ++= Map(
       "akka.version" -> Dependencies.akkaVersion,
       "scala.binaryVersion" -> scalaBinaryVersion.value,
       "scala.version" -> scalaVersion.value,
@@ -130,7 +130,8 @@ lazy val docs = project("docs")
         case akka.Doc.BinVer(_) => ""
         case _                  => "cross CrossVersion.full"
       }),
-      "extref.akka-docs.base_url" -> s"http://doc.akka.io/docs/akka/${Dependencies.akkaVersion}/%s"
+      "extref.akka-docs.base_url" -> s"http://doc.akka.io/docs/akka/${Dependencies.akkaVersion}/%s",
+      "github.base_url" -> GitHub.url(version.value)
     ),
     Formatting.docFormatSettings
   )

--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,8 @@ lazy val docs = project("docs")
       "crossString" -> (scalaVersion.value match {
         case akka.Doc.BinVer(_) => ""
         case _                  => "cross CrossVersion.full"
-      })
+      }),
+      "extref.akka-docs.base_url" -> s"http://doc.akka.io/docs/akka/${Dependencies.akkaVersion}/%s"
     ),
     Formatting.docFormatSettings
   )

--- a/docs/src/main/paradox/java/http/client-side/client-https-support.md
+++ b/docs/src/main/paradox/java/http/client-side/client-https-support.md
@@ -13,7 +13,7 @@ the static method `ConnectionContext.https` which is defined like this:
 @@snip [ConnectionContext.scala](../../../../../../../akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala) { #https-context-creation }
 
 In addition to the `outgoingConnection`, `newHostConnectionPool` and `cachedHostConnectionPool` methods the
-[akka.http.javadsl.Http](@github@/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala) extension also defines `outgoingConnectionTls`, `newHostConnectionPoolTls` and
+@github[akka.http.javadsl.Http](/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala) extension also defines `outgoingConnectionTls`, `newHostConnectionPoolTls` and
 `cachedHostConnectionPoolTls`. These methods work identically to their counterparts without the `-Tls` suffix,
 with the exception that all connections will always be encrypted.
 

--- a/docs/src/main/paradox/java/http/common/de-coding.md
+++ b/docs/src/main/paradox/java/http/common/de-coding.md
@@ -5,7 +5,7 @@ The [HTTP spec](http://tools.ietf.org/html/rfc7231#section-3.1.2.1) defines a `C
 
 Currently Akka HTTP supports the compression and decompression of HTTP requests and responses with the `gzip` or
 `deflate` encodings.
-The core logic for this lives in the [akka.http.scaladsl.coding](@github@/akka-http/src/main/scala/akka/http/scaladsl/coding) package.
+The core logic for this lives in the @github[akka.http.scaladsl.coding](/akka-http/src/main/scala/akka/http/scaladsl/coding) package.
 
 The support is not enabled automatically, but must be explicitly requested.
 For enabling message encoding/decoding with @ref[Routing DSL](../../../scala/http/routing-dsl/index.md#http-high-level-server-side-api) see the @ref[CodingDirectives](../routing-dsl/directives/coding-directives/index.md#codingdirectives).

--- a/docs/src/main/paradox/java/http/common/json-support.md
+++ b/docs/src/main/paradox/java/http/common/json-support.md
@@ -15,7 +15,7 @@ To make use of the support module, you need to add a dependency on *akka-http-ja
 Use `akka.http.javadsl.marshallers.jackson.Jackson.unmarshaller(T.class)` to create an `Unmarshaller<HttpEntity,T>` which expects the request
 body (HttpEntity) to be of type `application/json` and converts it to `T` using Jackson.
 
-See [this example](@github@/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java) in the sources for an example.
+See @github[this example](/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java) in the sources for an example.
 
 Use `akka.http.javadsl.marshallers.jackson.Jackson.marshaller(T.class)` to create a `Marshaller<T,RequestEntity>` which can be used with
 `RequestContext.complete` or `RouteDirectives.complete` to convert a POJO to an HttpResponse.

--- a/docs/src/main/paradox/java/http/common/marshalling.md
+++ b/docs/src/main/paradox/java/http/common/marshalling.md
@@ -46,7 +46,7 @@ This is how `Marshalling` is defined:
 Akka HTTP already predefines a number of marshallers for the most common types.
 Specifically these are:
 
- * [PredefinedToEntityMarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala)
+ * @github[PredefinedToEntityMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala)
     * `Array[Byte]`
     * `ByteString`
     * `Array[Char]`
@@ -54,7 +54,7 @@ Specifically these are:
     * `akka.http.scaladsl.model.FormData`
     * `akka.http.scaladsl.model.MessageEntity`
     * `T <: akka.http.scaladsl.model.Multipart`
- * [PredefinedToResponseMarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala)
+ * @github[PredefinedToResponseMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala)
     * `T`, if a `ToEntityMarshaller[T]` is available
     * `HttpResponse`
     * `StatusCode`
@@ -62,12 +62,12 @@ Specifically these are:
     * `(Int, T)`, if a `ToEntityMarshaller[T]` is available
     * `(StatusCode, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
     * `(Int, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
- * [PredefinedToRequestMarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala)
+ * @github[PredefinedToRequestMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala)
     * `HttpRequest`
     * `Uri`
     * `(HttpMethod, Uri, T)`, if a `ToEntityMarshaller[T]` is available
     * `(HttpMethod, Uri, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
- * [GenericMarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala)
+ * @github[GenericMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala)
     * `Marshaller[Throwable, T]`
     * `Marshaller[Option[A], B]`, if a `Marshaller[A, B]` and an `EmptyValue[B]` is available
     * `Marshaller[Either[A1, A2], B]`, if a `Marshaller[A1, B]` and a `Marshaller[A2, B]` is available

--- a/docs/src/main/paradox/java/http/common/unmarshalling.md
+++ b/docs/src/main/paradox/java/http/common/unmarshalling.md
@@ -26,7 +26,7 @@ content negotiation which saves two additional layers of indirection that are re
 Akka HTTP already predefines a number of marshallers for the most common types.
 Specifically these are:
 
- * [PredefinedFromStringUnmarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala)
+ * @github[PredefinedFromStringUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala)
     * `Byte`
     * `Short`
     * `Int`
@@ -34,13 +34,13 @@ Specifically these are:
     * `Float`
     * `Double`
     * `Boolean`
- * [PredefinedFromEntityUnmarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala)
+ * @github[PredefinedFromEntityUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala)
     * `Array[Byte]`
     * `ByteString`
     * `Array[Char]`
     * `String`
     * `akka.http.scaladsl.model.FormData`
- * [GenericUnmarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/GenericUnmarshallers.scala)
+ * @github[GenericUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/GenericUnmarshallers.scala)
     * `Unmarshaller[T, T]` (identity unmarshaller)
     * `Unmarshaller[Option[A], B]`, if an `Unmarshaller[A, B]` is available
     * `Unmarshaller[A, Option[B]]`, if an `Unmarshaller[A, B]` is available

--- a/docs/src/main/paradox/java/http/http-model.md
+++ b/docs/src/main/paradox/java/http/http-model.md
@@ -221,7 +221,7 @@ Connection
 the potential wish of the application to close the connection after the respective response has been sent out.
 The actual logic for determining whether to close the connection is quite involved. It takes into account the
 request's method, protocol and potential `Connection` header as well as the response's protocol, entity and
-potential `Connection` header. See [this test](@github@/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala#L422) for a full table of what happens when.
+potential `Connection` header. See @github[this test](/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala#L422) for a full table of what happens when.
 
 
 ## Parsing / Rendering

--- a/docs/src/main/paradox/java/http/routing-dsl/directives/future-directives/onCompleteWithBreaker.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/future-directives/onCompleteWithBreaker.md
@@ -4,7 +4,7 @@
 ## Description
 
 Evaluates its parameter of type `CompletionStage<T>` protecting it with the specified `CircuitBreaker`.
-Refer to <!-- FIXME: unresolved link reference: circuit-breaker --> circuit-breaker for a detailed description of this pattern.
+Refer to @extref[Circuit Breaker](akka-docs:common/circuitbreaker.html) for a detailed description of this pattern.
 
 If the `CircuitBreaker` is open, the request is rejected with a `CircuitBreakerOpenRejection`.
 Note that in this case the request's entity databytes stream is cancelled, and the connection is closed

--- a/docs/src/main/paradox/java/http/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/rejections.md
@@ -25,7 +25,7 @@ and handle any rejection.
 ## Predefined Rejections
 
 A rejection encapsulates a specific reason why a route was not able to handle a request. It is modeled as an object of
-type `Rejection`. Akka HTTP comes with a set of [predefined rejections](@github@/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala), which are used by the many
+type `Rejection`. Akka HTTP comes with a set of @github[predefined rejections](/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala), which are used by the many
 @ref[predefined directives](directives/alphabetically.md#predefined-directives-java).
 
 Rejections are gathered up over the course of a Route evaluation and finally converted to `HttpResponse` replies by
@@ -35,7 +35,7 @@ the @ref[handleRejections](../../../scala/http/routing-dsl/directives/execution-
 ## The RejectionHandler
 
 The @ref[handleRejections](../../../scala/http/routing-dsl/directives/execution-directives/handleRejections.md#handlerejections) directive delegates the actual job of converting a list of rejections to its argument, a
-[RejectionHandler](@github@/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala), which is defined like this:
+@github[RejectionHandler](/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala), which is defined like this:
 
 ```scala
 trait RejectionHandler extends (immutable.Seq[Rejection] => Option[Route])

--- a/docs/src/main/paradox/java/http/routing-dsl/routes.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/routes.md
@@ -33,7 +33,7 @@ function to be used with a `bindAndHandleXXX` call from the @ref[Low-Level Serve
 The request context wraps an `HttpRequest` instance to enrich it with additional information that are typically
 required by the routing logic, like an `ExecutionContext`, `Materializer`, `LoggingAdapter` and the configured
 `RoutingSettings`. It also contains the `unmatchedPath`, a value that describes how much of the request URI has not
-yet been matched by a <!-- FIXME: More than one link target with name pathdirectives in path Some(/java/http/routing-dsl/routes.rst) --> PathDirectives.
+yet been matched by a @ref[Path Directive](directives/path-directives/index.md).
 
 The `RequestContext` itself is immutable but contains several helper methods which allow for convenient creation of
 modified copies.

--- a/docs/src/main/paradox/java/http/server-side/low-level-server-side-api.md
+++ b/docs/src/main/paradox/java/http/server-side/low-level-server-side-api.md
@@ -49,7 +49,7 @@ the @ref[HTTP Model](../http-model.md#http-model-java) for more information on h
 
 ## Starting and Stopping
 
-On the most basic level an Akka HTTP server is bound by invoking the `bind` method of the [akka.http.javadsl.Http](@github@/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala)
+On the most basic level an Akka HTTP server is bound by invoking the `bind` method of the @github[akka.http.javadsl.Http](/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala)
 extension:
 
 @@snip [HttpServerExampleDocTest.java](../../../../../test/java/docs/http/javadsl/server/HttpServerExampleDocTest.java) { #binding-example }

--- a/docs/src/main/paradox/java/http/server-side/low-level-server-side-api.md
+++ b/docs/src/main/paradox/java/http/server-side/low-level-server-side-api.md
@@ -2,7 +2,7 @@
 # Low-Level Server-Side API
 
 Apart from the @ref[HTTP Client](../client-side/index.md#http-client-side-java) Akka HTTP also provides an embedded,
-[Reactive-Streams](http://www.reactive-streams.org/)-based, fully asynchronous HTTP/1.1 server implemented on top of <!-- FIXME: unresolved link reference: streams-java --> streams-java.
+[Reactive-Streams](http://www.reactive-streams.org/)-based, fully asynchronous HTTP/1.1 server implemented on top of @extref[Streams](akka-docs:java/stream/index.html).
 
 It sports the following features:
 
@@ -35,10 +35,10 @@ easier.
 
 ## Streams and HTTP
 
-The Akka HTTP server is implemented on top of <!-- FIXME: unresolved link reference: streams-java --> streams-java and makes heavy use of it - in its
+The Akka HTTP server is implemented on top of @extref[Streams](akka-docs:java/stream/index.html) and makes heavy use of it - in its
 implementation as well as on all levels of its API.
 
-On the connection level Akka HTTP offers basically the same kind of interface as <!-- FIXME: unresolved link reference: stream-io-java --> stream-io-java:
+On the connection level Akka HTTP offers basically the same kind of interface as @extref[Working with streaming IO](akka-docs:java/stream/stream-io.html):
 A socket binding is represented as a stream of incoming connections. The application pulls connections from this stream
 source and, for each of them, provides a `Flow<HttpRequest, HttpResponse, ?>` to "translate" requests into responses.
 
@@ -190,7 +190,7 @@ through the stream starting from the stage which failed, all the way downstream 
 
 #### Connections Source failures
 
-In the example below we add a custom `GraphStage` (see <!-- FIXME: unresolved link reference: stream-customize-java --> stream-customize-java) in order to react to the
+In the example below we add a custom `GraphStage` (see @extref[Custom stream processing](akka-docs:java/stream/stream-customize.html)) in order to react to the
 stream's failure. We signal a `failureMonitor` actor with the cause why the stream is going down, and let the Actor
 handle the rest – maybe it'll decide to restart the server or shutdown the ActorSystem, that however is not our concern anymore.
 

--- a/docs/src/main/paradox/java/http/server-side/websocket-support.md
+++ b/docs/src/main/paradox/java/http/server-side/websocket-support.md
@@ -76,7 +76,7 @@ subsequent messages may be stuck and message traffic in this direction will stal
 
 ### Example
 
-Let's look at an [example](@github@/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java).
+Let's look at an @github[example](/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java).
 
 WebSocket requests come in like any other requests. In the example, requests to `/greeter` are expected to be
 WebSocket requests:
@@ -112,4 +112,4 @@ uses the `handleWebSocketRequests` directive in place of the `WebSocket.handleWe
 
 The handling code itself will be the same as with using the low-level API.
 
-See the [full routing example](@github@/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java).
+See the @github[full routing example](/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java).

--- a/docs/src/main/paradox/scala/http/client-side/client-https-support.md
+++ b/docs/src/main/paradox/scala/http/client-side/client-https-support.md
@@ -13,7 +13,7 @@ the static method `ConnectionContext.https` which is defined like this:
 @@snip [ConnectionContext.scala](../../../../../../../akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala) { #https-context-creation }
 
 In addition to the `outgoingConnection`, `newHostConnectionPool` and `cachedHostConnectionPool` methods the
-[akka.http.scaladsl.Http](@github@/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala) extension also defines `outgoingConnectionTls`, `newHostConnectionPoolTls` and
+@github[akka.http.scaladsl.Http](/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala) extension also defines `outgoingConnectionTls`, `newHostConnectionPoolTls` and
 `cachedHostConnectionPoolTls`. These methods work identically to their counterparts without the `-Tls` suffix,
 with the exception that all connections will always be encrypted.
 

--- a/docs/src/main/paradox/scala/http/client-side/index.md
+++ b/docs/src/main/paradox/scala/http/client-side/index.md
@@ -10,16 +10,13 @@ from a background with non-"streaming first" HTTP Clients.
 
 Depending on your application's specific needs you can choose from three different API levels:
 
-:ref:
-*connection-level-api*
+@ref[Connection-Level Client-Side API](connection-level.md#connection-level-api)
 : for full-control over when HTTP connections are opened/closed and how requests are scheduled across them
 
-:ref:
-*host-level-api*
+@ref[Host-Level Client-Side API](host-level.md#host-level-api)
 : for letting Akka HTTP manage a connection-pool to *one specific* host/port endpoint
 
-:ref:
-*request-level-api*
+@ref[Request-Level Client-Side API](request-level.md#request-level-api)
 : for letting Akka HTTP perform all connection management
 
 

--- a/docs/src/main/paradox/scala/http/common/de-coding.md
+++ b/docs/src/main/paradox/scala/http/common/de-coding.md
@@ -5,7 +5,7 @@ The [HTTP spec](http://tools.ietf.org/html/rfc7231#section-3.1.2.1) defines a `C
 
 Currently Akka HTTP supports the compression and decompression of HTTP requests and responses with the `gzip` or
 `deflate` encodings.
-The core logic for this lives in the [akka.http.scaladsl.coding](@github@/akka-http/src/main/scala/akka/http/scaladsl/coding) package.
+The core logic for this lives in the @github[akka.http.scaladsl.coding](/akka-http/src/main/scala/akka/http/scaladsl/coding) package.
 
 The support is not enabled automatically, but must be explicitly requested.
 For enabling message encoding/decoding with @ref[Routing DSL](../routing-dsl/index.md#http-high-level-server-side-api) see the @ref[CodingDirectives](../routing-dsl/directives/coding-directives/index.md#codingdirectives).

--- a/docs/src/main/paradox/scala/http/common/http-model.md
+++ b/docs/src/main/paradox/scala/http/common/http-model.md
@@ -256,7 +256,7 @@ Connection
 the potential wish of the application to close the connection after the respective response has been sent out.
 The actual logic for determining whether to close the connection is quite involved. It takes into account the
 request's method, protocol and potential `Connection` header as well as the response's protocol, entity and
-potential `Connection` header. See [this test](@github@/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala#L422) for a full table of what happens when.
+potential `Connection` header. See @github[this test](/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala#L422) for a full table of what happens when.
 
 Strict-Transport-Security
 : HTTP Strict Transport Security (HSTS) is a web security policy mechanism which is communicated by the

--- a/docs/src/main/paradox/scala/http/common/json-support.md
+++ b/docs/src/main/paradox/scala/http/common/json-support.md
@@ -9,7 +9,7 @@ Other JSON libraries are supported by the community. See [the list of current co
 
 ## spray-json Support
 
-The [SprayJsonSupport](@github@/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala) trait provides a `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` for every type `T`
+The @github[SprayJsonSupport](/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala) trait provides a `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` for every type `T`
 that an implicit `spray.json.RootJsonReader` and/or `spray.json.RootJsonWriter` (respectively) is available for.
 
 To enable automatic support for (un)marshalling from and to JSON with [spray-json], add a library dependency onto:

--- a/docs/src/main/paradox/scala/http/common/marshalling.md
+++ b/docs/src/main/paradox/scala/http/common/marshalling.md
@@ -44,7 +44,7 @@ This is how `Marshalling` is defined:
 Akka HTTP already predefines a number of marshallers for the most common types.
 Specifically these are:
 
- * [PredefinedToEntityMarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala)
+ * @github[PredefinedToEntityMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala)
     * `Array[Byte]`
     * `ByteString`
     * `Array[Char]`
@@ -52,7 +52,7 @@ Specifically these are:
     * `akka.http.scaladsl.model.FormData`
     * `akka.http.scaladsl.model.MessageEntity`
     * `T <: akka.http.scaladsl.model.Multipart`
- * [PredefinedToResponseMarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala)
+ * @github[PredefinedToResponseMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala)
     * `T`, if a `ToEntityMarshaller[T]` is available
     * `HttpResponse`
     * `StatusCode`
@@ -60,12 +60,12 @@ Specifically these are:
     * `(Int, T)`, if a `ToEntityMarshaller[T]` is available
     * `(StatusCode, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
     * `(Int, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
- * [PredefinedToRequestMarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala)
+ * @github[PredefinedToRequestMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala)
     * `HttpRequest`
     * `Uri`
     * `(HttpMethod, Uri, T)`, if a `ToEntityMarshaller[T]` is available
     * `(HttpMethod, Uri, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
- * [GenericMarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala)
+ * @github[GenericMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala)
     * `Marshaller[Throwable, T]`
     * `Marshaller[Option[A], B]`, if a `Marshaller[A, B]` and an `EmptyValue[B]` is available
     * `Marshaller[Either[A1, A2], B]`, if a `Marshaller[A1, B]` and a `Marshaller[A2, B]` is available

--- a/docs/src/main/paradox/scala/http/common/unmarshalling.md
+++ b/docs/src/main/paradox/scala/http/common/unmarshalling.md
@@ -24,7 +24,7 @@ content negotiation which saves two additional layers of indirection that are re
 Akka HTTP already predefines a number of marshallers for the most common types.
 Specifically these are:
 
- * [PredefinedFromStringUnmarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala)
+ * @github[PredefinedFromStringUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala)
     * `Byte`
     * `Short`
     * `Int`
@@ -32,13 +32,13 @@ Specifically these are:
     * `Float`
     * `Double`
     * `Boolean`
- * [PredefinedFromEntityUnmarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala)
+ * @github[PredefinedFromEntityUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala)
     * `Array[Byte]`
     * `ByteString`
     * `Array[Char]`
     * `String`
     * `akka.http.scaladsl.model.FormData`
- * [GenericUnmarshallers](@github@/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/GenericUnmarshallers.scala)
+ * @github[GenericUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/GenericUnmarshallers.scala)
     * `Unmarshaller[T, T]` (identity unmarshaller)
     * `Unmarshaller[Option[A], B]`, if an `Unmarshaller[A, B]` is available
     * `Unmarshaller[A, Option[B]]`, if an `Unmarshaller[A, B]` is available

--- a/docs/src/main/paradox/scala/http/common/xml-support.md
+++ b/docs/src/main/paradox/scala/http/common/xml-support.md
@@ -10,7 +10,7 @@ For XML Akka HTTP currently provides support for [Scala XML](https://github.com/
 
 ## Scala XML Support
 
-The [ScalaXmlSupport](@github@/akka-http-marshallers-scala/akka-http-xml/src/main/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala) trait provides a `FromEntityUnmarshaller[NodeSeq]` and `ToEntityMarshaller[NodeSeq]` that
+The @github[ScalaXmlSupport](/akka-http-marshallers-scala/akka-http-xml/src/main/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala) trait provides a `FromEntityUnmarshaller[NodeSeq]` and `ToEntityMarshaller[NodeSeq]` that
 you can use directly or build upon.
 
 This is how you enable support for (un)marshalling from and to JSON with [Scala XML](https://github.com/scala/scala-xml) `NodeSeq`:

--- a/docs/src/main/paradox/scala/http/handling-blocking-operations-in-akka-http-routes.md
+++ b/docs/src/main/paradox/scala/http/handling-blocking-operations-in-akka-http-routes.md
@@ -77,7 +77,7 @@ my-blocking-dispatcher {
 }
 ```
 
-There are many dispatcher options available which can be found in <!-- FIXME: unresolved link reference: dispatchers-scala --> dispatchers-scala.
+There are many dispatcher options available which can be found in @extref[Dispatchers](akka-docs:scala/dispatchers.html).
 
 Here `thread-pool-executor` is used, which has a hard limit of threads, it can
 keep available for blocking operations. The size settings depend on the app

--- a/docs/src/main/paradox/scala/http/low-level-server-side-api.md
+++ b/docs/src/main/paradox/scala/http/low-level-server-side-api.md
@@ -54,7 +54,7 @@ the @ref[HTTP Model](common/http-model.md#http-model-scala) for more information
 
 ## Starting and Stopping
 
-On the most basic level an Akka HTTP server is bound by invoking the `bind` method of the [akka.http.scaladsl.Http](@github@/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala)
+On the most basic level an Akka HTTP server is bound by invoking the `bind` method of the @github[akka.http.scaladsl.Http](/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala)
 extension:
 
 @@snip [HttpServerExampleSpec.scala](../../../../test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala) { #binding-example }

--- a/docs/src/main/paradox/scala/http/low-level-server-side-api.md
+++ b/docs/src/main/paradox/scala/http/low-level-server-side-api.md
@@ -2,7 +2,7 @@
 # Low-Level Server-Side API
 
 Apart from the @ref[HTTP Client](client-side/index.md#http-client-side) Akka HTTP also provides an embedded,
-[Reactive-Streams](http://www.reactive-streams.org/)-based, fully asynchronous HTTP/1.1 server implemented on top of <!-- FIXME: unresolved link reference: streams-scala --> streams-scala.
+[Reactive-Streams](http://www.reactive-streams.org/)-based, fully asynchronous HTTP/1.1 server implemented on top of @extref[Streams](akka-docs:scala/stream/index.html).
 
 It sports the following features:
 
@@ -40,10 +40,10 @@ from a background with non-"streaming first" HTTP Servers.
 
 ## Streams and HTTP
 
-The Akka HTTP server is implemented on top of <!-- FIXME: unresolved link reference: streams-scala --> streams-scala and makes heavy use of it - in its
+The Akka HTTP server is implemented on top of @extref[Streams](akka-docs:scala/stream/index.html) and makes heavy use of it - in its
 implementation as well as on all levels of its API.
 
-On the connection level Akka HTTP offers basically the same kind of interface as <!-- FIXME: unresolved link reference: stream-io-scala --> stream-io-scala:
+On the connection level Akka HTTP offers basically the same kind of interface as @extref[Working with streaming IO](akka-docs:scala/stream/stream-io.html):
 A socket binding is represented as a stream of incoming connections. The application pulls connections from this stream
 source and, for each of them, provides a `Flow[HttpRequest, HttpResponse, _]` to "translate" requests into responses.
 
@@ -200,7 +200,7 @@ through the stream starting from the stage which failed, all the way downstream 
 
 #### Connections Source failures
 
-In the example below we add a custom `GraphStage` (see <!-- FIXME: unresolved link reference: stream-customize-scala --> stream-customize-scala) in order to react to the
+In the example below we add a custom `GraphStage` (see @extref[Custom stream processing](akka-docs:scala/stream/stream-customize.html)) in order to react to the
 stream's failure. We signal a `failureMonitor` actor with the cause why the stream is going down, and let the Actor
 handle the rest – maybe it'll decide to restart the server or shutdown the ActorSystem, that however is not our concern anymore.
 

--- a/docs/src/main/paradox/scala/http/migration-guide-2.4.x-experimental.md
+++ b/docs/src/main/paradox/scala/http/migration-guide-2.4.x-experimental.md
@@ -12,7 +12,7 @@ versions of the **experimental** part of Akka HTTP.
 > **Note:**
 Please note that experimental modules are allowed (and are expected to) break compatibility
 in search of the best API we can offer, before the API is frozen in a stable release.
-Please read <!-- FIXME: unresolved link reference: bincompatrules --> BinCompatRules to understand in depth what bin-compat rules are, and where they are applied.
+Please read @extref[Binary Compatibility Rules](akka-docs:common/binary-compatibility-rules.html) to understand in depth what bin-compat rules are, and where they are applied.
 
 ## Akka HTTP 2.4.7 -> 2.4.8
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/requestEncodedWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/requestEncodedWith.md
@@ -9,4 +9,4 @@ FIXME@@snip [CodingDirectives.scala](../../../../../../../../../akka-http/src/ma
 
 Passes the request to the inner route if the request is encoded with the argument encoding. Otherwise, rejects the request with an `UnacceptedRequestEncodingRejection(encoding)`.
 
-This directive is the [building block](@github@/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) for `decodeRequest` to reject unsupported encodings.
+This directive is the @github[building block](/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) for `decodeRequest` to reject unsupported encodings.

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
@@ -28,7 +28,7 @@ together in the @ref[BasicDirectives](basic-directives/index.md#basicdirectives)
 ## Transforming Directives
 
 The second option for creating new directives is to transform an existing one using one of the
-“transformation methods”, which are defined on the [Directive](@github@/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala) class, the base class of all “regular” directives.
+“transformation methods”, which are defined on the @github[Directive](/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala) class, the base class of all “regular” directives.
 
 Apart from the combinator operators (`|` and `&`) and the case-class extractor (`as[T]`)
 there following transformations is also defined on all `Directive` instances:
@@ -47,7 +47,7 @@ for simple transformations:
 
 @@snip [CustomDirectivesExamplesSpec.scala](../../../../../../test/scala/docs/http/scaladsl/server/directives/CustomDirectivesExamplesSpec.scala) { #map-0 }
 
-One example of a predefined directive relying on `map` is the [optionalHeaderValue](@github@/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala#L67) directive.
+One example of a predefined directive relying on `map` is the @github[optionalHeaderValue](/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala#L67) directive.
 
 The tmap modifier has this signature (somewhat simplified):
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/onCompleteWithBreaker.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/onCompleteWithBreaker.md
@@ -8,7 +8,7 @@ FIXME@@snip [FutureDirectives.scala](../../../../../../../../../akka-http/src/ma
 ## Description
 
 Evaluates its parameter of type `Future[T]` protecting it with the specified `CircuitBreaker`.
-Refer to <!-- FIXME: unresolved link reference: circuit-breaker --> circuit-breaker for a detailed description of this pattern.
+Refer to @extref[Circuit Breaker](akka-docs:common/circuitbreaker.html) for a detailed description of this pattern.
 
 If the `CircuitBreaker` is open, the request is rejected with a `CircuitBreakerOpenRejection`.
 Note that in this case the request's entity databytes stream is cancelled, and the connection is closed

--- a/docs/src/main/paradox/scala/http/routing-dsl/exception-handling.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/exception-handling.md
@@ -5,7 +5,7 @@ Exceptions thrown during route execution bubble up through the route structure t
 @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions) directive or the top of your route structure.
 
 Similarly to the way that @ref[Rejections](rejections.md#rejections-scala) are handled the @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions) directive delegates the actual job
-of converting an exception to its argument, an [ExceptionHandler](@github@/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala), which is defined like this:
+of converting an exception to its argument, an @github[ExceptionHandler](/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala), which is defined like this:
 
 ```scala
 trait ExceptionHandler extends PartialFunction[Throwable, Route]

--- a/docs/src/main/paradox/scala/http/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/rejections.md
@@ -23,7 +23,7 @@ and handle any rejection.
 ## Predefined Rejections
 
 A rejection encapsulates a specific reason why a route was not able to handle a request. It is modeled as an object of
-type `Rejection`. Akka HTTP comes with a set of [predefined rejections](@github@/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala), which are used by the many
+type `Rejection`. Akka HTTP comes with a set of @github[predefined rejections](/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala), which are used by the many
 @ref[predefined directives](directives/alphabetically.md#predefined-directives).
 
 Rejections are gathered up over the course of a Route evaluation and finally converted to `HttpResponse` replies by
@@ -33,7 +33,7 @@ the @ref[handleRejections](directives/execution-directives/handleRejections.md#h
 ## The RejectionHandler
 
 The @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections) directive delegates the actual job of converting a list of rejections to its argument, a
-[RejectionHandler](@github@/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala), which is defined like this:
+@github[RejectionHandler](/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala), which is defined like this:
 
 ```scala
 trait RejectionHandler extends (immutable.Seq[Rejection] => Option[Route])

--- a/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
@@ -87,4 +87,4 @@ and translates them to the respective `HttpResponse`.
 ## Examples
 
 A great pool of examples are the tests for all the predefined directives in Akka HTTP.
-They can be found [here](@github@/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/).
+They can be found @github[here](/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/).

--- a/docs/src/main/paradox/scala/http/routing-dsl/websocket-support.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/websocket-support.md
@@ -69,7 +69,7 @@ subsequent messages may be stuck and message traffic in this direction will stal
 
 ### Example
 
-Let's look at an [example](@github@/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala).
+Let's look at an @github[example](/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala).
 
 WebSocket requests come in like any other requests. In the example, requests to `/greeter` are expected to be
 WebSocket requests:


### PR DESCRIPTION
This is a preliminary PR to knock another two points off of #318 

It depends on lightbend/paradox#27 being available in a new Paradox release.