### PR TITLE
=ht2 parse and render priority information of HEADERS frames

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -26,7 +26,8 @@ final case class HeadersFrame(
   streamId:            Int,
   endStream:           Boolean,
   endHeaders:          Boolean,
-  headerBlockFragment: ByteString) extends StreamFrameEvent
+  headerBlockFragment: ByteString,
+  priorityInfo:        Option[PriorityFrame]) extends StreamFrameEvent
 final case class ContinuationFrame(
   streamId:   Int,
   endHeaders: Boolean,
@@ -66,5 +67,6 @@ final case class UnknownFrameEvent(
 final case class ParsedHeadersFrame(
   streamId:      Int,
   endStream:     Boolean,
-  keyValuePairs: Seq[(String, String)]
+  keyValuePairs: Seq[(String, String)],
+  priorityInfo:  Option[PriorityFrame]
 ) extends FrameEvent

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -139,7 +139,8 @@ class Http2ServerDemux extends GraphStage[BidiShape[Http2SubStream, FrameEvent, 
             case e: StreamFrameEvent if e.streamId > closedAfter.getOrElse(Int.MaxValue) ⇒
             // streams that will have a greater stream id than the one we sent with GOAWAY will be ignored
 
-            case frame @ ParsedHeadersFrame(streamId, endStream, headers) if lastStreamId < streamId ⇒
+            case frame @ ParsedHeadersFrame(streamId, endStream, headers, prioInfo) if lastStreamId < streamId ⇒
+              // TODO: process priority information
               val (data: Source[ByteString, NotUsed], outlet: Option[BufferedOutlet[ByteString]]) =
                 if (endStream) (Source.empty, None)
                 else {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
@@ -34,7 +34,7 @@ private[http2] object ResponseRendering {
         case header: HttpHeader if header.renderInResponses ⇒ header.lowercaseName → header.value
       }
 
-    val headers = ParsedHeadersFrame(streamId, endStream = response.entity.isKnownEmpty, headerPairs.result())
+    val headers = ParsedHeadersFrame(streamId, endStream = response.entity.isKnownEmpty, headerPairs.result(), None)
 
     Http2SubStream(
       headers,

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FramingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FramingSpec.scala
@@ -77,7 +77,7 @@ class Http2FramingSpec extends FreeSpec with Matchers with WithMaterializerSpec 
             xxxxxxxx=63
             xxxxxxxx=64
             xxxxxxxx=65
-         """ should parseTo(HeadersFrame(0x3546, endStream = false, endHeaders = true, ByteString("abcde")))
+         """ should parseTo(HeadersFrame(0x3546, endStream = false, endHeaders = true, ByteString("abcde"), None))
       }
       "with padding but without priority settings" in {
         b"""xxxxxxxx
@@ -99,7 +99,7 @@ class Http2FramingSpec extends FreeSpec with Matchers with WithMaterializerSpec 
             00000000     # padding
             00000000
             00000000
-         """ should parseTo(HeadersFrame(0x3546, endStream = false, endHeaders = false, ByteString("bcdefg")), checkRendering = false)
+         """ should parseTo(HeadersFrame(0x3546, endStream = false, endHeaders = false, ByteString("bcdefg"), None), checkRendering = false)
       }
       "without padding but with priority settings" in {
         b"""xxxxxxxx
@@ -115,13 +115,13 @@ class Http2FramingSpec extends FreeSpec with Matchers with WithMaterializerSpec 
              xxxxxxx
             xxxxxxxx
             xxxxxxxx
-            xxxxxxxx=100 # stream dependency
-            xxxxxxxx=55  # weight
+            xxxxxxxx=abdef0 # stream dependency
+            xxxxxxxx=bd  # weight
             xxxxxxxx=63  # data
             xxxxxxxx=64
             xxxxxxxx=65
             xxxxxxxx=66
-         """ should parseTo(HeadersFrame(0x3546, endStream = false, endHeaders = false, ByteString("cdef")), checkRendering = false)
+         """ should parseTo(HeadersFrame(0x3546, endStream = false, endHeaders = false, ByteString("cdef"), Some(PriorityFrame(0x3546, false, 0xabdef0, 0xbd))))
         // TODO: actually check that PriorityFrame is emitted as well
       }
       "with padding and priority settings" in pending

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -683,7 +683,7 @@ class Http2ServerSpec extends AkkaSpec with WithInPendingUntilFixed with Eventua
       sendFrame(FrameType.DATA, Flags.END_STREAM.ifSet(endStream), streamId, data)
 
     def sendHEADERS(streamId: Int, endStream: Boolean, endHeaders: Boolean, headerBlockFragment: ByteString): Unit =
-      sendBytes(FrameRenderer.render(HeadersFrame(streamId, endStream, endHeaders, headerBlockFragment)))
+      sendBytes(FrameRenderer.render(HeadersFrame(streamId, endStream, endHeaders, headerBlockFragment, None)))
     def sendCONTINUATION(streamId: Int, endHeaders: Boolean, headerBlockFragment: ByteString): Unit =
       sendBytes(FrameRenderer.render(ContinuationFrame(streamId, endHeaders, headerBlockFragment)))
 


### PR DESCRIPTION
Small one propagating the priority info from frames.

Initially, I thought we might just render this as an additional PriorityFrame. I think, however, that it might make sense to model it accurately, so that priority information is complete from the start.