### PR TITLE
Fix test timeouts

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -388,7 +388,7 @@ class ConnectionPoolSpec extends AkkaSpec("""
               case x ⇒ fail(x.toString)
             }.toMat(Sink.fold(0)(_ + _))(Keep.both).run()
 
-        Await.result(idSum, 30.seconds) shouldEqual N * (N + 1) / 2
+        Await.result(idSum, 35.seconds) shouldEqual N * (N + 1) / 2
       } catch {
         case thr: Throwable ⇒
           throw new RuntimeException(s"Failed at pipeliningLimit=$pipeliningLimit, poolFlow=$poolFlow", thr)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
@@ -327,7 +327,7 @@ class RequestRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll 
     serverAddress: InetSocketAddress    = new InetSocketAddress("test.com", 8080))
     extends HttpRequestRendererFactory(userAgent, requestHeaderSizeHint = 64, NoLogging) {
 
-    def awaitAtMost: FiniteDuration = 3.seconds
+    def awaitAtMost: FiniteDuration = 4.seconds
 
     def renderTo(expected: String): Matcher[HttpRequest] =
       equal(expected.stripMarginWithNewline("\r\n")).matcher[String] compose { request ⇒

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/MarshallingTestUtils.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/MarshallingTestUtils.scala
@@ -16,7 +16,7 @@ import scala.util.Try
 
 trait MarshallingTestUtils {
   def marshal[T: ToEntityMarshaller](value: T)(implicit ec: ExecutionContext, mat: Materializer): HttpEntity.Strict =
-    Await.result(Marshal(value).to[HttpEntity].flatMap(_.toStrict(1.second)), 1.second)
+    Await.result(Marshal(value).to[HttpEntity].flatMap(_.toStrict(1.second)), 2.second)
 
   def marshalToResponseForRequestAccepting[T: ToResponseMarshaller](value: T, mediaRanges: MediaRange*)(implicit ec: ExecutionContext, mat: Materializer): HttpResponse =
     marshalToResponse(value, HttpRequest(headers = Accept(mediaRanges: _*) :: Nil))


### PR DESCRIPTION
With a small cleanup to make future timeouts more explicit in `LowLevelOutgoingConnectionSpec`.
