### PR TITLE
Move common settings to an autoplugin 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,36 +1,6 @@
 import com.typesafe.sbt.pgp.PgpKeys._
 import akka._
 
-inThisBuild(Def.settings(
-  organization := "com.typesafe.akka",
-  organizationName := "Lightbend",
-  organizationHomepage := Some(url("https://www.lightbend.com")),
-  homepage := Some(url("http://akka.io")),
-  scmInfo := Some(
-    ScmInfo(url("https://github.com/akka/akka-http"), "git@github.com:akka/akka-http.git")),
-  developers := List(
-    Developer("contributors", "Contributors", "akka-user@googlegroups.com",
-      url("https://github.com/akka/akka-http/graphs/contributors"))
-  ),
-  startYear := Some(2014),
-  test in assembly := {},
-  licenses := Seq("Apache License 2.0" -> url("https://opensource.org/licenses/Apache-2.0")),
-  scalaVersion := "2.11.8",
-  crossVersion := CrossVersion.binary,
-  scalacOptions ++= Seq(
-    "-deprecation",
-    "-encoding", "UTF-8", // yes, this is 2 args
-    "-unchecked",
-    "-Xlint",
-    // "-Yno-adapted-args", //akka-http heavily depends on adapted args and => Unit implicits break otherwise
-    "-Ywarn-dead-code"
-    // "-Xfuture" // breaks => Unit implicits
-  ),
-  testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v"),
-  Dependencies.Versions,
-  Formatting.formatSettings
-))
-
 lazy val root = Project(
     id = "akka-http-root",
     base = file(".")

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,0 +1,38 @@
+package akka
+
+import sbt._
+import sbt.Keys._
+
+object Common extends AutoPlugin {
+
+  override def trigger = allRequirements
+  override def requires = plugins.JvmPlugin
+
+  override lazy val projectSettings = Seq(
+    organization := "com.typesafe.akka",
+    organizationName := "Lightbend",
+    organizationHomepage := Some(url("https://www.lightbend.com")),
+    homepage := Some(url("http://akka.io")),
+    scmInfo := Some(
+      ScmInfo(url("https://github.com/akka/akka-http"), "git@github.com:akka/akka-http.git")),
+    developers := List(
+      Developer("contributors", "Contributors", "akka-user@googlegroups.com",
+        url("https://github.com/akka/akka-http/graphs/contributors"))
+    ),
+    startYear := Some(2014),
+    test in sbtassembly.AssemblyKeys.assembly := {},
+    licenses := Seq("Apache License 2.0" -> url("https://opensource.org/licenses/Apache-2.0")),
+    crossVersion := CrossVersion.binary,
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-encoding", "UTF-8", // yes, this is 2 args
+      "-unchecked",
+      "-Xlint",
+      // "-Yno-adapted-args", //akka-http heavily depends on adapted args and => Unit implicits break otherwise
+      "-Ywarn-dead-code"
+        // "-Xfuture" // breaks => Unit implicits
+    ),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v")
+  ) ++ Dependencies.Versions ++ Formatting.formatSettings
+
+}


### PR DESCRIPTION
Fixes #408

`inThisBuild` sets project scope to the current build, but settings set in the `/build.sbt` are added to the root project only.

Instead moved common settings to an AutoPlugin that is applied to every project.