### PR TITLE
Add Documentation for Raw-Request-URI synthetic header #759

### DIFF
--- a/docs/src/main/paradox/java/http/common/http-model.md
+++ b/docs/src/main/paradox/java/http/common/http-model.md
@@ -57,7 +57,7 @@ named after HTTP methods to create a request with a given method and URI directl
 ### Synthetic Headers
 
 In some cases it may be necessary to deviate from fully RFC-Compliant behavior. For instance, Amazon S3 treats 
-the + character in the path part of the URL as a string, even though the RFC specifies that this behavior should
+the `+` character in the path part of the URL as a space, even though the RFC specifies that this behavior should
 be limited exclusively to the query portion of the URI.
 
 In order to work around these types of edge cases, Akka HTTP provides for the ability to provide extra, 

--- a/docs/src/main/paradox/java/http/common/http-model.md
+++ b/docs/src/main/paradox/java/http/common/http-model.md
@@ -53,6 +53,23 @@ new immutable instance, so instances can be shared freely. There exist some over
 simplify creating requests for common cases. Also, to aid readability, there are predefined alternatives for `create`
 named after HTTP methods to create a request with a given method and URI directly.
 
+<a id="synthetic-headers-scala"></a>
+### Synthetic Headers
+
+In some cases it may be necessary to deviate from fully RFC-Compliant behavior. For instance, Amazon S3 treats 
+the + character in the path part of the URL as a string, even though the RFC specifies that this behavior should
+be limited exclusively to the query portion of the URI.
+
+In order to work around these types of edge cases, Akka HTTP provides for the ability to provide extra, 
+non-standard information to the request via synthetic headers. These headers are not passed to the client
+but are instead consumed by the request engine and used to override default behavior.
+
+For instance, in order to provide a raw request uri, bypassing the default url normalization, you could do the
+following:
+
+@@snip [ModelDocTest.java](../../../../../test/java/docs/http/javadsl/ModelDocTest.java) { #synthetic-header-s3 }
+
+
 ## HttpResponse
 
 An `HttpResponse` consists of

--- a/docs/src/main/paradox/scala/http/common/http-model.md
+++ b/docs/src/main/paradox/scala/http/common/http-model.md
@@ -55,7 +55,7 @@ for common use cases to simplify the creation of request and response instances.
 ### Synthetic Headers
 
 In some cases it may be necessary to deviate from fully RFC-Compliant behavior. For instance, Amazon S3 treats 
-the + character in the path part of the URL as a string, even though the RFC specifies that this behavior should
+the `+` character in the path part of the URL as a space, even though the RFC specifies that this behavior should
 be limited exclusively to the query portion of the URI.
 
 In order to work around these types of edge cases, Akka HTTP provides for the ability to provide extra, 

--- a/docs/src/main/paradox/scala/http/common/http-model.md
+++ b/docs/src/main/paradox/scala/http/common/http-model.md
@@ -65,8 +65,7 @@ but are instead consumed by the request engine and used to override default beha
 For instance, in order to provide a raw request uri, bypassing the default url normalization, you could do the
 following:
 
-    import akka.http.scaladsl.model.headers.`Raw-Request-URI`
-    val req = HttpRequest(uri = "/ignored", headers=List(`Raw-Request-URI`("/a/b%2Bc")))
+@@snip [ModelSpec.scala](../../../../../test/scala/docs/http/scaladsl/ModelSpec.scala) { #synthetic-header-s3 }
 
 ## HttpResponse
 

--- a/docs/src/test/java/docs/http/javadsl/ModelDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/ModelDocTest.java
@@ -31,8 +31,8 @@ public class ModelDocTest {
         HttpRequest postRequest1 = HttpRequest.POST("/receive").withEntity(data);
 
         // customize every detail of HTTP request
-        //import HttpProtocols._
-        //import MediaTypes._
+        //import HttpProtocols.*
+        //import MediaTypes.*
         Authorization authorization = Authorization.basic("user", "pass");
         HttpRequest complexRequest =
             HttpRequest.PUT("/user")
@@ -88,4 +88,13 @@ public class ModelDocTest {
             return Optional.empty();
     }
     //#headers
+
+  @Test
+  public void syntheticHeaderS3() {
+    //#synthetic-header-s3
+    // imports akka.http.javadsl.model.headers.RawRequestURI
+    HttpRequest.create("/ignored").addHeader(RawRequestURI.create("/a/b%2Bc"));
+    //#synthetic-header-s3
+  }
+
 }

--- a/docs/src/test/scala/docs/http/scaladsl/ModelSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/ModelSpec.scala
@@ -88,4 +88,11 @@ class ModelSpec extends AkkaSpec {
     credentialsOfRequest(HttpRequest()) should be(None)
     credentialsOfRequest(HttpRequest(headers = List(Authorization(GenericHttpCredentials("Other", Map.empty[String, String]))))) should be(None)
   }
+
+  "Synthetic-header-s3" in {
+    //#synthetic-header-s3
+    import akka.http.scaladsl.model.headers.`Raw-Request-URI`
+    val req = HttpRequest(uri = "/ignored", headers=List(`Raw-Request-URI`("/a/b%2Bc")))
+    //#synthetic-header-s3
+  }
 }


### PR DESCRIPTION
Issue: #759
Contains:
* Java documentation
* Cleanup in comments for ModelDocTest
* Move Scala example to its own class and use @@snip instead of inline code