### PR TITLE
Cross compile to Scala 2.12.0-RC2 (#437)

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
@@ -13,6 +13,11 @@ class DebuggingDirectivesSpec extends RoutingSpec {
 
   def resetDebugMsg(): Unit = { debugMsg = "" }
 
+  // Gracefully handle prefix difference for `ByteString.ByteString1C`
+  // in Scala 2.12 due to https://issues.scala-lang.org/browse/SI-9019.
+  def normalizedDebugMsg(): String =
+    debugMsg.replace("ByteString.ByteString1C(", "ByteString(")
+
   val log = new LoggingAdapter {
     def isErrorEnabled = true
     def isWarningEnabled = true
@@ -36,7 +41,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        debugMsg shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1))\n"
+        normalizedDebugMsg shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1))\n"
       }
     }
   }
@@ -51,7 +56,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        debugMsg shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1)))\n"
+        normalizedDebugMsg shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1)))\n"
       }
     }
   }
@@ -66,10 +71,11 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        debugMsg shouldEqual """|3: Response for
-                              |  Request : HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1))
-                              |  Response: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1)))
-                              |""".stripMarginWithNewline("\n")
+        normalizedDebugMsg shouldEqual
+          """|3: Response for
+             |  Request : HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1))
+             |  Response: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1)))
+             |""".stripMarginWithNewline("\n")
       }
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ inThisBuild(Def.settings(
   startYear := Some(2014),
   //  test in assembly := {},
   licenses := Seq("Apache License 2.0" -> url("https://opensource.org/licenses/Apache-2.0")),
-  scalaVersion := "2.11.8",
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8", // yes, this is 2 args

--- a/docs/src/main/paradox/scala/http/common/json-support.md
+++ b/docs/src/main/paradox/scala/http/common/json-support.md
@@ -22,11 +22,7 @@ To enable automatic support for (un)marshalling from and to JSON with [spray-jso
 
 Next, provide a `RootJsonFormat[T]` for your type and bring it into scope. Check out the [spray-json] documentation for more info on how to do this.
 
-Finally, mix in the `akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport` trait as shown in the example below or import the `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` implicits directly from `SprayJsonSupport`
-
-```scala
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-```
+Finally, import the `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` implicits directly from `SprayJsonSupport` as shown in the example below or mix the `akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport` trait into your JSON support module.
 
 Once you have done this (un)marshalling between JSON and your type `T` should work nicely and transparently.
 

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonPrettyMarshalSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonPrettyMarshalSpec.scala
@@ -3,7 +3,6 @@
  */
 package docs.http.scaladsl
 
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.server.Directives
 import org.scalatest.{ Matchers, WordSpec }
 
@@ -11,18 +10,21 @@ class SprayJsonPrettyMarshalSpec extends server.RoutingSpec {
 
   "spray-json example" in {
     //#example
+    import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
     import spray.json._
 
     // domain model
     final case class PrettyPrintedItem(name: String, id: Long)
 
-    trait PrettyJsonFormatSupport extends DefaultJsonProtocol with SprayJsonSupport {
+    object PrettyJsonFormatSupport {
+      import DefaultJsonProtocol._
       implicit val printer = PrettyPrinter
       implicit val prettyPrintedItemFormat = jsonFormat2(PrettyPrintedItem)
     }
 
     // use it wherever json (un)marshalling is needed
-    class MyJsonService extends Directives with PrettyJsonFormatSupport {
+    class MyJsonService extends Directives {
+      import PrettyJsonFormatSupport._
 
       // format: OFF
       val route =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   lazy val java8CompatVersion = settingKey[String]("The version of scala-java8-compat to use.")
 
   val Versions = Seq(
-      crossScalaVersions := Seq("2.11.8"), // "2.12.0-RC1"
+      crossScalaVersions := Seq("2.11.8", "2.12.0-RC2"),
       scalaVersion := crossScalaVersions.value.head,
       scalaCheckVersion := sys.props.get("akka.build.scalaCheckVersion").getOrElse("1.13.2"),
       scalaTestVersion := {


### PR DESCRIPTION
Fixes two tests to work with Scala 2.12:
- SprayJsonPrettyMarshalSpec defined a trait inside a test scope, which
  resulted in a ClassFormatError:
  
  [info] docs.http.scaladsl.SprayJsonPrettyMarshalSpec **\* ABORTED ***
  [info]   java.lang.ClassFormatError: Duplicate field name&signature in class file docs/http/scaladsl/SprayJsonPrettyMarshalSpec$MyJsonService$1
  [info]   at java.lang.ClassLoader.defineClass1(Native Method)
- The fix for https://issues.scala-lang.org/browse/SI-9019 causes
  DebuggingDirectivesSpec to fail by printing `ByteString.ByteString1C`
  instead of `ByteString` in Scala 2.11.
