### PR TITLE
Deprecate compression and decompression helpers

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
@@ -21,7 +21,7 @@ class Deflate(val messageFilter: HttpMessage ⇒ Boolean) extends Coder with Str
 }
 object Deflate extends Deflate(Encoder.DefaultFilter)
 
-@deprecated("Use `akka.stream.scaladsl.Compression.inflate` instead", "3.0.0-RC2")
+@deprecated("Use `akka.stream.scaladsl.Compression.deflate` instead", "3.0.0-RC2")
 class DeflateCompressor extends Compressor {
   import DeflateCompressor._
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
@@ -21,6 +21,7 @@ class Deflate(val messageFilter: HttpMessage ⇒ Boolean) extends Coder with Str
 }
 object Deflate extends Deflate(Encoder.DefaultFilter)
 
+@deprecated("Use `akka.stream.scaladsl.Compression.inflate` instead", "3.0.0-RC2")
 class DeflateCompressor extends Compressor {
   import DeflateCompressor._
 
@@ -70,6 +71,7 @@ class DeflateCompressor extends Compressor {
   }
 }
 
+@deprecated("Use `akka.stream.scaladsl.Compression.inflate` instead", "3.0.0-RC2")
 private[http] object DeflateCompressor {
   val MinBufferSize = 1024
 
@@ -86,6 +88,7 @@ private[http] object DeflateCompressor {
   }
 }
 
+@deprecated("Use `akka.stream.scaladsl.Compression.inflate` instead", "3.0.0-RC2")
 class DeflateDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
 
   override def createLogic(attr: Attributes) = new DecompressorParsingLogic {
@@ -102,6 +105,7 @@ class DeflateDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefaul
   }
 }
 
+@deprecated("Use `akka.stream.scaladsl.Compression.inflate` instead", "3.0.0-RC2")
 abstract class DeflateDecompressorBase(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault)
   extends ByteStringParser[ByteString] {
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
@@ -54,6 +54,7 @@ object Encoder {
 }
 
 /** A stateful object representing ongoing compression. */
+@deprecated("Use `akka.stream.scaladsl.Compression` instead", "3.0.0-RC2")
 abstract class Compressor {
   /**
    * Compresses the given input and returns compressed data. The implementation

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Gzip.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Gzip.scala
@@ -26,6 +26,7 @@ object Gzip extends Gzip(Encoder.DefaultFilter) {
   def apply(messageFilter: HttpMessage ⇒ Boolean) = new Gzip(messageFilter)
 }
 
+@deprecated("Use `akka.stream.scaladsl.Compression.gzip` instead", "3.0.0-RC2")
 class GzipCompressor extends DeflateCompressor {
   override protected lazy val deflater = new Deflater(Deflater.BEST_COMPRESSION, true)
   private val checkSum = new CRC32 // CRC32 of uncompressed data
@@ -59,6 +60,7 @@ class GzipCompressor extends DeflateCompressor {
   }
 }
 
+@deprecated("Use `akka.stream.scaladsl.Compression.gunzip` instead", "3.0.0-RC2")
 class GzipDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
   override def createLogic(attr: Attributes) = new DecompressorParsingLogic {
     override val inflater: Inflater = new Inflater(true)
@@ -112,6 +114,7 @@ class GzipDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) 
 }
 
 /** INTERNAL API */
+@deprecated("Use `akka.stream.scaladsl.Compression.gunzip` instead", "3.0.0-RC2")
 private[http] object GzipDecompressor {
   // RFC 1952: http://tools.ietf.org/html/rfc1952 section 2.2
   val Header = ByteString(


### PR DESCRIPTION
Issue: #211.

This is the akka-http counterpart for akka/akka#21409 to
deprecate the internal Compressor and Decompressor classes
in favour of the Compression flows in akka-stream.
