### PR TITLE
Improve http client documentation

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -7,18 +7,18 @@ package docs.http.scaladsl
 import docs.CompileOnlySpec
 import org.scalatest.{ Matchers, WordSpec }
 
-import scala.concurrent.{ ExecutionContextExecutor, Future }
+import scala.concurrent.Future
 
 class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec {
 
   "manual-entity-consume-example-1" in compileOnlySpec {
     //#manual-entity-consume-example-1
     import java.io.File
+
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
-    import akka.stream.scaladsl.Framing
-    import akka.stream.scaladsl.FileIO
     import akka.http.scaladsl.model._
+    import akka.stream.ActorMaterializer
+    import akka.stream.scaladsl.{ FileIO, Framing }
     import akka.util.ByteString
 
     implicit val system = ActorSystem()
@@ -40,10 +40,11 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
   "manual-entity-consume-example-2" in compileOnlySpec {
     //#manual-entity-consume-example-2
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.model._
-    import scala.concurrent.duration._
+    import akka.stream.ActorMaterializer
     import akka.util.ByteString
+
+    import scala.concurrent.duration._
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
@@ -71,9 +72,9 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
   "manual-entity-discard-example-1" in compileOnlySpec {
     //#manual-entity-discard-example-1
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
-    import akka.http.scaladsl.model._
     import akka.http.scaladsl.model.HttpMessage.DiscardedEntity
+    import akka.http.scaladsl.model._
+    import akka.stream.ActorMaterializer
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
@@ -89,8 +90,8 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
   "manual-entity-discard-example-2" in compileOnlySpec {
     import akka.Done
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.model._
+    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.Sink
 
     implicit val system = ActorSystem()
@@ -181,12 +182,10 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
 
   "single-request-in-actor-example" in compileOnlySpec {
     //#single-request-in-actor-example
-    import akka.actor.ActorLogging
-    import akka.actor.Actor
+    import akka.actor.{ Actor, ActorLogging }
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
-    import akka.stream.ActorMaterializerSettings
+    import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
     import akka.util.ByteString
 
     class Myself extends Actor

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -4,13 +4,6 @@
 
 package docs.http.scaladsl
 
-import akka.Done
-import akka.actor.{ ActorLogging, ActorSystem }
-import akka.http.scaladsl.model.HttpEntity.Strict
-import akka.http.scaladsl.model.HttpMessage.DiscardedEntity
-import akka.stream.{ IOResult, Materializer }
-import akka.stream.scaladsl.{ Framing, Sink }
-import akka.util.ByteString
 import docs.CompileOnlySpec
 import org.scalatest.{ Matchers, WordSpec }
 
@@ -26,6 +19,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
     import akka.stream.scaladsl.Framing
     import akka.stream.scaladsl.FileIO
     import akka.http.scaladsl.model._
+    import akka.util.ByteString
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
@@ -45,11 +39,11 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
 
   "manual-entity-consume-example-2" in compileOnlySpec {
     //#manual-entity-consume-example-2
-    import java.io.File
     import akka.actor.ActorSystem
     import akka.stream.ActorMaterializer
     import akka.http.scaladsl.model._
     import scala.concurrent.duration._
+    import akka.util.ByteString
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
@@ -79,6 +73,7 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
     import akka.actor.ActorSystem
     import akka.stream.ActorMaterializer
     import akka.http.scaladsl.model._
+    import akka.http.scaladsl.model.HttpMessage.DiscardedEntity
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
@@ -92,9 +87,11 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
     //#manual-entity-discard-example-1
   }
   "manual-entity-discard-example-2" in compileOnlySpec {
+    import akka.Done
     import akka.actor.ActorSystem
     import akka.stream.ActorMaterializer
     import akka.http.scaladsl.model._
+    import akka.stream.scaladsl.Sink
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
@@ -184,11 +181,13 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
 
   "single-request-in-actor-example" in compileOnlySpec {
     //#single-request-in-actor-example
+    import akka.actor.ActorLogging
     import akka.actor.Actor
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
     import akka.stream.ActorMaterializer
     import akka.stream.ActorMaterializerSettings
+    import akka.util.ByteString
 
     class Myself extends Actor
       with ActorLogging {


### PR DESCRIPTION
Improves the examples by removing imports from the top of the file and explicitly importing inline within examples.

I'm happy to go through other parts of the documentation, just want to make sure I'm on the right track first!

cc @ktoso, per https://github.com/akka/akka-http/pull/487#issuecomment-258929762.