### PR TITLE
Fix #19: Bump leeway timeout to 1s in HttpServerBug21008Spec

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
@@ -15,19 +15,19 @@ import org.scalatest.Inside
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class HttpServerBug2108Spec extends AkkaSpec(
+class HttpServerBug21008Spec extends AkkaSpec(
   """
    akka.loglevel = WARNING
    akka.loggers = ["akka.testkit.TestEventListener", "akka.event.Logging$DefaultLogger"]
    akka.http.server.request-timeout = infinite
-   akka.test.filter-leeway=300ms""") with Inside { spec ⇒
+   akka.test.filter-leeway=1s""") with Inside { spec ⇒
   implicit val materializer = ActorMaterializer()
 
   "The HttpServer" should {
 
     "not cause internal graph failures when consuming a `100 Continue` entity triggers a failure" in assertAllStagesStopped(new HttpServerTestSetupBase {
-      override implicit def system = HttpServerBug2108Spec.this.system
-      override implicit def materializer: Materializer = HttpServerBug2108Spec.this.materializer
+      override implicit def system = HttpServerBug21008Spec.this.system
+      override implicit def materializer: Materializer = HttpServerBug21008Spec.this.materializer
 
       send("""POST / HTTP/1.1
              |Host: example.com
@@ -60,8 +60,8 @@ class HttpServerBug2108Spec extends AkkaSpec(
               Await.ready(done, 10.seconds)
               // and then when the failure has happened/future completes, we push a reply
               responses.sendNext(HttpResponse(entity = "Yeah"))
-
             }
+
             // got such an error, that is bad,
             sawException = true
           } catch {


### PR DESCRIPTION
Also renames the test to reflect the original bug number.

Ref: akka/akka#21008