### PR TITLE
Allow Java bind API to specify port zero (#660)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
@@ -29,54 +29,78 @@ object ConnectHttp {
 
   // TODO may be optimised a bit to avoid parsing the Uri entirely for the known port cases
 
-  /** Extracts host data from given Uri. */
-  def toHost(uriHost: Uri): ConnectHttp = {
-    val s = uriHost.scheme.toLowerCase(Locale.ROOT)
-    if (s == "https") new ConnectHttpsImpl(uriHost.host.address, effectivePort(s, uriHost.port))
-    else new ConnectHttpImpl(uriHost.host.address, effectivePort(s, uriHost.port))
-  }
+  /** Extracts HTTP or HTTPS connection data from given Uri. */
+  def toHost(uriHost: Uri): ConnectHttp =
+    toHost(uriHost, uriHost.port)
 
-  def toHost(host: String): ConnectHttp = {
-    if (isHttpOrHttps(host)) toHost(Uri.create(host))
-    else toHost(Uri.create(s"http://$host"))
-  }
+  /**
+   * Extract HTTP or HTTPS connection data from given host.
+   *
+   * The host string may contain a URI or a <host>:<port> pair.
+   */
+  def toHost(host: String): ConnectHttp =
+    toHost(createUriWithScheme("http", host))
 
+  /**
+   * Extracts HTTP or HTTPS connection data from given host and port.
+   *
+   * The host string may contain a URI or a <host>:<port> pair. In both cases the
+   * port is ignored.
+   */
   def toHost(host: String, port: Int): ConnectHttp = {
     require(port > 0, "port must be > 0")
-    val start = if (isHttpOrHttps(host)) host else s"http://$host"
-    toHost(Uri.create(start).port(port))
+    toHost(createUriWithScheme("http", host), port)
+  }
+
+  private def toHost(uriHost: Uri, port: Int): ConnectHttp = {
+    val s = uriHost.scheme.toLowerCase(Locale.ROOT)
+    if (s == "https") new ConnectHttpsImpl(uriHost.host.address, effectivePort(s, port))
+    else new ConnectHttpImpl(uriHost.host.address, effectivePort(s, port))
   }
 
   /**
-   * Extracts host data from given Uri.
-   * Forces an HTTPS connection to the given host, using the default HTTPS context and default port.
+   * Extracts HTTPS connection data from given host and port.
+   *
+   * Uses the default HTTPS context.
    */
   @throws(classOf[IllegalArgumentException])
-  def toHostHttps(uriHost: Uri): ConnectWithHttps = {
-    val s = uriHost.scheme.toLowerCase(Locale.ROOT)
-    require(s == "" || s == "https", "toHostHttps used with non https scheme! Was: " + uriHost)
-    val httpsHost = uriHost.scheme("https") // for effective port calculation
-    new ConnectHttpsImpl(httpsHost.host.address, effectivePort(uriHost))
-  }
+  def toHostHttps(uriHost: Uri): ConnectWithHttps =
+    toHostHttps(uriHost, uriHost.port)
 
-  /** Forces an HTTPS connection to the given host, using the default HTTPS context and default port. */
+  /**
+   * Extracts HTTPS connection data from given host and port.
+   *
+   * The host string may contain a URI or a <host>:<port> pair.
+   *
+   * Uses the default HTTPS context.
+   */
   @throws(classOf[IllegalArgumentException])
   def toHostHttps(host: String): ConnectWithHttps =
-    toHostHttps(Uri.create(host))
+    toHostHttps(createUriWithScheme("https", host))
 
-  /** Forces an HTTPS connection to the given host, using the default HTTPS context and given port. */
+  /**
+   * Extracts HTTPS connection data from given host and port, using the default HTTPS context.
+   *
+   * The host string may contain a URI or a <host>:<port> pair. In both cases the
+   * port is ignored.
+   *
+   * Uses the default HTTPS context.
+   */
   @throws(classOf[IllegalArgumentException])
   def toHostHttps(host: String, port: Int): ConnectWithHttps = {
     require(port > 0, "port must be > 0")
-    val start = if (isHttpOrHttps(host)) host else s"https://$host"
-    toHostHttps(Uri.create(s"$start").port(port))
+    toHostHttps(createUriWithScheme("https", host), port)
   }
 
-  private def isHttpOrHttps(s: String) = s.startsWith("http://") || s.startsWith("https://")
+  private def toHostHttps(uriHost: Uri, port: Int): ConnectWithHttps = {
+    val s = uriHost.scheme.toLowerCase(Locale.ROOT)
+    require(s == "" || s == "https", "toHostHttps used with non https scheme! Was: " + uriHost)
+    new ConnectHttpsImpl(uriHost.host.address, effectivePort("https", port))
+  }
 
-  private def effectivePort(uri: Uri): Int = {
-    val s = uri.scheme.toLowerCase(Locale.ROOT)
-    effectivePort(s, uri.port)
+  private def createUriWithScheme(defaultScheme: String, host: String) = {
+    if (host.startsWith("http://") || host.startsWith("https://")) Uri.create(host)
+    else Uri.create(s"$defaultScheme://$host")
   }
 
   private def effectivePort(scheme: String, port: Int): Int = {

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
@@ -46,9 +46,12 @@ object ConnectHttp {
    *
    * The host string may contain a URI or a <host>:<port> pair. In both cases the
    * port is ignored.
+   *
+   * If the given port is 0, a new local port will be assigned by the operating system,
+   * which can then be retrieved by the materialized [[akka.http.javadsl.Http.ServerBinding]].
    */
   def toHost(host: String, port: Int): ConnectHttp = {
-    require(port > 0, "port must be > 0")
+    require(port >= 0, "port must be >= 0")
     toHost(createUriWithScheme("http", host), port)
   }
 
@@ -84,11 +87,14 @@ object ConnectHttp {
    * The host string may contain a URI or a <host>:<port> pair. In both cases the
    * port is ignored.
    *
+   * If the given port is 0, a new local port will be assigned by the operating system,
+   * which can then be retrieved by the materialized [[akka.http.javadsl.Http.ServerBinding]].
+   *
    * Uses the default HTTPS context.
    */
   @throws(classOf[IllegalArgumentException])
   def toHostHttps(host: String, port: Int): ConnectWithHttps = {
-    require(port > 0, "port must be > 0")
+    require(port >= 0, "port must be >= 0")
     toHostHttps(createUriWithScheme("https", host), port)
   }
 
@@ -105,7 +111,7 @@ object ConnectHttp {
 
   private def effectivePort(scheme: String, port: Int): Int = {
     val s = scheme.toLowerCase(Locale.ROOT)
-    if (port > 0) port
+    if (port >= 0) port
     else if (s == "https" || s == "wss") 443
     else if (s == "http" || s == "ws") 80
     else throw new IllegalArgumentException("Scheme is not http/https/ws/wss and no port given!")

--- a/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
@@ -36,6 +36,13 @@ class ConnectHttpSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       connect.host should ===("127.0.0.1")
       connect.port should ===(8080)
     }
+    "connect toHost HTTP:0 when port is 0" in {
+      val connect = ConnectHttp.toHost("http://127.0.0.1", 0)
+      connect.isHttps should ===(false)
+      connect.connectionContext.isPresent should equal(false)
+      connect.host should ===("127.0.0.1")
+      connect.port should ===(0)
+    }
     "connect toHostHttps HTTPS:443 by default" in {
       val connect = ConnectHttp.toHostHttps("127.0.0.1")
       connect.isHttps should ===(true)
@@ -77,6 +84,13 @@ class ConnectHttpSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       connect.connectionContext.isPresent should equal(true)
       connect.host should ===("127.0.0.1")
       connect.port should ===(443)
+    }
+    "connect toHostHttps HTTPS:0 when port is 0" in {
+      val connect = ConnectHttp.toHostHttps("https://127.0.0.1", 0)
+      connect.isHttps should ===(true)
+      connect.connectionContext.isPresent should equal(false)
+      connect.host should ===("127.0.0.1")
+      connect.port should ===(0)
     }
     "throw when toHostHttps used but http:// prefix found" in {
       val ex = intercept[IllegalArgumentException] {

--- a/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
@@ -13,7 +13,7 @@ class ConnectHttpSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 
   val successResponse = HttpResponse.create().withStatus(200)
 
-  "HttpConnect" should {
+  "ConnectHttp" should {
 
     "connect toHost HTTP:80 by default" in {
       val connect = ConnectHttp.toHost("127.0.0.1")
@@ -24,6 +24,20 @@ class ConnectHttpSpec extends WordSpec with Matchers with BeforeAndAfterAll {
     }
     "connect toHost HTTPS:443 when https prefix given in host" in {
       val connect = ConnectHttp.toHost("https://127.0.0.1")
+      connect.isHttps should ===(true)
+      connect.connectionContext.isPresent should equal(false)
+      connect.host should ===("127.0.0.1")
+      connect.port should ===(443)
+    }
+    "connect toHost HTTP:8080 when <host>:<port> is given" in {
+      val connect = ConnectHttp.toHost("127.0.0.1:8080")
+      connect.isHttps should ===(false)
+      connect.connectionContext.isPresent should equal(false)
+      connect.host should ===("127.0.0.1")
+      connect.port should ===(8080)
+    }
+    "connect toHostHttps HTTPS:443 by default" in {
+      val connect = ConnectHttp.toHostHttps("127.0.0.1")
       connect.isHttps should ===(true)
       connect.connectionContext.isPresent should equal(false)
       connect.host should ===("127.0.0.1")
@@ -43,7 +57,7 @@ class ConnectHttpSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       connect.host should ===("127.0.0.1")
       connect.port should ===(9999)
     }
-    "connect toHost HTTPS:8080 when https prefix and port given" in {
+    "connect toHost HTTP:9999 when http prefix and port given" in {
       val connect = ConnectHttp.toHost("http://127.0.0.1:8080", 9999)
       connect.isHttps should ===(false)
       connect.connectionContext.isPresent should equal(false)


### PR DESCRIPTION
This fixes #660 by bringing feature parity with the Scala API and also reworks `ConnectHttp` to improve how connection data is extracted.

Tested manually in the Scala REPL using the Java HttpApp:
```
> sbt akka-http/console
[info] Starting scala interpreter...
[info]
Welcome to Scala 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_102).
Type in expressions for evaluation. Or try :help.

scala> :paste
// Entering paste mode (ctrl-D to finish)

import com.typesafe.config.ConfigFactory
import akka.http.javadsl.server.HttpApp
import akka.http.javadsl.settings.ServerSettings

object Server extends HttpApp {
  protected override def route = complete("hi")
  def run() = startServer("localhost", 0, ServerSettings.create(ConfigFactory.load()))
}

Server.run

// Exiting paste mode, now interpreting.

Press RETURN to stop...
[INFO] [01/22/2017 00:37:54.153] [ForkJoinPool.commonPool-worker-2] [akka.actor.ActorSystemImpl(readiwiwServer)] Server online at http://localhost:54855/
```