### PR TITLE
fix too tight timeout (because jenkins) #392

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/util/FastFutureSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/util/FastFutureSpec.scala
@@ -169,7 +169,7 @@ class FastFutureSpec extends FreeSpec with Matchers {
       val p = Promise[Int]
       val opped = op(p.future.fast)
       p.complete(result)
-      Await.ready(opped, 100.millis)
+      Await.ready(opped, 500.millis)
       check(opped.value.get)
     }
     testStrictly()


### PR DESCRIPTION
Increase timeout a bit.
Resolves https://github.com/akka/akka-http/issues/392