### PR TITLE
Add dilated to test durations

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
@@ -7,7 +7,7 @@ package akka.http.impl.engine.client
 import scala.concurrent.duration._
 import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, FlowShape }
 import akka.stream.scaladsl._
-import akka.testkit.AkkaSpec
+import akka.testkit._
 import akka.http.scaladsl.{ Http, TestUtils }
 import akka.http.scaladsl.model._
 import akka.stream.testkit.Utils
@@ -30,10 +30,10 @@ class HighLevelOutgoingConnectionSpec extends AkkaSpec {
         .take(N)
         .map(id ⇒ HttpRequest(uri = s"/r$id"))
         .via(Http().outgoingConnection(serverHostName, serverPort))
-        .mapAsync(4)(_.entity.toStrict(1.second))
+        .mapAsync(4)(_.entity.toStrict(1.second.dilated))
         .map { r ⇒ val s = r.data.utf8String; log.debug(s); s.toInt }
         .runFold(0)(_ + _)
-      result.futureValue(Timeout(10.seconds)) should ===(N * (N + 1) / 2)
+      result.futureValue(Timeout(10.seconds.dilated)) should ===(N * (N + 1) / 2)
       binding.futureValue.unbind()
     }
 
@@ -63,11 +63,11 @@ class HighLevelOutgoingConnectionSpec extends AkkaSpec {
         .take(N)
         .map(id ⇒ HttpRequest(uri = s"/r$id"))
         .via(doubleConnection)
-        .mapAsync(4)(_.entity.toStrict(1.second))
+        .mapAsync(4)(_.entity.toStrict(1.second.dilated))
         .map { r ⇒ val s = r.data.utf8String; log.debug(s); s.toInt }
         .runFold(0)(_ + _)
 
-      result.futureValue(Timeout(10.seconds)) should ===(C * N * (N + 1) / 2)
+      result.futureValue(Timeout(10.seconds.dilated)) should ===(C * N * (N + 1) / 2)
       binding.futureValue.unbind()
     }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.impl.util._
-import akka.testkit.AkkaSpec
+import akka.testkit._
 
 class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.loglevel = OFF") with Inside {
   implicit val materializer = ActorMaterializer()
@@ -547,7 +547,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
         }
 
         implicit class XResponse(response: HttpResponse) {
-          val timeout = 500.millis
+          val timeout = 500.millis.dilated
 
           def expectStrictEntityWithLength(bytes: Int) =
             response shouldEqual HttpResponse(
@@ -556,7 +556,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
           def expectEntity[T <: HttpEntity: ClassTag](bytes: Int) =
             inside(response) {
               case HttpResponse(_, _, entity: T, _) ⇒
-                entity.toStrict(100.millis).awaitResult(timeout).data.utf8String shouldEqual entityBase.take(bytes)
+                entity.toStrict(100.millis.dilated).awaitResult(timeout).data.utf8String shouldEqual entityBase.take(bytes)
             }
 
           def expectSizeErrorInEntityOfType[T <: HttpEntity: ClassTag](limit: Int, actualSize: Option[Long] = None) =
@@ -723,7 +723,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
             |
             |""")
         netOutSub.request(1)
-        netOut.expectNoMsg(50.millis)
+        netOut.expectNoMsg(50.millis.dilated)
 
         sendWireData(
           """HTTP/1.1 100 Continue
@@ -760,7 +760,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
             |
             |""")
         netOutSub.request(1)
-        netOut.expectNoMsg(50.millis)
+        netOut.expectNoMsg(50.millis.dilated)
 
         sendWireData(
           """HTTP/1.1 100 Continue
@@ -797,7 +797,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
             |
             |""")
         netOutSub.request(1)
-        netOut.expectNoMsg(50.millis)
+        netOut.expectNoMsg(50.millis.dilated)
 
         sendWireData(
           """HTTP/1.1 200 OK
@@ -828,7 +828,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
             |
             |""")
         netOutSub.request(1)
-        netOut.expectNoMsg(50.millis)
+        netOut.expectNoMsg(50.millis.dilated)
 
         sendWireData(
           """HTTP/1.1 400 Bad Request

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -29,7 +29,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.util.FastFuture._
-import akka.testkit.TestKit
+import akka.testkit._
 
 class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
   val testConf: Config = ConfigFactory.parseString("""
@@ -271,7 +271,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
       }
 
       "don't overflow the stack for large buffers of chunks" in new Test {
-        override val awaitAtMost = 10000.millis
+        override val awaitAtMost = 10000.millis.dilated
 
         val x = NotEnoughDataException
         val numChunks = 12000 // failed starting from 4000 with sbt started with `-Xss2m`
@@ -513,7 +513,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
   override def afterAll() = TestKit.shutdownActorSystem(system)
 
   private class Test {
-    def awaitAtMost: FiniteDuration = 3.seconds
+    def awaitAtMost: FiniteDuration = 3.seconds.dilated
     var closeAfterResponseCompletion = Seq.empty[Boolean]
 
     class StrictEqualHttpRequest(val req: HttpRequest) {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -29,7 +29,7 @@ import StatusCodes._
 import HttpEntity._
 import ParserOutput._
 import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
-import akka.testkit.TestKit
+import akka.testkit._
 
 class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
   val testConf: Config = ConfigFactory.parseString("""
@@ -253,7 +253,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
   override def afterAll() = TestKit.shutdownActorSystem(system)
 
   private class Test {
-    def awaitAtMost: FiniteDuration = 3.seconds
+    def awaitAtMost: FiniteDuration = 3.seconds.dilated
     var closeAfterResponseCompletion = Seq.empty[Boolean]
 
     class StrictEqualHttpResponse(val resp: HttpResponse) {
@@ -318,7 +318,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
         }.concatSubstreams
 
     def collectBlocking[T](source: Source[T, Any]): Seq[T] =
-      Await.result(source.limit(100000).runWith(Sink.seq), 1000.millis)
+      Await.result(source.limit(100000).runWith(Sink.seq), 1000.millis.dilated)
 
     protected def parserSettings: ParserSettings = ParserSettings(system)
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
@@ -21,7 +21,7 @@ import akka.stream.scaladsl._
 import akka.stream.ActorMaterializer
 import HttpEntity._
 import HttpMethods._
-import akka.testkit.TestKit
+import akka.testkit._
 
 class RequestRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
   val testConf: Config = ConfigFactory.parseString("""
@@ -327,7 +327,7 @@ class RequestRendererSpec extends FreeSpec with Matchers with BeforeAndAfterAll 
     serverAddress: InetSocketAddress    = new InetSocketAddress("test.com", 8080))
     extends HttpRequestRendererFactory(userAgent, requestHeaderSizeHint = 64, NoLogging) {
 
-    def awaitAtMost: FiniteDuration = 4.seconds
+    def awaitAtMost: FiniteDuration = 4.seconds.dilated
 
     def renderTo(expected: String): Matcher[HttpRequest] =
       equal(expected.stripMarginWithNewline("\r\n")).matcher[String] compose { request ⇒

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.{ ContentType, HttpRequest, HttpResponse }
 import akka.http.scaladsl.model.MediaTypes._
 import akka.stream.{ ActorMaterializer, Materializer }
 import akka.stream.testkit.Utils.{ TE, _ }
-import akka.testkit.{ AkkaSpec, EventFilter }
+import akka.testkit._
 import org.scalatest.Inside
 
 import scala.concurrent.Await
@@ -57,7 +57,7 @@ class HttpServerBug21008Spec extends AkkaSpec(
           try {
             EventFilter[IllegalArgumentException](occurrences = 1) intercept {
               // make sure the failure has happened
-              Await.ready(done, 10.seconds)
+              Await.ready(done, 10.seconds.dilated)
               // and then when the failure has happened/future completes, we push a reply
               responses.sendNext(HttpResponse(entity = "Yeah"))
             }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/PrepareRequestsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/PrepareRequestsSpec.scala
@@ -11,7 +11,7 @@ import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.{ Attributes, ActorMaterializer }
 import akka.stream.scaladsl.{ Sink, Source, Flow }
 import akka.stream.testkit.{ TestSubscriber, TestPublisher }
-import akka.testkit.AkkaSpec
+import akka.testkit._
 import akka.util.ByteString
 import scala.concurrent.duration._
 
@@ -93,7 +93,7 @@ class PrepareRequestsSpec extends AkkaSpec {
       inSub.expectRequest(1)
 
       // bug would fail stream here with exception
-      upstreamProbe.expectNoMsg(100.millis)
+      upstreamProbe.expectNoMsg(100.millis.dilated)
 
       inSub.sendNext(ParserOutput.EntityChunk(HttpEntity.ChunkStreamPart(ByteString("abc"))))
       entityProbe.expectNext()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/FramingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/FramingSpec.scala
@@ -11,6 +11,7 @@ import org.scalatest.{ FreeSpec, Matchers }
 import akka.util.ByteString
 import akka.stream.scaladsl.Source
 import akka.http.impl.util._
+import akka.testkit._
 
 import Protocol.Opcode
 
@@ -307,10 +308,10 @@ class FramingSpec extends FreeSpec with Matchers with WithMaterializerSpec {
 
   private def parseToEvents(bytes: Seq[ByteString]): immutable.Seq[FrameEvent] =
     Source(bytes.toVector).via(FrameEventParser).runFold(Vector.empty[FrameEvent])(_ :+ _)
-      .awaitResult(1.second)
+      .awaitResult(1.second.dilated)
   private def renderToByteString(events: immutable.Seq[FrameEvent]): ByteString =
     Source(events).via(newRenderer()).runFold(ByteString.empty)(_ ++ _)
-      .awaitResult(1.second)
+      .awaitResult(1.second.dilated)
 
   protected def newRenderer(): FrameEventRenderer = new FrameEventRenderer
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/Utf8CodingSpecs.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/Utf8CodingSpecs.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration._
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import akka.http.impl.util._
+import akka.testkit._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{ FreeSpec, Matchers }
 
@@ -43,7 +44,7 @@ class Utf8CodingSpecs extends FreeSpec with Matchers with PropertyChecks with Wi
   def encodeUtf8(str: String): ByteString =
     Source(str.map(ch ⇒ new String(Array(ch)))) // chunk in smallest chunks possible
       .via(Utf8Encoder)
-      .runFold(ByteString.empty)(_ ++ _).awaitResult(1.second)
+      .runFold(ByteString.empty)(_ ++ _).awaitResult(1.second.dilated)
 
   def decodeUtf8(bytes: ByteString): String = {
     val builder = new StringBuilder

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketClientSpec.scala
@@ -21,6 +21,7 @@ import akka.http.scaladsl.model.Uri
 import akka.stream.scaladsl._
 import akka.stream.testkit.{ TestSubscriber, TestPublisher }
 import akka.util.ByteString
+import akka.testkit._
 import org.scalatest.{ Matchers, FreeSpec }
 
 import akka.http.impl.util._
@@ -291,7 +292,7 @@ class WebSocketClientSpec extends FreeSpec with Matchers with WithMaterializerSp
   }
 
   abstract class TestSetup extends WSTestSetupBase {
-    protected def noMsgTimeout: FiniteDuration = 100.millis
+    protected def noMsgTimeout: FiniteDuration = 100.millis.dilated
     protected def clientImplementation: Flow[Message, Message, NotUsed]
     protected def requestedSubProtocol: Option[String] = None
 
@@ -357,7 +358,7 @@ class WebSocketClientSpec extends FreeSpec with Matchers with WithMaterializerSp
 
     import akka.http.impl.util._
     def expectInvalidUpgradeResponse(): InvalidUpgradeResponse =
-      response.awaitResult(1.second).asInstanceOf[InvalidUpgradeResponse]
+      response.awaitResult(1.second.dilated).asInstanceOf[InvalidUpgradeResponse]
   }
 
   trait ClientEchoes extends TestSetup {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler }
 import akka.util.ByteString
 import akka.stream.testkit.scaladsl.TestSink
-import akka.testkit.{ AkkaSpec, EventFilter }
+import akka.testkit._
 
 import scala.util.{ Failure, Success }
 
@@ -39,7 +39,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
           val upgrade = headers.collectFirst { case u: UpgradeToWebSocket ⇒ u }.get
           upgrade.handleMessages(Flow.fromSinkAndSource(Sink.ignore, Source.fromPublisher(source)), None)
       }, interface = "localhost", port = 0)
-      val binding = Await.result(bindingFuture, 3.seconds)
+      val binding = Await.result(bindingFuture, 3.seconds.dilated)
       val myPort = binding.localAddress.getPort
 
       val (response, sink) = Http().singleWebSocketRequest(
@@ -49,7 +49,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
       response.futureValue.response.status.isSuccess should ===(true)
       sink
         .request(10)
-        .expectNoMsg(500.millis)
+        .expectNoMsg(500.millis.dilated)
 
       source
         .sendNext(TextMessage("hello"))
@@ -68,7 +68,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
           val upgrade = headers.collectFirst { case u: UpgradeToWebSocket ⇒ u }.get
           upgrade.handleMessages(Flow.fromSinkAndSource(Sink.ignore, Source.fromPublisher(source)), None)
       }, interface = "localhost", port = 0)
-      val binding = Await.result(bindingFuture, 3.seconds)
+      val binding = Await.result(bindingFuture, 3.seconds.dilated)
       val myPort = binding.localAddress.getPort
 
       val completeOnlySwitch: Flow[ByteString, ByteString, Promise[Done]] = Flow.fromGraph(
@@ -108,7 +108,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
       response.futureValue.response.status.isSuccess should ===(true)
       sink
         .request(10)
-        .expectNoMsg(1500.millis)
+        .expectNoMsg(1500.millis.dilated)
 
       breaker.trySuccess(Done)
 
@@ -129,7 +129,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
           val upgrade = headers.collectFirst { case u: UpgradeToWebSocket ⇒ u }.get
           upgrade.handleMessages(Flow.apply, None)
       }, interface = "localhost", port = 0)
-      val binding = Await.result(bindingFuture, 3.seconds)
+      val binding = Await.result(bindingFuture, 3.seconds.dilated)
       val myPort = binding.localAddress.getPort
 
       val N = 100
@@ -170,7 +170,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
           val upgrade = headers.collectFirst { case u: UpgradeToWebSocket ⇒ u }.get
           upgrade.handleMessages(handler, None)
       }, interface = "localhost", port = 0)
-      val binding = Await.result(bindingFuture, 3.seconds)
+      val binding = Await.result(bindingFuture, 3.seconds.dilated)
       val myPort = binding.localAddress.getPort
 
       @volatile var messages = 0
@@ -199,7 +199,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
     "fail the materialized future if the request fails" in {
       val flow = Http().webSocketClientFlow(
         WebSocketRequest("ws://127.0.0.1:65535/no/server/here"),
-        settings = ClientConnectionSettings(system).withConnectingTimeout(250.millis))
+        settings = ClientConnectionSettings(system).withConnectingTimeout(250.millis.dilated))
 
       val future = Source.maybe[Message].viaMat(flow)(Keep.right).toMat(Sink.ignore)(Keep.left).run()
       import system.dispatcher

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
@@ -108,7 +108,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
       response.futureValue.response.status.isSuccess should ===(true)
       sink
         .request(10)
-        .expectNoMsg(1500.millis.dilated)
+        .expectNoMsg(1500.millis)
 
       breaker.trySuccess(Done)
 

--- a/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
@@ -13,7 +13,7 @@ import akka.stream.testkit._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import akka.testkit.AkkaSpec
+import akka.testkit._
 import org.scalatest.concurrent.Eventually
 
 class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
@@ -26,12 +26,12 @@ class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
 
     "be fully transparent for valid one-to-one streams" in assertAllStagesStopped {
       val f = One2OneBidiFlow[Int, Int](-1) join Flow[Int].map(_ * 2)
-      Await.result(test(f), 1.second) should ===(Seq(2, 4, 6))
+      Await.result(test(f), 1.second.dilated) should ===(Seq(2, 4, 6))
     }
 
     "be fully transparent to errors" in {
       val f = One2OneBidiFlow[Int, Int](-1) join Flow[Int].map(x ⇒ 10 / (x - 2))
-      an[ArithmeticException] should be thrownBy Await.result(test(f), 1.second)
+      an[ArithmeticException] should be thrownBy Await.result(test(f), 1.second.dilated)
     }
 
     "trigger an `OutputTruncationException` if the wrapped stream completes early" in assertAllStagesStopped {
@@ -111,7 +111,7 @@ class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
       // wait for pending elements to be filled
       // This test (and the one below) depends on the absence of input buffers
       // between the counting stage (`log(...)`) and the One2OneBidiFlow.
-      eventually(timeout(1.second)) {
+      eventually(timeout(1.second.dilated)) {
         seen.get should be(MAX_PENDING)
       }
 
@@ -121,7 +121,7 @@ class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
       // then make sure that again only as many elements are pulled in
       // as were resolved before so that again only MAX_PENDING elements
       // are pending (= MAX_PENDING + EMIT_ELEMENTS should have been pulled in)
-      eventually(timeout(1.second)) {
+      eventually(timeout(1.second.dilated)) {
         seen.get should be(MAX_PENDING + EMIT_ELEMENTS)
       }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
@@ -5,7 +5,7 @@ package akka.http.impl.util
 
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
-import akka.testkit.AkkaSpec
+import akka.testkit._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -21,17 +21,17 @@ class StreamUtilsSpec extends AkkaSpec {
 
         newSource.runWith(Sink.ignore)
 
-        Await.result(whenCompleted, 3.seconds) shouldBe (())
+        Await.result(whenCompleted, 3.seconds.dilated) shouldBe (())
       }
 
       "upstream fails" in {
         val ex = new RuntimeException("ex")
         val (newSource, whenCompleted) = StreamUtils.captureTermination(Source.failed[Int](ex))
         intercept[RuntimeException] {
-          Await.result(newSource.runWith(Sink.head), 3.second)
+          Await.result(newSource.runWith(Sink.head), 3.second.dilated)
         } should be theSameInstanceAs ex
 
-        Await.ready(whenCompleted, 3.seconds).value shouldBe Some(Failure(ex))
+        Await.ready(whenCompleted, 3.seconds.dilated).value shouldBe Some(Failure(ex))
       }
 
       "downstream cancels" in {
@@ -39,7 +39,7 @@ class StreamUtilsSpec extends AkkaSpec {
 
         newSource.runWith(Sink.head)
 
-        Await.result(whenCompleted, 3.seconds) shouldBe (())
+        Await.result(whenCompleted, 3.seconds.dilated) shouldBe (())
       }
     }
   }

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.{ BeforeAndAfterAll, Inside, Matchers, WordSpec }
 import akka.stream.ActorMaterializer
 import akka.actor.ActorSystem
 import akka.stream.javadsl.Source
-import akka.testkit.TestKit
+import akka.testkit._
 
 import scala.compat.java8.FutureConverters
 
@@ -33,7 +33,7 @@ class MultipartsSpec extends WordSpec with Matchers with Inside with BeforeAndAf
         Multiparts.createFormDataBodyPart("foo", HttpEntities.create("FOO")),
         Multiparts.createFormDataBodyPart("bar", HttpEntities.create("BAR")))
       val strictCS = streamed.toStrict(1000, materializer)
-      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second)
+      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second.dilated)
 
       strict shouldEqual akka.http.scaladsl.model.Multipart.FormData(
         Map("foo" → akka.http.scaladsl.model.HttpEntity("FOO"), "bar" → akka.http.scaladsl.model.HttpEntity("BAR")))
@@ -44,7 +44,7 @@ class MultipartsSpec extends WordSpec with Matchers with Inside with BeforeAndAf
         Multiparts.createFormDataBodyPart("bar", HttpEntities.create("BAR"))
       )))
       val strictCS = streamed.toStrict(1000, materializer)
-      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second)
+      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second.dilated)
       strict shouldEqual akka.http.scaladsl.model.Multipart.FormData(
         Map("foo" → akka.http.scaladsl.model.HttpEntity("FOO"), "bar" → akka.http.scaladsl.model.HttpEntity("BAR")))
     }
@@ -56,7 +56,7 @@ class MultipartsSpec extends WordSpec with Matchers with Inside with BeforeAndAf
       fields.put("foo", HttpEntities.create("FOO"))
       val streamed = Multiparts.createFormDataFromFields(fields)
       val strictCS = streamed.toStrict(1000, materializer)
-      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second)
+      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second.dilated)
 
       strict shouldEqual akka.http.scaladsl.model.Multipart.FormData(
         Map("foo" → akka.http.scaladsl.model.HttpEntity("FOO")))

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.{ Matchers, WordSpec }
 import scala.concurrent.duration._
 import scala.concurrent.Await
 import org.scalatest.BeforeAndAfterAll
-import akka.testkit.TestKit
+import akka.testkit._
 
 class ClientSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   val testConf: Config = ConfigFactory.parseString("""
@@ -33,21 +33,21 @@ class ClientSpec extends WordSpec with Matchers with BeforeAndAfterAll {
     "reuse connection pool" in {
       val (_, hostname, port) = TestUtils.temporaryServerHostnameAndPort()
       val bindingFuture = Http().bindAndHandleSync(_ ⇒ HttpResponse(), hostname, port)
-      val binding = Await.result(bindingFuture, 3.seconds)
+      val binding = Await.result(bindingFuture, 3.seconds.dilated)
 
       val respFuture = Http().singleRequest(HttpRequest(POST, s"http://$hostname:$port/"))
-      val resp = Await.result(respFuture, 3.seconds)
+      val resp = Await.result(respFuture, 3.seconds.dilated)
       resp.status shouldBe StatusCodes.OK
 
-      Await.result(Http().poolSize, 1.second) shouldEqual 1
+      Await.result(Http().poolSize, 1.second.dilated) shouldEqual 1
 
       val respFuture2 = Http().singleRequest(HttpRequest(POST, s"http://$hostname:$port/"))
-      val resp2 = Await.result(respFuture, 3.seconds)
+      val resp2 = Await.result(respFuture, 3.seconds.dilated)
       resp2.status shouldBe StatusCodes.OK
 
-      Await.result(Http().poolSize, 1.second) shouldEqual 1
+      Await.result(Http().poolSize, 1.second.dilated) shouldEqual 1
 
-      Await.ready(binding.unbind(), 1.second)
+      Await.ready(binding.unbind(), 1.second.dilated)
     }
   }
 }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
@@ -8,7 +8,7 @@ import akka.Done
 import akka.http.scaladsl.{ Http, TestUtils }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
-import akka.testkit.AkkaSpec
+import akka.testkit._
 import scala.concurrent.duration._
 import akka.util.ByteString
 
@@ -71,7 +71,7 @@ class EntityDiscardingSpec extends AkkaSpec {
         de.future.futureValue should ===(Done)
 
         val de2 = response.discardEntityBytes()
-        val secondRunException = intercept[IllegalStateException] { Await.result(de2.future, 3.seconds) }
+        val secondRunException = intercept[IllegalStateException] { Await.result(de2.future, 3.seconds.dilated) }
         secondRunException.getMessage should include("Source cannot be materialized more than once")
       } finally bound.unbind().futureValue
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -19,7 +19,7 @@ import akka.stream.scaladsl._
 import akka.stream.ActorMaterializer
 import akka.http.scaladsl.model.HttpEntity._
 import akka.http.impl.util.StreamUtils
-import akka.testkit.TestKit
+import akka.testkit._
 
 import scala.util.Random
 
@@ -38,7 +38,7 @@ class HttpEntitySpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
   implicit val materializer = ActorMaterializer()
   override def afterAll() = TestKit.shutdownActorSystem(system)
 
-  val awaitAtMost = 3.seconds
+  val awaitAtMost = 3.seconds.dilated
 
   "HttpEntity" - {
     "support dataBytes" - {
@@ -95,7 +95,7 @@ class HttpEntitySpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
       "Infinite data stream" in {
         val neverCompleted = Promise[ByteString]()
         intercept[TimeoutException] {
-          Await.result(Default(tpe, 42, Source.fromFuture(neverCompleted.future)).toStrict(100.millis), awaitAtMost)
+          Await.result(Default(tpe, 42, Source.fromFuture(neverCompleted.future)).toStrict(100.millis.dilated), awaitAtMost)
         }.getMessage must be("HttpEntity.toStrict timed out after 100 milliseconds while still waiting for outstanding data")
       }
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -95,7 +95,7 @@ class HttpEntitySpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
       "Infinite data stream" in {
         val neverCompleted = Promise[ByteString]()
         intercept[TimeoutException] {
-          Await.result(Default(tpe, 42, Source.fromFuture(neverCompleted.future)).toStrict(100.millis.dilated), awaitAtMost)
+          Await.result(Default(tpe, 42, Source.fromFuture(neverCompleted.future)).toStrict(100.millis), awaitAtMost)
         }.getMessage must be("HttpEntity.toStrict timed out after 100 milliseconds while still waiting for outstanding data")
       }
     }

--- a/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
@@ -14,7 +14,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
-import akka.testkit.TestKit
+import akka.testkit._
 import headers._
 
 /**
@@ -88,7 +88,7 @@ class HttpModelIntegrationSpec extends WordSpec with Matchers with BeforeAndAfte
 
       // Finally convert the body into an Array[Byte].
 
-      val entityBytes: Array[Byte] = Await.result(request.entity.toStrict(1.second), 2.seconds).data.toArray
+      val entityBytes: Array[Byte] = Await.result(request.entity.toStrict(1.second.dilated), 2.seconds.dilated).data.toArray
       entityBytes.to[Seq] shouldEqual ByteString("hello").to[Seq]
     }
 

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -7,7 +7,7 @@ package akka.http.scaladsl.testkit
 import scala.concurrent.duration._
 import org.scalatest.FreeSpec
 import org.scalatest.Matchers
-import akka.testkit.TestProbe
+import akka.testkit._
 import akka.util.Timeout
 import akka.pattern.ask
 import akka.http.scaladsl.model.headers.RawHeader
@@ -55,7 +55,7 @@ class ScalatestRouteTestSpec extends FreeSpec with Matchers with ScalatestRouteT
       val service = TestProbe()
       val handler = TestProbe()
       implicit def serviceRef = service.ref
-      implicit val askTimeout: Timeout = 1.second
+      implicit val askTimeout: Timeout = 1.second.dilated
 
       val result =
         Get() ~> pinkHeader ~> {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.MediaType.WithFixedCharset
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives
 import akka.stream.ActorMaterializer
-import akka.testkit.AkkaSpec
+import akka.testkit._
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.duration._
@@ -49,7 +49,7 @@ class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
       val response = Http().singleRequest(request).futureValue
 
       response.status should ===(StatusCodes.OK)
-      val responseBody = response.toStrict(1.second).futureValue.entity.dataBytes.runFold(ByteString.empty)(_ ++ _).futureValue.utf8String
+      val responseBody = response.toStrict(1.second.dilated).futureValue.entity.dataBytes.runFold(ByteString.empty)(_ ++ _).futureValue.utf8String
       responseBody should ===("application/custom = class akka.http.scaladsl.model.ContentType$WithFixedCharset")
     }
   }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/DecoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/DecoderSpec.scala
@@ -13,6 +13,7 @@ import akka.util.ByteString
 import akka.stream.stage._
 import akka.http.scaladsl.model._
 import akka.http.impl.util._
+import akka.testkit._
 import headers._
 import HttpMethods.POST
 
@@ -27,12 +28,12 @@ class DecoderSpec extends WordSpec with CodecSpecSupport {
       val request = HttpRequest(POST, entity = HttpEntity(smallText), headers = List(`Content-Encoding`(DummyDecoder.encoding)))
       val decoded = DummyDecoder.decode(request)
       decoded.headers shouldEqual Nil
-      decoded.entity.toStrict(3.seconds).awaitResult(3.seconds) shouldEqual HttpEntity(dummyDecompress(smallText))
+      decoded.entity.toStrict(3.seconds.dilated).awaitResult(3.seconds.dilated) shouldEqual HttpEntity(dummyDecompress(smallText))
     }
   }
 
   def dummyDecompress(s: String): String = dummyDecompress(ByteString(s, "UTF8")).decodeString("UTF8")
-  def dummyDecompress(bytes: ByteString): ByteString = DummyDecoder.decode(bytes).awaitResult(3.seconds)
+  def dummyDecompress(bytes: ByteString): ByteString = DummyDecoder.decode(bytes).awaitResult(3.seconds.dilated)
 
   case object DummyDecoder extends StreamDecoder {
     val encoding = HttpEncodings.compress

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/EncoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/EncoderSpec.scala
@@ -11,6 +11,7 @@ import headers._
 import HttpMethods.POST
 import scala.concurrent.duration._
 import akka.http.impl.util._
+import akka.testkit._
 
 class EncoderSpec extends WordSpec with CodecSpecSupport {
 
@@ -23,7 +24,7 @@ class EncoderSpec extends WordSpec with CodecSpecSupport {
       val request = HttpRequest(POST, entity = HttpEntity(smallText))
       val encoded = DummyEncoder.encode(request)
       encoded.headers shouldEqual List(`Content-Encoding`(DummyEncoder.encoding))
-      encoded.entity.toStrict(3.seconds).awaitResult(3.seconds) shouldEqual HttpEntity(dummyCompress(smallText))
+      encoded.entity.toStrict(3.seconds.dilated).awaitResult(3.seconds.dilated) shouldEqual HttpEntity(dummyCompress(smallText))
     }
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
@@ -16,6 +16,7 @@ import akka.util.ByteString
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.unmarshalling.{ Unmarshaller, Unmarshal }
 import akka.http.scaladsl.model._
+import akka.testkit._
 import MediaTypes._
 
 class ScalaXmlSupportSpec extends FreeSpec with Matchers with ScalatestRouteTest with Inside {
@@ -88,7 +89,7 @@ class ScalaXmlSupportSpec extends FreeSpec with Matchers with ScalatestRouteTest
   }
 
   def shouldHaveFailedWithSAXParseException(result: Future[NodeSeq]) =
-    inside(Await.result(result.failed, 1.second)) {
+    inside(Await.result(result.failed, 1.second.dilated)) {
       case _: SAXParseException ⇒
     }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -21,11 +21,12 @@ import akka.http.scaladsl.model.headers._
 import akka.http.impl.util._
 import akka.http.scaladsl.TestUtils.writeAllText
 import akka.http.scaladsl.model.Uri.Path
+import akka.testkit._
 
 class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Inside {
 
   // operations touch files, can be randomly hit by slowness
-  implicit val routeTestTimeout = RouteTestTimeout(3.seconds)
+  implicit val routeTestTimeout = RouteTestTimeout(3.seconds.dilated)
 
   // need to serve from the src directory, when sbt copies the resource directory over to the
   // target directory it will resolve symlinks in the process
@@ -89,7 +90,7 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
           header[`Content-Range`] shouldEqual None
           mediaType.withParams(Map.empty) shouldEqual `multipart/byteranges`
 
-          val parts = responseAs[Multipart.ByteRanges].toStrict(1.second).awaitResult(3.seconds).strictParts
+          val parts = responseAs[Multipart.ByteRanges].toStrict(1.second.dilated).awaitResult(3.seconds.dilated).strictParts
           parts.map(_.entity.data.utf8String) should contain theSameElementsAs List("BCDEFGHIJK", "QRSTUVWXYZ")
         }
       } finally file.delete
@@ -241,7 +242,7 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
     "return the resource content from an archive" in {
       Get() ~> getFromResource("com/typesafe/config/Config.class") ~> check {
         mediaType shouldEqual `application/octet-stream`
-        responseEntity.toStrict(1.second).awaitResult(1.second).data.asByteBuffer.getInt shouldEqual 0xCAFEBABE
+        responseEntity.toStrict(1.second.dilated).awaitResult(1.second.dilated).data.asByteBuffer.getInt shouldEqual 0xCAFEBABE
       }
     }
     "return the file content with MediaType 'application/octet-stream' on unknown file extensions" in {
@@ -278,7 +279,7 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
     "return the resource content from an archive" in {
       Get("Config.class") ~> getFromResourceDirectory("com/typesafe/config") ~> check {
         mediaType shouldEqual `application/octet-stream`
-        responseEntity.toStrict(1.second).awaitResult(1.second).data.asByteBuffer.getInt shouldEqual 0xCAFEBABE
+        responseEntity.toStrict(1.second.dilated).awaitResult(1.second.dilated).data.asByteBuffer.getInt shouldEqual 0xCAFEBABE
       }
     }
     "reject requests to directory resources" in {
@@ -501,9 +502,4 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
   }
 
   def prep(s: String) = s.stripMarginWithNewline("\n")
-
-  def evaluateTo[T](t: T, atMost: Duration = 100.millis)(implicit ec: ExecutionContext): Matcher[Future[T]] =
-    be(t).compose[Future[T]] { fut ⇒
-      fut.awaitResult(atMost)
-    }
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -10,12 +10,13 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.{ MissingFormFieldRejection, RoutingSpec }
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.util.ByteString
+import akka.testkit._
 import scala.concurrent.duration._
 
 class FileUploadDirectivesSpec extends RoutingSpec {
 
   // tests touches filesystem, so reqs may take longer than the default of 1.second to complete
-  implicit val routeTimeout = RouteTestTimeout(3.seconds)
+  implicit val routeTimeout = RouteTestTimeout(3.seconds.dilated)
 
   "the uploadedFile directive" should {
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FutureDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FutureDirectivesSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.pattern.CircuitBreaker
 
 import scala.concurrent.Future
-import akka.testkit.EventFilter
+import akka.testkit._
 import org.scalatest.Inside
 
 import scala.concurrent.duration._
@@ -25,8 +25,8 @@ class FutureDirectivesSpec extends RoutingSpec with Inside {
   }
 
   trait TestWithCircuitBreaker {
-    val breakerResetTimeout = 500.millis
-    val breaker = new CircuitBreaker(system.scheduler, maxFailures = 1, callTimeout = 10.seconds, breakerResetTimeout)
+    val breakerResetTimeout = 500.millis.dilated
+    val breaker = new CircuitBreaker(system.scheduler, maxFailures = 1, callTimeout = 10.seconds.dilated, breakerResetTimeout)
     def openBreaker() = breaker.withCircuitBreaker(Future.failed(new Exception("boom")))
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -9,6 +9,7 @@ import scala.concurrent.{ Await, Promise }
 import scala.concurrent.duration._
 import scala.util.Try
 import akka.http.scaladsl.model._
+import akka.testkit._
 import headers._
 import java.net.InetAddress
 
@@ -170,7 +171,7 @@ class MiscDirectivesSpec extends RoutingSpec {
               complete(lang.toString)
             }
           } ~> check(selected.complete(Try(responseAs[String])))
-          Await.result(selected.future, 1.second)
+          Await.result(selected.future, 1.second.dilated)
         }
       }
   }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
@@ -6,6 +6,7 @@ package akka.http.scaladsl.server.directives
 
 import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.IntegrationRoutingSpec
+import akka.testkit._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Future, Promise }
@@ -16,7 +17,7 @@ class TimeoutDirectivesSpec extends IntegrationRoutingSpec {
     "be configurable in routing layer" in {
 
       val route = path("timeout") {
-        withRequestTimeout(3.seconds) {
+        withRequestTimeout(3.seconds.dilated) {
           val response: Future[String] = slowFuture() // very slow
           complete(response)
         }
@@ -38,7 +39,7 @@ class TimeoutDirectivesSpec extends IntegrationRoutingSpec {
     val route =
       path("timeout") {
         // needs to be long because of the race between wRT and wRTR
-        withRequestTimeout(1.second) {
+        withRequestTimeout(1.second.dilated) {
           withRequestTimeoutResponse(request ⇒ timeoutResponse) {
             val response: Future[String] = slowFuture() // very slow
             complete(response)
@@ -47,7 +48,7 @@ class TimeoutDirectivesSpec extends IntegrationRoutingSpec {
       } ~
         path("equivalent") {
           // updates timeout and handler at
-          withRequestTimeout(1.second, request ⇒ timeoutResponse) {
+          withRequestTimeout(1.second.dilated, request ⇒ timeoutResponse) {
             val response: Future[String] = slowFuture() // very slow
             complete(response)
           }

--- a/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.{ Http2, TestUtils }
 import akka.stream.ActorMaterializer
-import akka.testkit.{ AkkaSpec, TestProbe }
+import akka.testkit._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.exceptions.TestPendingException
 
@@ -39,7 +39,7 @@ class H2SpecIntegrationSpec extends AkkaSpec(
   override def expectedTestDuration = 5.minutes // because slow jenkins, generally finishes below 1 or 2 minutes
 
   val echo = (req: HttpRequest) ⇒ {
-    req.entity.toStrict(1.second).map { entity ⇒
+    req.entity.toStrict(1.second.dilated).map { entity ⇒
       HttpResponse().withEntity(HttpEntity(entity.data))
     }
   }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -17,7 +17,7 @@ import akka.stream.scaladsl.{ Flow, Sink, Source }
 import akka.stream.testkit.TestPublisher.ManualProbe
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
 import akka.stream.{ ActorMaterializer, Materializer }
-import akka.testkit.{ AkkaSpec, TestProbe }
+import akka.testkit._
 import akka.util.{ ByteString, ByteStringBuilder }
 import com.twitter.hpack.{ Decoder, Encoder, HeaderListener }
 import org.scalatest.concurrent.Eventually
@@ -244,16 +244,16 @@ class Http2ServerSpec extends AkkaSpec("" + "akka.loglevel = debug")
           totallySentBytes += dataLength
         }
 
-        eventually(Timeout(1.second)) {
+        eventually(Timeout(1.second.dilated)) {
           sendWindowFullOfData()
           remainingToServerWindowFor(TheStreamId) shouldBe 0
-          expectNoWindowUpdates(100.millis) // might fail here until all buffers have been filled
+          expectNoWindowUpdates(100.millis.dilated) // might fail here until all buffers have been filled
         }
 
         // now drain entity source
         entityDataIn.expectBytes(totallySentBytes)
 
-        eventually(Timeout(1.second)) {
+        eventually(Timeout(1.second.dilated)) {
           remainingToServerWindowFor(TheStreamId) should be > 0
         }
       }
@@ -388,7 +388,7 @@ class Http2ServerSpec extends AkkaSpec("" + "akka.loglevel = debug")
           eventually(Timeout(timeout)) {
             while (publisherProbe.pending > 0) body
 
-            try expectRequest(10.millis)
+            try expectRequest(10.millis.dilated)
             catch {
               case ex: Throwable ⇒ // ignore error here
             }
@@ -396,7 +396,7 @@ class Http2ServerSpec extends AkkaSpec("" + "akka.loglevel = debug")
           }
         }
 
-        fulfillDemandWithin(entityDataOut, 3.seconds)(sendAWindow())
+        fulfillDemandWithin(entityDataOut, 3.seconds.dilated)(sendAWindow())
 
         sendWINDOW_UPDATE(TheStreamId, totalSentBytes)
         sendWINDOW_UPDATE(0, totalSentBytes)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
@@ -9,6 +9,7 @@ import akka.http.impl.engine.ws.{ BitBuilder, WithMaterializerSpec }
 import akka.http.impl.util._
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
+import akka.testkit._
 import org.scalatest.matchers.Matcher
 import org.scalatest.{ FreeSpec, Matchers }
 
@@ -451,8 +452,8 @@ class Http2FramingSpec extends FreeSpec with Matchers with WithMaterializerSpec 
 
   private def parseToEvents(bytes: Seq[ByteString]): immutable.Seq[FrameEvent] =
     Source(bytes.toVector).via(new Http2FrameParsing(shouldReadPreface = false)).runWith(Sink.seq)
-      .awaitResult(1.second)
+      .awaitResult(1.second.dilated)
   private def renderToByteString(events: immutable.Seq[FrameEvent]): ByteString =
     Source(events).map(FrameRenderer.render).runFold(ByteString.empty)(_ ++ _)
-      .awaitResult(1.second)
+      .awaitResult(1.second.dilated)
 }


### PR DESCRIPTION
No `.dilated` added in `docs/` test or test apps. When possible the application of `.dilated` is pushed into test abstractions to ensure that future updates automatically also use it.

I didn't track build failures explicitly recently, but didn't see any timeout failure issues being created so the part of #194 related with increasing timeouts we can leave for later, and we already did some back in November, e.g.see #414.