### PR TITLE
Fix SBT's ambiguous keys error for crossVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ inThisBuild(Def.settings(
   test in assembly := {},
   licenses := Seq("Apache License 2.0" -> url("https://opensource.org/licenses/Apache-2.0")),
   scalaVersion := "2.11.8",
-  crossVersion := CrossVersion.binary,
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8", // yes, this is 2 args

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -49,8 +49,8 @@ object NoPublish extends AutoPlugin {
 
   override def projectSettings = Seq(
     publishArtifact := false,
-    publish := (),
-    publishLocal := ()
+    publish := {},
+    publishLocal := {}
   )
 
 }

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -233,7 +233,7 @@ object ValidatePullRequest extends AutoPlugin {
       // Create a task for every validation task key and
       // then zip all of the tasks together discarding outputs.
       // Task failures are propagated as normal.
-      val zero: Def.Initialize[Seq[Task[Any]]] = Def.setting { Seq(task())}
+      val zero: Def.Initialize[Seq[Task[Any]]] = Def.setting { Seq(task(()))}
       validationTasks.map(taskKey => Def.task { taskKey.value } ).foldLeft(zero) { (acc, current) =>
         acc.zipWith(current) { case (taskSeq, task) =>
           taskSeq :+ task.asInstanceOf[Task[Any]]


### PR DESCRIPTION
Remove the crossVersion setting since SBT will automatically set it to
`CrossVersion.binary` when `crossPaths` is `true` which is the default.
As for the cause, defining it inside `inThisPlugin` creates a conflict
with SBT's default which is automatically added to each subproject.

Fixes the following error reported for `show crossVersion`:

    akka-http-root > show crossVersion
    [error] Ambiguous keys: {.}/*:crossVersion, *:crossVersion
    [error] show crossVersion
    [error]                  ^

---

With this I get the following:
```
akka-http-root > show crossVersion
[info] akka-http-testkit/*:crossVersion
[info] 	Binary
[info] akka-http-core/*:crossVersion
[info] 	Binary
[info] akka-http-jackson/*:crossVersion
[info] 	Binary
[info] akka-http-marshallers-java/*:crossVersion
[info] 	Binary
[info] docs/*:crossVersion
[info] 	Binary
[info] akka-http-spray-json/*:crossVersion
[info] 	Binary
[info] akka-http-xml/*:crossVersion
[info] 	Binary
[info] akka-http-marshallers-scala/*:crossVersion
[info] 	Binary
[info] akka-http/*:crossVersion
[info] 	Binary
[info] akka-parsing/*:crossVersion
[info] 	Binary
[info] akka-http-tests/*:crossVersion
[info] 	Binary
[info] akka-http-root/*:crossVersion
[info] 	Binary
```