### PR TITLE
Improve the server-side log message when default-host-header is not set

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -336,7 +336,9 @@ object HttpRequest {
     val hostHeader: OptionVal[Host] = findHost(headers)
     if (uri.isRelative) {
       def fail(detail: String) =
-        throw IllegalUriException(s"Cannot establish effective URI of request to `$uri`, request has a relative URI and $detail")
+        throw IllegalUriException(
+          s"Cannot establish effective URI of request to `$uri`, request has a relative URI and $detail; " +
+            "consider setting `akka.http.server.default-host-header`")
       val Host(host, port) = hostHeader match {
         case OptionVal.None                 ⇒ if (defaultHostHeader.isEmpty) fail("is missing a `Host` header") else defaultHostHeader
         case OptionVal.Some(x) if x.isEmpty ⇒ if (defaultHostHeader.isEmpty) fail("an empty `Host` header") else defaultHostHeader


### PR DESCRIPTION
When the server receives a request it will try to reconstruct the
effective request URI as defined in HTTP/1.1 [1]. Requests using
HTTP/1.0 will use the same code path but since the `Host` header is not
required in HTTP/1.0 Akka HTTP requires that a default `Host` header
value is configured in `akka.http.server.default-host-header`. In
addition to the documentation in `reference.conf` make this more clear
by also hinting to the setting in the error log as discussed in #596.

 [1]: https://tools.ietf.org/html/rfc7230#section-5.5