### PR TITLE
=htp #366 disable content-type negotiation for responses marshalled from status codes

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/MarshallingTestUtils.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/MarshallingTestUtils.scala
@@ -8,7 +8,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext }
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshal }
 import akka.http.scaladsl.marshalling._
-import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
+import akka.http.scaladsl.model.headers.Accept
+import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse, MediaRange }
 import akka.stream.Materializer
 
 import scala.util.Try
@@ -17,9 +18,11 @@ trait MarshallingTestUtils {
   def marshal[T: ToEntityMarshaller](value: T)(implicit ec: ExecutionContext, mat: Materializer): HttpEntity.Strict =
     Await.result(Marshal(value).to[HttpEntity].flatMap(_.toStrict(1.second)), 1.second)
 
-  def marshalToResponse[T: ToResponseMarshaller](value: T, request: HttpRequest = HttpRequest())(implicit ec: ExecutionContext, mat: Materializer): HttpResponse = {
+  def marshalToResponseForRequestAccepting[T: ToResponseMarshaller](value: T, mediaRanges: MediaRange*)(implicit ec: ExecutionContext, mat: Materializer): HttpResponse =
+    marshalToResponse(value, HttpRequest(headers = Accept(mediaRanges: _*) :: Nil))
+
+  def marshalToResponse[T: ToResponseMarshaller](value: T, request: HttpRequest = HttpRequest())(implicit ec: ExecutionContext, mat: Materializer): HttpResponse =
     Await.result(Marshal(value).toResponseFor(request), 1.second)
-  }
 
   def unmarshalValue[T: FromEntityUnmarshaller](entity: HttpEntity)(implicit ec: ExecutionContext, mat: Materializer): T =
     unmarshal(entity).get

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.http.scaladsl.marshalling
 
+import scala.collection.immutable
 import scala.collection.immutable.ListMap
 import org.scalatest.{ BeforeAndAfterAll, FreeSpec, Matchers }
 import akka.util.ByteString
@@ -41,18 +42,43 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
   }
 
   "The PredefinedToResponseMarshallers" - {
-    "fromStatusCode should properly marshal entities that are not supposed to have a body" in {
+    "fromStatusCode should properly marshal a status code that doesn't allow an entity" in {
       marshalToResponse(StatusCodes.NoContent) shouldEqual HttpResponse(StatusCodes.NoContent, entity = HttpEntity.Empty)
+
+      // no content-type negotiation for status code marshalling
+      marshalToResponseForRequestAccepting(StatusCodes.NoContent, MediaTypes.`application/json`) shouldEqual
+        HttpResponse(StatusCodes.NoContent, entity = HttpEntity.Empty)
     }
-    "fromStatusCode should properly marshal entities that contain pre-defined content" in {
+    "fromStatusCode should properly marshal a status code with a default message" in {
       marshalToResponse(StatusCodes.EnhanceYourCalm) shouldEqual
         HttpResponse(StatusCodes.EnhanceYourCalm, entity = HttpEntity(StatusCodes.EnhanceYourCalm.defaultMessage))
+
+      // no content-type negotiation for status code marshalling
+      marshalToResponseForRequestAccepting(StatusCodes.EnhanceYourCalm, MediaTypes.`application/json`) shouldEqual
+        HttpResponse(StatusCodes.EnhanceYourCalm, entity = HttpEntity(StatusCodes.EnhanceYourCalm.defaultMessage))
     }
-    "fromStatusCodeAndHeadersAndValue should properly marshal entities that are not supposed to have a body" in {
+    val headers: immutable.Seq[HttpHeader] = RawHeader("X-Test", "test") :: Nil
+    "fromStatusCodeAndHeaders should properly marshal for a status code that doesn't allow an entity" in {
+      marshalToResponse(StatusCodes.NoContent → headers) shouldEqual
+        HttpResponse(StatusCodes.NoContent, headers = headers, entity = HttpEntity.Empty)
+
+      // no content-type negotiation for status code marshalling
+      marshalToResponseForRequestAccepting(StatusCodes.NoContent → headers, MediaTypes.`application/json`) shouldEqual
+        HttpResponse(StatusCodes.NoContent, headers = headers, entity = HttpEntity.Empty)
+    }
+    "fromStatusCodeAndHeaders should properly marshal for a status code with a default message" in {
+      marshalToResponse(StatusCodes.EnhanceYourCalm → headers) shouldEqual
+        HttpResponse(StatusCodes.EnhanceYourCalm, headers = headers, entity = HttpEntity(StatusCodes.EnhanceYourCalm.defaultMessage))
+
+      // no content-type negotiation for status code marshalling
+      marshalToResponseForRequestAccepting(StatusCodes.EnhanceYourCalm → headers, MediaTypes.`application/json`) shouldEqual
+        HttpResponse(StatusCodes.EnhanceYourCalm, headers = headers, entity = HttpEntity(StatusCodes.EnhanceYourCalm.defaultMessage))
+    }
+    "fromStatusCodeAndHeadersAndValue should properly marshal for a status code that doesn't allow an entity" in {
       marshalToResponse((StatusCodes.NoContent, "This Content was intentionally left blank.")) shouldEqual
         HttpResponse(StatusCodes.NoContent, entity = HttpEntity.Empty)
     }
-    "fromStatusCodeAndHeadersAndValue should properly marshal entities that contain pre-defined content" in {
+    "fromStatusCodeAndHeadersAndValue should properly marshal a status code with a default message" in {
       marshalToResponse((StatusCodes.EnhanceYourCalm, "Patience, young padawan!")) shouldEqual
         HttpResponse(StatusCodes.EnhanceYourCalm, entity = HttpEntity("Patience, young padawan!"))
     }


### PR DESCRIPTION
RFC 7231 3.4.1 states:

```
   A user agent cannot rely on proactive negotiation preferences being
   consistently honored, since the origin server might not implement
   proactive negotiation for the requested resource or might decide that
   sending a response that doesn't conform to the user agent's
   preferences is better than sending a 406 (Not Acceptable) response.
```

So, especially for status code responses which usually won't contain any
actual "resource" at all, it makes more sense to return the status code
and a `text/plain` response with the status codes default message instead
of requiring the client to accept `text/plain` just to support receiving
status information.

Fixes #366.

/cc @leachbj
/cc @gosubpl (since you changed the code the last time)