### PR TITLE
Fix typo in the spray migration guide

### DIFF
--- a/docs/src/main/paradox/scala/http/migration-from-spray.md
+++ b/docs/src/main/paradox/scala/http/migration-from-spray.md
@@ -103,7 +103,7 @@ MediaType.custom("application/vnd.acme+json")
 Replace with:
 
 ```scala
-MediaType.applicationWithFixedCharset("application/vnd.acme+json", HttpCharsets.`UTF-8`)
+MediaType.applicationWithFixedCharset("vnd.acme+json", HttpCharsets.`UTF-8`)
 ```
 
 ## Changes in Rejection Handling


### PR DESCRIPTION
First argument of MediaType.applicationWithFixedCharset is only the subType, not the full MediaType name.