### PR TITLE
Update Akka Http version from 3.0 to 10.0 in misc places (Fixes #597)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ In case of questions about the contribution process or for discussion of specifi
 
 Depending on which version (or sometimes module) you want to work on, you should target a specific branch as explained below:
 
-* `master` – active development branch of akka-http 3.0-SNAPSHOT
+* `master` – active development branch of akka-http 10.0-SNAPSHOT
 
 ## Tags
 

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
@@ -53,7 +53,7 @@ public interface HttpEntity {
      * @deprecated Will be removed in Akka 3.x, use {@link HttpEntities#EMPTY} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 3.0
+    // FIXME: Remove in Akka 10.0
     HttpEntity.Strict EMPTY = HttpEntities.EMPTY;
 
     /**

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethod.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethod.java
@@ -50,6 +50,6 @@ public abstract class HttpMethod {
     /**
      * Java API: Returns the entity acceptance level for this method.
      */
-    // TODO: Rename it to requestEntityAcceptance() in Akka 3.0
+    // TODO: Rename it to requestEntityAcceptance() in Akka 10.0
     public abstract akka.http.javadsl.model.RequestEntityAcceptance getRequestEntityAcceptance();
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethods.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethods.java
@@ -37,7 +37,7 @@ public final class HttpMethods {
     /**
      * Create a custom method type.
      */
-    // TODO: Rename it to custom() in Akka 3.0
+    // TODO: Rename it to custom() in Akka 10.0
     public static HttpMethod createCustom(String value, boolean safe, boolean idempotent, akka.http.javadsl.model.RequestEntityAcceptance requestEntityAcceptance) {
         //This cast is safe as implementation of RequestEntityAcceptance only exists in Scala
         akka.http.scaladsl.model.RequestEntityAcceptance scalaRequestEntityAcceptance

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
@@ -37,6 +37,6 @@ public abstract class RemoteAddress {
      *             Will be removed in Akka 3.x, use {@link RemoteAddresses#UNKNOWN} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 3.0
+    // FIXME: Remove in Akka 10.0
     public static final RemoteAddress UNKNOWN = RemoteAddresses.UNKNOWN;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRange.java
@@ -20,6 +20,6 @@ public abstract class EntityTagRange {
      *             Will be removed in Akka 3.x, use {@link EntityTagRanges#ALL} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 3.0
+    // FIXME: Remove in Akka 10.0
     public static final EntityTagRange ALL = EntityTagRanges.ALL;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRange.java
@@ -25,6 +25,6 @@ public abstract class HttpEncodingRange {
      *             Will be removed in Akka 3.x, use {@link HttpEncodingRanges#ALL} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 3.0
+    // FIXME: Remove in Akka 10.0
     public static final HttpEncodingRange ALL = HttpEncodingRanges.ALL;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
@@ -23,6 +23,6 @@ public abstract class HttpOriginRange {
    * Will be removed in Akka 3.x, use {@link HttpEncodingRanges#ALL} instead.
    */
   @Deprecated
-  // FIXME: Remove in Akka 3.0
+  // FIXME: Remove in Akka 10.0
   public static final HttpOriginRange ALL = HttpOriginRanges.ALL;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LanguageRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LanguageRange.java
@@ -17,6 +17,6 @@ public interface LanguageRange {
      *             Will be removed in Akka 3.x, use {@link LanguageRanges#ALL} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 3.0
+    // FIXME: Remove in Akka 10.0
     public static final LanguageRange ALL = LanguageRanges.ALL;
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -67,7 +67,7 @@ sealed trait Multipart extends jm.Multipart {
   @deprecated(
     message = "This variant of `toEntity` is not supported any more. The charset parameter will be ignored. " +
     "Please use the variant without specifying the charset.",
-    since = "3.0.0")
+    since = "10.0.0")
   def toEntity(
     charset:  HttpCharset = HttpCharsets.`UTF-8`,
     boundary: String      = BodyPartRenderer.randomBoundary())(implicit log: LoggingAdapter = DefaultNoLogging): MessageEntity =
@@ -114,7 +114,7 @@ sealed trait Multipart extends jm.Multipart {
   @deprecated(
     message = "This variant of `toEntity` is not supported any more. The charset parameter will be ignored. " +
     "Please use the variant without specifying the charset.",
-    since = "3.0.0")
+    since = "10.0.0")
   def toEntity(charset: jm.HttpCharset, boundary: String): jm.RequestEntity =
     toEntity(boundary)
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpChallenge.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpChallenge.scala
@@ -23,7 +23,7 @@ final case class HttpChallenge(scheme: String, realm: String,
   def getParams: util.Map[String, String] = params.asJava
 }
 
-// FIXME: AbstractFunction3 required for bin compat. remove in Akka 3.0 and change realm in case class to option #20786
+// FIXME: AbstractFunction3 required for bin compat. remove in Akka 10.0 and change realm in case class to option #20786
 object HttpChallenge extends scala.runtime.AbstractFunction3[String, String, Map[String, String], HttpChallenge] {
 
   def apply(scheme: String, realm: Option[String]): HttpChallenge =

--- a/docs/src/main/paradox/java/http/migration-guide/index.md
+++ b/docs/src/main/paradox/java/http/migration-guide/index.md
@@ -6,6 +6,6 @@
 @@@ index
 
 * [migration-from-old-http-javadsl](migration-from-old-http-javadsl.md)
-* [migration-guide-2.4.x-3.0.x](migration-guide-2.4.x-3.0.x.md)
+* [migration-guide-2.4.x-10.0.x](migration-guide-2.4.x-10.0.x.md)
 
 @@@

--- a/docs/src/main/paradox/java/http/migration-guide/migration-guide-2.4.x-10.0.x.md
+++ b/docs/src/main/paradox/java/http/migration-guide/migration-guide-2.4.x-10.0.x.md
@@ -1,4 +1,4 @@
-# Migration Guide between Akka HTTP 2.4.x and 3.0.x
+# Migration Guide between Akka HTTP 2.4.x and 10.0.x
 
 ## General notes
 

--- a/docs/src/main/paradox/scala/http/migration-guide/index.md
+++ b/docs/src/main/paradox/scala/http/migration-guide/index.md
@@ -6,6 +6,6 @@
 @@@ index
 
 * [migration-from-spray](migration-from-spray.md)
-* [migration-guide-2.4.x-3.0.x](migration-guide-2.4.x-3.0.x.md)
+* [migration-guide-2.4.x-10.0.x](migration-guide-2.4.x-10.0.x.md)
 
 @@@

--- a/docs/src/main/paradox/scala/http/migration-guide/migration-guide-2.4.x-10.0.x.md
+++ b/docs/src/main/paradox/scala/http/migration-guide/migration-guide-2.4.x-10.0.x.md
@@ -1,4 +1,4 @@
-# Migration Guide between Akka HTTP 2.4.x and 3.0.x
+# Migration Guide between Akka HTTP 2.4.x and 10.0.x
 
 ## General notes
 


### PR DESCRIPTION
Refs #597 

* java/http/migration-guide/index.md
* scala/http/migration-guide/index.md

are important to fix paradox generation failure.

#### TODO, FIXME

As 10.0.0 already out, when do we work on these FIXMEs and TODOs? To be fixed in 11.0? 

If we fix them immediately, I added some of them (e.g. HttpMethods.java) before, so I can easily fix those in separate PRs.