### PR TITLE
Update bintray package

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A chat room is available for all questions related to *developing and contributi
 Maintenance
 -----------
 
-This project is maintained by Lightbend's core Akka Team as well as the extended Akka HTTP Team, consisting of excellent and experienced developers who have shown their dedication and knowledge about HTTP and the codebase. This team may grow dynamically, and it is possible to propose new members to it. 
+This project is maintained by Lightbend's core Akka Team as well as the extended Akka HTTP Team, consisting of excellent and experienced developers who have shown their dedication and knowledge about HTTP and the codebase. This team may grow dynamically, and it is possible to propose new members to it.
 
 Joining the extended team in such form gives you, in addition to street-cred, of course committer rights to this repository as well as higher impact onto the roadmap of the project. Come and join us!
 

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -25,7 +25,7 @@ object Publish extends AutoPlugin {
 
   override def projectSettings = Seq(
     bintrayOrganization := Some("akka"),
-    bintrayPackage := "akka-http"
+    bintrayPackage := "com.typesafe.akka:akka-http_2.11"
   )
 }
 


### PR DESCRIPTION
Because this is the package name we got from bintray which is linked to JCenter and can not rename it.