### PR TITLE
Disable Javadoc errors for missing references (#498)

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -137,6 +137,9 @@ object Unidoc extends AutoPlugin {
 
   override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(
     genjavadocExtraSettings ++ Seq(
+      javacOptions in compile += "-Xdoclint:none",
+      javacOptions in test += "-Xdoclint:none",
+      javacOptions in doc += "-Xdoclint:none",
       scalacOptions in Compile += "-P:genjavadoc:fabricateParams=true",
       unidocGenjavadocVersion in Global := "0.10",
       // FIXME: see #18056


### PR DESCRIPTION
Set -Xdoclint:none to fix genjavadoc:doc.

Based on akka/akka@098ef546d70b67a6e7b08c1e1223e5902b68ce2f but only add
the setting when `akka.genjavadoc.enabled=true`.

---

With this I get

```
> sbt -Dakka.genjavadoc.enabled=true genjavadoc:doc | grep 'Genjavadoc Java API documentation successful'
[info] Genjavadoc Java API documentation successful.
[info] Genjavadoc Java API documentation successful.
[info] Genjavadoc Java API documentation successful.
[info] Genjavadoc Java API documentation successful.
[info] Genjavadoc Java API documentation successful.
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[info] Genjavadoc Java API documentation successful.
[info] Genjavadoc Java API documentation successful.
[info] Genjavadoc Java API documentation successful.
[info] Genjavadoc Java API documentation successful.
```