### PR TITLE
=htc remove too restrictive sealed (java extends it)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCredentials.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCredentials.scala
@@ -10,7 +10,7 @@ import akka.http.impl.util.{ Rendering, ValueRenderable }
 import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.impl.util.JavaMapping.Implicits._
 
-sealed abstract class HttpCredentials extends jm.headers.HttpCredentials with ValueRenderable {
+abstract class HttpCredentials extends jm.headers.HttpCredentials with ValueRenderable {
   def scheme: String
   def token: String
   def params: Map[String, String]


### PR DESCRIPTION
Removing the sealed, as it breaks scaladoc.
Java extends this class.

Model is special, we'll write up that people should not be extending it randomly in any case.