### PR TITLE
Fix typo of the `tapply` method from `Directive`

### DIFF
--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
@@ -151,7 +151,7 @@ by directly subclassing the Directive class. The Directive is defined like this
 
 @@snip [Directive.scala](../../../../../../../../akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala) { #basic }
 
-It only has one abstract member that you need to implement, the happly method, which creates
+It only has one abstract member that you need to implement, the `tapply` method, which creates
 the Route the directives presents to the outside from its inner Route building function
 (taking the extractions as parameter).
 


### PR DESCRIPTION
As seen can be seen in the code sample directly above the modified sentence sentence, the methods name is `tapply` rather than `happly`.

Location in live documentation: http://doc.akka.io/docs/akka-http/current/scala/http/routing-dsl/directives/custom-directives.html#directives-from-scratch