### PR TITLE
Update to #339

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
@@ -120,13 +120,13 @@ public final class MediaTypes {
     public static final MediaType.Binary MESSAGE_DELIVERY_STATUS = akka.http.scaladsl.model.MediaTypes.message$divdelivery$minusstatus();
     public static final MediaType.Binary MESSAGE_RFC822 = akka.http.scaladsl.model.MediaTypes.message$divrfc822();
 
-    public static final MediaType.WithOpenCharset MULTIPART_MIXED = akka.http.scaladsl.model.MediaTypes.multipart$divmixed();
-    public static final MediaType.WithOpenCharset MULTIPART_ALTERNATIVE = akka.http.scaladsl.model.MediaTypes.multipart$divalternative();
-    public static final MediaType.WithOpenCharset MULTIPART_RELATED = akka.http.scaladsl.model.MediaTypes.multipart$divrelated();
-    public static final MediaType.WithOpenCharset MULTIPART_FORM_DATA = akka.http.scaladsl.model.MediaTypes.multipart$divform$minusdata();
-    public static final MediaType.WithOpenCharset MULTIPART_SIGNED = akka.http.scaladsl.model.MediaTypes.multipart$divsigned();
-    public static final MediaType.WithOpenCharset MULTIPART_ENCRYPTED = akka.http.scaladsl.model.MediaTypes.multipart$divencrypted();
-    public static final MediaType.WithOpenCharset MULTIPART_BYTERANGES = akka.http.scaladsl.model.MediaTypes.multipart$divbyteranges();
+    public static final MediaType.Binary MULTIPART_MIXED = akka.http.scaladsl.model.MediaTypes.multipart$divmixed();
+    public static final MediaType.Binary MULTIPART_ALTERNATIVE = akka.http.scaladsl.model.MediaTypes.multipart$divalternative();
+    public static final MediaType.Binary MULTIPART_RELATED = akka.http.scaladsl.model.MediaTypes.multipart$divrelated();
+    public static final MediaType.Binary MULTIPART_FORM_DATA = akka.http.scaladsl.model.MediaTypes.multipart$divform$minusdata();
+    public static final MediaType.Binary MULTIPART_SIGNED = akka.http.scaladsl.model.MediaTypes.multipart$divsigned();
+    public static final MediaType.Binary MULTIPART_ENCRYPTED = akka.http.scaladsl.model.MediaTypes.multipart$divencrypted();
+    public static final MediaType.Binary MULTIPART_BYTERANGES = akka.http.scaladsl.model.MediaTypes.multipart$divbyteranges();
 
     public static final MediaType.WithOpenCharset TEXT_ASP = akka.http.scaladsl.model.MediaTypes.text$divasp();
     public static final MediaType.WithOpenCharset TEXT_CACHE_MANIFEST = akka.http.scaladsl.model.MediaTypes.text$divcache$minusmanifest();

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
@@ -38,15 +38,46 @@ public interface Multipart {
 
     /**
      * Creates an entity from this multipart object.
+     *
+     * @deprecated This variant of `toEntity` is not supported any more. The charset parameter will be ignored.
+     * Please use the variant without specifying the charset.
+     */
+    @Deprecated
+    RequestEntity toEntity(HttpCharset charset, String boundary);
+
+    /**
+     * Creates an entity from this multipart object using the specified boundary.
      */
     RequestEntity toEntity(String boundary);
+
+    /**
+     * Creates an entity from this multipart object using a random boundary.
+     */
+    RequestEntity toEntity();
 
     interface Strict extends Multipart {
         Source<? extends Multipart.BodyPart.Strict, Object> getParts();
 
         Iterable<? extends Multipart.BodyPart.Strict> getStrictParts();
 
+        /**
+         * Creates an entity from this multipart object.
+         *
+         * @deprecated This variant of `toEntity` is not supported any more. The charset parameter will be ignored.
+         * Please use the variant without specifying the charset.
+         */
+        @Deprecated
         HttpEntity.Strict toEntity(HttpCharset charset, String boundary);
+
+        /**
+         * Creates an entity from this multipart object using the specified boundary.
+         */
+        HttpEntity.Strict toEntity(String boundary);
+
+        /**
+         * Creates an entity from this multipart object using a random boundary.
+         */
+        HttpEntity.Strict toEntity();
     }
 
     interface BodyPart {

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
@@ -39,7 +39,7 @@ public interface Multipart {
     /**
      * Creates an entity from this multipart object.
      */
-    RequestEntity toEntity(HttpCharset charset, String boundary);
+    RequestEntity toEntity(String boundary);
 
     interface Strict extends Multipart {
         Source<? extends Multipart.BodyPart.Strict, Object> getParts();

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
@@ -28,7 +28,7 @@ private[http] object BodyPartRenderer {
   def streamed(
     boundary:            String,
     partHeadersSizeHint: Int,
-    log:                 LoggingAdapter): GraphStage[FlowShape[Multipart.BodyPart, Source[ChunkStreamPart, Any]]] =
+    _log:                LoggingAdapter): GraphStage[FlowShape[Multipart.BodyPart, Source[ChunkStreamPart, Any]]] =
     new GraphStage[FlowShape[Multipart.BodyPart, Source[ChunkStreamPart, Any]]] {
       var firstBoundaryRendered = false
 
@@ -37,7 +37,9 @@ private[http] object BodyPartRenderer {
       override val shape: FlowShape[Multipart.BodyPart, Source[ChunkStreamPart, Any]] = FlowShape(in, out)
 
       override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-        new GraphStageLogic(shape) with InHandler with OutHandler {
+        new GraphStageLogic(shape) with InHandler with OutHandler with StageLogging {
+          override def logOverride: LoggingAdapter = _log
+
           override def onPush(): Unit = {
             val r = new ByteStringRendering(partHeadersSizeHint)
 

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StageLogging.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StageLogging.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ *
+ * Copied and adapted from akka-remote
+ * https://github.com/akka/akka/blob/c90121485fcfc44a3cee62a0c638e1982d13d812/akka-remote/src/main/scala/akka/remote/artery/StageLogging.scala
+ */
+package akka.http.impl.util
+
+import akka.stream.stage.GraphStageLogic
+import akka.event.LoggingAdapter
+import akka.stream.ActorMaterializer
+import akka.event.NoLogging
+
+// TODO this can be removed when https://github.com/akka/akka/issues/18793 has been implemented
+/**
+ * INTERNAL API
+ */
+private[akka] trait StageLogging { self: GraphStageLogic ⇒
+  def logOverride: LoggingAdapter = DefaultNoLogging
+
+  private var _log: LoggingAdapter = null
+
+  protected def logSource: Class[_] = this.getClass
+
+  def log: LoggingAdapter = {
+    // only used in StageLogic, i.e. thread safe
+    _log match {
+      case null ⇒
+        _log =
+          logOverride match {
+            case DefaultNoLogging ⇒
+              materializer match {
+                case a: ActorMaterializer ⇒ akka.event.Logging(a.system, logSource)
+                case _                    ⇒ NoLogging
+              }
+            case x ⇒ x
+          }
+      case _ ⇒
+    }
+    _log
+  }
+}
+
+/**
+ * A copy of NoLogging that can be used as a place-holder for "logging not explicitly specified".
+ * It can be matched on to be overridden with default behavior.
+ */
+object DefaultNoLogging extends LoggingAdapter {
+  /**
+   * Java API to return the reference to NoLogging
+   * @return The NoLogging instance
+   */
+  def getInstance = this
+
+  final override def isErrorEnabled = false
+  final override def isWarningEnabled = false
+  final override def isInfoEnabled = false
+  final override def isDebugEnabled = false
+
+  final protected override def notifyError(message: String): Unit = ()
+  final protected override def notifyError(cause: Throwable, message: String): Unit = ()
+  final protected override def notifyWarning(message: String): Unit = ()
+  final protected override def notifyInfo(message: String): Unit = ()
+  final protected override def notifyDebug(message: String): Unit = ()
+}

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/MediaType.scala
@@ -27,7 +27,7 @@ object MediaType {
     def toContentType(charset: HttpCharset): ContentType.WithCharset
   }
 
-  trait Multipart extends WithOpenCharset {
+  trait Multipart extends Binary {
   }
 
   trait Compressibility {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -240,13 +240,12 @@ object MediaType {
       customWithOpenCharset(mainType, subType, fileExtensions, params)
   }
 
-  final class Multipart(val subType: String, val params: Map[String, String])
-    extends WithOpenCharset with jm.MediaType.Multipart {
-    val value = renderValue(mainType, subType, params)
-    override def mainType = "multipart"
+  final class Multipart(subType: String, _params: Map[String, String])
+    extends Binary(renderValue("multipart", subType, _params), "multipart", subType, Compressible, Nil)
+    with jm.MediaType.Multipart {
+    override def params = _params
     override def isMultipart = true
-    override def fileExtensions = Nil
-    def withParams(params: Map[String, String]): MediaType.Multipart = new MediaType.Multipart(subType, params)
+    override def withParams(params: Map[String, String]): MediaType.Multipart = new MediaType.Multipart(subType, params)
     def withBoundary(boundary: String): MediaType.Multipart =
       withParams(if (boundary.isEmpty) params - "boundary" else params.updated("boundary", boundary))
   }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -6,13 +6,15 @@ package akka.http.scaladsl.model
 import java.io.File
 import java.nio.file.Path
 import java.util.Optional
-import akka.http.impl.util.Util
+
+import akka.http.impl.util.{ DefaultNoLogging, Util }
+
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
 import scala.collection.immutable
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
-import akka.event.{ NoLogging, LoggingAdapter }
+import akka.event.LoggingAdapter
 import akka.stream.impl.ConstantFun
 import akka.stream.Materializer
 import akka.stream.javadsl.{ Source ⇒ JSource }
@@ -23,8 +25,11 @@ import akka.http.impl.engine.rendering.BodyPartRenderer
 import akka.http.javadsl.{ model ⇒ jm }
 import FastFuture._
 import akka.http.impl.util.JavaMapping.Implicits._
+
 import scala.compat.java8.FutureConverters._
 import java.util.concurrent.CompletionStage
+
+import akka.http.javadsl.model.RequestEntity
 
 /**
  * The model of multipart content for media-types `multipart/\*` (general multipart content),
@@ -55,15 +60,39 @@ sealed trait Multipart extends jm.Multipart {
 
   /**
    * Creates a [[akka.http.scaladsl.model.MessageEntity]] from this multipart object.
+   *
+   * @deprecated This variant of `toEntity` is not supported any more. The charset parameter will be ignored. Please use
+   *             one of the other overloads instead.
    */
-  def toEntityWithLog(
-    boundary: String = BodyPartRenderer.randomBoundary())(implicit log: LoggingAdapter = NoLogging): MessageEntity = {
+  @deprecated(
+    message = "This variant of `toEntity` is not supported any more. The charset parameter will be ignored. " +
+    "Please use the variant without specifying the charset.",
+    since = "3.0.0")
+  def toEntity(
+    charset:  HttpCharset = HttpCharsets.`UTF-8`,
+    boundary: String      = BodyPartRenderer.randomBoundary())(implicit log: LoggingAdapter = DefaultNoLogging): MessageEntity =
+    toEntity(boundary, log)
+
+  /**
+   * Creates an entity from this multipart object using the specified boundary and logger.
+   */
+  def toEntity(boundary: String, log: LoggingAdapter): MessageEntity = {
     val chunks =
       parts
         .via(BodyPartRenderer.streamed(boundary, partHeadersSizeHint = 128, log))
         .flatMapConcat(ConstantFun.scalaIdentityFunction)
     HttpEntity.Chunked(mediaType withBoundary boundary, chunks)
   }
+
+  /**
+   * Creates an entity from this multipart object using the specified boundary.
+   */
+  def toEntity(boundary: String): MessageEntity = toEntity(boundary, DefaultNoLogging)
+
+  /**
+   * Creates an entity from this multipart object using a random boundary.
+   */
+  def toEntity: MessageEntity = toEntity(BodyPartRenderer.randomBoundary(), DefaultNoLogging)
 
   /** Java API */
   def getMediaType: jm.MediaType.Multipart = mediaType
@@ -77,8 +106,8 @@ sealed trait Multipart extends jm.Multipart {
     toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).toJava
 
   /** Java API */
-  def toEntity(boundary: String): jm.RequestEntity =
-    toEntityWithLog(boundary)
+  @deprecated def toEntity(charset: jm.HttpCharset, boundary: String): jm.RequestEntity =
+    toEntity(boundary)
 }
 
 object Multipart {
@@ -96,10 +125,26 @@ object Multipart {
      */
     def strictParts: immutable.Seq[Multipart.BodyPart.Strict]
 
-    override def toEntityWithLog(boundary: String)(implicit log: LoggingAdapter = NoLogging): HttpEntity.Strict = {
+    override def toEntity(charset: HttpCharset, boundary: String)(implicit log: LoggingAdapter = DefaultNoLogging): HttpEntity.Strict =
+      toEntity(boundary, log)
+
+    /**
+     * Creates an entity from this multipart object using the specified boundary and logger.
+     */
+    override def toEntity(boundary: String, log: LoggingAdapter): HttpEntity.Strict = {
       val data = BodyPartRenderer.strict(strictParts, boundary, partHeadersSizeHint = 128, log)
       HttpEntity(mediaType withBoundary boundary, data)
     }
+
+    /**
+     * Creates an entity from this multipart object using the specified boundary.
+     */
+    override def toEntity(boundary: String): HttpEntity.Strict = toEntity(boundary, DefaultNoLogging)
+
+    /**
+     * Creates an entity from this multipart object using a random boundary.
+     */
+    override def toEntity: HttpEntity.Strict = toEntity(BodyPartRenderer.randomBoundary(), DefaultNoLogging)
 
     /** Java API */
     override def getParts: JSource[_ <: jm.Multipart.BodyPart.Strict, AnyRef] =

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -212,11 +212,11 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
       "Content-Type: text/plain; charset=fancy-pants" =!=
         `Content-Type`(`text/plain` withCharset HttpCharset.custom("fancy-pants"))
       "Content-Type: multipart/mixed; boundary=ABC123" =!=
-        `Content-Type`(`multipart/mixed` withBoundary "ABC123" withCharset `UTF-8`)
-        .renderedTo("multipart/mixed; boundary=ABC123; charset=UTF-8")
+        `Content-Type`(`multipart/mixed` withBoundary "ABC123")
+        .renderedTo("multipart/mixed; boundary=ABC123")
       "Content-Type: multipart/mixed; boundary=\"ABC/123\"" =!=
-        `Content-Type`(`multipart/mixed` withBoundary "ABC/123" withCharset `UTF-8`)
-        .renderedTo("""multipart/mixed; boundary="ABC/123"; charset=UTF-8""")
+        `Content-Type`(`multipart/mixed` withBoundary "ABC/123")
+        .renderedTo("""multipart/mixed; boundary="ABC/123"""")
       "Content-Type: application/*" =!=
         `Content-Type`(MediaType.customBinary("application", "*", MediaType.Compressible, allowArbitrarySubtypes = true))
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
@@ -41,7 +41,7 @@ class MultipartSpec extends WordSpec with Matchers with Inside with BeforeAndAft
       val streamed = Multipart.General(
         MediaTypes.`multipart/mixed`,
         Source(Multipart.General.BodyPart(defaultEntity("data"), List(ETag("xzy"))) :: Nil))
-      val result = streamed.toEntityWithLog("boundary")
+      val result = streamed.toEntity("boundary")
       result.contentType shouldBe MediaTypes.`multipart/mixed`.withBoundary("boundary").toContentType
       val encoding = Await.result(result.dataBytes.runWith(Sink.seq), 1.second)
       encoding.map(_.utf8String).mkString shouldBe "--boundary\r\nContent-Type: text/plain; charset=UTF-8\r\nETag: \"xzy\"\r\n\r\ndata\r\n--boundary--"

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
@@ -41,8 +41,8 @@ class MultipartSpec extends WordSpec with Matchers with Inside with BeforeAndAft
       val streamed = Multipart.General(
         MediaTypes.`multipart/mixed`,
         Source(Multipart.General.BodyPart(defaultEntity("data"), List(ETag("xzy"))) :: Nil))
-      val result = streamed.toEntity(boundary = "boundary")
-      result.contentType shouldBe MediaTypes.`multipart/mixed`.withBoundary("boundary").withCharset(HttpCharsets.`UTF-8`)
+      val result = streamed.toEntityWithLog("boundary")
+      result.contentType shouldBe MediaTypes.`multipart/mixed`.withBoundary("boundary").toContentType
       val encoding = Await.result(result.dataBytes.runWith(Sink.seq), 1.second)
       encoding.map(_.utf8String).mkString shouldBe "--boundary\r\nContent-Type: text/plain; charset=UTF-8\r\nETag: \"xzy\"\r\n\r\ndata\r\n--boundary--"
     }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -100,25 +100,25 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
     "multipartMarshaller should correctly marshal multipart content with" - {
       "one empty part" in {
         marshal(Multipart.General(`multipart/mixed`, Multipart.General.BodyPart.Strict(""))) shouldEqual HttpEntity(
-          contentType = `multipart/mixed` withBoundary randomBoundary withCharset `UTF-8`,
-          string = s"""--$randomBoundary
+          contentType = (`multipart/mixed` withBoundary randomBoundary).toContentType,
+          data = ByteString(s"""--$randomBoundary
                       |Content-Type: text/plain; charset=UTF-8
                       |
                       |
-                      |--$randomBoundary--""".stripMarginWithNewline("\r\n"))
+                      |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
       }
       "one non-empty part" in {
         marshal(Multipart.General(`multipart/alternative`, Multipart.General.BodyPart.Strict(
           entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com"),
           headers = `Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" → "email")) :: Nil))) shouldEqual
           HttpEntity(
-            contentType = `multipart/alternative` withBoundary randomBoundary withCharset `UTF-8`,
-            string = s"""--$randomBoundary
+            contentType = (`multipart/alternative` withBoundary randomBoundary).toContentType,
+            data = ByteString(s"""--$randomBoundary
                         |Content-Type: text/plain; charset=UTF-8
                         |Content-Disposition: form-data; name=email
                         |
                         |test@there.com
-                        |--$randomBoundary--""".stripMarginWithNewline("\r\n"))
+                        |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
       }
       "two different parts" in {
         marshal(Multipart.General(
@@ -128,8 +128,8 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
             HttpEntity(`application/octet-stream`, ByteString("filecontent")),
             RawHeader("Content-Transfer-Encoding", "binary") :: Nil))) shouldEqual
           HttpEntity(
-            contentType = `multipart/related` withBoundary randomBoundary withCharset `UTF-8`,
-            string = s"""--$randomBoundary
+            contentType = (`multipart/related` withBoundary randomBoundary).toContentType,
+            data = ByteString(s"""--$randomBoundary
                       |Content-Type: text/plain; charset=US-ASCII
                       |
                       |first part, with a trailing linebreak
@@ -139,7 +139,7 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
                       |Content-Transfer-Encoding: binary
                       |
                       |filecontent
-                      |--$randomBoundary--""".stripMarginWithNewline("\r\n"))
+                      |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
       }
     }
 
@@ -149,8 +149,8 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
           "surname" → HttpEntity("Mike"),
           "age" → marshal(<int>42</int>)))) shouldEqual
           HttpEntity(
-            contentType = `multipart/form-data` withBoundary randomBoundary withCharset `UTF-8`,
-            string = s"""--$randomBoundary
+            contentType = (`multipart/form-data` withBoundary randomBoundary).toContentType,
+            data = ByteString(s"""--$randomBoundary
                       |Content-Type: text/plain; charset=UTF-8
                       |Content-Disposition: form-data; name=surname
                       |
@@ -160,7 +160,7 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
                       |Content-Disposition: form-data; name=age
                       |
                       |<int>42</int>
-                      |--$randomBoundary--""".stripMarginWithNewline("\r\n"))
+                      |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
       }
 
       "two fields having a custom `Content-Disposition`" in {
@@ -170,8 +170,8 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
           Multipart.FormData.BodyPart("attachment[1]", HttpEntity("naice!".getBytes),
             Map("filename" → "attachment2.csv"), List(RawHeader("Content-Transfer-Encoding", "binary"))))))) shouldEqual
           HttpEntity(
-            contentType = `multipart/form-data` withBoundary randomBoundary withCharset `UTF-8`,
-            string = s"""--$randomBoundary
+            contentType = (`multipart/form-data` withBoundary randomBoundary).toContentType,
+            data = ByteString(s"""--$randomBoundary
                         |Content-Type: text/csv; charset=UTF-8
                         |Content-Disposition: form-data; filename=attachment.csv; name="attachment[0]"
                         |
@@ -184,7 +184,7 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
                         |Content-Transfer-Encoding: binary
                         |
                         |naice!
-                        |--$randomBoundary--""".stripMarginWithNewline("\r\n"))
+                        |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
       }
     }
   }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -30,37 +30,38 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
 
     "multipartGeneralUnmarshaller should correctly unmarshal 'multipart/*' content with" - {
       "an empty part" in {
-        Unmarshal(HttpEntity(
-          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
-          """--XYZABC
-            |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
+        val entity = HttpEntity(
+          `multipart/mixed` withBoundary "XYZABC",
+          ByteString("""--XYZABC
+                       |--XYZABC--""".stripMarginWithNewline("\r\n")))
+        Unmarshal(entity).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/plain(UTF-8)`)))
       }
       "two empty parts" in {
         Unmarshal(HttpEntity(
-          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
-          """--XYZABC
-            |--XYZABC
-            |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
+          `multipart/mixed` withBoundary "XYZABC",
+          ByteString("""--XYZABC
+                       |--XYZABC
+                       |--XYZABC--""".stripMarginWithNewline("\r\n")))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/plain(UTF-8)`)),
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/plain(UTF-8)`)))
       }
       "a part without entity and missing header separation CRLF" in {
         Unmarshal(HttpEntity(
-          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
-          """--XYZABC
-            |Content-type: text/xml
-            |Age: 12
-            |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
+          `multipart/mixed` withBoundary "XYZABC",
+          ByteString("""--XYZABC
+                       |Content-type: text/xml
+                       |Age: 12
+                       |--XYZABC--""".stripMarginWithNewline("\r\n")))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/xml(UTF-8)`), List(Age(12))))
       }
       "an implicitly typed part (without headers) (Strict)" in {
         Unmarshal(HttpEntity(
-          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
-          """--XYZABC
-            |
-            |Perfectly fine part content.
-            |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
+          `multipart/mixed` withBoundary "XYZABC",
+          ByteString("""--XYZABC
+                       |
+                       |Perfectly fine part content.
+                       |--XYZABC--""".stripMarginWithNewline("\r\n")))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Perfectly fine part content.")))
       }
       "an implicitly typed part (without headers) (Default)" in {
@@ -69,36 +70,36 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
                         |Perfectly fine part content.
                         |--XYZABC--""".stripMarginWithNewline("\r\n")
         val byteStrings = content.map(c ⇒ ByteString(c.toString)) // one-char ByteStrings
-        Unmarshal(HttpEntity.Default(`multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`, content.length, Source(byteStrings)))
+        Unmarshal(HttpEntity.Default(`multipart/mixed` withBoundary "XYZABC", content.length, Source(byteStrings)))
           .to[Multipart.General] should haveParts(
             Multipart.General.BodyPart.Strict(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "Perfectly fine part content.")))
       }
       "one non-empty form-data part" in {
         Unmarshal(HttpEntity(
-          `multipart/form-data` withBoundary "-" withCharset `UTF-8`,
-          """---
-            |Content-type: text/plain; charset=UTF8
-            |content-disposition: form-data; name="email"
-            |
-            |test@there.com
-            |-----""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
+          `multipart/form-data` withBoundary "-",
+          ByteString("""---
+                       |Content-type: text/plain; charset=UTF8
+                       |content-disposition: form-data; name="email"
+                       |
+                       |test@there.com
+                       |-----""".stripMarginWithNewline("\r\n")))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(
             HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com"),
             List(`Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" → "email")))))
       }
       "two different parts" in {
         Unmarshal(HttpEntity(
-          `multipart/mixed` withBoundary "12345" withCharset `UTF-8`,
-          """--12345
-            |
-            |first part, with a trailing newline
-            |
-            |--12345
-            |Content-Type: application/octet-stream
-            |Content-Transfer-Encoding: binary
-            |
-            |filecontent
-            |--12345--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
+          `multipart/mixed` withBoundary "12345",
+          ByteString("""--12345
+                       |
+                       |first part, with a trailing newline
+                       |
+                       |--12345
+                       |Content-Type: application/octet-stream
+                       |Content-Transfer-Encoding: binary
+                       |
+                       |filecontent
+                       |--12345--""".stripMarginWithNewline("\r\n")))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "first part, with a trailing newline\r\n")),
           Multipart.General.BodyPart.Strict(
             HttpEntity(`application/octet-stream`, ByteString("filecontent")),
@@ -106,13 +107,13 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
       }
       "illegal headers" in (
         Unmarshal(HttpEntity(
-          `multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
-          """--XYZABC
-            |Date: unknown
-            |content-disposition: form-data; name=email
-            |
-            |test@there.com
-            |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
+          `multipart/form-data` withBoundary "XYZABC",
+          ByteString("""--XYZABC
+                       |Date: unknown
+                       |content-disposition: form-data; name=email
+                       |
+                       |test@there.com
+                       |--XYZABC--""".stripMarginWithNewline("\r\n")))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(
             HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com"),
             List(
@@ -120,19 +121,19 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
               `Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" → "email"))))))
       "a full example (Strict)" in {
         Unmarshal(HttpEntity(
-          `multipart/mixed` withBoundary "12345" withCharset `UTF-8`,
-          """preamble and
-            |more preamble
-            |--12345
-            |
-            |first part, implicitly typed
-            |--12345
-            |Content-Type: application/octet-stream
-            |
-            |second part, explicitly typed
-            |--12345--
-            |epilogue and
-            |more epilogue""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
+          `multipart/mixed` withBoundary "12345",
+          ByteString("""preamble and
+                       |more preamble
+                       |--12345
+                       |
+                       |first part, implicitly typed
+                       |--12345
+                       |Content-Type: application/octet-stream
+                       |
+                       |second part, explicitly typed
+                       |--12345--
+                       |epilogue and
+                       |more epilogue""".stripMarginWithNewline("\r\n")))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "first part, implicitly typed")),
           Multipart.General.BodyPart.Strict(HttpEntity(`application/octet-stream`, ByteString("second part, explicitly typed"))))
       }
@@ -150,61 +151,61 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
                         |epilogue and
                         |more epilogue""".stripMarginWithNewline("\r\n")
         val byteStrings = content.map(c ⇒ ByteString(c.toString)) // one-char ByteStrings
-        Unmarshal(HttpEntity.Default(`multipart/mixed` withBoundary "12345" withCharset `UTF-8`, content.length, Source(byteStrings)))
+        Unmarshal(HttpEntity.Default(`multipart/mixed` withBoundary "12345", content.length, Source(byteStrings)))
           .to[Multipart.General] should haveParts(
             Multipart.General.BodyPart.Strict(HttpEntity(ContentTypes.`text/plain(UTF-8)`, "first part, implicitly typed")),
             Multipart.General.BodyPart.Strict(HttpEntity(`application/octet-stream`, ByteString("second part, explicitly typed"))))
       }
       "a boundary with spaces" in {
         Unmarshal(HttpEntity(
-          `multipart/mixed` withBoundary "simple boundary" withCharset `UTF-8`,
-          """--simple boundary
-            |--simple boundary--""".stripMarginWithNewline("\r\n"))).to[Multipart.General] should haveParts(
+          `multipart/mixed` withBoundary "simple boundary",
+          ByteString("""--simple boundary
+                       |--simple boundary--""".stripMarginWithNewline("\r\n")))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/plain(UTF-8)`)))
       }
     }
 
     "multipartGeneralUnmarshaller should reject illegal multipart content with" - {
       "an empty entity" in {
-        Await.result(Unmarshal(HttpEntity(`multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`, ByteString.empty))
+        Await.result(Unmarshal(HttpEntity(`multipart/mixed` withBoundary "XYZABC", ByteString.empty))
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual "Unexpected end of multipart entity"
       }
       "an entity without initial boundary" in {
         Await.result(Unmarshal(HttpEntity(
-          `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
-          """this is
-            |just preamble text""".stripMarginWithNewline("\r\n")))
+          `multipart/mixed` withBoundary "XYZABC",
+          ByteString("""this is
+                       |just preamble text""".stripMarginWithNewline("\r\n"))))
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual "Unexpected end of multipart entity"
       }
       "a stray boundary" in {
         Await.result(Unmarshal(HttpEntity(
-          `multipart/form-data` withBoundary "ABC" withCharset `UTF-8`,
-          """--ABC
-            |Content-type: text/plain; charset=UTF8
-            |--ABCContent-type: application/json
-            |content-disposition: form-data; name="email"
-            |-----""".stripMarginWithNewline("\r\n")))
+          `multipart/form-data` withBoundary "ABC",
+          ByteString("""--ABC
+                       |Content-type: text/plain; charset=UTF8
+                       |--ABCContent-type: application/json
+                       |content-disposition: form-data; name="email"
+                       |-----""".stripMarginWithNewline("\r\n"))))
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual "Illegal multipart boundary in message content"
       }
       "duplicate Content-Type header" in {
         Await.result(Unmarshal(HttpEntity(
-          `multipart/form-data` withBoundary "-" withCharset `UTF-8`,
-          """---
-            |Content-type: text/plain; charset=UTF8
-            |Content-type: application/json
-            |content-disposition: form-data; name="email"
-            |
-            |test@there.com
-            |-----""".stripMarginWithNewline("\r\n")))
+          `multipart/form-data` withBoundary "-",
+          ByteString("""---
+                       |Content-type: text/plain; charset=UTF8
+                       |Content-type: application/json
+                       |content-disposition: form-data; name="email"
+                       |
+                       |test@there.com
+                       |-----""".stripMarginWithNewline("\r\n"))))
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual
           "multipart part must not contain more than one Content-Type header"
       }
       "a missing header-separating CRLF (in Strict entity)" in {
         Await.result(Unmarshal(HttpEntity(
-          `multipart/form-data` withBoundary "-" withCharset `UTF-8`,
-          """---
-            |not good here
-            |-----""".stripMarginWithNewline("\r\n")))
+          `multipart/form-data` withBoundary "-",
+          ByteString("""---
+                       |not good here
+                       |-----""".stripMarginWithNewline("\r\n"))))
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual "Illegal character ' ' in header name"
       }
       "a missing header-separating CRLF (in Default entity)" in {
@@ -215,20 +216,20 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
                         |not ok
                         |-----""".stripMarginWithNewline("\r\n")
         val byteStrings = content.map(c ⇒ ByteString(c.toString)) // one-char ByteStrings
-        val contentType = `multipart/form-data` withBoundary "-" withCharset `UTF-8`
+        val contentType = `multipart/form-data` withBoundary "-"
         Await.result(Unmarshal(HttpEntity.Default(contentType, content.length, Source(byteStrings)))
           .to[Multipart.General]
           .flatMap(_ toStrict 1.second).failed, 1.second).getMessage shouldEqual "Illegal character ' ' in header name"
       }
       "a boundary with a trailing space" in {
         Await.result(
-          Unmarshal(HttpEntity(`multipart/mixed` withBoundary "simple boundary " withCharset `UTF-8`, ByteString.empty))
+          Unmarshal(HttpEntity(`multipart/mixed` withBoundary "simple boundary ", ByteString.empty))
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual
           "requirement failed: 'boundary' parameter of multipart Content-Type must not end with a space char"
       }
       "a boundary with an illegal character" in {
         Await.result(
-          Unmarshal(HttpEntity(`multipart/mixed` withBoundary "simple&boundary" withCharset `UTF-8`, ByteString.empty))
+          Unmarshal(HttpEntity(`multipart/mixed` withBoundary "simple&boundary", ByteString.empty))
           .to[Multipart.General].failed, 1.second).getMessage shouldEqual
           "requirement failed: 'boundary' parameter of multipart Content-Type contains illegal character '&'"
       }
@@ -236,18 +237,18 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
 
     "multipartByteRangesUnmarshaller should correctly unmarshal multipart/byteranges content with two different parts" in {
       Unmarshal(HttpEntity(
-        `multipart/byteranges` withBoundary "12345" withCharset `UTF-8`,
-        """--12345
-          |Content-Range: bytes 0-2/26
-          |Content-Type: text/plain
-          |
-          |ABC
-          |--12345
-          |Content-Range: bytes 23-25/26
-          |Content-Type: text/plain
-          |
-          |XYZ
-          |--12345--""".stripMarginWithNewline("\r\n"))).to[Multipart.ByteRanges] should haveParts(
+        `multipart/byteranges` withBoundary "12345",
+        ByteString("""--12345
+                     |Content-Range: bytes 0-2/26
+                     |Content-Type: text/plain
+                     |
+                     |ABC
+                     |--12345
+                     |Content-Range: bytes 23-25/26
+                     |Content-Type: text/plain
+                     |
+                     |XYZ
+                     |--12345--""".stripMarginWithNewline("\r\n")))).to[Multipart.ByteRanges] should haveParts(
         Multipart.ByteRanges.BodyPart.Strict(ContentRange(0, 2, 26), HttpEntity(ContentTypes.`text/plain(UTF-8)`, "ABC")),
         Multipart.ByteRanges.BodyPart.Strict(ContentRange(23, 25, 26), HttpEntity(ContentTypes.`text/plain(UTF-8)`, "XYZ")))
     }
@@ -255,29 +256,29 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
     "multipartFormDataUnmarshaller should correctly unmarshal 'multipart/form-data' content" - {
       "with one element and no explicit content-type" in {
         Unmarshal(HttpEntity(
-          `multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
-          """--XYZABC
-            |content-disposition: form-data; name=email
-            |
-            |test@there.com
-            |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.FormData] should haveParts(
+          `multipart/form-data` withBoundary "XYZABC",
+          ByteString("""--XYZABC
+                       |content-disposition: form-data; name=email
+                       |
+                       |test@there.com
+                       |--XYZABC--""".stripMarginWithNewline("\r\n")))).to[Multipart.FormData] should haveParts(
           Multipart.FormData.BodyPart.Strict("email", HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com")))
       }
       "with one element" in {
         Unmarshal(HttpEntity(
-          `multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
-          """--XYZABC
-            |content-disposition: form-data; name=email
-            |Content-Type: application/octet-stream
-            |
-            |test@there.com
-            |--XYZABC--""".stripMarginWithNewline("\r\n"))).to[Multipart.FormData] should haveParts(
+          `multipart/form-data` withBoundary "XYZABC",
+          ByteString("""--XYZABC
+                       |content-disposition: form-data; name=email
+                       |Content-Type: application/octet-stream
+                       |
+                       |test@there.com
+                       |--XYZABC--""".stripMarginWithNewline("\r\n")))).to[Multipart.FormData] should haveParts(
           Multipart.FormData.BodyPart.Strict("email", HttpEntity(`application/octet-stream`, ByteString("test@there.com"))))
       }
       "with a file" in {
         Unmarshal {
           HttpEntity.Default(
-            contentType = `multipart/form-data` withBoundary "XYZABC" withCharset `UTF-8`,
+            contentType = `multipart/form-data` withBoundary "XYZABC",
             contentLength = 1, // not verified during unmarshalling
             data = Source {
               List(

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
@@ -14,9 +14,7 @@ trait MultipartMarshallers {
     Marshaller strict { value ⇒
       val boundary = randomBoundary()
       val mediaType = value.mediaType withBoundary boundary
-      Marshalling.WithOpenCharset(mediaType, { charset ⇒
-        value.toEntity(charset, boundary)(log)
-      })
+      Marshalling.WithFixedContentType(mediaType.toContentType, () ⇒ value.toEntityWithLog(boundary)(log))
     }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
@@ -5,16 +5,18 @@
 package akka.http.scaladsl.marshalling
 
 import java.util.concurrent.ThreadLocalRandom
-import akka.event.{ NoLogging, LoggingAdapter }
+
+import akka.event.{ LoggingAdapter, NoLogging }
 import akka.http.impl.engine.rendering.BodyPartRenderer
+import akka.http.impl.util.DefaultNoLogging
 import akka.http.scaladsl.model._
 
 trait MultipartMarshallers {
-  implicit def multipartMarshaller[T <: Multipart](implicit log: LoggingAdapter = NoLogging): ToEntityMarshaller[T] =
+  implicit def multipartMarshaller[T <: Multipart](implicit log: LoggingAdapter = DefaultNoLogging): ToEntityMarshaller[T] =
     Marshaller strict { value ⇒
       val boundary = randomBoundary()
       val mediaType = value.mediaType withBoundary boundary
-      Marshalling.WithFixedContentType(mediaType.toContentType, () ⇒ value.toEntityWithLog(boundary)(log))
+      Marshalling.WithFixedContentType(mediaType.toContentType, () ⇒ value.toEntity(boundary, log))
     }
 
   /**

--- a/docs/src/test/java/docs/http/javadsl/server/directives/FileUploadDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FileUploadDirectivesExamplesTest.java
@@ -51,9 +51,8 @@ public class FileUploadDirectivesExamplesTest extends JUnitRouteTest {
     // test:
     testRoute(route).run(HttpRequest.POST("/")
       .withEntity(
-        multipartForm.toEntity(HttpCharsets.UTF_8,
-          BodyPartRenderer
-            .randomBoundaryWithDefaults())))
+        multipartForm.toEntity(BodyPartRenderer
+		  .randomBoundaryWithDefaults())))
       .assertStatusCode(StatusCodes.OK);
     //#uploadedFile
   }
@@ -86,7 +85,7 @@ public class FileUploadDirectivesExamplesTest extends JUnitRouteTest {
 
     // test:
     testRoute(route).run(HttpRequest.POST("/").withEntity(
-      multipartForm.toEntity(HttpCharsets.UTF_8, BodyPartRenderer.randomBoundaryWithDefaults())))
+      multipartForm.toEntity(BodyPartRenderer.randomBoundaryWithDefaults())))
       .assertStatusCode(StatusCodes.OK).assertEntityAs(Unmarshaller.entityToString(), "Sum: 178");
     //#fileUpload
   }
@@ -130,7 +129,7 @@ public class FileUploadDirectivesExamplesTest extends JUnitRouteTest {
 
     // test:
     testRoute(route).run(HttpRequest.POST("/").withEntity(
-      multipartForm.toEntity(HttpCharsets.UTF_8, BodyPartRenderer.randomBoundaryWithDefaults())))
+      multipartForm.toEntity(BodyPartRenderer.randomBoundaryWithDefaults())))
       .assertStatusCode(StatusCodes.OK).assertEntityAs(Unmarshaller.entityToString(), "Sum: 178");
     //#fileProcessing
   }


### PR DESCRIPTION
Here's an update to @derekwyatt's #339. We somewhat break bin compat for the MediaType constants but try to keep it for `Multipart.toEntity`.