### PR TITLE
handle too long entity via setting limitable on it

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -605,11 +605,13 @@ object HttpEntity {
           // "no limit"
           case Some(SizeLimit(bytes, cl @ Some(contentLength))) ⇒
             if (contentLength > bytes) throw EntityStreamSizeException(bytes, cl)
-          // else we still count but never throw an error
+            maxBytes = bytes
+            bytesLeft = bytes
           case Some(SizeLimit(bytes, None)) ⇒
             maxBytes = bytes
             bytesLeft = bytes
           case None ⇒
+          // else we still count but never throw an error
         }
       }
 
@@ -617,7 +619,7 @@ object HttpEntity {
         val elem = grab(in)
         bytesLeft -= sizeOf(elem)
         if (bytesLeft >= 0) push(out, elem)
-        else failStage(EntityStreamSizeException(maxBytes))
+        else failStage(EntityStreamSizeException(maxBytes, Some(maxBytes - bytesLeft)))
       }
 
       override def onPull(): Unit = {


### PR DESCRIPTION
I had this WIP outstanding, but actually not sure if it's the correct way we want to handle this (as in, if it's the right place).
Though on the other hand, we do the counting anyway in `Limitable` nowadays too.