### PR TITLE
Add a way to transform a Source<BodyPart, Object> to a FormData object in Java

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Multiparts.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Multiparts.java
@@ -3,6 +3,7 @@
  */
 package akka.http.javadsl.model;
 
+import akka.stream.javadsl.Source;
 import scala.collection.immutable.List;
 import scala.collection.immutable.Nil$;
 
@@ -24,6 +25,13 @@ public final class Multiparts {
      */
     public static Multipart.FormData createFormDataFromParts(Multipart.FormData.BodyPart... parts) {
         return akka.http.scaladsl.model.Multipart.FormData$.MODULE$.createNonStrict(convertArray(parts));
+    }
+    /**
+     * Constructor for `multipart/form-data` content as defined in http://tools.ietf.org/html/rfc2388.
+     * All parts must have distinct names. (This is not verified!)
+     */
+    public static Multipart.FormData createFormDataFromSourceParts(Source<Multipart.FormData.BodyPart, Object> parts) {
+        return akka.http.scaladsl.model.Multipart.FormData$.MODULE$.createSource(parts.asScala());
     }
 
     /**

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -391,9 +391,7 @@ object Multipart {
     }
     /** INTERNAL API */
     private[akka] def createSource(parts: Source[akka.http.javadsl.model.Multipart.FormData.BodyPart, Any]): Multipart.FormData = {
-      apply(parts.map {
-        case bp: Multipart.FormData.BodyPart ⇒ bp
-      })
+      apply(parts.asInstanceOf[Source[Multipart.FormData.BodyPart, Any]])
     }
 
     def apply(fields: Map[String, HttpEntity.Strict]): Multipart.FormData.Strict = Multipart.FormData.Strict {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -389,6 +389,12 @@ object Multipart {
     private[akka] def createStrict(fields: Map[String, akka.http.javadsl.model.HttpEntity.Strict]): Multipart.FormData.Strict = Multipart.FormData.Strict {
       fields.map { case (name, entity: akka.http.scaladsl.model.HttpEntity.Strict) ⇒ Multipart.FormData.BodyPart.Strict(name, entity) }(collection.breakOut)
     }
+    /** INTERNAL API */
+    private[akka] def createSource(parts: Source[akka.http.javadsl.model.Multipart.FormData.BodyPart, Any]): Multipart.FormData = {
+      apply(parts.map {
+        case bp: Multipart.FormData.BodyPart ⇒ bp
+      })
+    }
 
     def apply(fields: Map[String, HttpEntity.Strict]): Multipart.FormData.Strict = Multipart.FormData.Strict {
       fields.map { case (name, entity) ⇒ Multipart.FormData.BodyPart.Strict(name, entity) }(collection.breakOut)

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
@@ -13,6 +13,7 @@ import scala.concurrent.duration._
 import org.scalatest.{ BeforeAndAfterAll, Inside, Matchers, WordSpec }
 import akka.stream.ActorMaterializer
 import akka.actor.ActorSystem
+import akka.stream.javadsl.Source
 import akka.testkit.TestKit
 
 import scala.compat.java8.FutureConverters
@@ -34,6 +35,16 @@ class MultipartsSpec extends WordSpec with Matchers with Inside with BeforeAndAf
       val strictCS = streamed.toStrict(1000, materializer)
       val strict = Await.result(FutureConverters.toScala(strictCS), 1.second)
 
+      strict shouldEqual akka.http.scaladsl.model.Multipart.FormData(
+        Map("foo" → akka.http.scaladsl.model.HttpEntity("FOO"), "bar" → akka.http.scaladsl.model.HttpEntity("BAR")))
+    }
+    "create a model from Multiparts.createFormDataFromSourceParts" in {
+      val streamed = Multiparts.createFormDataFromSourceParts(Source.from(util.Arrays.asList(
+        Multiparts.createFormDataBodyPart("foo", HttpEntities.create("FOO")),
+        Multiparts.createFormDataBodyPart("bar", HttpEntities.create("BAR"))
+      )))
+      val strictCS = streamed.toStrict(1000, materializer)
+      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second)
       strict shouldEqual akka.http.scaladsl.model.Multipart.FormData(
         Map("foo" → akka.http.scaladsl.model.HttpEntity("FOO"), "bar" → akka.http.scaladsl.model.HttpEntity("BAR")))
     }


### PR DESCRIPTION
java doesn't allow to cast:
```
akka.http.scaladsl.model.Multipart.FormData.BodyPart bp = (akka.http.scaladsl.model.Multipart.FormData.BodyPart)Multiparts.createFormDataBodyPartStrict("", HttpEntities.create(""));
```

java says it's ambigous, so it's impossible to call `akka.http.scaladsl.model.Multipart.FormData.apply(Source.single(bp));`


