### PR TITLE
Misc directives java examples

### DIFF
--- a/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/extractClientIP.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/extractClientIP.md
@@ -10,4 +10,4 @@ setting `akka.http.server.remote-address-header` is set to `on`. Per default it 
 
 ## Example
 
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: [write example snippets for Akka HTTP Java DSL #218](https://github.com/akka/akka-http/issues/218).
+@@snip [MiscDirectivesExamplesTest.java](../../../../../../../test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java) { #extractClientIPExample }

--- a/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/requestEntityEmpty.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/requestEntityEmpty.md
@@ -10,4 +10,4 @@ See also @ref[requestEntityPresent](requestEntityPresent.md#requestentitypresent
 
 ## Example
 
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: [write example snippets for Akka HTTP Java DSL #218](https://github.com/akka/akka-http/issues/218).
+@@snip [MiscDirectivesExamplesTest.java](../../../../../../../test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java) { #requestEntity-empty-present-example }

--- a/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/requestEntityPresent.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/requestEntityPresent.md
@@ -10,4 +10,4 @@ See also @ref[requestEntityEmpty](requestEntityEmpty.md#requestentityempty-java)
 
 ## Example
 
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: [write example snippets for Akka HTTP Java DSL #218](https://github.com/akka/akka-http/issues/218).
+@@snip [MiscDirectivesExamplesTest.java](../../../../../../../test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java) { #requestEntity-empty-present-example }

--- a/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/selectPreferredLanguage.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/selectPreferredLanguage.md
@@ -12,4 +12,4 @@ If there are several best language alternatives that the client has equal prefer
 
 ## Example
 
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: [write example snippets for Akka HTTP Java DSL #218](https://github.com/akka/akka-http/issues/218).
+@@snip [MiscDirectivesExamplesTest.java](../../../../../../../test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java) { #selectPreferredLanguage }

--- a/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/validate.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/validate.md
@@ -10,4 +10,4 @@ Otherwise, rejects the request with a `ValidationRejection` containing the given
 
 ## Example
 
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: [write example snippets for Akka HTTP Java DSL #218](https://github.com/akka/akka-http/issues/218).
+@@snip [MiscDirectivesExamplesTest.java](../../../../../../../test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java) { #validate-example }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -76,6 +76,7 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
         .orElseGet(() -> "unknown"))
     );
 
+    //tests:
     final String ip = "192.168.1.2";
     testRoute(route).run(HttpRequest.GET("/")
         .addHeader(RemoteAddress
@@ -96,6 +97,7 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
       complete("request entity present")
     ));
 
+    //tests:
     testRoute(route).run(HttpRequest.POST("/"))
       .assertEntity("request entity empty");
     testRoute(route).run(HttpRequest.POST("/").withEntity("foo"))
@@ -115,13 +117,15 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
         complete(lang.toString())
     );
 
+
+    //tests:
     final HttpRequest request = HttpRequest.GET("/").addHeader(AcceptLanguage.create(
       Language.create("en-US").withQValue(1f),
       Language.create("en").withQValue(0.7f),
       LanguageRanges.ALL.withQValue(0.1f),
       Language.create("de-DE").withQValue(0.5f)
     ));
-
+    
     testRoute(enRoute).run(request).assertEntity("en-US");
     testRoute(deHuRoute).run(request).assertEntity("de-DE");
     //#selectPreferredLanguage

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -3,15 +3,20 @@
  */
 package docs.http.javadsl.server.directives;
 
+import akka.http.javadsl.model.HttpHeader;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.model.headers.RemoteAddress;
 import akka.http.javadsl.server.Route;
 import akka.http.javadsl.unmarshalling.Unmarshaller;
 import akka.http.javadsl.testkit.JUnitRouteTest;
 import org.junit.Test;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class MiscDirectivesExamplesTest extends JUnitRouteTest {
 
@@ -59,6 +64,25 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
     testRoute(route).run(withEntityOfSize.apply(501))
       .assertStatusCode(StatusCodes.OK);
     //#withoutSizeLimitExample
+  }
+
+  @Test
+  public void testExtractClientIP() throws UnknownHostException {
+    //#extractClientIPExample
+    final Route route = extractClientIP(remoteAddr ->
+      complete("Client's IP is " + remoteAddr.getAddress().map(InetAddress::getHostAddress)
+        .orElseGet(() -> "unknown"))
+    );
+
+    final String ip = "192.168.1.2";
+    testRoute(route).run(HttpRequest.GET("/")
+        .addHeader(RemoteAddress
+          .create(akka.http.javadsl.model.RemoteAddress.create(InetAddress.getByName(ip)))))
+      .assertEntity("Client's IP is " + ip);
+
+    testRoute(route).run(HttpRequest.GET("/"))
+      .assertEntity("Client's IP is unknown");
+    //#extractClientIPExample
   }
 
 }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -3,26 +3,21 @@
  */
 package docs.http.javadsl.server.directives;
 
-import akka.http.impl.model.parser.AcceptLanguageHeader;
-import akka.http.javadsl.marshallers.jackson.Jackson;
-import akka.http.javadsl.model.HttpHeader;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.StatusCodes;
-import akka.http.javadsl.model.headers.*;
+import akka.http.javadsl.model.headers.AcceptLanguage;
+import akka.http.javadsl.model.headers.Language;
+import akka.http.javadsl.model.headers.LanguageRanges;
+import akka.http.javadsl.model.headers.RemoteAddress;
 import akka.http.javadsl.server.Route;
-import akka.http.javadsl.unmarshalling.Unmarshaller;
 import akka.http.javadsl.testkit.JUnitRouteTest;
-import jdk.nashorn.internal.runtime.FunctionInitializer;
+import akka.http.javadsl.unmarshalling.Unmarshaller;
 import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
-
-import static akka.http.javadsl.server.PathMatchers.*;
 
 
 public class MiscDirectivesExamplesTest extends JUnitRouteTest {
@@ -132,4 +127,20 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
     //#selectPreferredLanguage
   }
 
+  @Test
+  public void testValidate() {
+    //#validate-example
+    final Route route = extractUri(uri ->
+      validate(() -> uri.path().length() < 5,
+        "Path too long: " + uri.path(),
+        () -> complete("Full URI: " + uri.toString()))
+    );
+
+    //tests:
+    testRoute(route).run(HttpRequest.GET("/234"))
+      .assertEntity("Full URI: http://example.com/234");
+    testRoute(route).run(HttpRequest.GET("/abcdefghijkl"))
+      .assertEntity("Path too long: /abcdefghijkl");
+    //#validate-example
+  }
 }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -3,11 +3,12 @@
  */
 package docs.http.javadsl.server.directives;
 
+import akka.http.impl.model.parser.AcceptLanguageHeader;
 import akka.http.javadsl.marshallers.jackson.Jackson;
 import akka.http.javadsl.model.HttpHeader;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.StatusCodes;
-import akka.http.javadsl.model.headers.RemoteAddress;
+import akka.http.javadsl.model.headers.*;
 import akka.http.javadsl.server.Route;
 import akka.http.javadsl.unmarshalling.Unmarshaller;
 import akka.http.javadsl.testkit.JUnitRouteTest;
@@ -105,6 +106,30 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
     testRoute(route).run(HttpRequest.POST("/").withEntity("foo"))
       .assertEntity("request entity present");
     //#requestEntity-empty-present-example
+  }
+
+  @Test
+  public void testSelectPreferredLanguage() {
+    //#selectPreferredLanguage
+    final Route enRoute = selectPreferredLanguage(
+      Arrays.asList(Language.create("en"), Language.create("en-US")), lang ->
+        complete(lang.toString())
+    );
+    final Route deHuRoute = selectPreferredLanguage(
+      Arrays.asList(Language.create("de-DE"), Language.create("hu")), lang ->
+        complete(lang.toString())
+    );
+
+    final HttpRequest request = HttpRequest.GET("/").addHeader(AcceptLanguage.create(
+      Language.create("en-US").withQValue(1f),
+      Language.create("en").withQValue(0.7f),
+      LanguageRanges.ALL.withQValue(0.1f),
+      Language.create("de-DE").withQValue(0.5f)
+    ));
+
+    testRoute(enRoute).run(request).assertEntity("en-US");
+    testRoute(deHuRoute).run(request).assertEntity("de-DE");
+    //#selectPreferredLanguage
   }
 
 }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -3,6 +3,7 @@
  */
 package docs.http.javadsl.server.directives;
 
+import akka.http.javadsl.marshallers.jackson.Jackson;
 import akka.http.javadsl.model.HttpHeader;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.StatusCodes;
@@ -10,13 +11,18 @@ import akka.http.javadsl.model.headers.RemoteAddress;
 import akka.http.javadsl.server.Route;
 import akka.http.javadsl.unmarshalling.Unmarshaller;
 import akka.http.javadsl.testkit.JUnitRouteTest;
+import jdk.nashorn.internal.runtime.FunctionInitializer;
 import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import static akka.http.javadsl.server.PathMatchers.*;
+
 
 public class MiscDirectivesExamplesTest extends JUnitRouteTest {
 
@@ -83,6 +89,22 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
     testRoute(route).run(HttpRequest.GET("/"))
       .assertEntity("Client's IP is unknown");
     //#extractClientIPExample
+  }
+
+  @Test
+  public void testRequestEntityEmpty() {
+    //#requestEntity-empty-present-example
+    final Route route = requestEntityEmpty(() ->
+      complete("request entity empty")
+    ).orElse(requestEntityPresent(() ->
+      complete("request entity present")
+    ));
+
+    testRoute(route).run(HttpRequest.POST("/"))
+      .assertEntity("request entity empty");
+    testRoute(route).run(HttpRequest.POST("/").withEntity("foo"))
+      .assertEntity("request entity present");
+    //#requestEntity-empty-present-example
   }
 
 }


### PR DESCRIPTION
Issue: #218

Added Java Examples for `extractClientIP`, `requestEntityPresent`, `requestEntityEmpty`, `selectPreferredLanguage` and `validate`.

`rejectEmptyResponse` will come in separate PR.