### PR TITLE
Add Composing directives java (#620)

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ComposingDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ComposingDirectivesTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.http.javadsl.server.directives;
+
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import akka.http.javadsl.testkit.TestRoute;
+import org.junit.Test;
+
+import static akka.http.javadsl.server.Directives.*;
+import static akka.http.javadsl.common.PartialApplication.*;
+
+public class ComposingDirectivesTest extends JUnitRouteTest {
+
+  @Test
+  public void testAnyOf0Arg() {
+    TestRoute getOrPost = testRoute(path("hello", () ->
+      anyOf(this::get, this::post, () ->
+        complete("hi"))));
+
+    getOrPost
+      .run(HttpRequest.GET("/hello"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("hi");
+
+    getOrPost
+      .run(HttpRequest.POST("/hello"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("hi");
+
+    getOrPost
+      .run(HttpRequest.PUT("/hello"))
+      .assertStatusCode(StatusCodes.METHOD_NOT_ALLOWED);
+  }
+
+  @Test
+  public void testAnyOf1Arg() {
+    TestRoute someParam = testRoute(path("param", () ->
+      anyOf(bindParameter(this::parameter, "foo"), bindParameter(this::parameter, "bar"), (String param) -> complete("param is " + param)))
+    );
+
+    someParam
+      .run(HttpRequest.GET("/param?foo=foz"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("param is foz");
+
+    someParam
+      .run(HttpRequest.GET("/param?bar=baz"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("param is baz");
+
+    someParam
+      .run(HttpRequest.GET("/param?charlie=alice"))
+      .assertStatusCode(StatusCodes.NOT_FOUND);
+  }
+
+  @Test
+  public void testAllOf0Arg() {
+    TestRoute charlie = testRoute(allOf(
+      bindParameter(this::pathPrefix, "alice"),
+      bindParameter(this::path, "bob"),
+      () -> complete("Charlie!")));
+
+    charlie.run(HttpRequest.GET("/alice/bob"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("Charlie!");
+
+    charlie.run(HttpRequest.GET("/alice"))
+      .assertStatusCode(StatusCodes.NOT_FOUND);
+
+    charlie.run(HttpRequest.GET("/bob"))
+      .assertStatusCode(StatusCodes.NOT_FOUND);
+  }
+
+  @Test
+  public void testAllOf1Arg() {
+    TestRoute extractTwo = testRoute(path("extractTwo", () ->
+      allOf(this::extractScheme, this::extractMethod, (scheme, method) -> complete("You did a " + method.name() + " using " + scheme))
+    ));
+
+    extractTwo
+      .run(HttpRequest.GET("/extractTwo"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("You did a GET using http");
+
+    extractTwo
+      .run(HttpRequest.PUT("/extractTwo"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("You did a PUT using http");
+  }
+
+  @Test
+  public void testAllOf0And1Arg() {
+    TestRoute route = testRoute(allOf(bindParameter(this::pathPrefix, "guess"), this::extractMethod, method -> complete("You did a " + method.name())));
+
+    route
+      .run(HttpRequest.GET("/guess"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("You did a GET");
+
+    route
+      .run(HttpRequest.POST("/guess"))
+      .assertStatusCode(StatusCodes.OK)
+      .assertEntity("You did a POST");
+  }
+
+}

--- a/akka-http/src/main/scala/akka/http/javadsl/common/PartialApplication.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/common/PartialApplication.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.http.javadsl.common
+
+import java.util.function.{BiFunction, Function}
+
+/**
+  * Contains helpful methods to partially apply Functions for Java
+  */
+object PartialApplication {
+
+  /**
+   * It partially applies function A. In other words, it converts a 2 argument function to a 1 argument function by binding the first argument to {@code a}.
+   * Here you can see an example:
+   * <pre>
+   * {@code BiFunction<Int, Int, Int> adder = (x, y) -> x + y;
+   *   Function<Int, Int> add5 = bindParameter(adder, 5);
+   *   add5(1);
+   * }
+   * </pre>
+   * @param f the function to partially apply
+   * @param a the first parameter to partially apply
+   * @tparam A the type of the applied parameter
+   * @tparam B the type of the second parameter
+   * @tparam R the type of the return
+   * @return the function partially applied
+   */
+  // @akka.annotation.ApiMayChange // FIXME use the real ones once Akka dependency bumped
+  def bindParameter[A, B, R](f: BiFunction[A, B, R], a: A): Function[B, R] = {
+    new Function[B, R] {
+      override def apply(b: B): R = f.apply(a, b)
+    }
+  }
+
+}

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
@@ -1,8 +1,10 @@
 /*
- * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
  */
 
 package akka.http.javadsl.server
+
+import java.util.function.{ BiFunction, Function, Supplier }
 
 import akka.http.impl.util.JavaMapping
 import akka.http.javadsl.server.directives.{ FramedEntityStreamingDirectives, TimeoutDirectives }
@@ -26,4 +28,96 @@ object Directives extends AllDirectives {
 
   @varargs override def getFromBrowseableDirectories(directories: String*): Route =
     super.getFromBrowseableDirectories(directories: _*)
+
+  /**
+   * Composes two 0-argument directives which share the same inner Route. This is equivalent to
+   * `first(inner).orElse(second(inner))`
+   * Usage example:
+   * `anyOf(this::get, this::post, () -> complete("hi")))`
+   * @param first the first 0-argument directive
+   * @param second the second 0-argument directive
+   * @param inner the inner route Producer
+   * @return the resulting route
+   */
+  // @akka.annotation.ApiMayChange // FIXME use the real ones once Akka dependency bumped
+  def anyOf(first: Function[Supplier[Route], Route], second: Function[Supplier[Route], Route], inner: Supplier[Route]): Route = {
+    first.apply(inner).orElse(second.apply(inner))
+  }
+
+  /**
+   * Composes two 1-argument directives (directives whose inner route takes a parameter) which share the same inner route.
+   * This is the same as `first(inner).orElse(second(inner))`.
+   * This can be used also for directives that take an additional parameter if the directive is partially applied, ie. parameter
+   * Usage example:
+   * `anyOf(bindParameter(this::path, "bar"), bindParameter(this::path, "baz"), () -> complete("bar or baz"))`
+   * @param first the first 1-argument directive
+   * @param second the second 1-argument directive
+   * @param inner the inner route that takes one argument
+   * @tparam A the type of the parameter the directives extract and the inner route takes
+   * @return the resulting route
+   */
+  // @akka.annotation.ApiMayChange // FIXME use the real ones once Akka dependency bumped
+  def anyOf[A](first: Function[Function[A, Route], Route], second: Function[Function[A, Route], Route], inner: Function[A, Route]): Route = {
+    first.apply(inner).orElse(second.apply(inner))
+  }
+
+  /**
+   * Nests two 0-argument directives together
+   * Usage example:
+   * `allOf(bindParameter(this::pathPrefix, "alice"), bindParameter(this::path, "bob"), () -> complete("Charlie!"))`
+   * @param first the 0-argument directive (outer one)
+   * @param second the 0-argument directive (inner one)
+   * @param inner the inner route function
+   * @return the resulting route
+   */
+  // @akka.annotation.ApiMayChange // FIXME use the real ones once Akka dependency bumped
+  def allOf(first: Function[Supplier[Route], Route], second: Function[Supplier[Route], Route], inner: Supplier[Route]): Route = {
+    first.apply(new Supplier[Route] {
+      override def get(): Route =
+        second.apply(inner)
+    })
+  }
+
+  /**
+   * Nests two 1-argument directives together
+   * Usage example:
+   * `allOf(this::extractScheme, this::extractMethod, (scheme, method) -> complete("You did a " + method.name() + " using " + scheme))`
+   * @param first the first 1-argument directive (outer one)
+   * @param second the second 1-argument directive (inner one)
+   * @param inner the inner route function that takes 2 different parameters
+   * @tparam A the type extracted from the first directive
+   * @tparam B the type extracted from the second directive
+   * @return the resulting route
+   */
+  // @akka.annotation.ApiMayChange // FIXME use the real ones once Akka dependency bumped
+  def allOf[A, B](first: Function[Function[A, Route], Route], second: Function[Function[B, Route], Route], inner: BiFunction[A, B, Route]): Route = {
+    first.apply(new Function[A, Route] {
+      override def apply(a: A): Route =
+        second.apply(new Function[B, Route] {
+          override def apply(b: B): Route =
+            inner.apply(a, b)
+        })
+    })
+  }
+
+  /**
+   * Nests one 0-argument and 1-argument directives together
+   * Usage example:
+   * `allOf(bindParameter(this::pathPrefix, "guess"), this::extractMethod, method -> complete("You did a " + method.name()))`
+   * @param first the 0-argument directive (outer one)
+   * @param second the 1-argument directive (inner one)
+   * @param inner the inner route function that takes 1 parameter
+   * @tparam A the type extracted from the second directive
+   * @return the resulting route
+   */
+  // @akka.annotation.ApiMayChange // FIXME use the real ones once Akka dependency bumped
+  def allOf[A](first: Function[Supplier[Route], Route], second: Function[Function[A, Route], Route], inner: Function[A, Route]): Route = {
+    first.apply(new Supplier[Route] {
+      override def get(): Route =
+        second.apply(new Function[A, Route] {
+          override def apply(a: A): Route =
+            inner.apply(a)
+        })
+    })
+  }
 }

--- a/docs/src/main/paradox/java/http/routing-dsl/directives/index.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/index.md
@@ -96,11 +96,23 @@ serves as the inner route of the `path` directive. Let's rewrite it in the follo
 
 In this previous example, we combined the `get` and `put` directives into one composed directive and extracted it to its own method, which could be reused anywhere else in our code.
 
+Instead of extracting the composed directives to its own method, we can also use the available `anyOf` combinator. The following code is equivalent to the previous one:
+
+@@snip [DirectiveExamplesTest.java](../../../../../../test/java/docs/http/javadsl/server/DirectiveExamplesTest.java) { #getOrPutUsingAnyOf }
+
+The previous example, tries to complete the route first with a `GET` or with a `PUT` if the first one was rejected. 
+
 In case you are constantly nesting the same directives several times in you code, you could factor them out in their own method and use it everywhere:
 
 @@snip [DirectiveExamplesTest.java](../../../../../../test/java/docs/http/javadsl/server/DirectiveExamplesTest.java) { #composeNesting }
 
-Here we simple created our own combined directive that accepts either `GET` or `PUT` requests, then extracts the method and completes it with an inner route that takes this HTTP method as a parameter.
+Here we simple created our own combined directive that accepts `GET` requests, then extracts the method and completes it with an inner route that takes this HTTP method as a parameter.
+
+Again, instead of extracting own combined directives to its own method, we can make use of the `allOf` combinator. The following code is equivalent to the previous one:
+
+@@snip [DirectiveExamplesTest.java](../../../../../../test/java/docs/http/javadsl/server/DirectiveExamplesTest.java) { #composeNestingAllOf }
+
+In this previous example, the the inner route function provided to `allOf` will be called when the request is a `GET` and with the extracted client IP obtained from the second directive.
 
 As you have already seen in the previous section, you can also use the `route` method defined in `RouteDirectives` as an alternative to `orElse` chaining. Here you can see the first example again, rewritten using `route`:
 
@@ -118,3 +130,41 @@ is in fact the most readable one.
 
 Still, the purpose of the exercise presented here is to show you how flexible directives can be and how you can
 use their power to define your web service behavior at the level of abstraction that is right for **your** application.
+
+## Type Safety of Directives
+
+When you combine directives with `anyOf` and `allOf` methods the routing DSL makes sure that all extractions work as
+expected and logical constraints are enforced at compile-time.
+
+For example you cannot call `anyOf`  with a directive producing an extraction with one that doesn't:
+
+```java
+anyOf(this::get, this::extractClientIP, routeProvider) // doesn't compile
+```
+
+Also the number of extractions and their types have to match up:
+
+```java
+anyOf(this::extractClientIP, this::extractMethod, routeProvider) // doesn't compile
+anyOf(bindParameter(this::parameter, "foo"), bindParameter(this::parameter, "bar"), routeProvider) // ok
+```
+In this previous example we make use of the `bindParameter` function located in `akka-http/akka.http.javadsl.common.PartialApplication`.
+In order to be able to call `anyOf`, we need to convert our directive that takes 2 parameters to a function that takes only 1.
+In this particular case we want to use the `parameter` directive that takes a `String` and a function from `String` to `Route`,
+so to be able to use it in combination with `anyOf`, we need to bind the first parameter to `foo` and to `bar` in the second one. `bindParameter(this::parameter, "foo")` is equivalent 
+to define your own function like this:
+```java
+Route parameterFoo(Function<String, Route> inner) {
+  return parameter("foo", inner);
+}
+```
+
+When you combine directives producing extractions with the `allOf` method all extractions will be properly gathered up:
+
+```java
+allOf(this::extractScheme, this::extractMethod, (scheme, method) -> ...) 
+```
+
+Directives offer a great way of constructing your web service logic from small building blocks in a plug and play
+fashion while maintaining DRYness and full type-safety. If the large range of @ref[Predefined Directives](alphabetically.md#predefined-directives) does not
+fully satisfy your needs you can also easily create @ref[Custom Directives](custom-directives.md#custom-directives).

--- a/docs/src/test/java/docs/http/javadsl/ComposeDirectivesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/ComposeDirectivesExampleTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package docs.http.javadsl;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.PathMatcher1;
+import akka.http.javadsl.server.Route;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Flow;
+
+import static akka.http.javadsl.common.PartialApplication.*;
+import static akka.http.javadsl.server.PathMatchers.*;
+import static akka.http.javadsl.server.Directives.*;
+
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class ComposeDirectivesExampleTest extends AllDirectives {
+
+  public static void main(String[] args) throws Exception {
+    // boot up server using the route as defined below
+    ActorSystem system = ActorSystem.create("routes");
+
+    final Http http = Http.get(system);
+    final ActorMaterializer materializer = ActorMaterializer.create(system);
+
+    //In order to access all directives we need an instance where the routes are define.
+    ComposeDirectivesExampleTest app = new ComposeDirectivesExampleTest();
+
+    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
+    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
+        ConnectHttp.toHost("localhost", 8080), materializer);
+
+    System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
+    System.in.read(); // let it run until user presses return
+
+    binding
+        .thenCompose(ServerBinding::unbind) // trigger unbinding from the port
+        .thenAccept(unbound -> system.terminate()); // and shutdown when done
+  }
+
+  private Route createRoute() {
+    BiFunction<PathMatcher1<Integer>, Function<Integer,Route>, Route> pathWithInteger = this::path;
+
+    return route(
+      //anyOf examples
+      path("hello", () ->
+        anyOf(this::get, this::put, () ->
+          complete("<h1>Say hello to akka-http</h1>"))),
+      path("foo", () ->
+        anyOf(bindParameter(this::parameter, "foo"), bindParameter(this::parameter, "bar"), (String param) ->
+          complete("param is " + param))
+      ),
+      anyOf(bindParameter(this::path, "bar"), bindParameter(this::path, "baz"), () ->
+        complete("bar - baz")),
+
+      //allOf examples
+      allOf(bindParameter(this::pathPrefix, "alice"), bindParameter(this::path, "bob"), () ->
+        complete("Charlie!")),
+      allOf(bindParameter(this::pathPrefix, "guess"), this::extractMethod, method ->
+        complete("You did a " + method.name())),
+      path("two", () ->
+        allOf(this::extractScheme, this::extractMethod, (scheme, method) ->
+          complete("You did a " + method.name() + " using " + scheme))
+      ),
+      allOf(bindParameter(this::pathPrefix, "number"), bindParameter(pathWithInteger, integerSegment()), x ->
+        complete("Number is " + x))
+    );
+  }
+}


### PR DESCRIPTION
Issue: #620
Add composing capabilities for the Java DSL.
* `anyOf` is the equivalent of Scala's `|`
* `allOf` is the equivalent of Scala's `&`