### PR TITLE
Add rejectEmptyResponse example

### DIFF
--- a/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/rejectEmptyResponse.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/rejectEmptyResponse.md
@@ -5,10 +5,17 @@
 
 Replaces a response with no content with an empty rejection.
 
-The `rejectEmptyResponse` directive is mostly used with marshalling `Option[T]` instances. The value `None` is
-usually marshalled to an empty but successful result. In many cases `None` should instead be handled as
-`404 Not Found` which is the effect of using `rejectEmptyResponse`.
+The `rejectEmptyResponse` directive is can be used whenever responding with an empty `Entity` should be a rejection 
+instead of an `OK` response. One easy example where this can be used is when the entity is a `String` and the 
+empty `String` should be handled as `404 Not Found`.
+
+## Warning
+
+Java's `Optional<T>` does not behave like Scala's `Option[T]` as it's rendered as an own `Entity` instead of being 
+rendered according the parametrized `T` type, if present.
+
+This implies that, a non-empty `Optional` is rendered like `{"present":true}` and an empty one like `{"present":false}`.
 
 ## Example
 
-TODO: Example snippets for JavaDSL are subject to community contributions! Help us complete the docs, read more about it here: [write example snippets for Akka HTTP Java DSL #218](https://github.com/akka/akka-http/issues/218).
+@@snip [MiscDirectivesExamplesTest.java](../../../../../../../test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java) { #rejectEmptyResponse }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -3,15 +3,22 @@
  */
 package docs.http.javadsl.server.directives;
 
+import akka.http.javadsl.marshallers.jackson.Jackson;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.Route;
 import akka.http.javadsl.unmarshalling.Unmarshaller;
 import akka.http.javadsl.testkit.JUnitRouteTest;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Optional;
+import java.util.Optional;
 import java.util.function.Function;
+
+import static akka.http.javadsl.server.PathMatchers.integerSegment;
+import static akka.http.javadsl.server.PathMatchers.segment;
 
 public class MiscDirectivesExamplesTest extends JUnitRouteTest {
 
@@ -59,6 +66,57 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
     testRoute(route).run(withEntityOfSize.apply(501))
       .assertStatusCode(StatusCodes.OK);
     //#withoutSizeLimitExample
+  }
+
+    //#rejectEmptyResponse
+    private String explainIfEven(int i) {
+      if (i % 2 == 0) return "Number " + i + " is even";
+      else return "";
+    }
+
+    //#rejectEmptyResponse
+
+  @Test
+  public void testRejectEmptyResponse() {
+    //#rejectEmptyResponse
+    //This route responds with empty responses
+    final Route routeEmptyResponse = path(segment("even").slash(integerSegment()), (Integer i) ->
+      complete(explainIfEven(i))
+    );
+    //This route rejects when response is empty
+    final Route routeRejected = rejectEmptyResponse(() ->
+      path(segment("even").slash(integerSegment()), (Integer i) ->
+        complete(explainIfEven(i))
+      ));
+
+    //tests:
+    testRoute(routeEmptyResponse).run(HttpRequest.GET("/even/2"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("Number 2 is even");
+    testRoute(routeEmptyResponse).run(HttpRequest.GET("/even/1"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("");
+
+    testRoute(routeRejected).run(HttpRequest.GET("/even/2"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("Number 2 is even");
+    testRoute(routeRejected).run(HttpRequest.GET("/even/1"))
+      .assertStatusCode(StatusCodes.NOT_FOUND);
+    //#rejectEmptyResponse
+  }
+
+  @Test
+  @Ignore
+  public void foo() {
+
+    final Route route = path("foo", () -> completeOK(Optional.empty(), Jackson.marshaller()));
+    final Route route2 = rejectEmptyResponse(() -> path("/foo", () -> completeOK(Optional.empty(), Jackson.marshaller())));
+    final Route route3 = path("foo", () -> completeOK(Optional.of(3), Jackson.marshaller()));
+
+    testRoute(route).run(HttpRequest.GET("/foo")).assertEntity("");
+    testRoute(route2).run(HttpRequest.GET("/foo")).assertStatusCode(StatusCodes.NOT_FOUND);
+    testRoute(route3).run(HttpRequest.GET("/foo")).assertEntity("3");
+
   }
 
 }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -105,18 +105,4 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
     //#rejectEmptyResponse
   }
 
-  @Test
-  @Ignore
-  public void foo() {
-
-    final Route route = path("foo", () -> completeOK(Optional.empty(), Jackson.marshaller()));
-    final Route route2 = rejectEmptyResponse(() -> path("/foo", () -> completeOK(Optional.empty(), Jackson.marshaller())));
-    final Route route3 = path("foo", () -> completeOK(Optional.of(3), Jackson.marshaller()));
-
-    testRoute(route).run(HttpRequest.GET("/foo")).assertEntity("");
-    testRoute(route2).run(HttpRequest.GET("/foo")).assertStatusCode(StatusCodes.NOT_FOUND);
-    testRoute(route3).run(HttpRequest.GET("/foo")).assertEntity("3");
-
-  }
-
 }


### PR DESCRIPTION
Issue: #218 
Add example about `rejectEmptyResponse` for Java.
Add warning about completing a route with an Optional and its non expected output.