### PR TITLE
Bind and BindAndHandle handles remote address in the same way now (#344). Refactoring to decrease code duplication.

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
@@ -21,4 +21,6 @@ private[akka] object HttpAttributes {
   private[akka] def remoteAddress(address: Option[InetSocketAddress]) =
     Attributes(RemoteAddress(address))
 
+  private[akka] val empty =
+    Attributes()
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -55,8 +55,7 @@ import akka.http.scaladsl.model.ws.Message
  *                 +----------+                                   +-------------+  Context    +-----------+
  */
 private[http] object HttpServerBluePrint {
-  def apply(settings: ServerSettings, remoteAddress: Option[InetSocketAddress], log: LoggingAdapter): Http.ServerLayer = {
-    val theStack =
+  def apply(settings: ServerSettings, log: LoggingAdapter): Http.ServerLayer =
       userHandlerGuard(settings.pipeliningLimit) atop
         requestTimeoutSupport(settings.timeouts.requestTimeout) atop
         requestPreparation(settings) atop
@@ -64,10 +63,6 @@ private[http] object HttpServerBluePrint {
         parsingRendering(settings, log) atop
         websocketSupport(settings, log) atop
         tlsSupport
-
-    if (settings.remoteAddressHeader && remoteAddress.isDefined) theStack.withAttributes(HttpAttributes.remoteAddress(remoteAddress))
-    else theStack
-  }
 
   val tlsSupport: BidiFlow[ByteString, SslTlsOutbound, SslTlsInbound, SessionBytes, NotUsed] =
     BidiFlow.fromFlows(Flow[ByteString].map(SendBytes), Flow[SslTlsInbound].collect { case x: SessionBytes ⇒ x })

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -17,7 +17,6 @@ import akka.http.impl.engine.client._
 import akka.http.impl.engine.server._
 import akka.http.impl.engine.ws.WebSocketClientBlueprint
 import akka.http.impl.settings.{ ConnectionPoolSetup, HostConnectionPoolSetup }
-import akka.http.impl.util.{ MapError, StreamUtils }
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.Host
 import akka.http.scaladsl.model.ws.{ Message, WebSocketRequest, WebSocketUpgradeResponse }
@@ -57,7 +56,12 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
 
   private[this] final val DefaultPortForProtocol = -1 // any negative value
 
-  private def fuseServerLayer(settings: ServerSettings, connectionContext: ConnectionContext, log: LoggingAdapter)(implicit mat: Materializer): BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, NotUsed] = {
+  private type ServerLayerBidiFlow = BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, NotUsed]
+  private type ServerLayerFlow = Flow[ByteString, ByteString, Future[Done]]
+
+  private def fuseServerBidiFlow(settings: ServerSettings,
+                                 connectionContext: ConnectionContext,
+                                 log: LoggingAdapter)(implicit mat: Materializer): ServerLayerBidiFlow = {
     val httpLayer = serverLayer(settings, None, log)
     val tlsStage = sslTlsStage(connectionContext, Server)
     BidiFlow.fromGraph(Fusing.aggressive(GraphDSL.create() { implicit b ⇒
@@ -77,6 +81,36 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
       BidiShape(http.in1, timeouts.out, tls.in2, http.out2)
     }))
   }
+
+  private def fuseServerFlow(baseFlow: ServerLayerBidiFlow,
+                             handler: Flow[HttpRequest, HttpResponse, Any])(implicit mat: Materializer): ServerLayerFlow =
+    Flow.fromGraph(
+      Fusing.aggressive(
+        Flow[HttpRequest]
+          .watchTermination()(Keep.right)
+          .viaMat(handler)(Keep.left)
+          .joinMat(baseFlow)(Keep.left)
+      )
+    )
+
+  private def tcpBind(interface: String, port: Int, settings: ServerSettings) = Tcp()
+    .bind(
+      interface,
+      port,
+      settings.backlog,
+      settings.socketOptions,
+      halfClose = false,
+      settings.timeouts.idleTimeout
+    )
+
+  private def choosePort(port: Int, connectionContext: ConnectionContext) = if (port >= 0) port else connectionContext.defaultPort
+
+  private def materializeTcpBind(binding: Future[Tcp.ServerBinding])(implicit mat: Materializer) = binding
+    .map(tcpBinding ⇒ ServerBinding(tcpBinding.localAddress)(() ⇒ tcpBinding.unbind()))(mat.executionContext)
+
+  private def prepareAttributes(settings: ServerSettings, remoteAddress: InetSocketAddress) =
+    if (settings.remoteAddressHeader) HttpAttributes.remoteAddress(Some(remoteAddress))
+    else HttpAttributes.empty
 
   /**
    * Creates a [[akka.stream.scaladsl.Source]] of [[akka.http.scaladsl.Http.IncomingConnection]] instances which represents a prospective HTTP server binding
@@ -103,18 +137,11 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
            connectionContext: ConnectionContext = defaultServerHttpContext,
            settings:          ServerSettings    = ServerSettings(system),
            log:               LoggingAdapter    = system.log)(implicit fm: Materializer): Source[IncomingConnection, Future[ServerBinding]] = {
-    val effectivePort = if (port >= 0) port else connectionContext.defaultPort
+    val fullLayer = fuseServerBidiFlow(settings, connectionContext, log)
 
-    val fullLayer = fuseServerLayer(settings, connectionContext, log)
-
-    val connections: Source[Tcp.IncomingConnection, Future[Tcp.ServerBinding]] =
-      Tcp().bind(interface, effectivePort, settings.backlog, settings.socketOptions, halfClose = false, settings.timeouts.idleTimeout)
-    connections.map {
-      case Tcp.IncomingConnection(localAddress, remoteAddress, flow) ⇒
-        IncomingConnection(localAddress, remoteAddress, fullLayer join flow)
-    }.mapMaterializedValue {
-      _.map(tcpBinding ⇒ ServerBinding(tcpBinding.localAddress)(() ⇒ tcpBinding.unbind()))(fm.executionContext)
-    }
+    tcpBind(interface, choosePort(port, connectionContext), settings)
+      .map(incoming ⇒ IncomingConnection(incoming.localAddress, incoming.remoteAddress, fullLayer.addAttributes(prepareAttributes(settings, incoming.remoteAddress)) join incoming.flow))
+      .mapMaterializedValue(materializeTcpBind)
   }
 
   /**
@@ -133,26 +160,16 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
     connectionContext: ConnectionContext = defaultServerHttpContext,
     settings:          ServerSettings    = ServerSettings(system),
     log:               LoggingAdapter    = system.log)(implicit fm: Materializer): Future[ServerBinding] = {
-    val effectivePort = if (port >= 0) port else connectionContext.defaultPort
+    val fullLayer: Flow[ByteString, ByteString, Future[Done]] = fuseServerFlow(fuseServerBidiFlow(settings, connectionContext, log), handler)
 
-    val fullLayer: Flow[ByteString, ByteString, Future[Done]] = Flow.fromGraph(Fusing.aggressive(
-      Flow[HttpRequest]
-        .watchTermination()(Keep.right)
-        .viaMat(handler)(Keep.left)
-        .joinMat(fuseServerLayer(settings, connectionContext, log))(Keep.left)))
-
-    val connections: Source[Tcp.IncomingConnection, Future[Tcp.ServerBinding]] =
-      Tcp().bind(interface, effectivePort, settings.backlog, settings.socketOptions, halfClose = false, settings.timeouts.idleTimeout)
-
-    connections.mapAsyncUnordered(settings.maxConnections) {
-      case incoming: Tcp.IncomingConnection ⇒
+    tcpBind(interface, choosePort(port, connectionContext), settings)
+      .mapAsyncUnordered(settings.maxConnections) { incoming ⇒
         try {
-          val layer =
-            if (settings.remoteAddressHeader) fullLayer.addAttributes(HttpAttributes.remoteAddress(Some(incoming.remoteAddress)))
-            else fullLayer
-
-          layer.joinMat(incoming.flow)(Keep.left)
-            .run().recover {
+          fullLayer
+            .addAttributes(prepareAttributes(settings, incoming.remoteAddress))
+            .joinMat(incoming.flow)(Keep.left)
+            .run()
+            .recover {
               // Ignore incoming errors from the connection as they will cancel the binding.
               // As far as it is known currently, these errors can only happen if a TCP error bubbles up
               // from the TCP layer through the HTTP layer to the Http.IncomingConnection.flow.
@@ -165,10 +182,10 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
             log.error(e, "Could not materialize handling flow for {}", incoming)
             throw e
         }
-    }.mapMaterializedValue {
-      _.map(tcpBinding ⇒ ServerBinding(tcpBinding.localAddress)(() ⇒ tcpBinding.unbind()))(fm.executionContext)
-    }.to(Sink.ignore).run()
-
+      }
+      .mapMaterializedValue(materializeTcpBind)
+      .to(Sink.ignore)
+      .run()
   }
 
   /**
@@ -227,7 +244,7 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
     settings:      ServerSettings,
     remoteAddress: Option[InetSocketAddress] = None,
     log:           LoggingAdapter            = system.log)(implicit mat: Materializer): ServerLayer =
-    HttpServerBluePrint(settings, remoteAddress, log)
+    HttpServerBluePrint(settings, log)
 
   // ** CLIENT ** //
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -795,26 +795,6 @@ class HttpServerSpec extends AkkaSpec(
       netOut.expectComplete()
     })
 
-    "support remote-address-header" in assertAllStagesStopped(new TestSetup {
-      lazy val theAddress = InetAddress.getByName("127.5.2.1")
-
-      override def remoteAddress: Option[InetSocketAddress] =
-        Some(new InetSocketAddress(theAddress, 8080))
-
-      override def settings: ServerSettings =
-        super.settings.withRemoteAddressHeader(true)
-
-      send("""GET / HTTP/1.1
-             |Host: example.com
-             |
-             |""".stripMarginWithNewline("\r\n"))
-
-      val request = expectRequest()
-      request.headers should contain(`Remote-Address`(RemoteAddress(theAddress, Some(8080))))
-
-      shutdownBlueprint()
-    })
-
     "support remote-address-header when blueprint not constructed with it" in assertAllStagesStopped(new TestSetup {
       // coverage for #21130
       lazy val theAddress = InetAddress.getByName("127.5.2.1")

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -4,8 +4,6 @@
 
 package akka.http.impl.engine.server
 
-import java.net.InetSocketAddress
-
 import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.TLSProtocol._
@@ -31,7 +29,6 @@ abstract class HttpServerTestSetupBase {
 
   def settings = ServerSettings(system)
     .withServerHeader(Some(Server(List(ProductVersion("akka-http", "test")))))
-  def remoteAddress: Option[InetSocketAddress] = None
 
   // hook to modify server, for example add attributes
   def modifyServer(server: Http.ServerLayer): Http.ServerLayer = server
@@ -40,7 +37,7 @@ abstract class HttpServerTestSetupBase {
     val netIn = TestPublisher.probe[ByteString]()
     val netOut = ByteStringSinkProbe()
 
-    RunnableGraph.fromGraph(GraphDSL.create(modifyServer(HttpServerBluePrint(settings, remoteAddress = remoteAddress, log = NoLogging))) { implicit b ⇒ server ⇒
+    RunnableGraph.fromGraph(GraphDSL.create(modifyServer(HttpServerBluePrint(settings, log = NoLogging))) { implicit b ⇒ server ⇒
       import GraphDSL.Implicits._
       Source.fromPublisher(netIn) ~> Flow[ByteString].map(SessionBytes(null, _)) ~> server.in2
       server.out1 ~> Flow[SslTlsOutbound].collect { case SendBytes(x) ⇒ x }.buffer(1, OverflowStrategy.backpressure) ~> netOut.sink


### PR DESCRIPTION
Additionally, I've "borrowed" @jrudolph tests.
