### PR TITLE
BidiFlow backpressure test case checks if buffer has been filled up now (#423).

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.NotUsed
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.stream.testkit.Utils._
 import akka.stream.testkit._
 import org.scalactic.ConversionCheckedTripleEquals
@@ -105,19 +105,25 @@ class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
       val seen = new AtomicInteger
 
       Source(1 to 1000)
-        .log("", seen.set)
+        .log("", seen.set) // strange syntax to execute side-effects for every element that flows through
         .via(One2OneBidiFlow[Int, Int](MAX_PENDING) join Flow.fromSinkAndSourceMat(Sink.ignore, Source.fromPublisher(out))(Keep.left))
         .runWith(Sink.ignore)
 
-      eventually(timeout(500.millis)) {
-        seen.get should be (MAX_PENDING)
+      // wait for pending elements to be filled
+      // This test (and the one below) depends on the absence of input buffers
+      // between the counting stage (`log(...)`) and the One2OneBidiFlow.
+      eventually(timeout(1.second)) {
+        seen.get should be(MAX_PENDING)
       }
 
-      val counterBeforeProbe = seen.get
+      // now respond to a few input elements
       (1 to EMIT_ELEMENTS) foreach out.sendNext
 
-      eventually(timeout(500.millis)) {
-        seen.get should be (counterBeforeProbe + EMIT_ELEMENTS)
+      // then make sure that again only as many elements are pulled in
+      // as were resolved before so that again only MAX_PENDING elements
+      // are pending (= MAX_PENDING + EMIT_ELEMENTS should have been pulled in)
+      eventually(timeout(1.second)) {
+        seen.get should be(MAX_PENDING + EMIT_ELEMENTS)
       }
 
       out.sendComplete() // To please assertAllStagesStopped

--- a/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
@@ -99,6 +99,7 @@ class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
 
     "backpressure the input side if the maximum number of pending output elements has been reached" in assertAllStagesStopped {
       val MAX_PENDING = 24
+      val EMIT_ELEMENTS = 8
 
       val out = TestPublisher.probe[Int]()
       val seen = new AtomicInteger
@@ -109,14 +110,14 @@ class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
         .runWith(Sink.ignore)
 
       eventually(timeout(500.millis)) {
-        seen.get === MAX_PENDING
+        seen.get should be (MAX_PENDING)
       }
 
-      val counterBeforeProbe = seen.get()
-      (1 to 8) foreach out.sendNext
+      val counterBeforeProbe = seen.get
+      (1 to EMIT_ELEMENTS) foreach out.sendNext
 
       eventually(timeout(500.millis)) {
-        seen.get should ===(counterBeforeProbe + 8)
+        seen.get should be (counterBeforeProbe + EMIT_ELEMENTS)
       }
 
       out.sendComplete() // To please assertAllStagesStopped


### PR DESCRIPTION
It seems the test was meant to full the buffer and emit additional 8 elements. If we stall flow it should read  `0` vs `24` from counter and compare `24+8` to `0+8`. 