### PR TITLE
Add route sealing description to routes.md

### DIFF
--- a/docs/src/main/paradox/java/http/routing-dsl/exception-handling.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/exception-handling.md
@@ -20,5 +20,20 @@ Once you have defined your custom `ExceptionHandler` you can supply it as argume
 That will apply your handler to the inner route given to that directive. 
 
 Here is an example for wiring up a custom handler via @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions-java):
+`Route` class's `seal()` method internally wraps its argument route with the @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions-java) directive in order to "catch" and
+handle any exception.
 
-TODO
+So, if you'd like to customize the way certain exceptions are handled you need to write a custom `ExceptionHandler`.
+Once you have defined your custom `ExceptionHandler` you have two options.
+
+ 1. Pass it to the `seal()` method of the `Route` class
+ 2. Supply it as an argument to @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions-java) directive 
+
+In the first case your handler will be "sealed" (which means that it will receive the default handler as a fallback for
+all cases your handler doesn't handle itself) and used for all exceptions that are not handled within the route structure itself.
+
+The second case allows you to restrict the applicability of your handler to certain branches of your route structure.
+
+Here is an example for wiring up a custom handler via @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions-java):
+
+@@snip [ExceptionHandlerExamplesTest.java](../../../../../test/java/docs/http/javadsl/ExceptionHandlerExample.java) { #explicit-handler-example }

--- a/docs/src/main/paradox/java/http/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/rejections.md
@@ -113,8 +113,8 @@ This way the priority between rejections is properly defined via the order of yo
 
 Once you have defined your custom `RejectionHandler` you have two options for "activating" it:
 
- 1. Bring it into implicit scope at the top-level.
- 2. Supply it as argument to the @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections-java) directive.
+ 1. Pass it to the `seal()` method of the `Route` class
+ 2. Supply it as an argument to the @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections-java) directive 
 
 In the first case your handler will be "sealed" (which means that it will receive the default handler as a fallback for
 all cases your handler doesn't handle itself) and used for all rejections that are not handled within the route structure

--- a/docs/src/main/paradox/java/http/routing-dsl/routes.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/routes.md
@@ -106,3 +106,23 @@ Here five directives form a routing tree.
 Route 3 can therefore be seen as a "catch-all" route that only kicks in, if routes chained into preceding positions
 reject. This mechanism can make complex filtering logic quite easy to implement: simply put the most
 specific cases up front and the most general cases in the back.
+
+## Sealing a Route
+
+As described in @ref[Rejections](rejections.md#rejections-java) and @ref[Exception Handling](exception-handling.md#exception-handling-java),
+there are generally two ways to handle rejections and exceptions.
+
+ * Pass rejection/exception handlers to the `seal()` method of the `Route`
+ * Supply handlers as arguments to @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections) and @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions) directives 
+
+In the first case your handlers will be "sealed", (which means that it will receive the default handler as a fallback for all cases your handler doesn't handle itself) 
+and used for all rejections/exceptions that are not handled within the route structure itself.
+
+### Modify HttpResponse from a sealed Route
+
+You can use `Route` class's `seal()` method to perform modification on HttpResponse from the route.
+For example, if you want to add a special header, but still use the default rejection handler, then you can do the following.
+In the below case, the special header is added to rejected responses which did not match the route, as well as successful responses which matched the route.
+
+@@snip [RouteSealExample.java](../../../../../test/java/docs/http/javadsl/RouteSealExample.java) { #route-seal-example }
+                               

--- a/docs/src/main/paradox/java/http/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/testkit.md
@@ -61,3 +61,13 @@ Adding support for a custom test framework is achieved by creating new superclas
 `JUnitRouteTest` for writing tests with the custom test framework deriving from `akka.http.javadsl.testkit.RouteTest`
 and implementing its abstract methods. This will allow users of the test framework to use `testRoute` and
 to write assertions using the assertion methods defined on `TestResponse`.
+
+## Testing sealed Routes
+
+The section above describes how to test a "regular" branch of your route structure, which reacts to incoming requests
+with HTTP response parts or rejections. Sometimes, however, you will want to verify that your service also translates
+@ref[Rejections](rejections.md#rejections-java) to HTTP responses in the way you expect.
+
+You do this by calling the `seal()` method of the `Route` class. The `seal()` method applies the logic of @ref[ExceptionHandler](exception-handling.md#exception-handling-java) and
+@ref[RejectionHandler](rejections.md#the-rejectionhandler) passed as method arguments to all exceptions and rejections coming back from the route,
+and translates them to the respective `HttpResponse`.

--- a/docs/src/main/paradox/scala/http/routing-dsl/routes.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/routes.md
@@ -23,6 +23,8 @@ in the section about route composition what this is good for.
 
 A `Route` can be "sealed" using `Route.seal`, which relies on the in-scope `RejectionHandler` and `ExceptionHandler`
 instances to convert rejections and exceptions into appropriate HTTP responses for the client.
+@ref[Sealing a Route](#sealing-a-route) is described more in detail later. 
+
 
 Using `Route.handlerFlow` or `Route.asyncHandler` a `Route` can be lifted into a handler `Flow` or async handler
 function to be used with a `bindAndHandleXXX` call from the @ref[Low-Level Server-Side API](../low-level-server-side-api.md#http-low-level-server-side-api).
@@ -111,3 +113,14 @@ Here five directives form a routing tree.
 Route 3 can therefore be seen as a "catch-all" route that only kicks in, if routes chained into preceding positions
 reject. This mechanism can make complex filtering logic quite easy to implement: simply put the most
 specific cases up front and the most general cases in the back.
+
+## Sealing a Route
+
+As described in @ref[Rejections](rejections.md#rejections-scala) and @ref[Exception Handling](exception-handling.md#exception-handling-scala),
+there are generally two ways to handle rejections and exceptions.
+
+ * Bring rejection/exception handlers into implicit scope at the top-level
+ * Supply handlers as arguments to @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections) and @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions) directives 
+
+In the first case your handlers will be "sealed", (which means that it will receive the default handler as a fallback for all cases your handler doesn't handle itself) 
+and used for all rejections/exceptions that are not handled within the route structure itself.

--- a/docs/src/main/paradox/scala/http/routing-dsl/routes.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/routes.md
@@ -134,17 +134,4 @@ However, you can use `Route.seal()` to perform modification on HttpResponse from
 For example, if you want to add a special header, but still use the default rejection handler, then you can do the following.
 In the below case, the special header is added to rejected responses which did not match the route, as well as successful responses which matched the route.
 
-```scala
-    def addSpecialHeader(response: HttpResponse): HttpResponse =
-      response.addHeader(RawHeader("special-header","you always have this even in 404"))
-
-    val route = mapResponse(addSpecialHeader){
-      Route.seal(
-        get {
-          pathSingleSlash {
-            complete {"Captain on the bridge!"}
-          } 
-        }
-      )
-    }
-```
+@@snip [RouteSealExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/RouteSealExampleSpec.scala) { #route-seal-example }

--- a/docs/src/main/paradox/scala/http/routing-dsl/routes.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/routes.md
@@ -124,3 +124,27 @@ there are generally two ways to handle rejections and exceptions.
 
 In the first case your handlers will be "sealed", (which means that it will receive the default handler as a fallback for all cases your handler doesn't handle itself) 
 and used for all rejections/exceptions that are not handled within the route structure itself.
+
+### Route.seal() method to modify HttpResponse
+
+In application code, unlike @ref[test code](testkit.md#testing-sealed-routes), you don't need to use the `Route.seal()` method to seal a route.
+As long as you bring implicit rejection and/or exception handlers to the top-level scope, your route is sealed. 
+
+However, you can use `Route.seal()` to perform modification on HttpResponse from the route.
+For example, if you want to add a special header, but still use the default rejection handler, then you can do the following.
+In the below case, the special header is added to rejected responses which did not match the route, as well as successful responses which matched the route.
+
+```scala
+    def addSpecialHeader(response: HttpResponse): HttpResponse =
+      response.addHeader(RawHeader("special-header","you always have this even in 404"))
+
+    val route = mapResponse(addSpecialHeader){
+      Route.seal(
+        get {
+          pathSingleSlash {
+            complete {"Captain on the bridge!"}
+          } 
+        }
+      )
+    }
+```

--- a/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
@@ -73,16 +73,19 @@ The following inspectors are defined:
 which always produces absolute URIs for incoming request based on the request URI and the `Host`-header of
 the request. You can customize this behavior by bringing a custom instance of `DefaultHostInfo` into scope.
 
-## Sealing Routes
+## Testing sealed Routes
 
 The section above describes how to test a "regular" branch of your route structure, which reacts to incoming requests
 with HTTP response parts or rejections. Sometimes, however, you will want to verify that your service also translates
 @ref[Rejections](rejections.md#rejections-scala) to HTTP responses in the way you expect.
 
-You do this by wrapping your route with the `akka.http.scaladsl.server.Route.seal`.
-The `seal` wrapper applies the logic of the in-scope @ref[ExceptionHandler](exception-handling.md#exception-handling-scala) and
+You do this by wrapping your route with the `akka.http.scaladsl.server.Route.seal`. The `seal` wrapper applies the logic of the in-scope implicit @ref[ExceptionHandler](exception-handling.md#exception-handling-scala) and
 @ref[RejectionHandler](rejections.md#the-rejectionhandler) to all exceptions and rejections coming back from the route,
 and translates them to the respective `HttpResponse`.
+
+Note that `akka.http.scaladsl.server.Route.seal` is only needed in test code, but not in your application code.
+As described in @ref[Sealing a Route](routes.md#sealing-a-route), your application code only needs to bring 
+implicit rejection and exception handlers in scope.
 
 ## Examples
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
@@ -79,11 +79,11 @@ The section above describes how to test a "regular" branch of your route structu
 with HTTP response parts or rejections. Sometimes, however, you will want to verify that your service also translates
 @ref[Rejections](rejections.md#rejections-scala) to HTTP responses in the way you expect.
 
-You do this by wrapping your route with the `akka.http.scaladsl.server.Route.seal`. The `seal` wrapper applies the logic of the in-scope implicit @ref[ExceptionHandler](exception-handling.md#exception-handling-scala) and
+You do this by wrapping your route with the `akka.http.scaladsl.server.Route.seal`. The `seal` wrapper applies the logic of the in-scope @ref[ExceptionHandler](exception-handling.md#exception-handling-scala) and
 @ref[RejectionHandler](rejections.md#the-rejectionhandler) to all exceptions and rejections coming back from the route,
 and translates them to the respective `HttpResponse`.
 
-Note that `akka.http.scaladsl.server.Route.seal` is only needed in test code, but not in your application code.
+Note that explicit call on the `akka.http.scaladsl.server.Route.seal` method is needed in test code, but in your application code it is not necessary.
 As described in @ref[Sealing a Route](routes.md#sealing-a-route), your application code only needs to bring 
 implicit rejection and exception handlers in scope.
 

--- a/docs/src/test/java/docs/http/javadsl/ExceptionHandlerExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ExceptionHandlerExample.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.ExceptionHandler;
+import akka.http.javadsl.server.PathMatchers;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.Http;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+
+import java.io.IOException;
+import java.util.concurrent.CompletionStage;
+import static akka.http.javadsl.server.PathMatchers.integerSegment;
+
+//#explicit-handler-example
+public class ExceptionHandlerExample extends AllDirectives {
+  public static void main(String[] args) throws IOException {
+    final ActorSystem system = ActorSystem.create();
+    final ActorMaterializer materializer = ActorMaterializer.create(system);
+    final Http http = Http.get(system);
+
+    final ExceptionHandlerExample app = new ExceptionHandlerExample();
+
+    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
+    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
+  }
+
+
+  public Route createRoute() {
+    final ExceptionHandler divByZeroHandler = ExceptionHandler.newBuilder()
+      .match(ArithmeticException.class, x ->
+        complete(StatusCodes.BAD_REQUEST, "You've got your arithmetic wrong, fool!"))
+      .build();
+
+    return path(PathMatchers.segment("divide").slash(integerSegment()).slash(integerSegment()), (a, b) ->
+      handleExceptions(divByZeroHandler, () -> complete("The result is " + (a / b)))
+    );
+  }
+}
+//#explicit-handler-example

--- a/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
+++ b/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
@@ -38,8 +38,8 @@ public class RouteSealExample extends AllDirectives {
       )
     ).seal(system, materializer);
 
-    Route route = mapResponse(
-      response -> response.addHeader(RawHeader.create("special-header", "you always have this even in 404")),
+    Route route = respondWithHeader(
+      RawHeader.create("special-header", "you always have this even in 404"),
       () -> sealedRoute
     );
 

--- a/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
+++ b/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.model.*;
+import akka.http.javadsl.model.headers.RawHeader;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+
+import java.io.IOException;
+
+import java.util.concurrent.CompletionStage;
+
+//#route-seal-example
+public class RouteSealExample extends AllDirectives {
+
+  public static void main(String [] args) throws IOException {
+    RouteSealExample app = new RouteSealExample();
+    app.runServer();
+  }
+
+  public void runServer(){
+    ActorSystem system = ActorSystem.create();
+    final ActorMaterializer materializer = ActorMaterializer.create(system);
+
+    Route sealedRoute = get(
+      () -> pathSingleSlash( () ->
+        complete("Captain on the bridge!")
+      )
+    ).seal(system, materializer);
+
+    Route route = mapResponse(
+      response -> response.addHeader(RawHeader.create("special-header", "you always have this even in 404")),
+      () -> sealedRoute
+    );
+
+    final Http http = Http.get(system);
+    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = route.flow(system, materializer);
+    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
+  }
+}
+//#route-seal-example

--- a/docs/src/test/scala/docs/http/scaladsl/RouteSealExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/RouteSealExampleSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.scaladsl
+
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.{ Directives, Route, RoutingSpec }
+import docs.CompileOnlySpec
+
+class RouteSealExampleSpec extends RoutingSpec with Directives with CompileOnlySpec {
+
+  compileOnlySpec {
+    //#route-seal-example
+    def addSpecialHeader(response: HttpResponse): HttpResponse =
+      response.addHeader(RawHeader("special-header", "you always have this even in 404"))
+
+    val route = mapResponse(addSpecialHeader) {
+      Route.seal(
+        get {
+          pathSingleSlash {
+            complete { "Captain on the bridge!" }
+          }
+        }
+      )
+    }
+
+    //#route-seal-example
+  }
+}

--- a/docs/src/test/scala/docs/http/scaladsl/RouteSealExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/RouteSealExampleSpec.scala
@@ -13,10 +13,7 @@ class RouteSealExampleSpec extends RoutingSpec with Directives with CompileOnlyS
 
   compileOnlySpec {
     //#route-seal-example
-    def addSpecialHeader(response: HttpResponse): HttpResponse =
-      response.addHeader(RawHeader("special-header", "you always have this even in 404"))
-
-    val route = mapResponse(addSpecialHeader) {
+    val route = respondWithHeader(RawHeader("special-header", "you always have this even in 404")){
       Route.seal(
         get {
           pathSingleSlash {
@@ -25,7 +22,6 @@ class RouteSealExampleSpec extends RoutingSpec with Directives with CompileOnlyS
         }
       )
     }
-
     //#route-seal-example
   }
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7414320/19540577/8555ce46-969b-11e6-968e-6cd770132e33.png)

The following pages already have route sealing descriptions which I copied from.
[testkit](http://doc.akka.io/docs/akka/2.4.11/scala/http/routing-dsl/testkit.html#sealing-routes)
[rejection-handler](http://doc.akka.io/docs/akka/2.4.11/scala/http/routing-dsl/rejections.html#the-rejectionhandler)
[exception-handler](http://doc.akka.io/docs/akka/2.4.11/scala/http/routing-dsl/exception-handling.html#exception-handling-scala)

The Java documentation looks still under construction, so when we do rework, route-sealing sections should be extended?
[Java testkit (no mention to sealing)](http://doc.akka.io/docs/akka/2.4.11/java/http/routing-dsl/testkit.html#sealing-routes)
[Java rejection-handler](http://doc.akka.io/docs/akka/2.4.11/java/http/routing-dsl/rejections.html#the-rejectionhandler)
[Java exception-handler](http://doc.akka.io/docs/akka/2.4.11/java/http/routing-dsl/exception-handling.html#exception-handling-scala)
