### PR TITLE
WIP: Add test to detect undocumented directives

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/UndocumentedDirectivesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/UndocumentedDirectivesSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.scaladsl.server.directives
+
+import java.io.File
+import org.scalatest.WordSpec
+import scala.meta._
+
+class UndocumentedDirectivesSpec extends WordSpec {
+  val SourceDir = new File("akka-http/src/main/scala/akka/http/scaladsl/server/directives")
+  val ParadoxDir = new File("docs/src/main/paradox/scala/http/routing-dsl/directives")
+
+  SourceDir.listFiles.foreach { file =>
+    val traitName = file.getName.replace(".scala", "")
+    val dirName = traitName.replaceAll("(.)([A-Z])", "$1-$2").toLowerCase
+
+    s"$traitName has all directives documented" in {
+      val documented = documentedDirectives(dirName)
+      val undocumented = directivesInTrait(traitName).filterNot(documented)
+
+      assert(undocumented.isEmpty)
+    }
+  }
+
+  def documentedDirectives(dirName: String): Set[String] = {
+    val mdFiles = Option(new File(ParadoxDir, dirName).listFiles).getOrElse(Array())
+    mdFiles.map(_.getName.replace(".md", "")).filter("index".!=).toSet
+  }
+
+  def directivesInTrait(traitName: String): Set[String] = {
+    val file = new File(SourceDir, traitName + ".scala")
+    val source = file.parse[Source].get
+
+    def fromTrait(tree: Tree): Boolean = {
+      val grandParentIsTrait = for {
+        parent <- tree.parent if parent.is[Template]
+        grandParent <- parent.parent
+      } yield grandParent match {
+        case Defn.Trait(_, name, _, _, _) => name.value == traitName
+        case _                            => false
+      }
+
+      grandParentIsTrait.getOrElse(false)
+    }
+
+    val directives = source.collect {
+      case tree @ q"def $name[..$paramTypes](..$args): $restype = $body" if fromTrait(tree) ⇒
+        name.value
+
+      case tree @ q"def $name[..$paramTypes]: $restype = $body" if fromTrait(tree) ⇒
+        name.value
+    }
+
+    directives.toSet
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,8 +59,9 @@ object Dependencies {
     val alpnApi     = "org.eclipse.jetty.alpn"        % "alpn-api"                     % "1.1.3.v20160715" // ApacheV2
 
     object Docs {
-      val sprayJson   = "io.spray"                   %%  "spray-json"                  % "1.3.2"             % "test"
+      val sprayJson   = "io.spray"                   %% "spray-json"                   % "1.3.2"             % "test"
       val gson        = "com.google.code.gson"        % "gson"                         % "2.3.1"             % "test"
+      val scalaMeta   = "org.scalameta"              %% "scalameta"                    % "1.3.0"             % "test" // BSD-3
     }
 
     object Test {
@@ -156,7 +157,7 @@ object Dependencies {
 
   lazy val httpJackson = l ++= Seq(jackson)
 
-  lazy val docs = l ++= Seq(Docs.sprayJson, Docs.gson)
+  lazy val docs = l ++= Seq(Docs.sprayJson, Docs.gson, Docs.scalaMeta)
 
 }
 


### PR DESCRIPTION
Based on exploration done as part of #11, this uses scala.meta to detect undocumented directives by listing Paradox files and comparing with methods extracted from each trait. The test currently fails as expected as there are 9 undocumented Scala directives.

I am curious if this is useful as an interim solution until we manage to move docs to the traits?

```
[info] UndocumentedDirectivesSpec:
[info] - BasicDirectives has all directives documented *** FAILED ***
[info]   Set("extractParserSettings") was not empty (UndocumentedDirectivesSpec.scala:23)
[info] - CacheConditionDirectives has all directives documented
[info] - CodingDirectives has all directives documented *** FAILED ***
[info]   Set("withPrecompressedMediaTypeSupport") was not empty (UndocumentedDirectivesSpec.scala:23)
[info] - CookieDirectives has all directives documented
[info] - DebuggingDirectives has all directives documented
[info] - ExecutionDirectives has all directives documented
[info] - FileAndResourceDirectives has all directives documented
[info] - FileUploadDirectives has all directives documented
[info] - FormFieldDirectives has all directives documented
[info] - FramedEntityStreamingDirectives has all directives documented
[info] - FutureDirectives has all directives documented
[info] - HeaderDirectives has all directives documented
[info] - HostDirectives has all directives documented
[info] - MarshallingDirectives has all directives documented *** FAILED ***
[info]   Set("as", "instanceOf") was not empty (UndocumentedDirectivesSpec.scala:23)
[info] - MethodDirectives has all directives documented
[info] - MiscDirectives has all directives documented
[info] - ParameterDirectives has all directives documented
[info] - PathDirectives has all directives documented
[info] - RangeDirectives has all directives documented
[info] - RespondWithDirectives has all directives documented
[info] - RouteDirectives has all directives documented
[info] - SchemeDirectives has all directives documented
[info] - SecurityDirectives has all directives documented
[info] - TimeoutDirectives has all directives documented
[info] - WebSocketDirectives has all directives documented *** FAILED ***
[info]   Set("extractUpgradeToWebSocket", "extractOfferedWsProtocols", "handleWebSocketMessages", "handleWebSocketMessagesForOptionalProtocol", "handleWebSocketMessagesForProtocol") was not empty (UndocumentedDirectivesSpec.scala:23)
[info] ScalaTest
[info] Run completed in 1 second, 510 milliseconds.
[info] Total number of tests run: 25
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 21, failed 4, canceled 0, ignored 0, pending 0
[info] *** 4 TESTS FAILED ***
```