### PR TITLE
+ht2 #776 handle incoming SETTINGS_HEADER_TABLE_SIZE

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -43,7 +43,7 @@ case class PushPromiseFrame(
 
 final case class RstStreamFrame(streamId: Int, errorCode: ErrorCode) extends StreamFrameEvent
 final case class SettingsFrame(settings: immutable.Seq[Setting]) extends FrameEvent
-case object SettingsAckFrame extends FrameEvent
+final case class SettingsAckFrame(acked: immutable.Seq[Setting]) extends FrameEvent
 
 case class PingFrame(ack: Boolean, data: ByteString) extends FrameEvent
 final case class WindowUpdateFrame(

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
@@ -8,6 +8,8 @@ import akka.NotUsed
 import akka.stream.scaladsl.{ BidiFlow, Flow }
 import akka.util.ByteString
 
+import scala.collection.immutable.Seq
+
 /**
  * INTERNAL API
  */
@@ -76,8 +78,9 @@ private[http2] object FrameLogger {
           }.mkString(", ")
           LogEntry(0, "SETT", settingsInfo)
 
-        case SettingsAckFrame ⇒
-          LogEntry(0, "SETA", "")
+        case SettingsAckFrame(s) ⇒
+          val acksInfo = formatSettings(s)
+          LogEntry(0, "SETA", acksInfo)
 
         case WindowUpdateFrame(streamId, windowSizeIncrement) ⇒
           LogEntry(streamId, "WIND", s"+ $windowSizeIncrement")
@@ -96,4 +99,10 @@ private[http2] object FrameLogger {
     }
     display(entryForFrame(frameEvent))
   }
+
+  private def formatSettings(s: Seq[Setting]) =
+    s.map {
+      case Setting(id, value) ⇒ s"$id -> $value"
+    }.mkString(", ")
+
 }

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Protocol.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Protocol.scala
@@ -46,6 +46,44 @@ object Http2Protocol {
   final val InitialMaxFrameSize = 16384
 
   /**
+   * Minimum frame size that can be written.
+   *
+   * See http://httpwg.org/specs/rfc7540.html#rfc.section.4.2
+   *
+   * The size of a frame payload is limited by the maximum size that a receiver advertises in the SETTINGS_MAX_FRAME_SIZE setting.
+   * This setting can have any value between 2^14^ (16,384) and 2^24^-1 (16,777,215) octets, inclusive.
+   */
+  final val MinFrameSize = 16384
+
+  /**
+   * Maximum frame size that can be written.
+   *
+   * See http://httpwg.org/specs/rfc7540.html#rfc.section.4.2
+   *
+   * The size of a frame payload is limited by the maximum size that a receiver advertises in the SETTINGS_MAX_FRAME_SIZE setting.
+   * This setting can have any value between 2^14^ (16,384) and 2^24^-1 (16,777,215) octets, inclusive.
+   */
+  final val MaxFrameSize = 16777215
+
+  /**
+   * Initial maximum size of the header compression table used to decode header blocks, in octets.
+   *
+   * See http://httpwg.org/specs/rfc7540.html#SettingValues
+   */
+  final val InitialMaxHeaderTableSize = 4096
+
+  /**
+   * This advisory setting informs a peer of the maximum size of header list that the sender is prepared to accept, in octets.
+   *
+   * The value is based on the uncompressed size of header fields,
+   * including the length of the name and value in octets plus an overhead of 32 octets for each header field.
+   * For any given request, a lower limit than what is advertised MAY be enforced.
+   *
+   * See http://httpwg.org/specs/rfc7540.html#SettingValues
+   */
+  final val InitialMaxHeaderListSize = Int.MaxValue // "unlimited"
+
+  /**
    * The stream id to be used for frames not associated with any individual stream
    * as defined by the specification.
    *
@@ -57,6 +95,8 @@ object Http2Protocol {
    *   opposed to an individual stream.
    */
   final val NoStreamId = 0
+
+  final val PushPromiseEnabledDefault = true
 
   sealed abstract class FrameType(val id: Int) extends Product
   object FrameType {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
@@ -94,7 +94,7 @@ private[http2] object FrameRenderer {
           bb.result()
         )
 
-      case SettingsAckFrame ⇒
+      case _: SettingsAckFrame ⇒
         renderFrame(
           Http2Protocol.FrameType.SETTINGS,
           Http2Protocol.Flags.ACK,

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
@@ -100,7 +100,7 @@ private[http2] class Http2FrameParsing(shouldReadPreface: Boolean) extends ByteS
               if (payload.hasRemaining)
                 throw new Http2Compliance.IllegalPayloadInSettingsAckFrame(payload.remainingSize, s"SETTINGS ACK frame MUST NOT contain payload (spec 6.5)!")
 
-              SettingsAckFrame
+              SettingsAckFrame(Nil) // TODO if we were to send out settings, here would be the spot to include the acks for the ones we've sent out
             } else {
               def readSettings(read: List[Setting]): immutable.Seq[Setting] =
                 if (payload.hasRemaining) {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameRendering.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2.framing
+
+import akka.event.Logging
+import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
+import akka.http.impl.engine.http2._
+import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import akka.util.ByteString
+
+import scala.collection.immutable
+
+/** INTERNAL API */
+private[http] class Http2FrameRendering extends GraphStage[FlowShape[FrameEvent, ByteString]] {
+
+  val frameIn = Inlet[FrameEvent]("Http2FrameRendering.frameIn")
+  val netOut = Outlet[ByteString]("Http2FrameRendering.netOut")
+
+  override def initialAttributes = Attributes.name(Logging.simpleName(getClass))
+
+  override val shape = FlowShape[FrameEvent, ByteString](frameIn, netOut)
+
+  override def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with InHandler with OutHandler {
+    setHandlers(frameIn, netOut, this)
+
+    override def onPush(): Unit = {
+      val frame = grab(frameIn)
+
+      frame match {
+        case ack @ SettingsAckFrame(s) ⇒
+          applySettings(s)
+          push(netOut, FrameRenderer.render(ack))
+
+        case _ ⇒
+          // normal frame, just render it:
+          val rendered = FrameRenderer.render(frame)
+          // Http2Compliance.requireFrameSizeLessOrEqualThan(rendered.length, settings.maxOutFrameSize, hint = s"Frame type was ${Logging.simpleName(frame)}")
+          push(netOut, rendered)
+      }
+    }
+
+    override def onPull(): Unit = pull(frameIn)
+
+    private def applySettings(s: immutable.Seq[Setting]): Unit = {
+      s foreach {
+        case _ ⇒ // FIXME handle acked settings here
+      }
+    }
+  }
+
+}

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
@@ -269,7 +269,7 @@ class Http2FramingSpec extends FreeSpec with Matchers with WithMaterializerSpec 
             xxxxxxxx
             xxxxxxxx
             xxxxxxxx=0   # no stream ID
-         """ should parseTo(SettingsAckFrame)
+         """ should parseTo(SettingsAckFrame(Nil))
       }
     }
     "PING frame" - {


### PR DESCRIPTION
Minimal changes to get the settings handling rolling, handle incoming SETTINGS_HEADER_TABLE_SIZE. Not handling outgoing, since we don't send them anyway.

The Rendering stage I'd like to keep, at least for now, since the Data rendering there will be nice to impl there. I'm not so very keen on making it a statefulMapConcat for now, we can later if indeed looks good?

Resolves https://github.com/akka/akka-http/issues/776