### PR TITLE
Fixes #784 exclude leading double slash from Uri.Authority.toString

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -803,6 +803,7 @@ object UriRendering {
   def renderUriWithoutFragment[R <: Rendering](r: R, value: Uri, charset: Charset): r.type = {
     import value._
     if (isAbsolute) r ~~ scheme ~~ ':'
+    if (authority.nonEmpty) r ~~ '/' ~~ '/'
     renderAuthority(r, authority, path, scheme, charset)
     renderPath(r, path, charset, encodeFirstSegmentColons = isRelative)
     rawQueryString.foreach(r ~~ '?' ~~ _)
@@ -815,7 +816,6 @@ object UriRendering {
   def renderAuthority[R <: Rendering](r: R, authority: Authority, path: Path, scheme: String, charset: Charset): r.type =
     if (authority.nonEmpty) {
       import authority._
-      r ~~ '/' ~~ '/'
       if (!userinfo.isEmpty) encode(r, userinfo, charset, `userinfo-char`) ~~ '@'
       r ~~ host
       if (port != 0) r ~~ ':' ~~ port else r

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -731,6 +731,13 @@ class UriSpec extends WordSpec with Matchers {
       Uri("https://host:3030/").withPort(4450).effectivePort shouldEqual 4450
     }
 
+    "properly render authority" in {
+      Uri("http://localhost/test").authority.toString shouldEqual "localhost"
+      Uri("http://example.com:80/test").authority.toString shouldEqual "example.com:80"
+      Uri("ftp://host/").authority.toString shouldEqual "host"
+      Uri("http://user@host").authority.toString shouldEqual "user@host"
+    }
+
     "keep the specified authority port" in {
       Uri("example.com").withPort(0).authority.port shouldEqual 0
       Uri("example.com").withPort(80).authority.port shouldEqual 80


### PR DESCRIPTION
Applied @jrudolph's comment in #784 