### PR TITLE
Add Intro documentation for Java API (#454)

### DIFF
--- a/docs/src/main/paradox/java/http/index.md
+++ b/docs/src/main/paradox/java/http/index.md
@@ -31,6 +31,7 @@ akka-http-jackson
 
 @@@ index
 
+* [introduction](introduction.md)
 * [configuration](configuration.md)
 * [common/index](common/index.md)
 * [http-model](http-model.md)

--- a/docs/src/main/paradox/java/http/introduction.md
+++ b/docs/src/main/paradox/java/http/introduction.md
@@ -21,6 +21,8 @@ However, if your application is not primarily a web application because its core
 
 Akka HTTP was designed specifically as “not-a-framework”, not because we don’t like frameworks, but for use cases where a framework is not the right choice. Akka HTTP is made for building integration layers based on HTTP and as such tries to “stay on the sidelines”. Therefore you normally don’t build your application “on top of” Akka HTTP, but you build your application on top of whatever makes sense and use Akka HTTP merely for the HTTP integration needs.
 
+On the other hand, if you prefer to build your applications with the guidance of a framework, you should give Play Framework or Lagom a try, which both use Akka internally.
+
 ## Using Akka HTTP
 
 Akka HTTP is provided in a separate jar file, to use it make sure to include the following dependency:

--- a/docs/src/main/paradox/java/http/introduction.md
+++ b/docs/src/main/paradox/java/http/introduction.md
@@ -52,8 +52,7 @@ done separately from the route declarations, in marshallers, which are pulled in
 This means that you can `complete` a request with any kind of object a as long as there is an implicit marshaller
 available in scope.
 
-Default marshallers are provided for simple objects like String or ByteString, and you can define your own for example
-for JSON. An additional module provides JSON serialization using the spray-json library (see @ref[JSON Support](common/json-support.md#akka-http-spray-json)
+JSON support is possible in `akka-http` by the use of Jackson, an external artifact (see @ref[JSON Support](common/json-support.md#json-support-via-jackson)
 for details).
 
 The `Route` created using the Route DSL is then "bound" to a port to start serving HTTP requests:
@@ -65,10 +64,10 @@ this case shown by two separate routes. The first route queries an asynchronous 
 `CompletionStage<Optional<Item>>` result into a JSON response. The second unmarshalls an `Order` from the incoming request
 saves it to the database and replies with an OK when done.
 
-@@snip [SprayJsonExampleTest.java](../../../../test/java/docs/http/javadsl/SprayJsonExampleTest.java) { #second-spray-json-example }
+@@snip [JacksonExampleTest.java](../../../../test/java/docs/http/javadsl/JacksonExampleTest.java) { #second-jackson-example }
 
-The logic for the marshalling and unmarshalling JSON in this example is provided by the "spray-json" library
-(details on how to use that here: @ref[JSON Support](common/json-support.md#akka-http-spray-json)).
+The logic for the marshalling and unmarshalling JSON in this example is provided by the "Jackson" library
+(details on how to use that here: @ref[JSON Support](common/json-support.md#json-support-via-jackson)).
 
 One of the strengths of Akka HTTP is that streaming data is at its heart meaning that both request and response bodies
 can be streamed through the server achieving constant memory usage even for very large requests or responses. Streaming
@@ -90,8 +89,8 @@ as json and returned when the response arrives from the actor.
 
 @@snip [HttpServerActorInteractionExample.java](../../../../test/java/docs/http/javadsl/HttpServerActorInteractionExample.java) { #actor-interaction }
 
-Again the logic for the marshalling and unmarshalling JSON in this example is provided by the "spray-json" library
-(details on how to use that here: @ref[JSON Support](common/json-support.md#akka-http-spray-json))
+Again the logic for the marshalling and unmarshalling JSON in this example is provided by the "Jackson" library
+(details on how to use that here: @ref[JSON Support](common/json-support.md#json-support-via-jackson))
 
 Read more about the details of the high level APIs in the section @ref[High-level Server-Side API](routing-dsl/index.md#http-high-level-server-side-api).
 
@@ -132,8 +131,3 @@ Details can be found in sections @ref[Low-Level Server-Side API](server-side/low
 
 akka-http-testkit
 : A test harness and set of utilities for verifying server-side service implementations
-
-akka-http-spray-json
-: Predefined glue-code for (de)serializing custom types from/to JSON with [spray-json](https://github.com/spray/spray-json)
-Details can be found here: @ref[JSON Support](common/json-support.md#akka-http-spray-json)
-

--- a/docs/src/main/paradox/java/http/introduction.md
+++ b/docs/src/main/paradox/java/http/introduction.md
@@ -1,0 +1,140 @@
+# Introduction
+
+The Akka HTTP modules implement a full server- and client-side HTTP stack on top of *akka-actor* and *akka-stream*. It's
+not a web-framework but rather a more general toolkit for providing and consuming HTTP-based services. While interaction
+with a browser is of course also in scope it is not the primary focus of Akka HTTP.
+
+Akka HTTP follows a rather open design and many times offers several different API levels for "doing the same thing".
+You get to pick the API level of abstraction that is most suitable for your application.
+This means that, if you have trouble achieving something using a high-level API, there's a good chance that you can get
+it done with a low-level API, which offers more flexibility but might require you to write more application code.
+
+## Philosophy
+
+Akka HTTP has been driven with a clear focus on providing tools for building integration layers rather than application cores. As such it regards itself as a suite of libraries rather than a framework.
+
+A framework, as we’d like to think of the term, gives you a “frame”, in which you build your application. It comes with a lot of decisions already pre-made and provides a foundation including support structures that lets you get started and deliver results quickly. In a way a framework is like a skeleton onto which you put the “flesh” of your application in order to have it come alive. As such frameworks work best if you choose them before you start application development and try to stick to the frameworks “way of doing things” as you go along.
+
+For example, if you are building a browser-facing web application it makes sense to choose a web framework and build your application on top of it because the “core” of the application is the interaction of a browser with your code on the web-server. The framework makers have chosen one “proven” way of designing such applications and let you “fill in the blanks” of a more or less flexible “application-template”. Being able to rely on best-practice architecture like this can be a great asset for getting things done quickly.
+
+However, if your application is not primarily a web application because its core is not browser-interaction but some specialized maybe complex business service and you are merely trying to connect it to the world via a REST/HTTP interface a web-framework might not be what you need. In this case the application architecture should be dictated by what makes sense for the core not the interface layer. Also, you probably won’t benefit from the possibly existing browser-specific framework components like view templating, asset management, JavaScript- and CSS generation/manipulation/minification, localization support, AJAX support, etc.
+
+Akka HTTP was designed specifically as “not-a-framework”, not because we don’t like frameworks, but for use cases where a framework is not the right choice. Akka HTTP is made for building integration layers based on HTTP and as such tries to “stay on the sidelines”. Therefore you normally don’t build your application “on top of” Akka HTTP, but you build your application on top of whatever makes sense and use Akka HTTP merely for the HTTP integration needs.
+
+## Using Akka HTTP
+
+Akka HTTP is provided in a separate jar file, to use it make sure to include the following dependency:
+
+@@@vars
+```sbt
+"com.typesafe.akka" %% "akka-http" % "$project.version$" $crossString$
+```
+@@@
+
+Mind that `akka-http` comes in two modules: `akka-http` and `akka-http-core`. Because `akka-http`
+depends on `akka-http-core` you don't need to bring the latter explicitly. Still you may need to this in case you rely
+solely on low-level API.
+
+## Routing DSL for HTTP servers
+
+The high-level, routing API of Akka HTTP provides a DSL to describe HTTP "routes" and how they should be handled.
+Each route is composed of one or more level of `Directive` s that narrows down to handling one specific type of
+request.
+
+For example one route might start with matching the `path` of the request, only matching if it is "/hello", then
+narrowing it down to only handle HTTP `get` requests and then `complete` those with a string literal, which
+will be sent back as a HTTP OK with the string as response body.
+
+Transforming request and response bodies between over-the-wire formats and objects to be used in your application is
+done separately from the route declarations, in marshallers, which are pulled in implicitly using the "magnet" pattern.
+This means that you can `complete` a request with any kind of object a as long as there is an implicit marshaller
+available in scope.
+
+Default marshallers are provided for simple objects like String or ByteString, and you can define your own for example
+for JSON. An additional module provides JSON serialization using the spray-json library (see @ref[JSON Support](common/json-support.md#akka-http-spray-json)
+for details).
+
+The `Route` created using the Route DSL is then "bound" to a port to start serving HTTP requests:
+
+@@snip [HttpServerMinimalExampleTest.java](../../../../test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java) { #minimal-routing-example }
+
+A common use case is to reply to a request using a model object having the marshaller transform it into JSON. In
+this case shown by two separate routes. The first route queries an asynchronous database and marshalls the
+`CompletionStage<Optional<Item>>` result into a JSON response. The second unmarshalls an `Order` from the incoming request
+saves it to the database and replies with an OK when done.
+
+@@snip [SprayJsonExampleTest.java](../../../../test/java/docs/http/javadsl/SprayJsonExampleTest.java) { #second-spray-json-example }
+
+The logic for the marshalling and unmarshalling JSON in this example is provided by the "spray-json" library
+(details on how to use that here: @ref[JSON Support](common/json-support.md#akka-http-spray-json)).
+
+One of the strengths of Akka HTTP is that streaming data is at its heart meaning that both request and response bodies
+can be streamed through the server achieving constant memory usage even for very large requests or responses. Streaming
+responses will be backpressured by the remote client so that the server will not push data faster than the client can
+handle, streaming requests means that the server decides how fast the remote client can push the data of the request
+body.
+
+Example that streams random numbers as long as the client accepts them:
+
+@@snip [HttpServerStreamRandomNumbersTest.java](../../../../test/java/docs/http/javadsl/HttpServerStreamRandomNumbersTest.java) { #stream-random-numbers }
+
+Connecting to this service with a slow HTTP client would backpressure so that the next random number is produced on
+demand with constant memory usage on the server. This can be seen using curl and limiting the rate
+`curl --limit-rate 50b 127.0.0.1:8080/random`
+
+Akka HTTP routes easily interacts with actors. In this example one route allows for placing bids in a fire-and-forget
+style while the second route contains a request-response interaction with an actor. The resulting response is rendered
+as json and returned when the response arrives from the actor.
+
+@@snip [HttpServerActorInteractionExample.java](../../../../test/java/docs/http/javadsl/HttpServerActorInteractionExample.java) { #actor-interaction }
+
+Again the logic for the marshalling and unmarshalling JSON in this example is provided by the "spray-json" library
+(details on how to use that here: @ref[JSON Support](common/json-support.md#akka-http-spray-json))
+
+Read more about the details of the high level APIs in the section @ref[High-level Server-Side API](routing-dsl/index.md#http-high-level-server-side-api).
+
+## Low-level HTTP server APIs
+
+The low-level Akka HTTP server APIs allows for handling connections or individual requests by accepting
+`HttpRequest` s and answering them by producing `HttpResponse` s. This is provided by the `akka-http-core` module.
+APIs for handling such request-responses as function calls and as a `Flow<HttpRequest, HttpResponse, NotUsed>` are available.
+
+@@snip [HttpServerLowLevelExample.java](../../../../test/java/docs/http/javadsl/HttpServerLowLevelExample.java) { #low-level-server-example }
+
+Read more details about the low level APIs in the section @ref[Low-Level Server-Side API](low-level-server-side-api.md#http-low-level-server-side-api).
+
+## HTTP client API
+
+The client APIs provide methods for calling a HTTP server using the same `HttpRequest` and `HttpResponse` abstractions
+that Akka HTTP server uses but adds the concept of connection pools to allow multiple requests to the same server to be
+handled more performantly by re-using TCP connections to the server.
+
+Example simple request:
+
+@@snip [ClientSingleRequestExample.java](../../../../test/java/docs/http/javadsl/ClientSingleRequestExample.java) { #single-request-example }
+
+Read more about the details of the client APIs in the section @ref[Consuming HTTP-based Services (Client-Side)](client-side/index.md#http-client-side).
+
+## The modules that make up Akka HTTP
+
+Akka HTTP is structured into several modules:
+
+akka-http
+: Higher-level functionality, like (un)marshalling, (de)compression as well as a powerful DSL
+for defining HTTP-based APIs on the server-side, this is the recommended way to write HTTP servers
+with Akka HTTP. Details can be found in the section @ref[High-level Server-Side API](routing-dsl/index.md#http-high-level-server-side-api)
+
+akka-http-core
+: A complete, mostly low-level, server- and client-side implementation of HTTP (incl. WebSockets)
+Details can be found in sections @ref[Low-Level Server-Side API](low-level-server-side-api.md#http-low-level-server-side-api) and @ref[Consuming HTTP-based Services (Client-Side)](client-side/index.md#http-client-side)
+
+akka-http-testkit
+: A test harness and set of utilities for verifying server-side service implementations
+
+akka-http-spray-json
+: Predefined glue-code for (de)serializing custom types from/to JSON with [spray-json](https://github.com/spray/spray-json)
+Details can be found here: @ref[JSON Support](common/json-support.md#akka-http-spray-json)
+
+akka-http-xml
+: Predefined glue-code for (de)serializing custom types from/to XML with [scala-xml](https://github.com/scala/scala-xml)
+Details can be found here: @ref[XML Support](common/xml-support.md#akka-http-xml-marshalling)

--- a/docs/src/main/paradox/java/http/introduction.md
+++ b/docs/src/main/paradox/java/http/introduction.md
@@ -101,7 +101,7 @@ APIs for handling such request-responses as function calls and as a `Flow<HttpRe
 
 @@snip [HttpServerLowLevelExample.java](../../../../test/java/docs/http/javadsl/HttpServerLowLevelExample.java) { #low-level-server-example }
 
-Read more details about the low level APIs in the section @ref[Low-Level Server-Side API](low-level-server-side-api.md#http-low-level-server-side-api).
+Read more details about the low level APIs in the section @ref[Low-Level Server-Side API](server-side/low-level-server-side-api.md#http-low-level-server-side-api).
 
 ## HTTP client API
 
@@ -126,7 +126,7 @@ with Akka HTTP. Details can be found in the section @ref[High-level Server-Side 
 
 akka-http-core
 : A complete, mostly low-level, server- and client-side implementation of HTTP (incl. WebSockets)
-Details can be found in sections @ref[Low-Level Server-Side API](low-level-server-side-api.md#http-low-level-server-side-api) and @ref[Consuming HTTP-based Services (Client-Side)](client-side/index.md#http-client-side)
+Details can be found in sections @ref[Low-Level Server-Side API](server-side/low-level-server-side-api.md#http-low-level-server-side-api) and @ref[Consuming HTTP-based Services (Client-Side)](client-side/index.md#http-client-side)
 
 akka-http-testkit
 : A test harness and set of utilities for verifying server-side service implementations
@@ -135,6 +135,3 @@ akka-http-spray-json
 : Predefined glue-code for (de)serializing custom types from/to JSON with [spray-json](https://github.com/spray/spray-json)
 Details can be found here: @ref[JSON Support](common/json-support.md#akka-http-spray-json)
 
-akka-http-xml
-: Predefined glue-code for (de)serializing custom types from/to XML with [scala-xml](https://github.com/scala/scala-xml)
-Details can be found here: @ref[XML Support](common/xml-support.md#akka-http-xml-marshalling)

--- a/docs/src/main/paradox/scala/http/introduction.md
+++ b/docs/src/main/paradox/scala/http/introduction.md
@@ -21,6 +21,8 @@ However, if your application is not primarily a web application because its core
 
 Akka HTTP was designed specifically as “not-a-framework”, not because we don’t like frameworks, but for use cases where a framework is not the right choice. Akka HTTP is made for building integration layers based on HTTP and as such tries to “stay on the sidelines”. Therefore you normally don’t build your application “on top of” Akka HTTP, but you build your application on top of whatever makes sense and use Akka HTTP merely for the HTTP integration needs.
 
+On the other hand, if you prefer to build your applications with the guidance of a framework, you should give Play Framework or Lagom a try, which both use Akka internally.
+
 ## Using Akka HTTP
 
 Akka HTTP is provided in a separate jar file, to use it make sure to include the following dependency:

--- a/docs/src/test/java/docs/http/javadsl/ClientSingleRequestExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ClientSingleRequestExample.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl;
+
+//#single-request-example
+import akka.actor.ActorSystem;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+
+import java.util.concurrent.CompletionStage;
+
+public class ClientSingleRequestExample {
+
+  public static void main(String[] args) {
+    final ActorSystem system = ActorSystem.create();
+    final Materializer materializer = ActorMaterializer.create(system);
+
+    final CompletionStage<HttpResponse> responseFuture =
+      Http.get(system)
+        .singleRequest(HttpRequest.create("http://akka.io"), materializer);
+    //#single-request-example
+  }
+}

--- a/docs/src/test/java/docs/http/javadsl/ClientSingleRequestExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ClientSingleRequestExample.java
@@ -23,6 +23,7 @@ public class ClientSingleRequestExample {
     final CompletionStage<HttpResponse> responseFuture =
       Http.get(system)
         .singleRequest(HttpRequest.create("http://akka.io"), materializer);
-    //#single-request-example
   }
 }
+//#single-request-example
+

--- a/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
@@ -5,7 +5,6 @@
 package docs.http.javadsl;
 
 //#actor-interaction
-
 import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;

--- a/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl;
+
+//#actor-interaction
+
+import akka.NotUsed;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.actor.UntypedActor;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.marshallers.jackson.Jackson;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.unmarshalling.StringUnmarshallers;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+import akka.util.Timeout;
+import scala.concurrent.duration.FiniteDuration;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static akka.pattern.PatternsCS.ask;
+
+
+public class HttpServerActorInteractionExample extends AllDirectives {
+
+  private final ActorRef auction;
+
+  public static void main(String[] args) throws Exception {
+    // boot up server using the route as defined below
+    ActorSystem system = ActorSystem.create("routes");
+
+    final Http http = Http.get(system);
+    final ActorMaterializer materializer = ActorMaterializer.create(system);
+
+    //In order to access all directives we need an instance where the routes are define.
+    HttpServerActorInteractionExample app = new HttpServerActorInteractionExample(system);
+
+    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
+    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
+      ConnectHttp.toHost("localhost", 8080), materializer);
+
+    System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
+    System.in.read(); // let it run until user presses return
+
+    binding
+      .thenCompose(ServerBinding::unbind) // trigger unbinding from the port
+      .thenAccept(unbound -> system.terminate()); // and shutdown when done
+  }
+
+  private HttpServerActorInteractionExample(final ActorSystem system) {
+    auction = system.actorOf(Auction.props(), "auction");
+  }
+
+  private Route createRoute() {
+    return route(
+      path("auction", () -> route(
+        put(() ->
+          parameter(StringUnmarshallers.INTEGER, "bid", bid ->
+            parameter("user", user -> {
+              // place a bid, fire-and-forget
+              auction.tell(new Bid(user, bid), ActorRef.noSender());
+              return complete(StatusCodes.ACCEPTED, "bid placed");
+            })
+          )),
+        get(() -> {
+          final Timeout timeout = Timeout.durationToTimeout(FiniteDuration.apply(5, TimeUnit.SECONDS));
+          // query the actor for the current auction state
+          CompletionStage<Bids> bids = ask(auction, new GetBids(), timeout).thenApply((Bids.class::cast));
+          return completeOKWithFuture(bids, Jackson.marshaller());
+        }))));
+  }
+
+  static class Bid {
+    final String userId;
+    final int bid;
+
+    Bid(String userId, int bid) {
+      this.userId = userId;
+      this.bid = bid;
+    }
+  }
+
+  static class GetBids {
+
+  }
+
+  static class Bids {
+    final List<Bid> bids;
+
+    Bids(List<Bid> bids) {
+      this.bids = bids;
+    }
+  }
+
+  //#actor-interaction
+  static class Auction extends UntypedActor {
+    static Props props() {
+      return Props.create(Auction.class);
+    }
+
+    @Override
+    public void onReceive(Object message) throws Throwable {
+
+    }
+  }
+  //#actor-interaction
+}
+//#actor-interaction

--- a/docs/src/test/java/docs/http/javadsl/HttpServerLowLevelExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerLowLevelExample.java
@@ -5,7 +5,6 @@
 package docs.http.javadsl;
 
 //#low-level-server-example
-
 import akka.actor.ActorSystem;
 import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;

--- a/docs/src/test/java/docs/http/javadsl/HttpServerLowLevelExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerLowLevelExample.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl;
+
+//#low-level-server-example
+
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.model.ContentTypes;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCodes;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.util.ByteString;
+
+import java.util.concurrent.CompletionStage;
+
+public class HttpServerLowLevelExample {
+
+  public static void main(String[] args) throws Exception {
+    ActorSystem system = ActorSystem.create();
+
+    try {
+      final Materializer materializer = ActorMaterializer.create(system);
+      CompletionStage<ServerBinding> serverBindingFuture =
+        Http.get(system).bindAndHandleSync(
+          request -> {
+            if (request.getUri().path().equals("/"))
+              return HttpResponse.create().withEntity(ContentTypes.TEXT_HTML_UTF8,
+                ByteString.fromString("<html><body>Hello world!</body></html>"));
+            else if (request.getUri().path().equals("/ping"))
+              return HttpResponse.create().withEntity(ByteString.fromString("PONG!"));
+            else if (request.getUri().path().equals("/crash"))
+              throw new RuntimeException("BOOM!");
+            else {
+              request.discardEntityBytes(materializer);
+              return HttpResponse.create().withStatus(StatusCodes.NOT_FOUND).withEntity("Unknown resource!");
+            }
+          }, ConnectHttp.toHost("localhost", 8080), materializer);
+
+      System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
+      System.in.read(); // let it run until user presses return
+
+      serverBindingFuture
+        .thenCompose(ServerBinding::unbind) // trigger unbinding from the port
+        .thenAccept(unbound -> system.terminate()); // and shutdown when done
+
+    } catch (RuntimeException e) {
+      system.terminate();
+    }
+  }
+}
+//#low-level-server-example

--- a/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
@@ -3,7 +3,6 @@
  */
 package docs.http.javadsl;
 //#minimal-routing-example
-
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.http.javadsl.ConnectHttp;

--- a/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package docs.http.javadsl;
+//#minimal-routing-example
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+
+import java.util.concurrent.CompletionStage;
+
+public class HttpServerMinimalExampleTest extends AllDirectives {
+
+  public static void main(String[] args) throws Exception {
+    // boot up server using the route as defined below
+    ActorSystem system = ActorSystem.create("routes");
+
+    final Http http = Http.get(system);
+    final ActorMaterializer materializer = ActorMaterializer.create(system);
+
+    //In order to access all directives we need an instance where the routes are define.
+    HttpServerMinimalExampleTest app = new HttpServerMinimalExampleTest();
+
+    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
+    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
+        ConnectHttp.toHost("localhost", 8080), materializer);
+
+    System.out.println("Server online at http://localhost:8080/\\nPress RETURN to stop...");
+    System.in.read(); // let it run until user presses return
+
+    binding
+        .thenCompose(ServerBinding::unbind) // trigger unbinding from the port
+        .thenAccept(unbound -> system.terminate()); // and shutdown when done
+  }
+  private Route createRoute() {
+    return route(
+        path("hello", () ->
+            get(() ->
+                complete("<h1>Say hello to akka-http</h1>"))));
+  }
+}
+//#minimal-routing-example

--- a/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
@@ -34,13 +34,14 @@ public class HttpServerMinimalExampleTest extends AllDirectives {
     final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
         ConnectHttp.toHost("localhost", 8080), materializer);
 
-    System.out.println("Server online at http://localhost:8080/\\nPress RETURN to stop...");
+    System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
     System.in.read(); // let it run until user presses return
 
     binding
         .thenCompose(ServerBinding::unbind) // trigger unbinding from the port
         .thenAccept(unbound -> system.terminate()); // and shutdown when done
   }
+
   private Route createRoute() {
     return route(
         path("hello", () ->

--- a/docs/src/test/java/docs/http/javadsl/HttpServerStreamRandomNumbersTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerStreamRandomNumbersTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl;
+
+//#stream-random-numbers
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.model.*;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+
+import java.util.Random;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+
+public class HttpServerStreamRandomNumbersTest extends AllDirectives {
+
+  public static void main(String[] args) throws Exception {
+    // boot up server using the route as defined below
+    ActorSystem system = ActorSystem.create("routes");
+
+    final Http http = Http.get(system);
+    final ActorMaterializer materializer = ActorMaterializer.create(system);
+
+    //In order to access all directives we need an instance where the routes are define.
+    HttpServerStreamRandomNumbersTest app = new HttpServerStreamRandomNumbersTest();
+
+    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
+    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
+        ConnectHttp.toHost("localhost", 8080), materializer);
+
+    System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
+    System.in.read(); // let it run until user presses return
+
+    binding
+        .thenCompose(ServerBinding::unbind) // trigger unbinding from the port
+        .thenAccept(unbound -> system.terminate()); // and shutdown when done
+  }
+
+
+  private Route createRoute() {
+    final Random rnd = new Random();
+    // streams are re-usable so we can define it here
+    // and use it for every request
+    Source<Integer, NotUsed> numbers = Source.fromIterator(() -> Stream.generate(rnd::nextInt).iterator());
+
+    return route(
+        path("random", () ->
+            get(() ->
+                complete(HttpEntities.create(ContentTypes.TEXT_PLAIN_UTF8,
+                    // transform each number to a chunk of bytes
+                    numbers.map(x -> ByteString.fromString(x + "\n")))))));
+  }
+}
+//#stream-random-numbers

--- a/docs/src/test/java/docs/http/javadsl/JacksonExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/JacksonExampleTest.java
@@ -3,7 +3,7 @@
  */
 
 package docs.http.javadsl;
-//#second-spray-json-example
+//#second-jackson-example
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletionStage;
 
 import static akka.http.javadsl.server.PathMatchers.longSegment;
 
-public class SprayJsonExampleTest extends AllDirectives {
+public class JacksonExampleTest extends AllDirectives {
 
   public static void main(String[] args) throws Exception {
     // boot up server using the route as defined below
@@ -38,7 +38,7 @@ public class SprayJsonExampleTest extends AllDirectives {
     final ActorMaterializer materializer = ActorMaterializer.create(system);
 
     //In order to access all directives we need an instance where the routes are define.
-    SprayJsonExampleTest app = new SprayJsonExampleTest();
+    JacksonExampleTest app = new JacksonExampleTest();
 
     final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
     final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
@@ -120,4 +120,4 @@ public class SprayJsonExampleTest extends AllDirectives {
     }
   }
 }
-//#second-spray-json-example
+//#second-jackson-example

--- a/docs/src/test/java/docs/http/javadsl/SprayJsonExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/SprayJsonExampleTest.java
@@ -88,7 +88,7 @@ public class SprayJsonExampleTest extends AllDirectives {
     );
   }
 
-  private class Item {
+  private static class Item {
 
     final String name;
     final long id;
@@ -109,7 +109,7 @@ public class SprayJsonExampleTest extends AllDirectives {
     }
   }
 
-  private class Order {
+  private static class Order {
 
     final List<Item> items;
 

--- a/docs/src/test/java/docs/http/javadsl/SprayJsonExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/SprayJsonExampleTest.java
@@ -4,8 +4,6 @@
 
 package docs.http.javadsl;
 //#second-spray-json-example
-
-
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;

--- a/docs/src/test/java/docs/http/javadsl/SprayJsonExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/SprayJsonExampleTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl;
+//#second-spray-json-example
+
+
+import akka.Done;
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.marshallers.jackson.Jackson;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import static akka.http.javadsl.server.PathMatchers.longSegment;
+
+public class SprayJsonExampleTest extends AllDirectives {
+
+  public static void main(String[] args) throws Exception {
+    // boot up server using the route as defined below
+    ActorSystem system = ActorSystem.create("routes");
+
+    final Http http = Http.get(system);
+    final ActorMaterializer materializer = ActorMaterializer.create(system);
+
+    //In order to access all directives we need an instance where the routes are define.
+    SprayJsonExampleTest app = new SprayJsonExampleTest();
+
+    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
+    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
+      ConnectHttp.toHost("localhost", 8080), materializer);
+
+    System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
+    System.in.read(); // let it run until user presses return
+
+    binding
+      .thenCompose(ServerBinding::unbind) // trigger unbinding from the port
+      .thenAccept(unbound -> system.terminate()); // and shutdown when done
+  }
+
+
+  private CompletionStage<Optional<Item>> fetchItem(long itemId) {
+    return CompletableFuture.completedFuture(Optional.of(new Item("foo", itemId)));
+  }
+
+  private CompletionStage<Done> saveOrder(final Order order) {
+    return CompletableFuture.completedFuture(Done.getInstance());
+  }
+
+  private Route createRoute() {
+
+    return route(
+      get(() ->
+        pathPrefix("item", () ->
+          path(longSegment(), (Long id) -> {
+            final CompletionStage<Optional<Item>> futureMaybeItem = fetchItem(id);
+            return onSuccess(() -> futureMaybeItem, maybeItem -> {
+              if (!maybeItem.isPresent()) {
+                return complete(StatusCodes.NOT_FOUND);
+              }
+              return completeOK(maybeItem.get(), Jackson.marshaller());
+            });
+          }))),
+      post(() ->
+        path("create-order", () ->
+          entity(Jackson.unmarshaller(Order.class), order -> {
+            CompletionStage<Done> futureSaved = saveOrder(order);
+            return onSuccess(() -> futureSaved, done ->
+              complete("order created")
+            );
+          })))
+    );
+  }
+
+  private class Item {
+
+    final String name;
+    final long id;
+
+    @JsonCreator
+    Item(@JsonProperty("name") String name,
+         @JsonProperty("id") long id) {
+      this.name = name;
+      this.id = id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public long getId() {
+      return id;
+    }
+  }
+
+  private class Order {
+
+    final List<Item> items;
+
+    @JsonCreator
+    Order(@JsonProperty("items") List<Item> items) {
+      this.items = items;
+    }
+
+    public List<Item> getItems() {
+      return items;
+    }
+  }
+}
+//#second-spray-json-example


### PR DESCRIPTION
Issue: #454
Add Java snippets for:

- Minimal Server (#minimal-routing-example)
- Spray JSON example (#second-spray-json-example)
- Streaming Random Numbers (#stream-random-numbers)

Missing Java snippets for:
- Actor Interaction (#actor-interaction)
- Low Level Server Example (#actor-interaction)
- Single Client Request (#single-request-example)