### PR TITLE
=doc Remove akka.pattern package from Scaladoc (#684)

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -42,7 +42,13 @@ object Scaladoc extends AutoPlugin {
 
   def scaladocOptions(ver: String, base: File): List[String] = {
     val urlString = GitHub.url(ver) + "/€{FILE_PATH}.scala"
-    val opts = List("-implicits", "-groups", "-doc-source-url", urlString, "-sourcepath", base.getAbsolutePath)
+    val opts = List(
+      "-implicits",
+      "-groups",
+      "-doc-source-url", urlString,
+      "-sourcepath", base.getAbsolutePath,
+      "-skip-packages", "akka.pattern"
+    )
     CliOptions.scaladocDiagramsEnabled.ifTrue("-diagrams").toList ::: opts
   }
 


### PR DESCRIPTION
Fix #684 by using -skip-packages to ignore the package from generated
Scaladoc.