### PR TITLE
=doc create new `@signature` directive to support directive documentation

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
@@ -93,7 +93,6 @@ trait HeaderDirectives {
   def headerValueByType[T](magnet: HeaderMagnet[T]): Directive1[T] =
     headerValuePF(magnet.extractPF) | reject(MissingHeaderRejection(magnet.headerName))
 
-  //#optional-header
   /**
    * Extracts an optional HTTP header value using the given function.
    * If the given function throws an exception the request is rejected
@@ -105,7 +104,6 @@ trait HeaderDirectives {
     headerValue(f).map(Some(_): Option[T]).recoverPF {
       case Nil ⇒ provide(None)
     }
-  //#optional-header
 
   /**
    * Extracts an optional HTTP header value using the given partial function.

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,0 +1,1 @@
+akka.ParadoxSupport.paradoxWithSignatureDirective

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/cancelRejection.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/cancelRejection.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #cancelRejection }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #cancelRejection }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/cancelRejections.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/cancelRejections.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #cancelRejections }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #cancelRejections }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extract.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extract.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extract }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extract }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractActorSystem.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractActorSystem.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractActorSystem }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractActorSystem }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractDataBytes.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractDataBytes.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractDataBytes }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractDataBytes }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractExecutionContext.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractExecutionContext.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractExecutionContext }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractExecutionContext }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractLog.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractLog.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractLog }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractLog }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractMaterializer.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractMaterializer.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractMaterializer }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractMaterializer }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractRequest.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractRequest.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractRequest }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractRequest }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractRequestContext.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractRequestContext.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractRequestContext }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractRequestContext }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractRequestEntity.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractRequestEntity.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractRequestEntity }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractRequestEntity }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractSettings.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractSettings.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractSettings }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractSettings }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractStrictEntity.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractStrictEntity.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractStrictEntity }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractStrictEntity }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractUnmatchedPath.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractUnmatchedPath.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractUnmatchedPath }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractUnmatchedPath }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractUri.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractUri.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractUri }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #extractUri }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapInnerRoute.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapInnerRoute.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapInnerRoute }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapInnerRoute }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRejections.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRejections.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRejections }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRejections }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRequest.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRequest.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRequest }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRequest }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRequestContext.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRequestContext.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRequestContext }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRequestContext }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapResponse.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapResponse.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapResponse }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapResponse }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapResponseEntity.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapResponseEntity.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapResponseEntity }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapResponseEntity }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapResponseHeaders.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapResponseHeaders.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapResponseHeaders }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapResponseHeaders }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResult.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResult.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResult }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResult }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResultFuture.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResultFuture.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResultFuture }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResultFuture }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResultPF.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResultPF.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResultPF }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResultPF }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResultWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResultWith.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResultWith }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResultWith }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResultWithPF.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResultWithPF.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResultWithPF }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapRouteResultWithPF }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapSettings.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapSettings.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapSettings }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapSettings }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapUnmatchedPath.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapUnmatchedPath.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapUnmatchedPath }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #mapUnmatchedPath }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/pass.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/pass.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #pass }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #pass }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/provide.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/provide.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #provide }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #provide }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/recoverRejections.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/recoverRejections.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #recoverRejections }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #recoverRejections }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/recoverRejectionsWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/recoverRejectionsWith.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #recoverRejectionsWith }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #recoverRejectionsWith }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/textract.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/textract.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #textract }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #textract }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/toStrictEntity.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/toStrictEntity.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #toStrictEntity }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #toStrictEntity }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/tprovide.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/tprovide.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #tprovide }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #tprovide }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withExecutionContext.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withExecutionContext.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #withExecutionContext }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #withExecutionContext }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withLog.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withLog.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #withLog }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #withLog }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withMaterializer.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withMaterializer.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #withMaterializer }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #withMaterializer }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withSettings.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withSettings.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #withSettings }
+@@signature [BasicDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala) { #withSettings }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/cache-condition-directives/conditional.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/cache-condition-directives/conditional.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CacheConditionDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CacheConditionDirectives.scala) { #conditional }
+@@signature [CacheConditionDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CacheConditionDirectives.scala) { #conditional }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/decodeRequest.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/decodeRequest.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #decodeRequest }
+@@signature [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #decodeRequest }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/decodeRequestWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/decodeRequestWith.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #decodeRequestWith }
+@@signature [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #decodeRequestWith }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/encodeResponse.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/encodeResponse.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #encodeResponse }
+@@signature [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #encodeResponse }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/encodeResponseWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/encodeResponseWith.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #encodeResponseWith }
+@@signature [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #encodeResponseWith }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/requestEncodedWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/requestEncodedWith.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #requestEncodedWith }
+@@signature [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #requestEncodedWith }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/responseEncodingAccepted.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/responseEncodingAccepted.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #responseEncodingAccepted }
+@@signature [CodingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) { #responseEncodingAccepted }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/cookie-directives/cookie.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/cookie-directives/cookie.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CookieDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala) { #cookie }
+@@signature [CookieDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala) { #cookie }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/cookie-directives/deleteCookie.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/cookie-directives/deleteCookie.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CookieDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala) { #deleteCookie }
+@@signature [CookieDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala) { #deleteCookie }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/cookie-directives/optionalCookie.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/cookie-directives/optionalCookie.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CookieDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala) { #optionalCookie }
+@@signature [CookieDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala) { #optionalCookie }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/cookie-directives/setCookie.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/cookie-directives/setCookie.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [CookieDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala) { #setCookie }
+@@signature [CookieDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala) { #setCookie }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
@@ -91,7 +91,7 @@ from the RequestContext with the extract directive and then flatMap with
 some kind of filtering logic. For example, this is the implementation
 of the method directive:
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #method }
+@@signature [MethodDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #method }
 
 The explicit type parameter `[Unit]` on the flatMap i`s needed in this case
 because the result of the flatMap is directly concatenated with the
@@ -113,7 +113,7 @@ def require(predicate: T ⇒ Boolean, rejections: Rejection*): Directive0
 
 One example of a predefined directive relying on require is the first overload of the host directive:
 
-FIXME@@snip [HostDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala) { #require-host }
+@@signature [HostDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala) { #require-host }
 
 You can only call require on single-extraction directives. The trequire modifier is the
 more general variant, which takes a predicate of type `Tuple => Boolean`.
@@ -141,7 +141,7 @@ def recoverPF[R >: L: Tuple](
 
 One example of a predefined directive relying `recoverPF` is the optionalHeaderValue directive:
 
-FIXME@@snip [HeaderDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optional-header }
+@@signature [HeaderDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optional-header }
 
 ## Directives from Scratch
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
@@ -113,7 +113,7 @@ def require(predicate: T ⇒ Boolean, rejections: Rejection*): Directive0
 
 One example of a predefined directive relying on require is the first overload of the host directive:
 
-@@signature [HostDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala) { #require-host }
+@@snip[HostDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala) { #require-host }
 
 You can only call require on single-extraction directives. The trequire modifier is the
 more general variant, which takes a predicate of type `Tuple => Boolean`.
@@ -139,9 +139,9 @@ def recoverPF[R >: L: Tuple](
   recovery: PartialFunction[Seq[Rejection], Directive[R]]): Directive[R]
 ```
 
-One example of a predefined directive relying `recoverPF` is the optionalHeaderValue directive:
+One example of a predefined directive relying `recoverPF` is the `optionalHeaderValue` directive:
 
-@@signature [HeaderDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optional-header }
+@@signature [HeaderDirectives.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optionalHeaderValue }
 
 ## Directives from Scratch
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/execution-directives/handleExceptions.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/execution-directives/handleExceptions.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [ExecutionDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ExecutionDirectives.scala) { #handleExceptions }
+@@signature [ExecutionDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ExecutionDirectives.scala) { #handleExceptions }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/execution-directives/handleRejections.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/execution-directives/handleRejections.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [ExecutionDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ExecutionDirectives.scala) { #handleRejections }
+@@signature [ExecutionDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ExecutionDirectives.scala) { #handleRejections }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromBrowseableDirectories.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromBrowseableDirectories.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromBrowseableDirectories }
+@@signature [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromBrowseableDirectories }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromBrowseableDirectory.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromBrowseableDirectory.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromBrowseableDirectory }
+@@signature [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromBrowseableDirectory }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromDirectory.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromDirectory.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromDirectory }
+@@signature [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromDirectory }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromFile.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromFile.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromFile }
+@@signature [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromFile }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromResource.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromResource.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromResource }
+@@signature [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromResource }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromResourceDirectory.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/getFromResourceDirectory.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromResourceDirectory }
+@@signature [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #getFromResourceDirectory }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/listDirectoryContents.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/file-and-resource-directives/listDirectoryContents.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #listDirectoryContents }
+@@signature [FileAndResourceDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala) { #listDirectoryContents }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/file-upload-directives/fileUpload.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/file-upload-directives/fileUpload.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FileUploadDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala) { #fileUpload }
+@@signature [FileUploadDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala) { #fileUpload }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/file-upload-directives/uploadedFile.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/file-upload-directives/uploadedFile.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FileUploadDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala) { #uploadedFile }
+@@signature [FileUploadDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala) { #uploadedFile }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/form-field-directives/formField.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/form-field-directives/formField.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FormFieldDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala) { #formField }
+@@signature [FormFieldDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala) { #formField }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/form-field-directives/formFieldMap.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/form-field-directives/formFieldMap.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FormFieldDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala) { #formFieldMap }
+@@signature [FormFieldDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala) { #formFieldMap }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/form-field-directives/formFieldMultiMap.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/form-field-directives/formFieldMultiMap.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FormFieldDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala) { #formFieldMultiMap }
+@@signature [FormFieldDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala) { #formFieldMultiMap }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/form-field-directives/formFieldSeq.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/form-field-directives/formFieldSeq.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FormFieldDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala) { #formFieldSeq }
+@@signature [FormFieldDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala) { #formFieldSeq }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/completeOrRecoverWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/completeOrRecoverWith.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FutureDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala) { #completeOrRecoverWith }
+@@signature [FutureDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala) { #completeOrRecoverWith }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/onComplete.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/onComplete.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FutureDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala) { #onComplete }
+@@signature [FutureDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala) { #onComplete }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/onCompleteWithBreaker.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/onCompleteWithBreaker.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FutureDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala) { #onCompleteWithBreaker }
+@@signature [FutureDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala) { #onCompleteWithBreaker }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/onSuccess.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/future-directives/onSuccess.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [FutureDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala) { #onSuccess }
+@@signature [FutureDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala) { #onSuccess }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/checkSameOrigin.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/checkSameOrigin.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #checkSameOrigin }
+@@signature [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #checkSameOrigin }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/headerValue.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/headerValue.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #headerValue }
+@@signature [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #headerValue }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/headerValueByName.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/headerValueByName.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #headerValueByName }
+@@signature [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #headerValueByName }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/headerValuePF.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/headerValuePF.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #headerValuePF }
+@@signature [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #headerValuePF }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/optionalHeaderValue.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/optionalHeaderValue.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optionalHeaderValue }
+@@signature [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optionalHeaderValue }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/optionalHeaderValueByName.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/optionalHeaderValueByName.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optionalHeaderValueByName }
+@@signature [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optionalHeaderValueByName }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/optionalHeaderValuePF.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/header-directives/optionalHeaderValuePF.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optionalHeaderValuePF }
+@@signature [HeaderDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optionalHeaderValuePF }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/host-directives/extractHost.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/host-directives/extractHost.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [HostDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala) { #extractHost }
+@@signature [HostDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala) { #extractHost }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/host-directives/host.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/host-directives/host.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [HostDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala) { #host }
+@@signature [HostDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala) { #host }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/marshalling-directives/completeWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/marshalling-directives/completeWith.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MarshallingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala) { #completeWith[T] }
+@@signature [MarshallingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala) { #completeWith }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/marshalling-directives/entity.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/marshalling-directives/entity.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MarshallingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala) { #entity }
+@@signature [MarshallingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala) { #entity }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/marshalling-directives/handleWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/marshalling-directives/handleWith.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MarshallingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala) { #handleWith }
+@@signature [MarshallingDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala) { #handleWith }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/delete.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/delete.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #delete }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #delete }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/extractMethod.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/extractMethod.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #extractMethod }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #extractMethod }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/get.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/get.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #get }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #get }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/head.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/head.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #head }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #head }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/method.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/method.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #method }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #method }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/options.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/options.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #options }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #options }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/overrideMethodWithParameter.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/overrideMethodWithParameter.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #overrideMethodWithParameter }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #overrideMethodWithParameter }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/patch.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/patch.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #patch }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #patch }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/post.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/post.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #post }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #post }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/put.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/method-directives/put.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #put }
+@@signature [MethodDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala) { #put }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/extractClientIP.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/extractClientIP.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #extractClientIP }
+@@signature [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #extractClientIP }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/rejectEmptyResponse.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/rejectEmptyResponse.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #rejectEmptyResponse }
+@@signature [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #rejectEmptyResponse }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/requestEntityEmpty.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/requestEntityEmpty.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #requestEntityEmpty }
+@@signature [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #requestEntityEmpty }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/requestEntityPresent.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/requestEntityPresent.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #requestEntityPresent }
+@@signature [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #requestEntityPresent }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/selectPreferredLanguage.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/selectPreferredLanguage.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #selectPreferredLanguage }
+@@signature [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #selectPreferredLanguage }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/validate.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/validate.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #validate }
+@@signature [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #validate }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/withSizeLimit.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/withSizeLimit.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #withSizeLimit }
+@@signature [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #withSizeLimit }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/withoutSizeLimit.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/withoutSizeLimit.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #withoutSizeLimit }
+@@signature [MiscDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala) { #withoutSizeLimit }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/parameter-directives/parameter.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/parameter-directives/parameter.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [ParameterDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala) { #parameter }
+@@signature [ParameterDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala) { #parameter }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/parameter-directives/parameterMap.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/parameter-directives/parameterMap.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [ParameterDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala) { #parameterMap }
+@@signature [ParameterDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala) { #parameterMap }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/parameter-directives/parameterMultiMap.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/parameter-directives/parameterMultiMap.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [ParameterDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala) { #parameterMultiMap }
+@@signature [ParameterDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala) { #parameterMultiMap }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/parameter-directives/parameterSeq.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/parameter-directives/parameterSeq.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [ParameterDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala) { #parameterSeq }
+@@signature [ParameterDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala) { #parameterSeq }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/path.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/path.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #path }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #path }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathEnd.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathEnd.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathEnd }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathEnd }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathEndOrSingleSlash.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathEndOrSingleSlash.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathEndOrSingleSlash }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathEndOrSingleSlash }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathPrefix.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathPrefix.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathPrefix }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathPrefix }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathPrefixTest.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathPrefixTest.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathPrefixTest }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathPrefixTest }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathSingleSlash.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathSingleSlash.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathSingleSlash }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathSingleSlash }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathSuffix.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathSuffix.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathSuffix }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathSuffix }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathSuffixTest.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/pathSuffixTest.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathSuffixTest }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #pathSuffixTest }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/rawPathPrefix.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/rawPathPrefix.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #rawPathPrefix }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #rawPathPrefix }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/rawPathPrefixTest.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/rawPathPrefixTest.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #rawPathPrefixTest }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #rawPathPrefixTest }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/redirectToNoTrailingSlashIfPresent.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/redirectToNoTrailingSlashIfPresent.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #redirectToNoTrailingSlashIfPresent }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #redirectToNoTrailingSlashIfPresent }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/redirectToTrailingSlashIfMissing.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/path-directives/redirectToTrailingSlashIfMissing.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #redirectToTrailingSlashIfMissing }
+@@signature [PathDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala) { #redirectToTrailingSlashIfMissing }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeader.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeader.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [RespondWithDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala) { #respondWithDefaultHeader }
+@@signature [RespondWithDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala) { #respondWithDefaultHeader }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeaders.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/respond-with-directives/respondWithDefaultHeaders.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [RespondWithDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala) { #respondWithDefaultHeaders }
+@@signature [RespondWithDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala) { #respondWithDefaultHeaders }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/respond-with-directives/respondWithHeader.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/respond-with-directives/respondWithHeader.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [RespondWithDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala) { #respondWithHeader }
+@@signature [RespondWithDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala) { #respondWithHeader }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/respond-with-directives/respondWithHeaders.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/respond-with-directives/respondWithHeaders.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [RespondWithDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala) { #respondWithHeaders }
+@@signature [RespondWithDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala) { #respondWithHeaders }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/route-directives/failWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/route-directives/failWith.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [RouteDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RouteDirectives.scala) { #failWith }
+@@signature [RouteDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RouteDirectives.scala) { #failWith }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/route-directives/redirect.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/route-directives/redirect.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [RouteDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RouteDirectives.scala) { #redirect }
+@@signature [RouteDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RouteDirectives.scala) { #redirect }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/route-directives/reject.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/route-directives/reject.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [RouteDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RouteDirectives.scala) { #reject }
+@@signature [RouteDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/RouteDirectives.scala) { #reject }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/scheme-directives/extractScheme.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/scheme-directives/extractScheme.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [SchemeDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SchemeDirectives.scala) { #extractScheme }
+@@signature [SchemeDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SchemeDirectives.scala) { #extractScheme }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/scheme-directives/scheme.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/scheme-directives/scheme.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [SchemeDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SchemeDirectives.scala) { #scheme }
+@@signature [SchemeDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SchemeDirectives.scala) { #scheme }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasic.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasic.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #Authenticator }
 
 @@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasic }
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasic.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasic.md
@@ -3,9 +3,9 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasic }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasic }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicAsync.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicAsync.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #async-authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #AsyncAuthenticator }
 
 @@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasicAsync }
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicAsync.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicAsync.md
@@ -3,9 +3,9 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #async-authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #async-authenticator }
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasicAsync }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasicAsync }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicPF.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicPF.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator-pf }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #AuthenticatorPF }
 
 @@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasicPF }
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicPF.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicPF.md
@@ -3,9 +3,9 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator-pf }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator-pf }
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasicPF }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasicPF }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicPFAsync.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicPFAsync.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #async-authenticator-pf }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #AsyncAuthenticatorPF }
 
 @@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasicPFAsync }
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicPFAsync.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateBasicPFAsync.md
@@ -3,9 +3,9 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #async-authenticator-pf }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #async-authenticator-pf }
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasicPFAsync }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateBasicPFAsync }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #Authenticator }
 
 @@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2 }
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2.md
@@ -3,9 +3,9 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2 }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2 }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2Async.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2Async.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #async-authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #AsyncAuthenticator }
 
 @@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2Async }
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2Async.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2Async.md
@@ -3,9 +3,9 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #async-authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #async-authenticator }
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2Async }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2Async }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2PF.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2PF.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #AuthenticatorPF }
 
 @@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2PF }
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2PF.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2PF.md
@@ -3,9 +3,9 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2PF }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2PF }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2PFAsync.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2PFAsync.md
@@ -5,7 +5,7 @@ Wraps the inner route with OAuth Bearer Token authentication support using a giv
 
 ## Signature
 
-@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #AsyncAuthenticatorPF }
 
 @@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2PFAsync }
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2PFAsync.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOAuth2PFAsync.md
@@ -5,9 +5,9 @@ Wraps the inner route with OAuth Bearer Token authentication support using a giv
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticator }
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2PFAsync }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOAuth2PFAsync }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOrRejectWithChallenge.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOrRejectWithChallenge.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authentication-result }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #AuthenticationResult }
 
 @@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOrRejectWithChallenge }
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOrRejectWithChallenge.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authenticateOrRejectWithChallenge.md
@@ -3,9 +3,9 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authentication-result }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authentication-result }
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOrRejectWithChallenge }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authenticateOrRejectWithChallenge }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authorize.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authorize.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authorize }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authorize }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authorizeAsync.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authorizeAsync.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authorizeAsync }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #authorizeAsync }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/extractCredentials.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/extractCredentials.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #extractCredentials }
+@@signature [SecurityDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala) { #extractCredentials }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/timeout-directives/withRequestTimeout.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/timeout-directives/withRequestTimeout.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [TimeoutDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala) { #withRequestTimeout }
+@@signature [TimeoutDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala) { #withRequestTimeout }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/timeout-directives/withRequestTimeoutResponse.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/timeout-directives/withRequestTimeoutResponse.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [TimeoutDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala) { #withRequestTimeoutResponse }
+@@signature [TimeoutDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala) { #withRequestTimeoutResponse }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/timeout-directives/withoutRequestTimeout.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/timeout-directives/withoutRequestTimeout.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [TimeoutDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala) { #withoutRequestTimeout }
+@@signature [TimeoutDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala) { #withoutRequestTimeout }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/websocket-directives/handleWebSocketMessages.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/websocket-directives/handleWebSocketMessages.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [WebSocketDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/WebSocketDirectives.scala) { #handleWebSocketMessages }
+@@signature [WebSocketDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/WebSocketDirectives.scala) { #handleWebSocketMessages }
 
 ## Description
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/websocket-directives/handleWebSocketMessagesForProtocol.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/websocket-directives/handleWebSocketMessagesForProtocol.md
@@ -3,7 +3,7 @@
 
 ## Signature
 
-FIXME@@snip [WebSocketDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/WebSocketDirectives.scala) { #handleWebSocketMessagesForProtocol }
+@@signature [WebSocketDirectives.scala](../../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/directives/WebSocketDirectives.scala) { #handleWebSocketMessagesForProtocol }
 
 ## Description
 

--- a/project/ParadoxSignatureDirective.scala
+++ b/project/ParadoxSignatureDirective.scala
@@ -1,0 +1,55 @@
+package akka
+
+import sbt._
+import java.io.{File, FileNotFoundException}
+
+import com.lightbend.paradox._
+import markdown.Writer
+import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport._
+import com.lightbend.paradox.markdown.{LeafBlockDirective, _}
+import org.pegdown.Printer
+import org.pegdown.ast.{DirectiveNode, VerbatimNode, Visitor}
+
+import scala.collection.JavaConverters._
+import scala.io.Source
+
+object ParadoxSupport {
+  val paradoxWithSignatureDirective = Seq(
+    paradoxProcessor in Compile ~= { _ =>
+      // FIXME: this is a HACK so far that copies stuff over from paradox
+      // it would be better if the plugin has a way of specifying extra directives through normal sbt mechanisms
+      // see https://github.com/lightbend/paradox/issues/35
+      new ParadoxProcessor(writer =
+        new Writer(serializerPlugins = context =>
+          Seq(
+          new ActiveLinkSerializer,
+          new AnchorLinkSerializer,
+          new DirectiveSerializer(Writer.defaultDirectives(context) :+
+            new SignatureDirective(context.location.tree.label)
+      ))))
+    }
+  )
+
+  class SignatureDirective(page: Page) extends LeafBlockDirective("signature") {
+    def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit =
+      try {
+        val labels = node.attributes.values("identifier").asScala
+        val file = new File(page.file.getParentFile, node.source)
+
+        val Signature = """\s*((?:def|val) (\w+)(?=[:(\[]).*)\s+\=.*""".r // stupid approximation to match a signature
+        //println(s"Looking for signature regex '$Signature'")
+        val text =
+          Source.fromFile(file).getLines.collect {
+            case line@Signature(full, l, _*) if labels contains l =>
+              //println(s"Found label '$l' with sig '$full' in line $line")
+              full
+          }.mkString("\n")
+
+        val lang = Option(node.attributes.value("type")).getOrElse(Snippet.language(file))
+        new VerbatimNode(text, lang).accept(visitor)
+      } catch {
+        case e: FileNotFoundException =>
+          throw new SnipDirective.LinkException(s"Unknown snippet [${e.getMessage}] referenced from [${page.path}]")
+      }
+  }
+}

--- a/project/ParadoxSignatureDirective.scala
+++ b/project/ParadoxSignatureDirective.scala
@@ -1,21 +1,22 @@
 package akka
 
-import sbt._
 import java.io.{File, FileNotFoundException}
 
+import sbt._
+import Keys._
 import com.lightbend.paradox._
-import markdown.Writer
+import com.lightbend.paradox.markdown._
 import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport._
-import com.lightbend.paradox.markdown.{LeafBlockDirective, _}
 import org.pegdown.Printer
-import org.pegdown.ast.{DirectiveNode, VerbatimNode, Visitor}
+import org.pegdown.ast.{DirectiveNode, HtmlBlockNode, VerbatimNode, Visitor}
 
 import scala.collection.JavaConverters._
 import scala.io.Source
 
 object ParadoxSupport {
   val paradoxWithSignatureDirective = Seq(
-    paradoxProcessor in Compile ~= { _ =>
+    (paradoxProcessor in Compile) := {
+      val _ = paradoxProcessor in Compile // touch old reference
       // FIXME: this is a HACK so far that copies stuff over from paradox
       // it would be better if the plugin has a way of specifying extra directives through normal sbt mechanisms
       // see https://github.com/lightbend/paradox/issues/35
@@ -25,28 +26,37 @@ object ParadoxSupport {
           new ActiveLinkSerializer,
           new AnchorLinkSerializer,
           new DirectiveSerializer(Writer.defaultDirectives(context) :+
-            new SignatureDirective(context.location.tree.label)
+            new SignatureDirective(context.location.tree.label, msg => streams.value.log.warn(msg))
       ))))
     }
   )
 
-  class SignatureDirective(page: Page) extends LeafBlockDirective("signature") {
+  class SignatureDirective(page: Page, logWarn: String => Unit) extends LeafBlockDirective("signature") {
     def render(node: DirectiveNode, visitor: Visitor, printer: Printer): Unit =
       try {
-        val labels = node.attributes.values("identifier").asScala
+        val labels = node.attributes.values("identifier").asScala.map(_.toLowerCase())
         val file = new File(page.file.getParentFile, node.source)
 
-        val Signature = """\s*((?:def|val) (\w+)(?=[:(\[]).*)\s+\=.*""".r // stupid approximation to match a signature
+        val Signature = """\s*((def|val|type) (\w+)(?=[:(\[]).*)(\s+\=.*)""".r // stupid approximation to match a signature
         //println(s"Looking for signature regex '$Signature'")
         val text =
           Source.fromFile(file).getLines.collect {
-            case line@Signature(full, l, _*) if labels contains l =>
+            case line@Signature(signature, kind, l, definition) if labels contains l.toLowerCase() =>
               //println(s"Found label '$l' with sig '$full' in line $line")
-              full
+              if (kind == "type") signature + definition
+              else signature
           }.mkString("\n")
 
-        val lang = Option(node.attributes.value("type")).getOrElse(Snippet.language(file))
-        new VerbatimNode(text, lang).accept(visitor)
+        if (text.trim.isEmpty) {
+          logWarn(
+            s"Did not find any signatures with one of those names [${labels.mkString(", ")}] in ${node.source} " +
+            s"(was referenced from [${page.path}])")
+
+          new HtmlBlockNode(s"""<div style="color: red;">[Broken signature inclusion [${labels.mkString(", ")}] to [${node.source}]</div>""").accept(visitor)
+        } else {
+          val lang = Option(node.attributes.value("type")).getOrElse(Snippet.language(file))
+          new VerbatimNode(text, lang).accept(visitor)
+        }
       } catch {
         case e: FileNotFoundException =>
           throw new SnipDirective.LinkException(s"Unknown snippet [${e.getMessage}] referenced from [${page.path}]")


### PR DESCRIPTION
This is basically a port from the old `includecode2.py` script customization we built for spray.

I guess that's as good as it gets without spending too much time on it if #11 is the way to go eventually.

WDYT, @jonas?