### PR TITLE
Fix spray-json unmarshalling

### DIFF
--- a/akka-http-marshallers-scala/akka-http-spray-json/src/main/mima-filters/10.0.1.backwards.excludes
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/main/mima-filters/10.0.1.backwards.excludes
@@ -1,0 +1,5 @@
+# Mima filters needed to check newer versions against 10.0.1
+
+# Code compiled with 10.0.0 would have to be a class extending from SprayJsonSupport that is then used in 10.0.1 code
+# and would actually use the new implicit. Unlikely pattern.
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.sprayJsValueByteStringUnmarshaller")

--- a/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonByteStringParserInput.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonByteStringParserInput.scala
@@ -4,64 +4,22 @@
 
 package akka.http.scaladsl.marshallers.sprayjson
 
-import java.nio.{ ByteBuffer, CharBuffer }
-import java.nio.charset.{ Charset, StandardCharsets }
+import java.nio.charset.StandardCharsets
 
 import akka.util.ByteString
-import spray.json.ParserInput.DefaultParserInput
-import scala.annotation.tailrec
+import spray.json.ParserInput.IndexedBytesParserInput
 
 /**
+ * INTERNAL API
+ *
  * ParserInput reading directly off a ByteString. (Based on the ByteArrayBasedParserInput)
  * that avoids a separate decoding step.
+ *
+ * TODO: make private before next major version
  */
-final class SprayJsonByteStringParserInput(bytes: ByteString) extends DefaultParserInput {
-
-  import SprayJsonByteStringParserInput._
-
-  private[this] val byteBuffer = ByteBuffer.allocate(4)
-  private[this] val charBuffer = CharBuffer.allocate(2)
-
-  private[this] val decoder = Charset.forName("UTF-8").newDecoder()
-
-  override def nextChar() = {
-    _cursor += 1
-    if (_cursor < bytes.length) (bytes(_cursor) & 0xFF).toChar else EOI
-  }
-
-  override def nextUtf8Char() = {
-    @tailrec def decode(byte: Byte, remainingBytes: Int): Char = {
-      byteBuffer.put(byte)
-      if (remainingBytes > 0) {
-        _cursor += 1
-        if (_cursor < bytes.length) decode(bytes(_cursor), remainingBytes - 1) else ErrorChar
-      } else {
-        byteBuffer.flip()
-        val coderResult = decoder.decode(byteBuffer, charBuffer, false)
-        charBuffer.flip()
-        val result = if (coderResult.isUnderflow & charBuffer.hasRemaining) charBuffer.get() else ErrorChar
-        byteBuffer.clear()
-        if (!charBuffer.hasRemaining) charBuffer.clear()
-        result
-      }
-    }
-
-    if (charBuffer.position() > 0) {
-      val result = charBuffer.get()
-      charBuffer.clear()
-      result
-    } else {
-      _cursor += 1
-      if (_cursor < bytes.length) {
-        val byte = bytes(_cursor)
-        if (byte >= 0) byte.toChar // 7-Bit ASCII
-        else if ((byte & 0xE0) == 0xC0) decode(byte, 1) // 2-byte UTF-8 sequence
-        else if ((byte & 0xF0) == 0xE0) decode(byte, 2) // 3-byte UTF-8 sequence
-        else if ((byte & 0xF8) == 0xF0) decode(byte, 3) // 4-byte UTF-8 sequence
-        else ErrorChar
-      } else EOI
-    }
-  }
+@deprecated("Will be made private.", "10.0.2")
+final class SprayJsonByteStringParserInput(bytes: ByteString) extends IndexedBytesParserInput {
+  protected def byteAt(offset: Int): Byte = bytes(offset)
 
   override def length: Int = bytes.size
   override def sliceString(start: Int, end: Int): String =
@@ -70,6 +28,7 @@ final class SprayJsonByteStringParserInput(bytes: ByteString) extends DefaultPar
     StandardCharsets.UTF_8.decode(bytes.slice(start, end).asByteBuffer).array()
 }
 
+@deprecated("Not needed any more. Should have been private.", "10.0.2")
 object SprayJsonByteStringParserInput {
   private final val EOI = '\uFFFF'
   // compile-time constant

--- a/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -9,9 +9,10 @@ import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.MessageEntity
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.ActorMaterializer
-
+import akka.util.ByteString
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
+import spray.json.{ JsArray, JsString, JsValue }
 
 class SprayJsonSupportSpec extends WordSpec with Matchers with ScalaFutures {
   import SprayJsonSupport._
@@ -23,17 +24,33 @@ class SprayJsonSupportSpec extends WordSpec with Matchers with ScalaFutures {
   implicit val mat = ActorMaterializer()
   import sys.dispatcher
 
+  val TestString = "Contains all UTF-8 characters: 2-byte: £, 3-byte: ﾖ, 4-byte: 😁, 4-byte as a literal surrogate pair: \uD83D\uDE01"
+
   "SprayJsonSupport" should {
-    "allow round trip via Marshal / Unmarshal" in {
-      val init = Example("3-byte UTF-8 chars like ﾖ, ᄅ or ᐁ.")
+    "allow round trip via Marshal / Unmarshal case class <-> HttpEntity" in {
+      val init = Example(TestString)
 
       val js = Marshal(init).to[MessageEntity].futureValue
       val example = Unmarshal(js).to[Example].futureValue
 
       example should ===(init)
     }
-  }
+    "allow round trip via Marshal / Unmarshal JsValue <-> HttpEntity" in {
+      val init = JsArray(JsString(TestString))
 
+      val js = Marshal(init).to[MessageEntity].futureValue
+      val example = Unmarshal(js).to[JsValue].futureValue
+
+      example should ===(init)
+    }
+    "allow Unmarshalling from ByteString -> case class" in {
+      val init = Example(TestString)
+      val js = ByteString(s"""{"username": "$TestString"}""")
+      val example = Unmarshal(js).to[Example].futureValue
+
+      example should ===(init)
+    }
+  }
 }
 
 object SprayJsonSupportSpec {

--- a/akka-http/src/main/mima-filters/10.0.1.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.0.1.backwards.excludes
@@ -1,0 +1,7 @@
+# Mima filters needed to check newer versions against 10.0.1
+
+# Method is currently only called from akka-http-spray-json-marshaller on a known marshaller under our control.
+# It could be a problem if code compiled with 10.0.1 calls `andThen` on a general `Unmarshaller`. If someone
+# passes in such an Unmarshaller that was compiled with 10.0.0 it would then fail. The likelihood is small
+# so we are ignoring that for now.
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.unmarshalling.Unmarshaller.andThen")

--- a/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -104,7 +104,16 @@ abstract class Unmarshaller[-A, B] extends UnmarshallerBase[A, B] {
   /** INTERNAL API */
   private[akka] def asScalaCastInput[I]: unmarshalling.Unmarshaller[I, B] = asScala.asInstanceOf[unmarshalling.Unmarshaller[I, B]]
 
-  def unmarshall(a: A, ec: ExecutionContext, mat: Materializer): CompletionStage[B] = asScala.apply(a)(ec, mat).toJava
+  /**
+   * Apply this Unmarshaller to the given value.
+   */
+  def unmarshal(value: A, ec: ExecutionContext, mat: Materializer): CompletionStage[B] = asScala.apply(value)(ec, mat).toJava
+
+  /**
+   * Deprecated in favor of [[unmarshal]].
+   */
+  @deprecated("Use unmarshal instead.", "10.0.2")
+  def unmarshall(a: A, ec: ExecutionContext, mat: Materializer): CompletionStage[B] = unmarshal(a, ec, mat)
 
   /**
    * Transform the result `B` of this unmarshaller to a `C` producing a marshaller that turns `A`s into `C`s

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshaller.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshaller.scala
@@ -28,6 +28,9 @@ trait Unmarshaller[-A, B] extends akka.http.javadsl.unmarshalling.Unmarshaller[A
   def flatMap[C](f: ExecutionContext ⇒ Materializer ⇒ B ⇒ Future[C]): Unmarshaller[A, C] =
     transform(implicit ec ⇒ mat ⇒ _.fast flatMap f(ec)(mat))
 
+  def andThen[C](other: Unmarshaller[B, C]): Unmarshaller[A, C] =
+    flatMap(ec ⇒ mat ⇒ data ⇒ other(data)(ec, mat))
+
   def recover[C >: B](pf: ExecutionContext ⇒ Materializer ⇒ PartialFunction[Throwable, C]): Unmarshaller[A, C] =
     transform(implicit ec ⇒ mat ⇒ _.fast recover pf(ec)(mat))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
     val sslConfigAkka = "com.typesafe"               %% "ssl-config-akka"              % "0.2.1"       // ApacheV2
 
     // For akka-http spray-json support
-    val sprayJson   = "io.spray"                     %% "spray-json"                   % "1.3.2"       // ApacheV2
+    val sprayJson   = "io.spray"                     %% "spray-json"                   % "1.3.3"       // ApacheV2
 
     // For akka-http-jackson support
     val jackson     = "com.fasterxml.jackson.core"    % "jackson-databind"             % "2.7.6"       // ApacheV2
@@ -57,7 +57,7 @@ object Dependencies {
     val alpnApi     = "org.eclipse.jetty.alpn"        % "alpn-api"                     % "1.1.3.v20160715" // ApacheV2
 
     object Docs {
-      val sprayJson   = "io.spray"                   %%  "spray-json"                  % "1.3.2"             % "test"
+      val sprayJson   = Compile.sprayJson                                                                    % "test"
       val gson        = "com.google.code.gson"        % "gson"                         % "2.3.1"             % "test"
     }
 
@@ -72,6 +72,7 @@ object Dependencies {
       val log4j        = "log4j"                       % "log4j"                        % "1.2.14"           % "test" // ApacheV2
       val junitIntf    = "com.novocode"                % "junit-interface"              % "0.11"             % "test" // MIT
       val scalaXml     = "org.scala-lang.modules"     %% "scala-xml"                    % "1.0.4"            % "test"
+      val sprayJson    = Compile.sprayJson                                                                   % "test" // ApacheV2
 
       // in-memory filesystem for file related tests
       val jimfs        = "com.google.jimfs"            % "jimfs"                        % "1.1"              % "test" // ApacheV2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,20 +78,18 @@ object Dependencies {
       val jimfs        = "com.google.jimfs"            % "jimfs"                        % "1.1"              % "test" // ApacheV2
 
       // metrics, measurements, perf testing
-      val metrics         = "com.codahale.metrics"        % "metrics-core"                 % "3.0.2"            % "test" // ApacheV2
-      val metricsJvm      = "com.codahale.metrics"        % "metrics-jvm"                  % "3.0.2"            % "test" // ApacheV2
-      val latencyUtils    = "org.latencyutils"            % "LatencyUtils"                 % "1.0.3"            % "test" // Free BSD
-      val hdrHistogram    = "org.hdrhistogram"            % "HdrHistogram"                 % "2.1.9"            % "test" // CC0
-      val metricsAll      = Seq(metrics, metricsJvm, latencyUtils, hdrHistogram)
+      val metrics      = "com.codahale.metrics"        % "metrics-core"                 % "3.0.2"            % "test" // ApacheV2
+      val metricsJvm   = "com.codahale.metrics"        % "metrics-jvm"                  % "3.0.2"            % "test" // ApacheV2
+      val latencyUtils = "org.latencyutils"            % "LatencyUtils"                 % "1.0.3"            % "test" // Free BSD
+      val hdrHistogram = "org.hdrhistogram"            % "HdrHistogram"                 % "2.1.9"            % "test" // CC0
+      val metricsAll   = Seq(metrics, metricsJvm, latencyUtils, hdrHistogram)
 
       // sigar logging
-      val slf4jJul      = "org.slf4j"                   % "jul-to-slf4j"                 % "1.7.16"    % "test"    // MIT
-      val slf4jLog4j    = "org.slf4j"                   % "log4j-over-slf4j"             % "1.7.16"    % "test"    // MIT
-
-      lazy val sprayJson = Compile.sprayJson % "test"
+      val slf4jJul     = "org.slf4j"                   % "jul-to-slf4j"                 % "1.7.16"           % "test" // MIT
+      val slf4jLog4j   = "org.slf4j"                   % "log4j-over-slf4j"             % "1.7.16"           % "test" // MIT
 
       // reactive streams tck
-      val reactiveStreamsTck = "org.reactivestreams" % "reactive-streams-tck" % "1.0.0" % "test" // CC0
+      val reactiveStreamsTck = "org.reactivestreams"   % "reactive-streams-tck"         % "1.0.0"            % "test" // CC0
     }
 
     object Provided {


### PR DESCRIPTION
Changes:

   * upgrade to spray-json 1.3.3 (which has working 4-byte UTF-8 character decoding for all Scala versions)
   * use new IndexedBytesParserInput to avoid copied code from spray-json
   * refactor unmarshallers to base all on a single implementation
   * fix tests to actually test more kinds of UTF-8 characters

Fixes #691.