### PR TITLE
+htp #673 allow mapping rejection handled responses

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
@@ -3,10 +3,9 @@
  */
 package akka.http.scaladsl.server
 
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 import scala.collection.JavaConverters._
 
-class RejectionSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
+class RejectionSpec extends RoutingSpec {
 
   "The Transformation Rejection" should {
 
@@ -21,4 +20,41 @@ class RejectionSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
       result should ===(rejections)
     }
   }
+
+  "RejectionHandler" should {
+    import akka.http.scaladsl.model._
+
+    implicit def myRejectionHandler =
+      RejectionHandler.default
+        .mapRejectionResponse {
+          case res @ HttpResponse(_, _, ent: HttpEntity.Strict, _) ⇒
+            val message = ent.data.utf8String.replaceAll("\"", """\"""")
+            res.copy(entity = HttpEntity(ContentTypes.`application/json`, s"""{"rejection": "$message"}"""))
+
+          case x ⇒ x // pass through all other types of responses
+        }
+
+    val route =
+      Route.seal(
+        path("hello") {
+          complete("Hello there")
+        }
+      )
+
+    "mapResponse must not affect normal responses" in {
+      Get("/hello") ~> route ~> check {
+        status should ===(StatusCodes.OK)
+        contentType should ===(ContentTypes.`text/plain(UTF-8)`)
+        responseAs[String] should ===("""Hello there""")
+      }
+    }
+    "mapResponse should alter rejection response" in {
+      Get("/nope") ~> route ~> check {
+        status should ===(StatusCodes.NotFound)
+        contentType should ===(ContentTypes.`application/json`)
+        responseAs[String] should ===("""{"rejection": "The requested resource could not be found."}""")
+      }
+    }
+  }
+
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
@@ -41,14 +41,14 @@ class RejectionSpec extends RoutingSpec {
         }
       )
 
-    "mapResponse must not affect normal responses" in {
+    "mapRejectionResponse must not affect normal responses" in {
       Get("/hello") ~> route ~> check {
         status should ===(StatusCodes.OK)
         contentType should ===(ContentTypes.`text/plain(UTF-8)`)
         responseAs[String] should ===("""Hello there""")
       }
     }
-    "mapResponse should alter rejection response" in {
+    "mapRejectionResponse should alter rejection response" in {
       Get("/nope") ~> route ~> check {
         status should ===(StatusCodes.NotFound)
         contentType should ===(ContentTypes.`application/json`)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -15,8 +15,10 @@ import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.common.EntityStreamingSupport
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.io.StdIn
+import scala.util.Failure
 
 object TestServer extends App {
   val testConf: Config = ConfigFactory.parseString("""

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -15,10 +15,8 @@ import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.common.EntityStreamingSupport
 
-import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.io.StdIn
-import scala.util.Failure
 
 object TestServer extends App {
   val testConf: Config = ConfigFactory.parseString("""

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -28,7 +28,7 @@ trait RejectionHandler extends (immutable.Seq[Rejection] ⇒ Option[Route]) { se
           isDefault = false)
 
       case other ⇒
-        throw new IllegalArgumentException("Can only mapRejectionResult on BuiltRejectionHandler " +
+        throw new IllegalArgumentException("Can only mapRejectionResponse on BuiltRejectionHandler " +
           s"(e.g. obtained by calling `.result()` on the `RejectionHandler` builder). Type was: ${other.getClass}")
     }
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -19,7 +19,7 @@ trait RejectionHandler extends (immutable.Seq[Rejection] ⇒ Option[Route]) { se
   import RejectionHandler._
 
   /** Map any HTTP response which was returned by this RejectionHandler to a different one before rendering it. */
-  def mapRejectionResponse(map: HttpResponse ⇒ HttpResponse)(implicit ec: ExecutionContext): RejectionHandler = {
+  def mapRejectionResponse(map: HttpResponse ⇒ HttpResponse): RejectionHandler = {
     this match {
       case a: BuiltRejectionHandler ⇒
         new BuiltRejectionHandler(
@@ -108,10 +108,10 @@ object RejectionHandler {
   }
 
   private sealed abstract class Handler {
-    def mapResponse(map: HttpResponse ⇒ HttpResponse)(implicit ec: ExecutionContext): Handler
+    def mapResponse(map: HttpResponse ⇒ HttpResponse): Handler
   }
   private final case class CaseHandler(pf: PartialFunction[Rejection, Route]) extends Handler {
-    override def mapResponse(map: HttpResponse ⇒ HttpResponse)(implicit ec: ExecutionContext): CaseHandler = {
+    override def mapResponse(map: HttpResponse ⇒ HttpResponse): CaseHandler = {
       copy(pf.andThen(route ⇒ BasicDirectives.mapResponse(map)(route)))
     }
   }
@@ -120,7 +120,7 @@ object RejectionHandler {
     def isDefinedAt(rejection: Rejection): Boolean = runtimeClass isInstance rejection
     def apply(rejection: Rejection): T = rejection.asInstanceOf[T]
 
-    override def mapResponse(map: HttpResponse ⇒ HttpResponse)(implicit ec: ExecutionContext): TypeHandler[T] = {
+    override def mapResponse(map: HttpResponse ⇒ HttpResponse): TypeHandler[T] = {
       copy(f = f.andThen(route ⇒ BasicDirectives.mapResponse(map)(route)))
     }
   }

--- a/docs/src/main/paradox/scala/http/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/rejections.md
@@ -119,3 +119,17 @@ all cases your handler doesn't handle itself) and used for all rejections that a
 itself.
 
 The second case allows you to restrict the applicability of your handler to certain branches of your route structure.
+
+### Customising rejection HTTP Responses
+
+It is also possible to customise just the responses that are returned by a defined rejection handler.
+This can be useful for example if you like the rejection messages and status codes of the default handler,
+however you'd like to wrap those responses in JSON or some other content type.
+
+Please note that since those are not 200 responses, a different content type than the one that was sent in
+a client's ``Accept`` header *is* legal. Thus the default handler renders such rejections as ``text/plain``.
+
+In order to customise the HTTP Responses of an existing handler you can call the 
+``mapRejectionResponse`` method on such handler as shown in the example below:
+
+@@snip [RejectionHandlerExamplesSpec.scala](../../../../../test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala) { #example-json }

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -4,6 +4,10 @@
 
 package docs.http.scaladsl.server
 
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.server.{ Rejection, Route }
+import akka.http.scaladsl.server.RouteResult.Complete
+
 // format: OFF
 
 object MyRejectionHandler {
@@ -67,6 +71,40 @@ class RejectionHandlerExamplesSpec extends RoutingSpec {
         }
       }
     //#example-1
+  }
+  
+  "example-2-all-exceptions-json" in {
+    //#example-json
+    import akka.http.scaladsl.model._
+    import akka.http.scaladsl.server.RejectionHandler
+
+    implicit def myRejectionHandler =
+      RejectionHandler.default
+        .mapRejectionResponse {
+          case res if res.entity.isInstanceOf[HttpEntity.Strict] =>
+            // since all Akka default rejection responses are Strict this will handle all rejections
+            val message = res.entity.asInstanceOf[HttpEntity.Strict].data.utf8String.replaceAll("\"", """\"""")
+            
+            // we copy the response in order to keep all headers and status code, wrapping the message as hand rolled JSON
+            // you could the entity using your favourite marshalling library (e.g. spray json or anything else) 
+            res.copy(entity = HttpEntity(ContentTypes.`application/json`, s"""{"rejection": "$message"}"""))
+            
+          case x => x // pass through all other types of responses
+        }
+    
+    val route =
+      Route.seal(
+        path("hello") {
+          complete("Hello there")
+        }
+      )
+      
+    //#example-json
+    Get("/nope") ~> route ~> check {
+      status should === (StatusCodes.NotFound)
+      contentType should === (ContentTypes.`application/json`)
+      responseAs[String] should ===("""{"rejection": "The requested resource could not be found."}""")
+    }
   }
 
   "test custom handler example" in {


### PR DESCRIPTION
Improves ease of customising rejection triggered http responses, and only those so it's more precise than the solution proposed in http://stackoverflow.com/questions/34620297/how-to-generically-wrap-a-rejection-with-akka-http 

Resolves https://github.com/akka/akka-http/issues/673

Please review @jrudolph 