### PR TITLE
Match path maps in order of longest matching key prefix (#394)

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.http.scaladsl.server.directives
 
+import scala.collection.immutable.ListMap
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
 import org.scalactic.source.Position
@@ -61,6 +62,73 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
     val test = testFor(path("") { echoUnmatchedPath })
     "reject [/foo]" inThe test()
     "accept [/] and clear the unmatchedPath" in test("")
+  }
+
+  """path(Map("a" → 1, "aa" → 2))""" should {
+    val test = testFor(path(Map("a" → 1, "aa" → 2)) { echoCaptureAndUnmatchedPath })
+    "accept [/a]" inThe test("1:")
+    "accept [/aa]" inThe test("2:")
+    "reject [/aaa]" inThe test()
+  }
+
+  """path(Map("sv_SE" → 3, "sv" → 1, "sv_FI" → 2))""" should {
+    val test = testFor(path(Map("sv_SE" → 3, "sv" → 1, "sv_FI" → 2)) { echoCaptureAndUnmatchedPath })
+    "accept [/sv]" inThe test("1:")
+    "accept [/sv_FI]" inThe test("2:")
+    "accept [/sv_SE]" inThe test("3:")
+    "reject [/sv_DK]" inThe test()
+  }
+
+  """path(Map("a" -> 1, "ab" -> 2, "ba" -> 3, "b" -> 4, "c" -> 5, "d" -> 6, "da" -> 7))""" should {
+    val test = testFor(path(Map("a" → 1, "ab" → 2, "ba" → 3, "b" → 4, "c" → 5, "d" → 6, "da" → 7)) { echoCaptureAndUnmatchedPath })
+    "accept [/a]" inThe test("1:")
+    "accept [/ab]" inThe test("2:") // FAIL
+    "accept [/ba]" inThe test("3:")
+    "accept [/b]" inThe test("4:")
+    "accept [/c]" inThe test("5:")
+    "accept [/d]" inThe test("6:")
+    "accept [/da]" inThe test("7:")
+    "reject [/e]" inThe test()
+    "reject [/ac]" inThe test()
+  }
+
+  """path(ListMap("a" -> 1, "ab" -> 2, "ba" -> 3, "b" -> 4, "c" -> 5, "d" -> 6, "da" -> 7))""" should {
+    val test = testFor(path(ListMap("a" → 1, "ab" → 2, "ba" → 3, "b" → 4, "c" → 5, "d" → 6, "da" → 7)) { echoCaptureAndUnmatchedPath })
+    "accept [/a]" inThe test("1:")
+    "accept [/ab]" inThe test("2:")
+    "accept [/ba]" inThe test("3:")
+    "accept [/b]" inThe test("4:")
+    "accept [/c]" inThe test("5:")
+    "accept [/d]" inThe test("6:")
+    "accept [/da]" inThe test("7:")
+    "reject [/e]" inThe test()
+    "reject [/ac]" inThe test()
+  }
+
+  """path(ListMap("a" -> 1, "aa" -> 2, "bb" -> 3, "b" -> 4, "c" -> 5, "d" -> 6, "dd" -> 7))""" should {
+    val test = testFor(path(ListMap("a" → 1, "aa" → 2, "bb" → 3, "b" → 4, "c" → 5, "d" → 6, "dd" → 7)) { echoCaptureAndUnmatchedPath })
+    "accept [/a]" inThe test("1:")
+    "accept [/aa]" inThe test("2:")
+    "accept [/bb]" inThe test("3:")
+    "accept [/b]" inThe test("4:")
+    "accept [/c]" inThe test("5:")
+    "accept [/d]" inThe test("6:")
+    "accept [/dd]" inThe test("7:")
+    "reject [/e]" inThe test()
+    "reject [/ac]" inThe test()
+  }
+
+  """path(Map("a" -> 1, "aa" -> 2, "bb" -> 3, "b" -> 4, "c" -> 5, "d" -> 6, "dd" -> 7))""" should {
+    val test = testFor(path(Map("a" → 1, "aa" → 2, "bb" → 3, "b" → 4, "c" → 5, "d" → 6, "dd" → 7)) { echoCaptureAndUnmatchedPath })
+    "accept [/a]" inThe test("1:")
+    "accept [/aa]" inThe test("2:")
+    "accept [/bb]" inThe test("3:")
+    "accept [/b]" inThe test("4:")
+    "accept [/c]" inThe test("5:")
+    "accept [/d]" inThe test("6:")
+    "accept [/dd]" inThe test("7:")
+    "reject [/e]" inThe test()
+    "reject [/ac]" inThe test()
   }
 
   """pathPrefix("foo")""" should {

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
@@ -289,12 +289,13 @@ trait ImplicitPathMatcherConstruction {
    * Creates a PathMatcher from the given Map of path segments (prefixes) to extracted values.
    * If the unmatched path starts with a segment having one of the maps keys as a prefix
    * the matcher consumes this path segment (prefix) and extracts the corresponding map value.
+   * For keys sharing a common prefix the longest matching prefix is selected.
    *
    * @group pathmatcherimpl
    */
   implicit def _valueMap2PathMatcher[T](valueMap: Map[String, T]): PathMatcher1[T] =
     if (valueMap.isEmpty) PathMatchers.nothingMatcher
-    else valueMap.map { case (prefix, value) ⇒ _stringExtractionPair2PathMatcher((prefix, value)) }.reduceLeft(_ | _)
+    else valueMap.toSeq.sortWith(_._1 > _._1).map(_stringExtractionPair2PathMatcher).reduceLeft(_ | _)
 }
 
 /**


### PR DESCRIPTION
Fixes #394 by ensuring order of the provided mappings instead of leaving it up to the undefined order provided by the map implementation.

It might be a bit overkill to include all of the test cases created by @gosubpl but I included them for completeness and to test with `ListMap`.