### PR TITLE
Scala docs reorg

### DIFF
--- a/docs/src/main/paradox/java/http/common/index.md
+++ b/docs/src/main/paradox/java/http/common/index.md
@@ -11,7 +11,6 @@ which are specific to one side only.
 
 @@@ index
 
-* [../http-model](../http-model.md)
 * [marshalling](marshalling.md)
 * [unmarshalling](unmarshalling.md)
 * [de-coding](de-coding.md)

--- a/docs/src/main/paradox/java/http/index.md
+++ b/docs/src/main/paradox/java/http/index.md
@@ -33,8 +33,8 @@ akka-http-jackson
 
 * [introduction](introduction.md)
 * [configuration](configuration.md)
-* [common/index](common/index.md)
 * [http-model](http-model.md)
+* [common/index](common/index.md)
 * [implications-of-streaming-http-entity](implications-of-streaming-http-entity.md)
 * [server-side/low-level-server-side-api](server-side/low-level-server-side-api.md)
 * [routing-dsl/index](routing-dsl/index.md)

--- a/docs/src/main/paradox/scala/http/common/index.md
+++ b/docs/src/main/paradox/scala/http/common/index.md
@@ -11,7 +11,6 @@ which are specific to one side only.
 
 @@@ index
 
-* [http-model](http-model.md)
 * [marshalling](marshalling.md)
 * [unmarshalling](unmarshalling.md)
 * [de-coding](de-coding.md)

--- a/docs/src/main/paradox/scala/http/index.md
+++ b/docs/src/main/paradox/scala/http/index.md
@@ -7,10 +7,12 @@
 
 * [introduction](introduction.md)
 * [configuration](configuration.md)
+* [http-model](common/http-model.md)
 * [common/index](common/index.md)
 * [implications-of-streaming-http-entity](implications-of-streaming-http-entity.md)
 * [low-level-server-side-api](low-level-server-side-api.md)
 * [routing-dsl/index](routing-dsl/index.md)
+* [websocket-support](websocket-support.md)
 * [client-side/index](client-side/index.md)
 * [server-side-https-support](server-side-https-support.md)
 * [handling-blocking-operations-in-akka-http-routes](handling-blocking-operations-in-akka-http-routes.md)

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/websocket-directives/handleWebSocketMessages.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/websocket-directives/handleWebSocketMessages.md
@@ -13,7 +13,7 @@ with the passed handler. Otherwise, the request is rejected with an `ExpectedWeb
 WebSocket subprotocols offered in the `Sec-WebSocket-Protocol` header of the request are ignored. If you want to
 support several protocols use the @ref[handleWebSocketMessagesForProtocol](handleWebSocketMessagesForProtocol.md#handlewebsocketmessagesforprotocol) directive, instead.
 
-For more information about the WebSocket support, see @ref[Server-Side WebSocket Support](../../websocket-support.md#server-side-websocket-support-scala).
+For more information about the WebSocket support, see @ref[Server-Side WebSocket Support](../../../websocket-support.md#server-side-websocket-support-scala).
 
 ## Example
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/websocket-directives/handleWebSocketMessagesForProtocol.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/websocket-directives/handleWebSocketMessagesForProtocol.md
@@ -18,7 +18,7 @@ either rejected with an `ExpectedWebSocketRequestRejection` or an `UnsupportedWe
 To support several subprotocols, for example at the same path, several instances of `handleWebSocketMessagesForProtocol` can
 be chained using `~` as you can see in the below example.
 
-For more information about the WebSocket support, see @ref[Server-Side WebSocket Support](../../websocket-support.md#server-side-websocket-support-scala).
+For more information about the WebSocket support, see @ref[Server-Side WebSocket Support](../../../websocket-support.md#server-side-websocket-support-scala).
 
 ## Example
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/index.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/index.md
@@ -25,7 +25,6 @@ from a background with non-"streaming first" HTTP Servers.
 * [case-class-extraction](case-class-extraction.md)
 * [source-streaming-support](source-streaming-support.md)
 * [testkit](testkit.md)
-* [websocket-support](websocket-support.md)
 
 @@@
 

--- a/docs/src/main/paradox/scala/http/websocket-support.md
+++ b/docs/src/main/paradox/scala/http/websocket-support.md
@@ -14,7 +14,7 @@ i.e. a sequence of octets or a text message, i.e. a sequence of Unicode code poi
 
 Akka HTTP provides a straight-forward model for this abstraction:
 
-@@snip [Message.scala](../../../../../../../akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala) { #message-model }
+@@snip [Message.scala](../../../../../../akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala) { #message-model }
 
 The data of a message is provided as a stream because WebSocket messages do not have a predefined size and could
 (in theory) be infinitely long. However, only one message can be open per direction of the WebSocket connection,
@@ -74,7 +74,7 @@ Let's look at an @github[example](/docs/src/test/scala/docs/http/scaladsl/server
 WebSocket requests come in like any other requests. In the example, requests to `/greeter` are expected to be
 WebSocket requests:
 
-@@snip [WebSocketExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala) { #websocket-request-handling }
+@@snip [WebSocketExampleSpec.scala](../../../../test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala) { #websocket-request-handling }
 
 It uses pattern matching on the path and then inspects the request to query for the `UpgradeToWebSocket` header. If
 such a header is found, it is used to generate a response by passing a handler for WebSocket messages to the
@@ -83,22 +83,22 @@ such a header is found, it is used to generate a response by passing a handler f
 The passed handler expects text messages where each message is expected to contain (a person's) name
 and then responds with another text message that contains a greeting:
 
-@@snip [WebSocketExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala) { #websocket-handler }
+@@snip [WebSocketExampleSpec.scala](../../../../test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala) { #websocket-handler }
 
 @@@ note
-Inactive WebSocket connections will be dropped according to the @ref[idle-timeout settings](../common/timeouts.md#idle-timeouts-scala).
+Inactive WebSocket connections will be dropped according to the @ref[idle-timeout settings](common/timeouts.md#idle-timeouts-scala).
 In case you need to keep inactive connections alive, you can either tweak your idle-timeout or inject
 'keep-alive' messages regularly.
 @@@
 
 ## Routing support
 
-The routing DSL provides the @ref[handleWebSocketMessages](directives/websocket-directives/handleWebSocketMessages.md#handlewebsocketmessages) directive to install a WebSocket handler if the request
+The routing DSL provides the @ref[handleWebSocketMessages](routing-dsl/directives/websocket-directives/handleWebSocketMessages.md#handlewebsocketmessages) directive to install a WebSocket handler if the request
 was a WebSocket request. Otherwise, the directive rejects the request.
 
 Here's the above simple request handler rewritten as a route:
 
-@@snip [WebSocketDirectivesExamplesSpec.scala](../../../../../test/scala/docs/http/scaladsl/server/directives/WebSocketDirectivesExamplesSpec.scala) { #greeter-service }
+@@snip [WebSocketDirectivesExamplesSpec.scala](../../../../test/scala/docs/http/scaladsl/server/directives/WebSocketDirectivesExamplesSpec.scala) { #greeter-service }
 
 The example also includes code demonstrating the testkit support for WebSocket services. It allows to create WebSocket
 requests to run against a route using *WS* which can be used to provide a mock WebSocket probe that allows manual


### PR DESCRIPTION
Issue: #465
Make Http Model entry a first level topic
Make server side Websocket Support a first level topic
Additionally, fixed the Java docs, Http Model was supposed to be first level topic but it wasn't shown as it also belogned to `commons/index.md`