### PR TITLE
PREVIEW: supporting a first server push API

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -75,12 +75,12 @@ final case class UnknownFrameEvent(
 final case class ParsedHeadersFrame(
   streamId:      Int,
   endStream:     Boolean,
-  keyValuePairs: Seq[(String, String)],
+  keyValuePairs: immutable.Seq[(String, String)],
   priorityInfo:  Option[PriorityFrame]
 ) extends FrameEvent
 
 final case class ParsedPushPromiseFrame(
   streamId:         Int,
   promisedStreamId: Int,
-  keyValuePairs:    Seq[(String, String)]
+  keyValuePairs:    immutable.Seq[(String, String)]
 ) extends FrameEvent

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -78,3 +78,9 @@ final case class ParsedHeadersFrame(
   keyValuePairs: Seq[(String, String)],
   priorityInfo:  Option[PriorityFrame]
 ) extends FrameEvent
+
+final case class ParsedPushPromiseFrame(
+  streamId:         Int,
+  promisedStreamId: Int,
+  keyValuePairs:    Seq[(String, String)]
+) extends FrameEvent

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
@@ -85,6 +85,9 @@ private[http2] object FrameLogger {
         case WindowUpdateFrame(streamId, windowSizeIncrement) ⇒
           LogEntry(streamId, "WIND", s"+ $windowSizeIncrement")
 
+        case PushPromiseFrame(streamId, endHeaders, promisedStreamId, headerBlockFragment) ⇒
+          LogEntry(streamId, "PUSH", s"promisedStreamId = $promisedStreamId, ${hex(headerBlockFragment)}", flag(endHeaders, "EH"))
+
         case other: StreamFrameEvent ⇒
           LogEntry(other.streamId, "UNKN", other.toString)
         case other ⇒

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -15,7 +15,7 @@ import akka.util.ByteString
  */
 private[http2] trait Http2Multiplexer {
   def pushControlFrame(frame: FrameEvent): Unit
-  def registerSubStream(sub: Http2SubStream): Unit
+  def registerSubStream(sub: Http2ResponseSubStream): Unit
   def cancelSubStream(streamId: Int): Unit
   def updateWindow(streamId: Int, increment: Int): Unit
   def updateFrameSize(newFrameSize: Int): Unit
@@ -40,7 +40,7 @@ private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with Stage
       private val outStreams = mutable.Map.empty[Int, OutStream]
 
       def pushControlFrame(frame: FrameEvent): Unit = push(frame)
-      def registerSubStream(sub: Http2SubStream): Unit = {
+      def registerSubStream(sub: Http2ResponseSubStream): Unit = {
         pushControlFrame(sub.initialHeaders)
         if (!sub.initialHeaders.endStream) { // if endStream is set, the source is never read
           val subIn = new SubSinkInlet[ByteString](s"substream-in-${sub.streamId}")

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestRendering.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+
+import akka.http.scaladsl.model.{ HttpHeader, HttpRequest }
+
+import scala.collection.immutable
+import scala.collection.immutable.VectorBuilder
+
+object RequestRendering {
+  def renderRequestToHeaderPairs(request: HttpRequest): immutable.Seq[(String, String)] = {
+    val headerPairs = new VectorBuilder[(String, String)]()
+
+    // scheme, method, path, authority
+    headerPairs += ":method" → request.method.value
+    headerPairs += ":scheme" → request.uri.scheme
+    headerPairs += ":authority" → request.uri.authority.toString.drop(2) // Authority.toString renders leading double slashes see #784
+    headerPairs += ":path" → request.uri.path.toString
+
+    headerPairs ++=
+      request.headers.collect {
+        case header: HttpHeader if header.renderInResponses ⇒ header.lowercaseName → header.value
+      }
+
+    headerPairs.result()
+  }
+}

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/Http2PushRequestsHeader.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/Http2PushRequestsHeader.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.model.http2
+
+import akka.http.impl.engine.ws.InternalCustomHeader
+import akka.http.scaladsl.model.HttpRequest
+
+final case class Http2PushRequestsHeader(requests: HttpRequest*) extends InternalCustomHeader("x-http2-push-requests") {
+  requests.foreach(checkIfIsValidForPushing)
+
+  /**
+   * Checks that a given request is valid for pushing according to the rules from the spec:
+   *
+   *   Promised requests MUST be cacheable (see [RFC7231], Section 4.2.3),
+   *   MUST be safe (see [RFC7231], Section 4.2.1), and MUST NOT include a
+   *   request body.
+   */
+  private def checkIfIsValidForPushing(request: HttpRequest): Unit = {
+    // TODO:
+    require(request.method.isIdempotent, "Pushed requests must be idempotent (cacheable)") // TODO: check if that's a correct interpretation
+    require(request.method.isSafe, "Pushed requests must be safe")
+    require(request.entity.isKnownEmpty, "Pushed requests must not include a request body.")
+  }
+}

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -10,8 +10,11 @@ import akka.actor.ActorSystem
 import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{ CacheDirective, CacheDirectives }
+import akka.http.scaladsl.model.http2.Http2PushRequestsHeader
 import akka.stream._
-import akka.stream.scaladsl.FileIO
+import akka.stream.scaladsl.{ FileIO, Flow, Source }
+import akka.util.ByteString
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
@@ -23,7 +26,7 @@ import scala.util.Random
 
 object Http2ServerTest extends App {
   val testConf: Config = ConfigFactory.parseString("""
-    akka.loglevel = INFO
+    akka.loglevel = DEBUG
     akka.log-dead-letters = off
     akka.stream.materializer.debug.fuzzing-mode = off
     akka.actor.serialize-creators = off
@@ -44,6 +47,8 @@ object Http2ServerTest extends App {
     akka.pattern.after(millis.millis, system.scheduler)(Future.successful(t))
   }
 
+  val lastModifiedHeader = model.headers.`Last-Modified`(DateTime.now)
+
   val syncHandler: HttpRequest ⇒ HttpResponse = {
     case HttpRequest(GET, Uri.Path("/"), _, _, _)           ⇒ index
     case HttpRequest(GET, Uri.Path("/ping"), _, _, _)       ⇒ HttpResponse(entity = "PONG!")
@@ -53,7 +58,17 @@ object Http2ServerTest extends App {
     case HttpRequest(GET, Uri(_, _, p, _, _), _, _, _) if p.toString.startsWith("/image2") ⇒
       HttpResponse(entity = HttpEntity(MediaTypes.`image/jpeg`, FileIO.fromPath(Paths.get("bigimage2.jpg"), 150000).mapAsync(1)(slowDown(2))))
     case HttpRequest(GET, Uri.Path("/crash"), _, _, _) ⇒ sys.error("BOOM!")
-    case _: HttpRequest                                ⇒ HttpResponse(404, entity = "Unknown resource!")
+    case HttpRequest(GET, Uri.Path("/main.css"), _, _, _) ⇒
+      HttpResponse(
+        entity = "h1 { font-family: sans-serif; }",
+        headers =
+        lastModifiedHeader ::
+          model.headers.Expires(DateTime.now.copy(day = 18)) ::
+          model.headers.ETag("blubber") ::
+          model.headers.`Cache-Control`(CacheDirectives.`max-age`(60), CacheDirectives.`public`) ::
+          Nil
+      ).mapEntity(_.transformDataBytes(addMegabyteOfBlanks))
+    case _: HttpRequest ⇒ HttpResponse(404, entity = "Unknown resource!")
   }
 
   val asyncHandler: HttpRequest ⇒ Future[HttpResponse] =
@@ -80,16 +95,19 @@ object Http2ServerTest extends App {
     entity = HttpEntity(
       ContentTypes.`text/html(UTF-8)`,
       """|<html>
-        | <body>
-        |    <h1>Say hello to <i>akka-http-core</i>!</h1>
-        |    <p>Defined resources:</p>
-        |    <ul>
-        |      <li><a href="/ping">/ping</a></li>
-        |      <li><a href="/image-page">/image-page</a></li>
-        |      <li><a href="/crash">/crash</a></li>
-        |    </ul>
-        |  </body>
-        |</html>""".stripMargin))
+         |  <head>
+         |    <link rel="stylesheet" type="text/css" href="/main.css">
+         |  </head>
+         |  <body>
+         |    <h1>Say hello to <i>akka-http-core</i>!</h1>
+         |    <p>Defined resources:</p>
+         |    <ul>
+         |      <li><a href="/ping">/ping</a></li>
+         |      <li><a href="/image-page">/image-page</a></li>
+         |      <li><a href="/crash">/crash</a></li>
+         |    </ul>
+         |  </body>
+         |</html>""".stripMargin), headers = Http2PushRequestsHeader(HttpRequest(uri = "https://localhost:9001/main.css")) :: Nil)
 
   def imagesBlock = {
     def one(): String =
@@ -97,16 +115,26 @@ object Http2ServerTest extends App {
          |<img width="80" height="60" src="/image2?cachebuster=${Random.nextInt}"></img>
          |""".stripMargin
 
-    Seq.fill(20)(one()).mkString
+    Seq.fill(3)(one()).mkString
   }
 
+  lazy val thousandBlanks = ByteString(Array.fill(1000)(' '.toByte))
+  lazy val addMegabyteOfBlanks =
+    Flow[ByteString].concat(
+      Source.fromIterator(() ⇒ Iterator.fill(1000)(thousandBlanks))
+    //.mapAsync(1)(x ⇒ akka.pattern.after(10.millis, system.scheduler)(Future.successful(x)))
+    )
   lazy val imagePage = HttpResponse(
     entity = HttpEntity(
       ContentTypes.`text/html(UTF-8)`,
       s"""|<html>
-          | <body>
+          |  <head>
+          |    <link rel="stylesheet" type="text/css" href="/main.css">
+          |  </head>
+          |  <body>
           |    <h1>Image Page</h1>
           |    $imagesBlock
           |  </body>
-          |</html>""".stripMargin))
+          |</html>""".stripMargin).transformDataBytes(addMegabyteOfBlanks),
+    headers = Http2PushRequestsHeader(HttpRequest(uri = "https://localhost:9001/main.css")) :: Nil)
 }


### PR DESCRIPTION
As most of the pieces now came together, I took a first stab at providing a simple low-level server push API.

The idea is that a response can contain the synthetic `Http2PushRequestsHeader` which contains a set of requests to push. These requests are then rendered as PushPromise frames and also reinjected into the normal user-supplied request / response pipeline.

The data flow so far is:

 * original request comes in
 * user-handler produces response including Http2PushRequestsHeader
 * ResponseRendering renders response to new `Http2ResponseSubStream` which includes the rendered kvPairs for pushed requests as well
 * In Demux / Multiplexer: original response in rendered with HEADERS
 * In Demux / Multiplexer: all pushed requests are rendered with PUSH_PROMISE
 * In Demux / Multiplexer: at the same time, all those requests kvPairs are again reinjected as new Http2Substreams
 * RequestParsing will parse those kvPairs again
 * HttpRequests will be dispatched to normal user handler
 * (pushed responses go their normal way)

So, this path currently contains an extra round-trip from HttpRequest -> kvPair -> HttpResponse which we'd probably like to avoid. This can probably most easily done by removing the `httpLayer` stage (which only `map`s its inputs) and just do the mapping directly in the multiplexer.

DO NOT MERGE YET