### PR TITLE
=htc content-disposition with charset get's parsed/rendered wrong

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentDispositionHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentDispositionHeader.scala
@@ -26,7 +26,7 @@ private[parser] trait ContentDispositionHeader { this: Parser with CommonRules w
 
   def `filename-parm` = rule(
     ignoreCase("filename") ~ OWS ~ ws('=') ~ push("filename") ~ word
-      | ignoreCase("filename*") ~ OWS ~ ws('=') ~ push("filename") ~ `ext-value`)
+      | ignoreCase("filename*") ~ OWS ~ ws('=') ~ push("filename*") ~ `ext-value`)
 
   def `disp-ext-parm` = rule(
     token ~ ws('=') ~ word

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -676,6 +676,10 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
       HeaderParser.parseFull("location", "http://example.org/?abc=def=ghi", HeaderParser.Settings(uriParsingMode = Uri.ParsingMode.Relaxed)) shouldEqual
         Right(Location(targetUri))
     }
+    "correctly parse a Content-Disposition header with and without charset" in {
+      HttpHeader.parse("Content-Disposition", "inline; filename=\"fn\"; filename*=utf-8''fn") shouldEqual
+        ParsingResult.Ok(`Content-Disposition`(ContentDispositionTypes.inline, Map("filename" → "fn", "filename*" → "utf-8''fn")), List())
+    }
   }
 
   implicit class TestLine(line: String) {


### PR DESCRIPTION
Actually there's a small mistake in the Content-Disposition parser, because of that it will actually render a Content-Disposition header with a filename and a charset wrong and will print `filename=utf-8''name` instead of `filename*=utf-8''name`.

Thanks @shkhln for catching that.