### PR TITLE
=doc fix typos in High-level Server-Side API

### DIFF
--- a/docs/src/main/paradox/java/http/routing-dsl/index.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/index.md
@@ -34,7 +34,7 @@ end-point explicitly.
 
 For example the server might be unable to bind to the given port. For example when the port
 is already taken by another application, or if the port is privileged (i.e. only usable by `root`).
-In this case the "binding future" will fail immediately, and we can react to if by listening on the CompletionStage's completion:
+In this case the "binding future" will fail immediately, and we can react to it by listening on the CompletionStage's completion:
 
 @@snip [HighLevelServerBindFailureExample.java](../../../../../test/java/docs/http/javadsl/server/HighLevelServerBindFailureExample.java) { #binding-failure-high-level-example }
 
@@ -45,8 +45,8 @@ refer to the @ref[Handling HTTP Server failures in the Low-Level API](../server-
 ### Failures and exceptions inside the Routing DSL
 
 Exception handling within the Routing DSL is done by providing `ExceptionHandler` s which are documented in-depth
-in the @ref[Exception Handling](exception-handling.md#exception-handling-java) section of the documtnation. You can use them to transform exceptions into
-`HttpResponse` s with apropriate error codes and human-readable failure descriptions.
+in the @ref[Exception Handling](exception-handling.md#exception-handling-java) section of the documentation. You can use them to transform exceptions into
+`HttpResponse` s with appropriate error codes and human-readable failure descriptions.
 
 ### File uploads
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/index.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/index.md
@@ -57,7 +57,7 @@ end-point explicitly.
 
 For example the server might be unable to bind to the given port. For example when the port
 is already taken by another application, or if the port is privileged (i.e. only usable by `root`).
-In this case the "binding future" will fail immediately, and we can react to if by listening on the Future's completion:
+In this case the "binding future" will fail immediately, and we can react to it by listening on the Future's completion:
 
 @@snip [HttpServerExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala) { #binding-failure-high-level-example }
 
@@ -68,8 +68,8 @@ refer to the @ref[Handling HTTP Server failures in the Low-Level API](../low-lev
 ### Failures and exceptions inside the Routing DSL
 
 Exception handling within the Routing DSL is done by providing `ExceptionHandler` s which are documented in-depth
-in the @ref[Exception Handling](exception-handling.md#exception-handling-scala) section of the documtnation. You can use them to transform exceptions into
-`HttpResponse` s with apropriate error codes and human-readable failure descriptions.
+in the @ref[Exception Handling](exception-handling.md#exception-handling-scala) section of the documentation. You can use them to transform exceptions into
+`HttpResponse` s with appropriate error codes and human-readable failure descriptions.
 
 ### File uploads
 


### PR DESCRIPTION
Found some typos in the java and scala version of [High-level Server-Side API](http://doc.akka.io/docs/akka/2.4/scala/http/routing-dsl/index.html) and fixed them.