### PR TITLE
Reenable sbt-unidoc settings

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
@@ -145,7 +145,7 @@ public interface HttpEntity {
     /**
      * Discards the entities data bytes by running the {@code dataBytes} Source contained in this entity.
      *
-     * Note: It is crucial that entities are either discarded, or consumed by running the underlying [[Source]]
+     * Note: It is crucial that entities are either discarded, or consumed by running the underlying [[akka.stream.javadsl.Source]]
      * as otherwise the lack of consuming of the data will trigger back-pressure to the underlying TCP connection
      * (as designed), however possibly leading to an idle-timeout that will close the connection, instead of
      * just having ignored the data.

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -62,7 +62,7 @@ public interface HttpMessage {
      * Discards the entities data bytes by running the {@code dataBytes} Source contained by the {@code entity} 
      * of this HTTP message.
      * 
-     * Note: It is crucial that entities are either discarded, or consumed by running the underlying [[Source]]
+     * Note: It is crucial that entities are either discarded, or consumed by running the underlying [[akka.stream.javadsl.Source]]
      * as otherwise the lack of consuming of the data will trigger back-pressure to the underlying TCP connection
      * (as designed), however possibly leading to an idle-timeout that will close the connection, instead of 
      * just having ignored the data.

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -45,14 +45,14 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
   private lazy val delegate = akka.http.scaladsl.Http(system)
 
   /**
-   * Constructs a server layer stage using the configured default [[akka.http.javadsl.settings.ServerSettings]]. The returned [[BidiFlow]] isn't
+   * Constructs a server layer stage using the configured default [[akka.http.javadsl.settings.ServerSettings]]. The returned [[akka.stream.javadsl.BidiFlow]] isn't
    * reusable and can only be materialized once.
    */
   def serverLayer(materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
     adaptServerLayer(delegate.serverLayer()(materializer))
 
   /**
-   * Constructs a server layer stage using the given [[akka.http.javadsl.settings.ServerSettings]]. The returned [[BidiFlow]] isn't reusable and
+   * Constructs a server layer stage using the given [[akka.http.javadsl.settings.ServerSettings]]. The returned [[akka.stream.javadsl.BidiFlow]] isn't reusable and
    * can only be materialized once.
    */
   def serverLayer(
@@ -61,7 +61,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     adaptServerLayer(delegate.serverLayer(settings.asScala)(materializer))
 
   /**
-   * Constructs a server layer stage using the given [[akka.http.javadsl.settings.ServerSettings]]. The returned [[BidiFlow]] isn't reusable and
+   * Constructs a server layer stage using the given [[akka.http.javadsl.settings.ServerSettings]]. The returned [[akka.stream.javadsl.BidiFlow]] isn't reusable and
    * can only be materialized once. The `remoteAddress`, if provided, will be added as a header to each [[HttpRequest]]
    * this layer produces if the `akka.http.server.remote-address-header` configuration option is enabled.
    */
@@ -72,7 +72,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     adaptServerLayer(delegate.serverLayer(settings.asScala, remoteAddress.asScala)(materializer))
 
   /**
-   * Constructs a server layer stage using the given [[ServerSettings]]. The returned [[BidiFlow]] isn't reusable and
+   * Constructs a server layer stage using the given [[ServerSettings]]. The returned [[akka.stream.javadsl.BidiFlow]] isn't reusable and
    * can only be materialized once. The remoteAddress, if provided, will be added as a header to each [[HttpRequest]]
    * this layer produces if the `akka.http.server.remote-address-header` configuration option is enabled.
    */
@@ -84,7 +84,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     adaptServerLayer(delegate.serverLayer(settings.asScala, remoteAddress.asScala, log)(materializer))
 
   /**
-   * Creates a [[Source]] of [[IncomingConnection]] instances which represents a prospective HTTP server binding
+   * Creates a [[akka.stream.javadsl.Source]] of [[IncomingConnection]] instances which represents a prospective HTTP server binding
    * on the given `endpoint`.
    *
    * If the given port is 0 the resulting source can be materialized several times. Each materialization will
@@ -106,7 +106,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
   }
 
   /**
-   * Creates a [[Source]] of [[IncomingConnection]] instances which represents a prospective HTTP server binding
+   * Creates a [[akka.stream.javadsl.Source]] of [[IncomingConnection]] instances which represents a prospective HTTP server binding
    * on the given `endpoint`.
    *
    * If the given port is 0 the resulting source can be materialized several times. Each materialization will
@@ -131,7 +131,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
   }
 
   /**
-   * Creates a [[Source]] of [[IncomingConnection]] instances which represents a prospective HTTP server binding
+   * Creates a [[akka.stream.javadsl.Source]] of [[IncomingConnection]] instances which represents a prospective HTTP server binding
    * on the given `endpoint`.
    *
    * If the given port is 0 the resulting source can be materialized several times. Each materialization will
@@ -158,7 +158,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
 
   /**
    * Convenience method which starts a new HTTP server at the given endpoint and uses the given `handler`
-   * [[Flow]] for processing all incoming connections.
+   * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
    * the `akka.http.server.max-connections` setting.
@@ -179,7 +179,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
 
   /**
    * Convenience method which starts a new HTTP server at the given endpoint and uses the given `handler`
-   * [[Flow]] for processing all incoming connections.
+   * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
    * the `akka.http.server.max-connections` setting.
@@ -202,7 +202,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
 
   /**
    * Convenience method which starts a new HTTP server at the given endpoint and uses the given `handler`
-   * [[Flow]] for processing all incoming connections.
+   * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
    * the `akka.http.server.max-connections` setting.
@@ -221,7 +221,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
 
   /**
    * Convenience method which starts a new HTTP server at the given endpoint and uses the given `handler`
-   * [[Flow]] for processing all incoming connections.
+   * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
    * the `akka.http.server.max-connections` setting.
@@ -244,7 +244,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
 
   /**
    * Convenience method which starts a new HTTP server at the given endpoint and uses the given `handler`
-   * [[Flow]] for processing all incoming connections.
+   * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
    * the `akka.http.server.max-connections` setting.
@@ -263,7 +263,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
 
   /**
    * Convenience method which starts a new HTTP server at the given endpoint and uses the given `handler`
-   * [[Flow]] for processing all incoming connections.
+   * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
    *
    * The number of concurrently accepted connections can be configured by overriding
    * the `akka.http.server.max-connections` setting.
@@ -308,7 +308,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     adaptClientLayer(delegate.clientLayer(JavaMapping.toScala(hostHeader), settings.asScala, log))
 
   /**
-   * Creates a [[Flow]] representing a prospective HTTP client connection to the given endpoint.
+   * Creates a [[akka.stream.javadsl.Flow]] representing a prospective HTTP client connection to the given endpoint.
    * Every materialization of the produced flow will attempt to establish a new outgoing connection.
    *
    * If the hostname is given with an `https://` prefix, the default [[HttpsConnectionContext]] will be used.
@@ -317,7 +317,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     outgoingConnection(ConnectHttp.toHost(host))
 
   /**
-   * Creates a [[Flow]] representing a prospective HTTP client connection to the given endpoint.
+   * Creates a [[akka.stream.javadsl.Flow]] representing a prospective HTTP client connection to the given endpoint.
    * Every materialization of the produced flow will attempt to establish a new outgoing connection.
    *
    * Use the [[ConnectHttp]] DSL to configure target host and whether HTTPS should be used.
@@ -329,7 +329,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     }
 
   /**
-   * Creates a [[Flow]] representing a prospective HTTP client connection to the given endpoint.
+   * Creates a [[akka.stream.javadsl.Flow]] representing a prospective HTTP client connection to the given endpoint.
    * Every materialization of the produced flow will attempt to establish a new outgoing connection.
    */
   def outgoingConnection(
@@ -345,7 +345,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     }
 
   /**
-   * Starts a new connection pool to the given host and configuration and returns a [[Flow]] which dispatches
+   * Starts a new connection pool to the given host and configuration and returns a [[akka.stream.javadsl.Flow]] which dispatches
    * the requests from all its materializations across this pool.
    * While the started host connection pool internally shuts itself down automatically after the configured idle
    * timeout it will spin itself up again if more requests arrive from an existing or a new client flow
@@ -362,7 +362,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     newHostConnectionPool[T](ConnectHttp.toHost(host), materializer)
 
   /**
-   * Starts a new connection pool to the given host and configuration and returns a [[Flow]] which dispatches
+   * Starts a new connection pool to the given host and configuration and returns a [[akka.stream.javadsl.Flow]] which dispatches
    * the requests from all its materializations across this pool.
    * While the started host connection pool internally shuts itself down automatically after the configured idle
    * timeout it will spin itself up again if more requests arrive from an existing or a new client flow
@@ -399,11 +399,11 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     }
 
   /**
-   * Returns a [[Flow]] which dispatches incoming HTTP requests to the per-ActorSystem pool of outgoing
+   * Returns a [[akka.stream.javadsl.Flow]] which dispatches incoming HTTP requests to the per-ActorSystem pool of outgoing
    * HTTP connections to the given target host endpoint. For every ActorSystem, target host and pool
    * configuration a separate connection pool is maintained.
    * The HTTP layer transparently manages idle shutdown and restarting of connections pools as configured.
-   * The returned [[Flow]] instances therefore remain valid throughout the lifetime of the application.
+   * The returned [[akka.stream.javadsl.Flow]] instances therefore remain valid throughout the lifetime of the application.
    *
    * The internal caching logic guarantees that there will never be more than a single pool running for the
    * given target host endpoint and configuration (in this ActorSystem).
@@ -419,11 +419,11 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     cachedHostConnectionPool(ConnectHttp.toHost(host), materializer)
 
   /**
-   * Returns a [[Flow]] which dispatches incoming HTTP requests to the per-ActorSystem pool of outgoing
+   * Returns a [[akka.stream.javadsl.Flow]] which dispatches incoming HTTP requests to the per-ActorSystem pool of outgoing
    * HTTP connections to the given target host endpoint. For every ActorSystem, target host and pool
    * configuration a separate connection pool is maintained.
    * The HTTP layer transparently manages idle shutdown and restarting of connections pools as configured.
-   * The returned [[Flow]] instances therefore remain valid throughout the lifetime of the application.
+   * The returned [[akka.stream.javadsl.Flow]] instances therefore remain valid throughout the lifetime of the application.
    *
    * The internal caching logic guarantees that there will never be more than a single pool running for the
    * given target host endpoint and configuration (in this ActorSystem).
@@ -547,7 +547,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     delegate.singleRequest(request.asScala, connectionContext.asScala, settings.asScala, log)(materializer).toJava
 
   /**
-   * Constructs a WebSocket [[BidiFlow]].
+   * Constructs a WebSocket [[akka.stream.javadsl.BidiFlow]].
    *
    * The layer is not reusable and must only be materialized once.
    */
@@ -555,7 +555,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     adaptWsBidiFlow(delegate.webSocketClientLayer(request.asScala))
 
   /**
-   * Constructs a WebSocket [[BidiFlow]] using the configured default [[ClientConnectionSettings]],
+   * Constructs a WebSocket [[akka.stream.javadsl.BidiFlow]] using the configured default [[ClientConnectionSettings]],
    * configured using the `akka.http.client` config section.
    *
    * The layer is not reusable and must only be materialized once.
@@ -566,7 +566,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     adaptWsBidiFlow(delegate.webSocketClientLayer(request.asScala, settings.asScala))
 
   /**
-   * Constructs a WebSocket [[BidiFlow]] using the configured default [[ClientConnectionSettings]],
+   * Constructs a WebSocket [[akka.stream.javadsl.BidiFlow]] using the configured default [[ClientConnectionSettings]],
    * configured using the `akka.http.client` config section.
    *
    * The layer is not reusable and must only be materialized once.
@@ -659,7 +659,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     }
 
   /**
-   * Triggers an orderly shutdown of all host connections pools currently maintained by the [[ActorSystem]].
+   * Triggers an orderly shutdown of all host connections pools currently maintained by the [[akka.actor.ActorSystem]].
    * The returned future is completed when all pools that were live at the time of this method call
    * have completed their shutdown process.
    *

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ServerBinding.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ServerBinding.scala
@@ -13,13 +13,13 @@ import scala.compat.java8.FutureConverters._
  */
 class ServerBinding private[http] (delegate: akka.http.scaladsl.Http.ServerBinding) {
   /**
-   * The local address of the endpoint bound by the materialization of the `connections` [[Source]].
+   * The local address of the endpoint bound by the materialization of the `connections` [[akka.stream.javadsl.Source]].
    */
   def localAddress: InetSocketAddress = delegate.localAddress
 
   /**
    * Asynchronously triggers the unbinding of the port that was bound by the materialization of the `connections`
-   * [[Source]]
+   * [[akka.stream.javadsl.Source]]
    *
    * The produced [[java.util.concurrent.CompletionStage]] is fulfilled when the unbinding has been completed.
    */

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -105,8 +105,17 @@ sealed trait Multipart extends jm.Multipart {
   def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[_ <: jm.Multipart.Strict] =
     toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).toJava
 
-  /** Java API */
-  @deprecated def toEntity(charset: jm.HttpCharset, boundary: String): jm.RequestEntity =
+  /**
+   * Java API
+   *
+   * @deprecated This variant of `toEntity` is not supported any more. The charset parameter will be ignored. Please use
+   *             one of the other overloads instead.
+   */
+  @deprecated(
+    message = "This variant of `toEntity` is not supported any more. The charset parameter will be ignored. " +
+    "Please use the variant without specifying the charset.",
+    since = "3.0.0")
+  def toEntity(charset: jm.HttpCharset, boundary: String): jm.RequestEntity =
     toEntity(boundary)
 }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -16,7 +16,7 @@ import akka.util.ByteString
 import scala.language.implicitConversions
 
 /**
- * Allows the [[MarshallingDirectives.entity]] directive to extract a [[Source]] of elements.
+ * Allows the [[MarshallingDirectives.entity]] directive to extract a [[akka.stream.scaladsl.Source]] of elements.
  *
  * See [[common.EntityStreamingSupport]] for useful default framing `Flow` instances and
  * support traits such as `SprayJsonSupport` (or your other favourite JSON library) to provide the needed [[Marshaller]] s.
@@ -26,7 +26,7 @@ trait FramedEntityStreamingDirectives extends MarshallingDirectives {
   type RequestToSourceUnmarshaller[T] = FromRequestUnmarshaller[Source[T, NotUsed]]
 
   /**
-   * Extracts entity as [[Source]] of elements of type `T`.
+   * Extracts entity as [[akka.stream.scaladsl.Source]] of elements of type `T`.
    * This is achieved by applying the implicitly provided (in the following order):
    *
    * - 1st: chunk-up the incoming [[ByteString]]s by applying the `Content-Type`-aware framing
@@ -35,7 +35,7 @@ trait FramedEntityStreamingDirectives extends MarshallingDirectives {
    * The request will be rejected with an [[akka.http.scaladsl.server.UnsupportedRequestContentTypeRejection]] if
    * its [[ContentType]] is not supported by the used `framing` or `unmarshaller`.
    *
-   * Cancelling extracted [[Source]] closes the connection abruptly (same as cancelling the `entity.dataBytes`).
+   * Cancelling extracted [[akka.stream.scaladsl.Source]] closes the connection abruptly (same as cancelling the `entity.dataBytes`).
    *
    * See also [[MiscDirectives.withoutSizeLimit]] as you may want to allow streaming infinite streams of data in this route.
    * By default the uploaded data is limited by the `akka.http.parsing.max-content-length`.
@@ -44,7 +44,7 @@ trait FramedEntityStreamingDirectives extends MarshallingDirectives {
     asSourceOfInternal(um, support)
 
   /**
-   * Extracts entity as [[Source]] of elements of type `T`.
+   * Extracts entity as [[akka.stream.scaladsl.Source]] of elements of type `T`.
    * This is achieved by applying the implicitly provided (in the following order):
    *
    * - 1st: chunk-up the incoming [[ByteString]]s by applying the `Content-Type`-aware framing
@@ -53,7 +53,7 @@ trait FramedEntityStreamingDirectives extends MarshallingDirectives {
    * The request will be rejected with an [[akka.http.scaladsl.server.UnsupportedRequestContentTypeRejection]] if
    * its [[ContentType]] is not supported by the used `framing` or `unmarshaller`.
    *
-   * Cancelling extracted [[Source]] closes the connection abruptly (same as cancelling the `entity.dataBytes`).
+   * Cancelling extracted [[akka.stream.scaladsl.Source]] closes the connection abruptly (same as cancelling the `entity.dataBytes`).
    *
    * See also [[MiscDirectives.withoutSizeLimit]] as you may want to allow streaming infinite streams of data in this route.
    * By default the uploaded data is limited by the `akka.http.parsing.max-content-length`.

--- a/akka-parsing/build.sbt
+++ b/akka-parsing/build.sbt
@@ -8,8 +8,5 @@ Dependencies.parsing
 unmanagedSourceDirectories in ScalariformKeys.format in Test <<= unmanagedSourceDirectories in Test
 scalacOptions += "-language:_"
 
-// ScalaDoc doesn't like the macros
-sources in doc in Compile := List()
-
 enablePlugins(ScaladocNoVerificationOfDiagrams)
 disablePlugins(MimaPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,11 @@ lazy val root = Project(
     id = "akka-http-root",
     base = file(".")
   )
-  .enablePlugins(NoPublish)
+  .enablePlugins(UnidocRoot, NoPublish)
+  .settings(
+    // Unidoc doesn't like macros
+    unidocProjectExcludes := Seq(parsing)
+  )
   .aggregate(
     parsing,
     httpCore,

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -31,7 +31,30 @@ object Scaladoc extends AutoPlugin {
       scalacOptions in Compile <++= (version, baseDirectory in ThisBuild) map scaladocOptions,
       autoAPIMappings := CliOptions.scaladocAutoAPI.get
     )) ++
-    Seq(validateDiagrams in Compile := true) ++
+    Seq(
+      validateDiagrams in Compile := true,
+      apiMappings ++= {
+        // Based on https://github.com/ThoughtWorksInc/sbt-api-mappings
+        val IvyRegex = """^.*[/\\]([\.\-_\w]+)[/\\]([\.\-_\w]+)[/\\](?:jars|bundles)[/\\]([\.\-_\w]+)\.jar$""".r
+
+        for {
+          jar <- (dependencyClasspath in Compile in doc).value.toSet ++ (dependencyClasspath in Test in doc).value
+          fullyFile = jar.data
+          url <- fullyFile.getCanonicalPath match {
+            case IvyRegex(organization, name, jarBaseFile) if jarBaseFile.startsWith(s"$name-") => {
+              val version = jarBaseFile.substring(name.length + 1, jarBaseFile.length)
+              organization match {
+                case "com.typesafe.akka" =>
+                  Some(url(s"http://doc.akka.io/api/akka/$version/"))
+                case _ =>
+                  None
+              }
+            }
+            case _ => None
+          }
+        } yield fullyFile -> url
+      }.toMap
+    ) ++
     CliOptions.scaladocDiagramsEnabled.ifTrue(doc in Compile := {
       val docs = (doc in Compile).value
       if ((validateDiagrams in Compile).value)

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -91,3 +91,56 @@ object ScaladocNoVerificationOfDiagrams extends AutoPlugin {
     Scaladoc.validateDiagrams in Compile := false
   )
 }
+
+/**
+ * Unidoc settings for root project. Adds unidoc command.
+ */
+object UnidocRoot extends AutoPlugin {
+
+  object autoImport {
+    val unidocProjectExcludes = settingKey[Seq[ProjectReference]]("Excluded unidoc projects")
+  }
+  import autoImport._
+
+  object CliOptions {
+    val genjavadocEnabled = CliOption("akka.genjavadoc.enabled", false)
+  }
+
+  override def trigger = noTrigger
+
+  val akkaSettings = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(Seq(
+    javacOptions in (JavaUnidoc, unidoc) ++= Seq("-Xdoclint:none"),
+    // genjavadoc needs to generate synthetic methods since the java code uses them
+    scalacOptions += "-P:genjavadoc:suppressSynthetic=false",
+    // FIXME: see #18056
+    sources in(JavaUnidoc, unidoc) ~= (_.filterNot(_.getPath.contains("Access$minusControl$minusAllow$minusOrigin")))
+  )).getOrElse(Nil)
+
+  val settings = inTask(unidoc)(Seq(
+    unidocProjectFilter in ScalaUnidoc := inAnyProject -- inProjects(unidocProjectExcludes.value: _*),
+    unidocProjectFilter in JavaUnidoc := inAnyProject -- inProjects(unidocProjectExcludes.value: _*)
+  ))
+
+  override lazy val projectSettings =
+    CliOptions.genjavadocEnabled.ifTrue(scalaJavaUnidocSettings).getOrElse(scalaUnidocSettings) ++
+    settings ++
+    akkaSettings
+}
+
+/**
+ * Unidoc settings for every multi-project. Adds genjavadoc specific settings.
+ */
+object Unidoc extends AutoPlugin {
+
+  override def trigger = allRequirements
+  override def requires = plugins.JvmPlugin
+
+  override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(
+    genjavadocExtraSettings ++ Seq(
+      scalacOptions in Compile += "-P:genjavadoc:fabricateParams=true",
+      unidocGenjavadocVersion in Global := "0.10",
+      // FIXME: see #18056
+      sources in(Genjavadoc, doc) ~= (_.filterNot(_.getPath.contains("Access$minusControl$minusAllow$minusOrigin")))
+    )
+  ).getOrElse(Seq.empty)
+}

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -19,7 +19,11 @@ object Publish extends AutoPlugin {
     publishMavenStyle := true,
     pomIncludeRepository := { x => false },
     defaultPublishTo := crossTarget.value / "repository",
-    releasePublishArtifactsAction := PgpKeys.publishSigned.value
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+    apiURL := {
+      val apiVersion = if (isSnapshot.value) "current" else version.value
+      Some(url(s"http://doc.akka.io/api/akka-http/$apiVersion/"))
+    }
   )
 
   private def akkaPublishTo = Def.setting {


### PR DESCRIPTION
Adapts the Unidoc auto plugins from akka/akka to work in akka/akka-http with minimal changes.