### PR TITLE
Provide HttpApp API for Scala and Java

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.javadsl.server;
+
+import akka.Done;
+import akka.actor.ActorSystem;
+import scala.runtime.BoxedUnit;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletableFuture;
+
+public class MinimalHttpApp extends HttpApp {
+
+  CompletableFuture<Done> shutdownTrigger = new CompletableFuture<>();
+
+  @Override
+  protected Route route() {
+    return route(path("foo", () ->
+        complete("bar")
+      ),
+      path("shutdown", () -> {
+        if (shutdownTrigger.complete(Done.getInstance())) {
+          return complete("Shutdown request accepted");
+        } else {
+          return complete("Shutdown is already in progress");
+        }
+      }));
+  }
+
+  @Override
+  protected CompletionStage<Done> waitForShutdownSignal(ActorSystem system) {
+    return shutdownTrigger;
+  }
+}

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/SneakHttpApp.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/SneakHttpApp.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.javadsl.server;
+
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ServerBinding;
+import scala.runtime.BoxedUnit;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class SneakHttpApp extends MinimalHttpApp {
+
+  AtomicBoolean postServerShutdownCalled = new AtomicBoolean(false);
+  AtomicBoolean postBindingCalled = new AtomicBoolean(false);
+  AtomicBoolean postBindingFailureCalled = new AtomicBoolean(false);
+
+  @Override
+  protected void postServerShutdown(Optional<Throwable> failure, ActorSystem system) {
+    postServerShutdownCalled.set(true);
+  }
+
+  @Override
+  protected void postHttpBinding(ServerBinding binding) {
+    postBindingCalled.set(true);
+  }
+
+  @Override
+  protected void postHttpBindingFailure(Throwable cause) {
+    postBindingFailureCalled.set(true);
+  }
+}

--- a/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.javadsl.server
+
+import java.util.concurrent.TimeUnit
+
+import akka.http.javadsl.settings.ServerSettings
+import akka.http.scaladsl.{ Http, TestUtils }
+import akka.http.scaladsl.client.RequestBuilding
+import akka.http.scaladsl.model.{ HttpRequest, StatusCodes }
+import akka.stream.ActorMaterializer
+import akka.testkit.AkkaSpec
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Eventually
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future }
+import scala.runtime.BoxedUnit
+
+class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
+  import system.dispatcher
+
+  "HttpApp" should {
+
+    "start without ActorSystem" in {
+      val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+      val minimal = new MinimalHttpApp()
+
+      val server = Future {
+        minimal.startServer(host, port, ServerSettings.create(ConfigFactory.load))
+      }
+
+      callAndVerify(host, port, "foo")
+
+      // Requesting the server to shutdown
+      callAndVerify(host, port, "shutdown")
+
+      Await.ready(server, Duration(1, TimeUnit.SECONDS))
+      server.isCompleted should ===(true)
+
+    }
+
+    "start providing an ActorSystem" in {
+      val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+      val minimal = new MinimalHttpApp()
+
+      val server = Future {
+        minimal.startServer(host, port, ServerSettings.create(system), system)
+      }
+
+      callAndVerify(host, port, "foo")
+
+      // Requesting the server to shutdown
+      callAndVerify(host, port, "shutdown")
+
+      Await.ready(server, Duration(1, TimeUnit.SECONDS))
+      server.isCompleted should ===(true)
+      system.isTerminated should ===(false)
+    }
+
+    "provide binding if available" in {
+      val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+      val minimal = new MinimalHttpApp()
+
+      intercept[IllegalStateException] {
+        minimal.binding()
+      }
+
+      val server = Future {
+        minimal.startServer(host, port, ServerSettings.create(ConfigFactory.load))
+      }
+
+      callAndVerify(host, port, "foo")
+
+      minimal.binding().localAddress.getPort should ===(port)
+      minimal.binding().localAddress.getHostName should ===(host)
+
+      // Requesting the server to shutdown
+      callAndVerify(host, port, "shutdown")
+      Await.ready(server, Duration(1, TimeUnit.SECONDS))
+      server.isCompleted should ===(true)
+    }
+
+    "let get notified" when {
+
+      "shutting down" in {
+        val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+        val sneaky = new SneakHttpApp()
+
+        val server = Future {
+          sneaky.startServer(host, port, ServerSettings.create(ConfigFactory.load))
+        }
+
+        sneaky.postServerShutdownCalled.get() should ===(false)
+
+        // Requesting the server to shutdown
+        callAndVerify(host, port, "shutdown")
+        Await.ready(server, Duration(1, TimeUnit.SECONDS))
+        server.isCompleted should ===(true)
+        eventually {
+          sneaky.postServerShutdownCalled.get() should ===(true)
+        }
+      }
+
+      "after binding is successful" in {
+        val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+        val sneaky = new SneakHttpApp()
+
+        val server = Future {
+          sneaky.startServer(host, port, ServerSettings.create(ConfigFactory.load))
+        }
+
+        callAndVerify(host, port, "foo")
+
+        sneaky.postBindingCalled.get() should ===(true)
+
+        // Requesting the server to shutdown
+        callAndVerify(host, port, "shutdown")
+        Await.ready(server, Duration(1, TimeUnit.SECONDS))
+        server.isCompleted should ===(true)
+      }
+
+      "after binding is unsuccessful" in {
+        val sneaky = new SneakHttpApp()
+
+        sneaky.startServer("localhost", 1, ServerSettings.create(ConfigFactory.load))
+
+        eventually {
+          sneaky.postBindingFailureCalled.get() should ===(true)
+        }
+      }
+
+    }
+
+  }
+
+  private def callAndVerify(host: String, port: Int, path: String) = {
+
+    val request = HttpRequest(uri = s"http://$host:$port/$path")
+
+    implicit val mat = ActorMaterializer()
+
+    eventually {
+      val response = Http().singleRequest(request)
+      response.futureValue.status should ===(StatusCodes.OK)
+    }
+  }
+
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.server
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.{ Http, TestUtils }
+import akka.http.scaladsl.client.RequestBuilding
+import akka.http.scaladsl.model.{ HttpRequest, StatusCodes }
+import akka.http.scaladsl.settings.ServerSettings
+import akka.stream.ActorMaterializer
+import akka.testkit.AkkaSpec
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Eventually
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
+import scala.util.Try
+
+class HttpAppSpec extends AkkaSpec with Directives with RequestBuilding with Eventually {
+  import system.dispatcher
+
+  class Minimal extends HttpApp {
+
+    private val shutdownPromise = Promise[Done]()
+
+    override protected def route: Route =
+      path("foo") {
+        complete("bar")
+      } ~
+        path("shutdown") {
+          if (shutdownPromise.isCompleted) complete("Shutdown already in process")
+          else {
+            shutdownPromise.success(Done)
+            complete("Shutdown request accepted")
+          }
+        }
+
+    override protected def waitForShutdownSignal(system: ActorSystem)(implicit ec: ExecutionContext): Future[Done] = {
+      shutdownPromise.future
+    }
+  }
+
+  "HttpApp" should {
+
+    "start without ActorSystem" in {
+      val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+      val minimal = new Minimal()
+
+      val server = Future {
+        minimal.startServer(host, port, ServerSettings(ConfigFactory.load))
+      }
+
+      callAndVerify(host, port, "foo")
+
+      // Requesting the server to shutdown
+      callAndVerify(host, port, "shutdown")
+      Await.ready(server, Duration(1, TimeUnit.SECONDS))
+      server.isCompleted should ===(true)
+
+    }
+
+    "start providing an ActorSystem" in {
+      val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+      val minimal = new Minimal()
+
+      val server = Future {
+        minimal.startServer(host, port, ServerSettings(system), system)
+      }
+
+      callAndVerify(host, port, "foo")
+
+      // Requesting the server to shutdown
+      callAndVerify(host, port, "shutdown")
+      Await.ready(server, Duration(1, TimeUnit.SECONDS))
+      server.isCompleted should ===(true)
+      system.isTerminated should ===(false)
+    }
+
+    "provide binding if available" in {
+      val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+      val minimal = new Minimal()
+
+      minimal.binding().isFailure should ===(true)
+
+      val server = Future {
+        minimal.startServer(host, port, ServerSettings(ConfigFactory.load))
+      }
+
+      callAndVerify(host, port, "foo")
+
+      minimal.binding().isSuccess should ===(true)
+      minimal.binding().get.localAddress.getPort should ===(port)
+      minimal.binding().get.localAddress.getHostName should ===(host)
+
+      // Requesting the server to shutdown
+      callAndVerify(host, port, "shutdown")
+      Await.ready(server, Duration(1, TimeUnit.SECONDS))
+      server.isCompleted should ===(true)
+    }
+
+    "let get notified" when {
+      class SneakSever extends HttpApp {
+
+        private val shutdownPromise = Promise[Done]()
+
+        val postBindingCalled = new AtomicBoolean(false)
+        val postBindingFailureCalled = new AtomicBoolean(false)
+        val postShutdownCalled = new AtomicBoolean(false)
+
+        override protected def route: Route =
+          path("foo") {
+            complete("bar")
+          } ~
+            path("shutdown") {
+              if (shutdownPromise.isCompleted) complete("Shutdown already in process")
+              else {
+                shutdownPromise.success(Done)
+                complete("Shutdown request accepted")
+              }
+            }
+
+        override protected def waitForShutdownSignal(system: ActorSystem)(implicit ec: ExecutionContext): Future[Done] = {
+          shutdownPromise.future
+        }
+
+        override protected def postHttpBindingFailure(cause: Throwable): Unit = postBindingFailureCalled.set(true)
+
+        override protected def postHttpBinding(binding: ServerBinding): Unit = postBindingCalled.set(true)
+
+        override protected def postServerShutdown(attempt: Try[Done], system: ActorSystem): Unit = postShutdownCalled.set(true)
+      }
+
+      "shutting down" in {
+        val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+        val sneaky = new SneakSever()
+
+        val server = Future {
+          sneaky.startServer(host, port, ServerSettings(ConfigFactory.load))
+        }
+
+        sneaky.postShutdownCalled.get() should ===(false)
+
+        // Requesting the server to shutdown
+        callAndVerify(host, port, "shutdown")
+        Await.ready(server, Duration(1, TimeUnit.SECONDS))
+        server.isCompleted should ===(true)
+        eventually {
+          sneaky.postShutdownCalled.get() should ===(true)
+        }
+      }
+
+      "after binding is successful" in {
+        val (_, host, port) = TestUtils.temporaryServerHostnameAndPort()
+
+        val sneaky = new SneakSever()
+
+        val server = Future {
+          sneaky.startServer(host, port, ServerSettings(ConfigFactory.load))
+        }
+
+        callAndVerify(host, port, "foo")
+
+        sneaky.postBindingCalled.get() should ===(true)
+
+        // Requesting the server to shutdown
+        callAndVerify(host, port, "shutdown")
+        Await.ready(server, Duration(1, TimeUnit.SECONDS))
+        server.isCompleted should ===(true)
+      }
+
+      "after binding is unsuccessful" in {
+        val sneaky = new SneakSever()
+
+        sneaky.startServer("localhost", 1, ServerSettings(ConfigFactory.load))
+
+        eventually {
+          sneaky.postBindingFailureCalled.get() should ===(true)
+        }
+      }
+
+    }
+
+  }
+
+  private def callAndVerify(host: String, port: Int, path: String) = {
+
+    val request = HttpRequest(uri = s"http://$host:$port/$path")
+
+    implicit val mat = ActorMaterializer()
+
+    eventually {
+      val response = Http().singleRequest(request)
+      response.futureValue.status should ===(StatusCodes.OK)
+    }
+  }
+}

--- a/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.http.javadsl.server;
+
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.event.Logging;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.settings.ServerSettings;
+import akka.stream.ActorMaterializer;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * API MAY CHANGE - EXPERIMENTAL
+ * Bootstrap trait for Http Server. It helps booting up an akka-http server by only defining the desired routes.
+ * It offers additional hooks to modify the default behavior.
+ */
+// @akka.annotation.ApiMayChange // FIXME replace with real annotation once Akka dependency bumped
+public abstract class HttpApp extends AllDirectives {
+
+  private AtomicReference<ServerBinding> serverBinding = new AtomicReference<>();
+  /**
+   * Holds a reference to the {@link ActorSystem} used to start this server. Stopping this system will interfere with the proper functioning condition of the server.
+   */
+  protected AtomicReference<ActorSystem> systemReference = new AtomicReference<>();
+
+  /**
+   * Start a server on the specified host and port, using provided settings.
+   * Note that this method is blocking.
+   */
+  public void startServer(String host, int port, ServerSettings settings) throws ExecutionException, InterruptedException {
+    startServer(host, port, settings, Optional.empty());
+  }
+
+  /**
+   * Start a server on the specified host and port, using provided settings and [[ActorSystem]].
+   * Note that this method is blocking.
+   */
+  public void startServer(String host, int port, ServerSettings settings, ActorSystem system) throws ExecutionException, InterruptedException {
+    startServer(host, port, settings, Optional.of(system));
+  }
+
+  /**
+   * Start a server on the specified host and port, using provided settings and [[ActorSystem]] if present.
+   * Note that this method is blocking.
+   * This method may throw an {@link ExecutionException} or {@link InterruptedException} if the future that signals that
+   * the server should shutdown is interrupted or cancelled.
+   */
+  public void startServer(String host, int port, ServerSettings settings, Optional<ActorSystem> system) throws ExecutionException, InterruptedException {
+
+    final ActorSystem theSystem = system.orElseGet(() -> ActorSystem.create(Logging.simpleName(this).replaceAll("\\$", "")));
+    systemReference.set(theSystem);
+    final ActorMaterializer materializer = ActorMaterializer.create(theSystem);
+
+    CompletionStage<ServerBinding> bindingFuture = Http
+      .get(theSystem)
+      .bindAndHandle(route().flow(theSystem, materializer),
+        ConnectHttp.toHost(host, port),
+        settings,
+        theSystem.log(),
+        materializer);
+
+    bindingFuture.handle((binding, exception) -> {
+      if (exception != null) {
+        postHttpBindingFailure(exception);
+      } else {
+        //setting the server binding for possible future uses in the client
+        serverBinding.set(binding);
+        postHttpBinding(binding);
+      }
+      return null;
+    });
+
+    try {
+      bindingFuture
+        .thenCompose(ignore -> waitForShutdownSignal(theSystem)) // chaining both futures to fail fast
+        .toCompletableFuture()
+        .exceptionally(ignored -> Done.getInstance()) // If the future fails, we want to complete normally
+        .get(); // It's waiting forever because maybe there is never a shutdown signal
+    } finally {
+      bindingFuture.thenCompose(ServerBinding::unbind).handle( (success, exception) -> {
+        postServerShutdown(Optional.ofNullable(exception), theSystem);
+        if (!system.isPresent()) {
+          // we created the system. we should cleanup!
+          theSystem.terminate();
+        }
+        return null;
+      });
+    }
+
+  }
+
+  /**
+   * It tries to retrieve the {@link ServerBinding} if the server has been successfully started. It throws an {@link IllegalStateException} otherwise.
+   * You can use this method to attempt to retrieve the {@link ServerBinding} at any point in time to, for example, stop the server due to unexpected circumstances.
+   */
+  ServerBinding binding() {
+    if (serverBinding.get() == null)
+      throw new IllegalStateException("Binding not yet stored. Have you called startServer?");
+    return serverBinding.get();
+  }
+
+  /**
+   * Hook that will be called just after the server termination. Override this method if you want to perform some cleanup actions after the server is stopped.
+   * The {@code failure} parameter contains a {@link Throwable} only if there has been a problem shutting down the server.
+   */
+  protected void postServerShutdown(Optional<Throwable> failure, ActorSystem system) {
+    systemReference.get().log().info("Shutting down the server");
+  }
+
+  /**
+   * Hook that will be called just after the Http server binding is done. Override this method if you want to perform some actions after the server is up.
+   */
+  protected void postHttpBinding (ServerBinding binding) {
+    systemReference.get().log().info("Server online at http://" + binding.localAddress().getHostName() + ":" + binding.localAddress().getPort() + "/");
+  }
+
+  /**
+   * Hook that will be called in case the Http server binding fails. Override this method if you want to perform some actions after the server binding failed.
+   */
+  protected void postHttpBindingFailure(Throwable cause) {
+    systemReference.get().log().error(cause, "Error starting the server: " + cause.getMessage());
+  }
+
+  /**
+   * Hook that lets the user specify the future that will signal the shutdown of the server whenever completed.
+   */
+  protected CompletionStage<Done> waitForShutdownSignal (ActorSystem system) {
+    return CompletableFuture.supplyAsync( () -> {
+      System.out.println("Press RETURN to stop...");
+      try {
+        System.in.read();
+      } catch (IOException e) {
+        systemReference.get().log().error(e, "Problem occurred! " + e.getMessage());
+      }
+      return Done.getInstance();
+    });
+  }
+
+  /**
+   * Override to implement the route that will be served by this http server.
+   */
+  protected abstract Route route();
+
+
+}

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.server
+
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.Http.ServerBinding
+import akka.stream.ActorMaterializer
+import akka.http.scaladsl.settings.ServerSettings
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContext, Future }
+import scala.io.StdIn
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * API MAY CHANGE - EXPERIMENTAL
+ * Bootstrap trait for Http Server. It helps booting up an akka-http server by only defining the desired routes.
+ * It offers additional hooks to modify the default behavior.
+ */
+// @akka.annotation.ApiMayChange // FIXME replace with real annotation once Akka dependency bumped
+trait HttpApp {
+
+  private val serverBinding = new AtomicReference[ServerBinding]()
+  /**
+   * [[ActorSystem]] used to start this server. Stopping this system will interfere with the proper functioning condition of the server.
+   */
+  protected val systemReference = new AtomicReference[ActorSystem]()
+
+  /**
+   * Start a server on the specified host and port, using provided settings.
+   * Note that this method is blocking.
+   */
+  def startServer(host: String, port: Int, settings: ServerSettings): Unit = {
+    startServer(host, port, settings, None)
+  }
+
+  /**
+   * Start a server on the specified host and port, using provided settings and [[ActorSystem]].
+   * Note that this method is blocking.
+   */
+  def startServer(host: String, port: Int, settings: ServerSettings, system: ActorSystem): Unit = {
+    startServer(host, port, settings, Some(system))
+  }
+
+  /**
+   * Start a server on the specified host and port, using provided settings and [[ActorSystem]] if present.
+   * Note that this method is blocking.
+   */
+  def startServer(host: String, port: Int, settings: ServerSettings, system: Option[ActorSystem]): Unit = {
+    implicit val theSystem = system.getOrElse(ActorSystem(Logging.simpleName(this).replaceAll("\\$", "")))
+    systemReference.set(theSystem)
+    implicit val materializer = ActorMaterializer()
+    implicit val executionContext = theSystem.dispatcher
+
+    val bindingFuture = Http().bindAndHandle(
+      handler = route,
+      interface = host,
+      port = port,
+      settings = settings)
+
+    bindingFuture.onComplete {
+      case Success(binding) ⇒
+        //setting the server binding for possible future uses in the client
+        serverBinding.set(binding)
+        postHttpBinding(binding)
+      case Failure(cause) ⇒
+        postHttpBindingFailure(cause)
+    }
+
+    Await.ready(
+      bindingFuture.flatMap(_ ⇒ waitForShutdownSignal(theSystem)), // chaining both futures to fail fast
+      Duration.Inf) // It's waiting forever because maybe there is never a shutdown signal
+
+    bindingFuture
+      .flatMap(_.unbind())
+      .onComplete(attempt ⇒ {
+        postServerShutdown(attempt.map(_ ⇒ Done), theSystem)
+        // we created the system. we should cleanup!
+        if (system.isEmpty) theSystem.terminate()
+      })
+  }
+
+  /**
+   * It tries to retrieve the [[ServerBinding]] if the server has been successfully started. It fails otherwise.
+   * You can use this method to attempt to retrieve the [[ServerBinding]] at any point in time to, for example, stop the server due to unexpected circumstances.
+   */
+  def binding(): Try[ServerBinding] = {
+    if (serverBinding.get() == null) Failure(new IllegalStateException("Binding not yet stored. Have you called startServer?"))
+    else Success(serverBinding.get())
+  }
+
+  /**
+   * Hook that will be called just after the server termination. Override this method if you want to perform some cleanup actions after the server is stopped.
+   * The `attempt` parameter is represented with a [[Try]] type that is successful only if the server was successfully shut down.
+   */
+  protected def postServerShutdown(attempt: Try[Done], system: ActorSystem): Unit = {
+    systemReference.get().log.info("Shutting down the server")
+  }
+
+  /**
+   * Hook that will be called just after the Http server binding is done. Override this method if you want to perform some actions after the server is up.
+   */
+  protected def postHttpBinding(binding: Http.ServerBinding): Unit = {
+    systemReference.get().log.info(s"Server online at http://${binding.localAddress.getHostName}:${binding.localAddress.getPort}/")
+  }
+
+  /**
+   * Hook that will be called in case the Http server binding fails. Override this method if you want to perform some actions after the server binding failed.
+   */
+  protected def postHttpBindingFailure(cause: Throwable): Unit = {
+    systemReference.get().log.error(cause, s"Error starting the server ${cause.getMessage}")
+  }
+
+  /**
+   * Hook that lets the user specify the future that will signal the shutdown of the server whenever completed.
+   */
+  protected def waitForShutdownSignal(system: ActorSystem)(implicit ec: ExecutionContext): Future[Done] = {
+    Future {
+      StdIn.readLine("Press RETURN to stop...\n")
+      Done
+    }
+  }
+
+  /**
+   * Override to implement the route that will be served by this http server.
+   */
+  protected def route: Route
+
+}

--- a/docs/src/main/paradox/java/http/routing-dsl/HttpApp.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/HttpApp.md
@@ -1,0 +1,70 @@
+<a id="http-app"></a>
+# HttpApp Bootstrap
+
+@@@ warning { title="API may change" }
+This is experimental and the API is subjected to change in future releases of Akka HTTP.
+For further information about this marker, see [The @DoNotInherit and @ApiMayChange markers](http://doc.akka.io/docs/akka/current/common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers)
+in the Akka documentation.
+@@@
+
+@@toc { depth=1 }
+
+## Introduction
+
+The objective of `HttpApp` is to help you start an HTTP server with just a few lines of code.
+This is accomplished just by extending `HttpApp` and implementing the `route()` method.
+If desired, `HttpApp` provides different hook methods that can be overridden to change its default behavior.
+
+## Minimal Example
+
+The following example shows how to start a server:
+
+@@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #imports #minimal-routing-example }
+
+Firstly we define a `class` that extends `HttpApp` and we just implement the routes this server will handle.
+After that, we can start a server just by providing a `host`, `port` and `ServerProperties`. Calling `startServer` blocks the current thread until the server is signaled for termination.
+The default behavior of `HttpApp` is to start a server, and shut it down after `ENTER` is pressed. When the call to `startServer` returns the server is properly shut down.
+
+## Reacting to Bind Failures
+
+`HttpApp` provides different hooks that will be called after a successful and unsuccessful initialization. For example, the server
+might not start due to the port being already in use, or because it is a privileged one.
+
+Here you can see an example server that overrides the `postHttpBindingFailure` hook and prints the error to the console (this is also the default behavior)
+
+@@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #imports #bindingError }
+
+So if the port `80` would be already taken by another app, the call to `startServer` returns immediately and the `postHttpBindingFailure` hook will be called.
+
+## Providing your own Actor System
+
+`HttpApp` creates its own `ActorSystem` instance when one is not provided.
+In case you already created an `ActorSystem` in your application you can
+pass it to `startServer` as illustrated in the following example:
+
+@@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #imports #ownActorSystem }
+
+## Overriding Termination Signal
+
+As already described previously, the default trigger that shuts down the server is pressing `ENTER`.
+For simple examples this is sufficient, but for bigger applications this is, most probably, not what you want to do.
+`HttpApp` can be configured to signal the server termination just by overriding the method `waitForShutdownSignal`.
+This method must return a `CompletionStage` that, when terminated, will shutdown the server.
+
+This following example shows how to override the default termination signal:
+
+@@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #imports #selfClosing #serverTerminationSignal }
+
+Here the termination signal is defined by a future that will be automatically completed after 5 seconds. 
+
+## Getting Notified on Server Shutdown
+
+There are some cases in which you might want to clean up any resources you were using in your server. In order to do this
+in a coordinated way, you can override `HttpApp`'s `postServerShutdown` method.
+
+Here you can find an example:
+
+@@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #imports #postShutdown }
+
+The `postServerShutdown` method will be only called once the server attempt to shutdown has completed. Please notice that in
+the exception that this method is called with, may be null. It will be a non-null one only when `unbind` fails to stop the server.

--- a/docs/src/main/paradox/java/http/routing-dsl/index.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/index.md
@@ -20,8 +20,30 @@ To use the high-level API you need to add a dependency to the `akka-http` module
 * [source-streaming-support](source-streaming-support.md)
 * [rejections](rejections.md)
 * [testkit](testkit.md)
+* [http-app](HttpApp.md)
 
 @@@
+
+## Minimal Example
+
+This is a complete, very basic Akka HTTP application relying on the Routing DSL:
+
+@@snip [HttpServerMinimalExampleTest.java](../../../../../test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java) { #minimal-routing-example }
+
+It starts an HTTP Server on localhost and replies to GET requests to `/hello` with a simple response.
+
+@@@ warning { title="API may change" }
+The following example uses an experimental feature and its API is subjected to change in future releases of Akka HTTP.
+For further information about this marker, see @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers)
+in the Akka documentation.
+@@@
+
+To help start a server Akka HTTP provides an experimental helper class called `HttpApp`.
+This is the same example as before rewritten using `HttpApp`:
+
+@@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #minimal-routing-example }
+
+See @ref[HttpApp Bootstrap](HttpApp.md) for more details about setting up a server using this approach.
 
 ## Handling HTTP Server failures in the High-Level API
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/HttpApp.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/HttpApp.md
@@ -1,0 +1,70 @@
+<a id="http-app"></a>
+# HttpApp Bootstrap
+
+@@@ warning { title="API may change" }
+This is experimental and the API is subjected to change in future releases of Akka HTTP.
+For further information about this marker, see [The @DoNotInherit and @ApiMayChange markers](http://doc.akka.io/docs/akka/current/common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers)
+in the Akka documentation.
+@@@
+
+@@toc { depth=1 }
+
+## Introduction
+
+The objective of `HttpApp` is to help you start an HTTP server with just a few lines of code.
+This is accomplished just by extending `HttpApp` and implementing the `route()` method.
+If desired, `HttpApp` provides different hook methods that can be overridden to change its default behavior.
+
+## Minimal Example
+
+The following example shows how to start a server:
+
+@@snip [HttpAppExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala) { #minimal-routing-example }
+
+Firstly we define an `object` (it can also be a `class`) that extends `HttpApp` and we just implement the routes this server will handle.
+After that, we can start a server just by providing a `host`, `port` and `ServerProperties`. Calling `startServer` blocks the current thread until the server is signaled for termination.
+The default behavior of `HttpApp` is to start a server, and shut it down after `ENTER` is pressed. When the call to `startServer` returns the server is properly shut down.
+
+## Reacting to Bind Failures
+
+`HttpApp` provides different hooks that will be called after a successful and unsuccessful initialization. For example, the server
+might not start due to the port being already in use, or because it is a privileged one.
+
+Here you can see an example server that overrides the `postHttpBindingFailure` hook and prints the error to the console (this is also the default behavior)
+
+@@snip [HttpAppExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala) { #failed-binding-example }
+
+So if the port `80` would be already taken by another app, the call to `startServer` returns immediately and the `postHttpBindingFailure` hook will be called.
+
+## Providing your own Actor System
+
+`HttpApp` creates its own `ActorSystem` instance when one is not provided.
+In case you already created an `ActorSystem` in your application you can
+pass it to `startServer` as illustrated in the following example:
+ 
+@@snip [HttpAppExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala) { #with-actor-system }
+
+## Overriding Termination Signal
+
+As already described previously, the default trigger that shuts down the server is pressing `ENTER`.
+For simple examples this is sufficient, but for bigger applications this is, most probably, not what you want to do.
+`HttpApp` can be configured to signal the server termination just by overriding the method `waitForShutdownSignal`.
+This method must return a `Future` that, when terminated, will shutdown the server.
+
+This following example shows how to override the default termination signal:
+
+@@snip [HttpAppExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala) { #override-termination-signal }
+
+Here the termination signal is defined by a future that will be automatically completed after 5 seconds. 
+
+## Getting Notified on Server Shutdown
+
+There are some cases in which you might want to clean up any resources you were using in your server. In order to do this
+in a coordinated way, you can override `HttpApp`'s `postServerShutdown` method.
+
+Here you can find an example:
+
+@@snip [HttpAppExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala) { #cleanup-after-shutdown }
+
+The `postServerShutdown` method will be only called once the server attempt to shutdown has completed. Please notice that in
+the case that `unbind` fails to stop the server, this method will also be called with a failed `Try`.

--- a/docs/src/main/paradox/scala/http/routing-dsl/index.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/index.md
@@ -25,6 +25,7 @@ from a background with non-"streaming first" HTTP Servers.
 * [case-class-extraction](case-class-extraction.md)
 * [source-streaming-support](source-streaming-support.md)
 * [testkit](testkit.md)
+* [http-app](HttpApp.md)
 
 @@@
 
@@ -35,6 +36,19 @@ This is a complete, very basic Akka HTTP application relying on the Routing DSL:
 @@snip [HttpServerExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala) { #minimal-routing-example }
 
 It starts an HTTP Server on localhost and replies to GET requests to `/hello` with a simple response.
+
+@@@ warning { title="API may change" }
+The following example uses an experimental feature and its API is subjected to change in future releases of Akka HTTP.
+For further information about this marker, see @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers)
+in the Akka documentation.
+@@@
+
+To help start a server Akka HTTP provides an experimental helper class called `HttpApp`.
+This is the same example as before rewritten using `HttpApp`:
+
+@@snip [HttpAppExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala) { #minimal-routing-example }
+
+See @ref[HttpApp Bootstrap](HttpApp.md) for more details about setting up a server using this approach.
 
 <a id="long-example"></a>
 ## Longer Example

--- a/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
@@ -1,0 +1,178 @@
+package docs.http.javadsl.server;
+
+//#imports
+import akka.Done;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.server.HttpApp;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.settings.ServerSettings;
+import com.typesafe.config.ConfigFactory;
+//#imports
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+
+//#selfClosing
+import scala.concurrent.duration.Duration;
+import scala.runtime.BoxedUnit;
+//#selfClosing
+//#imports
+import java.util.Optional;
+import java.util.concurrent.*;
+//#imports
+//#selfClosing
+
+import static akka.pattern.PatternsCS.after;
+//#selfClosing
+
+
+/**
+ * Created by josep on 10/01/2017.
+ */
+public class HttpAppExampleTest extends JUnitSuite {
+
+  @Test
+  public void compileOnlySpec() throws Exception {
+    // just making sure for it to be really compiled / run even if empty
+  }
+
+  static
+  //#minimal-routing-example
+  //#ownActorSystem
+
+    // Server definition
+    class MinimalHttpApp extends HttpApp {
+      @Override
+      protected Route route() {
+        return path("hello", () ->
+          get(() ->
+            complete("<h1>Say hello to akka-http</h1>")
+          )
+        );
+      }
+    }
+
+  //#minimal-routing-example
+  //#ownActorSystem
+
+  void minimalServer() throws ExecutionException, InterruptedException {
+    //#minimal-routing-example
+    // Starting the server
+    final MinimalHttpApp myServer = new MinimalHttpApp();
+    myServer.startServer("localhost", 8080, ServerSettings.create(ConfigFactory.load()));
+    //#minimal-routing-example
+ }
+
+
+  static
+  //#serverTerminationSignal
+
+    // Server definition
+    class SelfDestroyingHttpApp extends HttpApp {
+
+      @Override
+      protected Route route() {
+        return path("hello", () ->
+          get(() ->
+              complete("<h1>Say hello to akka-http</h1>")
+          )
+        );
+      }
+
+      @Override
+      protected CompletionStage<Done> waitForShutdownSignal(ActorSystem system) {
+        return after(Duration.apply(5, TimeUnit.SECONDS),
+          system.scheduler(),
+          system.dispatcher().prepare(),
+          CompletableFuture.completedFuture(Done.getInstance()));
+      }
+    }
+
+  //#serverTerminationSignal
+
+  void selfDestroyingServer() throws ExecutionException, InterruptedException {
+    //#serverTerminationSignal
+    // Starting the server
+    final SelfDestroyingHttpApp myServer = new SelfDestroyingHttpApp();
+    myServer.startServer("localhost", 8080, ServerSettings.create(ConfigFactory.load()));
+    //#serverTerminationSignal
+  }
+
+
+  static
+  //#bindingError
+
+    // Server definition
+    class FailBindingOverrideHttpApp extends HttpApp {
+
+      @Override
+      protected Route route() {
+        return path("hello", () ->
+          get(() ->
+            complete("<h1>Say hello to akka-http</h1>")
+          )
+        );
+      }
+
+      @Override
+      protected void postHttpBindingFailure(Throwable cause) {
+        System.out.println("I can't bind!");
+      }
+    }
+
+  //#bindingError
+
+  void errorBinding() throws ExecutionException, InterruptedException {
+    //#bindingError
+    // Starting the server
+    final FailBindingOverrideHttpApp myServer = new FailBindingOverrideHttpApp();
+    myServer.startServer("localhost", 80, ServerSettings.create(ConfigFactory.load()));
+    //#bindingError
+  }
+
+  void ownActorSystem() throws ExecutionException, InterruptedException {
+    //#ownActorSystem
+    // Starting the server
+    ActorSystem system = ActorSystem.apply("myOwn");
+    new MinimalHttpApp().startServer("localhost", 8080, ServerSettings.create(system), system);
+    // ActorSystem is not terminated after server shutdown
+    // It must be manually terminated
+    system.terminate();
+    //#ownActorSystem
+  }
+
+
+  static
+  //#postShutdown
+
+    // Server definition
+    class PostShutdownOverrideHttpApp extends HttpApp {
+
+      @Override
+      protected Route route() {
+        return path("hello", () ->
+          get(() ->
+            complete("<h1>Say hello to akka-http</h1>")
+          )
+        );
+      }
+
+      private void cleanUpResources() {
+      }
+
+      @Override
+      protected void postServerShutdown(Optional<Throwable> failure, ActorSystem system) {
+        cleanUpResources();
+      }
+    }
+
+  //#postShutdown
+
+  void overridePostShutdown() throws ExecutionException, InterruptedException {
+    //#postShutdown
+    // Starting the server
+    ActorSystem system = ActorSystem.apply("myActorSystem");
+    new PostShutdownOverrideHttpApp().startServer("localhost", 8080, ServerSettings.create(system), system);
+    //#postShutdown
+  }
+
+}

--- a/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package docs.http.scaladsl
+
+import docs.CompileOnlySpec
+import org.scalatest.{ Matchers, WordSpec }
+
+class HttpAppExampleSpec extends WordSpec with Matchers
+  with CompileOnlySpec {
+
+  "minimal-routing-example" in compileOnlySpec {
+    //#minimal-routing-example
+    import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
+    import akka.http.scaladsl.server.Directives._
+    import akka.http.scaladsl.server.HttpApp
+    import akka.http.scaladsl.server.Route
+    import akka.http.scaladsl.settings.ServerSettings
+    import com.typesafe.config.ConfigFactory
+
+    // Server definition
+    object WebServer extends HttpApp {
+      def route: Route =
+        path("hello") {
+          get {
+            complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
+          }
+        }
+    }
+
+    // Starting the server
+    WebServer.startServer("localhost", 8080, ServerSettings(ConfigFactory.load))
+    //#minimal-routing-example
+  }
+
+  "failed-binding" in compileOnlySpec {
+    //#failed-binding-example
+    import akka.http.scaladsl.model._
+    import akka.http.scaladsl.server.Directives._
+    import akka.http.scaladsl.server.HttpApp
+    import akka.http.scaladsl.server.Route
+    import akka.http.scaladsl.settings.ServerSettings
+    import com.typesafe.config.ConfigFactory
+
+    // Server definition
+    object WebServer extends HttpApp {
+      def route: Route =
+        path("hello") {
+          get {
+            complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
+          }
+        }
+
+      override protected def postHttpBindingFailure(cause: Throwable): Unit = {
+        println(s"The server could not be started due to $cause")
+      }
+    }
+
+    // Starting the server
+    WebServer.startServer("localhost", 80, ServerSettings(ConfigFactory.load))
+    //#failed-binding-example
+  }
+
+  "minimal-routing-example self destroying in 5 seconds" in compileOnlySpec {
+    //#override-termination-signal
+    import akka.Done
+    import akka.actor.ActorSystem
+    import akka.http.scaladsl.model._
+    import akka.http.scaladsl.server.Directives._
+    import akka.http.scaladsl.server.HttpApp
+    import akka.pattern
+    import akka.http.scaladsl.server.Route
+    import akka.http.scaladsl.settings.ServerSettings
+    import com.typesafe.config.ConfigFactory
+    import scala.concurrent.duration._
+    import scala.concurrent.{ ExecutionContext, Future }
+    import scala.language.postfixOps
+
+    // Server definition
+    object WebServer extends HttpApp {
+      def route: Route =
+        path("hello") {
+          get {
+            complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
+          }
+        }
+
+      override def waitForShutdownSignal(actorSystem: ActorSystem)(implicit executionContext: ExecutionContext): Future[Done] = {
+        pattern.after(5 seconds, actorSystem.scheduler)(Future.successful(Done))
+      }
+    }
+
+    // Starting the server
+    WebServer.startServer("localhost", 8080, ServerSettings(ConfigFactory.load))
+    //#override-termination-signal
+  }
+
+  "webserver-as-providing-actor-system" in compileOnlySpec {
+    //#with-actor-system
+    import akka.actor.ActorSystem
+    import akka.http.scaladsl.model._
+    import akka.http.scaladsl.server.Directives._
+    import akka.http.scaladsl.server.HttpApp
+    import akka.http.scaladsl.server.Route
+    import akka.http.scaladsl.settings.ServerSettings
+
+    // Server definition
+    object WebServer extends HttpApp {
+      def route: Route =
+        path("hello") {
+          get {
+            complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
+          }
+        }
+    }
+
+    // Starting the server
+    val system = ActorSystem("ownActorSystem")
+    WebServer.startServer("localhost", 8080, ServerSettings(system), system)
+    system.terminate()
+    //#with-actor-system
+  }
+
+  "stopping-system-on-shutdown" in compileOnlySpec {
+    //#cleanup-after-shutdown
+    import akka.Done
+    import akka.actor.ActorSystem
+    import akka.http.scaladsl.model._
+    import akka.http.scaladsl.server.Directives._
+    import akka.http.scaladsl.server.HttpApp
+    import akka.http.scaladsl.server.Route
+    import akka.http.scaladsl.settings.ServerSettings
+    import scala.util.Try
+    import com.typesafe.config.ConfigFactory
+
+    // Server definition
+    class WebServer extends HttpApp {
+      def route: Route =
+        path("hello") {
+          get {
+            complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
+          }
+        }
+
+      private def cleanUpResources(): Unit = ???
+
+      override def postServerShutdown(attempt: Try[Done], system: ActorSystem): Unit = {
+        cleanUpResources()
+      }
+    }
+
+    // Starting the server
+    new WebServer().startServer("localhost", 8080, ServerSettings(ConfigFactory.load))
+    //#cleanup-after-shutdown
+  }
+
+}


### PR DESCRIPTION
Issue: #156
Add a bootstrap trait that does all the boilerplate for you. Just write as much as you need, not more.

I converted some of the examples under the docs project to Objects extending `HttpApp` to see how the trait works and how much code it saves.

Feedback and additional hooks proposal are highly welcomed!