### PR TITLE
=htc #616 replace OutputTruncationException for the http client use case

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -412,7 +412,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
         info.summary shouldEqual "HTTP message had declared Content-Length 8 but entity data stream amounts to 2 bytes less"
         netInSub.sendComplete()
         responsesSub.request(1)
-        responses.expectError(One2OneBidiFlow.OutputTruncationException)
+        responses.expectError().getMessage shouldBe "The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests"
       }
 
       "catch the request entity stream being longer than the Content-Length" in new TestSetup {
@@ -438,7 +438,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
         info.summary shouldEqual "HTTP message had declared Content-Length 8 but entity data stream amounts to more bytes"
         netInSub.sendComplete()
         responsesSub.request(1)
-        responses.expectError(One2OneBidiFlow.OutputTruncationException)
+        responses.expectError().getMessage shouldBe "The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests"
       }
 
       "catch illegal response starts" in new TestSetup {

--- a/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
@@ -62,8 +62,8 @@ class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
 
       flowOutProbe.sendComplete()
       upstreamProbe.expectCancellation()
-      flowInProbe.expectError(One2OneBidiFlow.OutputTruncationException)
-      downstreamProbe.expectError(One2OneBidiFlow.OutputTruncationException)
+      flowInProbe.expectError(One2OneBidiFlow.OutputTruncationException(1))
+      downstreamProbe.expectError(One2OneBidiFlow.OutputTruncationException(1))
     }
 
     "trigger an `UnexpectedOutputException` if the wrapped stream produces out-of-order elements" in assertAllStagesStopped {
@@ -76,7 +76,7 @@ class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
 
         outOut.request(1)
         outIn.sendNext(3)
-        outOut.expectError(new One2OneBidiFlow.UnexpectedOutputException(3))
+        outOut.expectError(One2OneBidiFlow.UnexpectedOutputException(3))
       }
     }
 


### PR DESCRIPTION
We will now send an `UnexpectedConnectionClosureException` which more
closely explains the problem at hand.

Also, the error is reported with `failStage` instead of throwing which
prevents the noisy logging.

Fixes #616.