### PR TITLE
Fix PR validation to build the documentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import akka._
 import AkkaDependency._
+import akka.ValidatePullRequest._
 
 inThisBuild(Def.settings(
   organization := "com.typesafe.akka",
@@ -166,5 +167,6 @@ lazy val docs = project("docs")
       "github.base_url" -> GitHub.url(version.value)
     ),
     Formatting.docFormatSettings,
+    additionalTasks in ValidatePR += paradox in Compile,
     deployRsyncArtifact := List((paradox in Compile).value -> s"www/docs/akka-http/${version.value}")
   )

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -1,7 +1,8 @@
 /**
   * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
   */
-import akka.GitHub
+package akka
+
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaReportBinaryIssues
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import net.virtualvoid.sbt.graph.backend.SbtUpdateReport


### PR DESCRIPTION
Run the paradox task to validate that PRs do not introduce doc
regressions. Since doc generation is not timing sensitive it is fine to
run this outside of the Jenkins cluster and this avoids to further
complicate the PR validation code.

-----

Based on https://github.com/akka/akka-http/pull/798#issuecomment-273898023
/cc @jlprat @ktoso 