### PR TITLE
=pro manually maintain list of previous versions in MiMa.scala

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,6 +3,7 @@
 1. Create a [new release](https://github.com/akka/akka-http/releases/new) with the next tag version (e.g. `v13.3.7`), title and release decsription including notable changes mentioning external contributors.
 2. Travis CI will start a [CI build](https://travis-ci.org/akka/akka-http/builds) for the new tag and publish artifacts to Bintray and will sync them to Maven Central.
 3. Checkout the newly created tag and run `sbt -Dakka.genjavadoc.enabled=true "++2.12.0 deployRsync repo.akka.io"` to deploy API and reference documentation.
+4. Add the released version to `project/MiMa.scala` to the `mimaPreviousArtifacts` key.
 
 ### Under the Travis hood
 

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -25,7 +25,12 @@ object MiMa extends AutoPlugin {
       if (directory.exists) loadMimaIgnoredProblems(directory, ".backwards.excludes")
       else Map.empty
     },
-    mimaPreviousArtifacts := mimaBackwardIssueFilters.value.keys.map((version: String) => organization.value %% name.value % version).toSet
+    mimaPreviousArtifacts :=
+      // manually maintained list of previous versions to make sure all incompatibilities are found
+      // even if so far no files have been been created in this project's mima-filters directory
+      Set("10.0.0",
+          "10.0.1")
+        .map((version: String) => organization.value %% name.value % version)
   )
 
   case class FilterAnyProblem(name: String) extends com.typesafe.tools.mima.core.ProblemFilter {


### PR DESCRIPTION
Otherwise, we would only check subprojects against versions for which a
`mima-filters/<version>.*` file would have already been created.