### PR TITLE
Docs. Change snippet id to not start with a number

### DIFF
--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extract.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extract.md
@@ -15,4 +15,4 @@ See @ref[Providing Values to Inner Routes](index.md#providedirectives) for an ov
 
 ## Example
 
-@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #0extract }
+@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #extract0 }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractLog.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/extractLog.md
@@ -16,4 +16,4 @@ See @ref[extract](extract.md#extract) and @ref[Providing Values to Inner Routes]
 
 ## Example
 
-@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #0extractLog }
+@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #extract0Log }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRequest.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRequest.md
@@ -18,4 +18,4 @@ See @ref[Request Transforming Directives](index.md#request-transforming-directiv
 
 ## Example
 
-@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #0mapRequest }
+@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #mapRequest0 }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapResponse.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapResponse.md
@@ -15,8 +15,8 @@ See also @ref[mapResponseHeaders](mapResponseHeaders.md#mapresponseheaders) or @
 
 ## Example: Override status
 
-@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #0mapResponse }
+@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #mapResponse0 }
 
 ## Example: Default to empty JSON response on errors
 
-@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #1mapResponse-advanced }
+@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #mapResponse1-advanced }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResult.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/mapRouteResult.md
@@ -16,4 +16,4 @@ See @ref[Result Transformation Directives](index.md#result-transformation-direct
 
 ## Example
 
-@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #0mapRouteResult }
+@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #mapRouteResult0 }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/provide.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/provide.md
@@ -16,4 +16,4 @@ See @ref[Providing Values to Inner Routes](index.md#providedirectives) for an ov
 
 ## Example
 
-@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #0provide }
+@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #provide0 }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withLog.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/basic-directives/withLog.md
@@ -14,4 +14,4 @@ or used by directives which internally extract the materializer without surfacin
 
 ## Example
 
-@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #0withLog }
+@@snip [BasicDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala) { #withLog0 }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authorize.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authorize.md
@@ -28,4 +28,4 @@ See also @ref[Authentication vs. Authorization](index.md#authentication-vs-autho
 
 ## Example
 
-@@snip [SecurityDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala) { #0authorize-0 }
+@@snip [SecurityDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala) { #authorize0-0 }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authorizeAsync.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/authorizeAsync.md
@@ -28,4 +28,4 @@ See also @ref[Authentication vs. Authorization](index.md#authentication-vs-autho
 
 ## Example
 
-@@snip [SecurityDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala) { #0authorizeAsync }
+@@snip [SecurityDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala) { #authorizeAsync0 }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/extractCredentials.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/security-directives/extractCredentials.md
@@ -14,4 +14,4 @@ See @ref[Credentials and password timing attacks](index.md#credentials-and-timin
 
 ## Example
 
-@@snip [SecurityDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala) { #0extractCredentials }
+@@snip [SecurityDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala) { #extractCredentials0 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
@@ -23,7 +23,7 @@ import scala.util.control.NonFatal
 
 class BasicDirectivesExamplesSpec extends RoutingSpec {
   "0extract" in {
-    //#0extract
+    //#extract0
     val uriLength = extract(_.request.uri.toString.length)
     val route =
       uriLength { len =>
@@ -34,10 +34,10 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     Get("/abcdef") ~> route ~> check {
       responseAs[String] shouldEqual "The length of the request URI is 25"
     }
-    //#0extract
+    //#extract0
   }
   "0extractLog" in {
-    //#0extractLog
+    //#extract0Log
     val route =
       extractLog { log =>
         log.debug("I'm logging things in much detail..!")
@@ -48,7 +48,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     Get("/abcdef") ~> route ~> check {
       responseAs[String] shouldEqual "It's amazing!"
     }
-    //#0extractLog
+    //#extract0Log
   }
   "withMaterializer-0" in {
     //#withMaterializer-0
@@ -152,7 +152,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     //#extractExecutionContext-0
   }
   "0withLog" in {
-    //#0withLog
+    //#withLog0
     val special = Logging(system, "SpecialRoutes")
 
     def sample() =
@@ -180,7 +180,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     Get("/special/sample") ~> route ~> check {
       responseAs[String] shouldEqual s"Logging using $special!"
     }
-    //#0withLog
+    //#withLog0
   }
   "withSettings-0" in compileOnlySpec {
     //#withSettings-0
@@ -245,7 +245,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     //#tprovide
   }
   "0mapResponse" in {
-    //#0mapResponse
+    //#mapResponse0
     def overwriteResultStatus(response: HttpResponse): HttpResponse =
       response.copy(status = StatusCodes.BadGateway)
     val route = mapResponse(overwriteResultStatus)(complete("abc"))
@@ -254,10 +254,10 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     Get("/abcdef?ghi=12") ~> route ~> check {
       status shouldEqual StatusCodes.BadGateway
     }
-    //#0mapResponse
+    //#mapResponse0
   }
   "1mapResponse-advanced-json" in {
-    //#1mapResponse-advanced
+    //#mapResponse1-advanced
     trait ApiRoutes {
       protected def system: ActorSystem
 
@@ -277,7 +277,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
       def apiRoute(innerRoutes: => Route): Route =
         mapResponse(nonSuccessToEmptyJsonEntity)(innerRoutes)
     }
-    //#1mapResponse-advanced
+    //#mapResponse1-advanced
 
     import StatusCodes._
     val __system = system
@@ -286,7 +286,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     }
     import routes.apiRoute
 
-    //#1mapResponse-advanced
+    //#mapResponse1-advanced
     val route: Route =
       apiRoute {
         get {
@@ -298,7 +298,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     Get("/") ~> route ~> check {
       responseAs[String] shouldEqual "{}"
     }
-    //#1mapResponse-advanced
+    //#mapResponse1-advanced
   }
   "mapRouteResult" in {
     //#mapRouteResult
@@ -500,7 +500,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     //#recoverRejectionsWith
   }
   "0mapRequest" in {
-    //#0mapRequest
+    //#mapRequest0
     def transformToPostRequest(req: HttpRequest): HttpRequest = req.copy(method = HttpMethods.POST)
     val route =
       mapRequest(transformToPostRequest) {
@@ -512,7 +512,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     Get("/") ~> route ~> check {
       responseAs[String] shouldEqual "The request method was POST"
     }
-    //#0mapRequest
+    //#mapRequest0
   }
   "mapRequestContext" in {
     //#mapRequestContext
@@ -533,7 +533,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     //#mapRequestContext
   }
   "0mapRouteResult" in {
-    //#0mapRouteResult
+    //#mapRouteResult0
     val rejectAll = // not particularly useful directive
       mapRouteResult {
         case _ => Rejected(List(AuthorizationFailedRejection))
@@ -547,7 +547,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     Get("/") ~> route ~> check {
       rejections.nonEmpty shouldEqual true
     }
-    //#0mapRouteResult
+    //#mapRouteResult0
   }
   "mapRouteResultPF" in {
     //#mapRouteResultPF
@@ -615,7 +615,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     //#pass
   }
   "0provide" in {
-    //#0provide
+    //#provide0
     def providePrefixedString(value: String): Directive1[String] = provide("prefix:" + value)
     val route =
       providePrefixedString("test") { value =>
@@ -626,7 +626,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec {
     Get("/") ~> route ~> check {
       responseAs[String] shouldEqual "prefix:test"
     }
-    //#0provide
+    //#provide0
   }
   "cancelRejections-filter-example" in {
     //#cancelRejections-filter-example

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
@@ -230,7 +230,7 @@ class SecurityDirectivesExamplesSpec extends RoutingSpec {
   }
 
   "0authorize-0" in {
-    //#0authorize-0
+    //#authorize0-0
     case class User(name: String)
 
     // authenticate the user:
@@ -269,11 +269,11 @@ class SecurityDirectivesExamplesSpec extends RoutingSpec {
       route ~> check {
         responseAs[String] shouldEqual "'Peter' visited Peter's lair"
       }
-    //#0authorize-0
+    //#authorize0-0
   }
 
   "0authorizeAsync" in {
-    //#0authorizeAsync
+    //#authorizeAsync0
     case class User(name: String)
 
     // authenticate the user:
@@ -313,11 +313,11 @@ class SecurityDirectivesExamplesSpec extends RoutingSpec {
       route ~> check {
         responseAs[String] shouldEqual "'Peter' visited Peter's lair"
       }
-    //#0authorizeAsync
+    //#authorizeAsync0
   }
 
   "0extractCredentials" in {
-    //#0extractCredentials
+    //#extractCredentials0
     val route =
       extractCredentials { creds =>
         complete {
@@ -338,6 +338,6 @@ class SecurityDirectivesExamplesSpec extends RoutingSpec {
     Get("/") ~> route ~> check {
       responseAs[String] shouldEqual "No credentials"
     }
-    //#0extractCredentials
+    //#extractCredentials0
   }
 }


### PR DESCRIPTION
Issue: #636
Paradox doesn't seem to support snippets whose id starts with a number.
Change id format for offending ones.