### PR TITLE
`actor-interaction` example should now run

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -509,15 +509,9 @@ class HttpServerExampleSpec extends WordSpec with Matchers
     //#stream-random-numbers
   }
 
-
-  object Auction {
-    import akka.actor.Props
-    def props: Props = ???
-  }
-
   "interact with an actor" in compileOnlySpec {
     //#actor-interaction
-    import akka.actor.ActorSystem
+    import akka.actor.{Actor, ActorSystem, Props}
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.StatusCodes
     import akka.http.scaladsl.server.Directives._
@@ -535,6 +529,13 @@ class HttpServerExampleSpec extends WordSpec with Matchers
       case object GetBids
       case class Bids(bids: List[Bid])
 
+      class Auction extends Actor {
+        def receive = {
+          case Bid(userId, bid) => println(s"Bid complete: $userId, $bid")
+          case _ => println("Invalid message")
+        }
+      }
+
       // these are from spray-json
       implicit val bidFormat = jsonFormat2(Bid)
       implicit val bidsFormat = jsonFormat1(Bids)
@@ -545,7 +546,7 @@ class HttpServerExampleSpec extends WordSpec with Matchers
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
-        val auction = system.actorOf(Auction.props, "auction")
+        val auction = system.actorOf(Props[Auction], "auction")
 
         val route =
           path("auction") {


### PR DESCRIPTION
The actor interaction example in the Introduction page of the Scala docs doesn't actually compile or even run. 

Firstly, the Auction actor itself is not defined. A companion object was written, but was mistakenly put outside of the test's scope. I defined a simple Auction actor that, upon receiving a `Bid`, prints a message to stdout. If it receives any other message, it prints "Invalid message".

Secondly, `Props` is used incorrectly - it's assuming there is a companion object - and some imports are missing. I fixed both of these issues as well.