### PR TITLE
Http2 multiplexer rewrite and plugable prioritizers

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -45,7 +45,9 @@ final case class RstStreamFrame(streamId: Int, errorCode: ErrorCode) extends Str
 final case class SettingsFrame(settings: immutable.Seq[Setting]) extends FrameEvent
 final case class SettingsAckFrame(acked: immutable.Seq[Setting]) extends FrameEvent
 
-case class PingFrame(ack: Boolean, data: ByteString) extends FrameEvent
+case class PingFrame(ack: Boolean, data: ByteString) extends FrameEvent {
+  require(data.size == 8, s"PingFrame payload must be of size 8 but was ${data.size}")
+}
 final case class WindowUpdateFrame(
   streamId:            Int,
   windowSizeIncrement: Int) extends StreamFrameEvent

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -4,9 +4,12 @@
 
 package akka.http.impl.engine.http2
 
+import akka.stream.Attributes
+
 import scala.collection.mutable
-import akka.stream.stage.{ GraphStageLogic, InHandler, StageLogging }
-import akka.util.ByteString
+import scala.collection.immutable
+import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler, StageLogging }
+import akka.util.{ ByteString, OptionVal }
 
 /**
  * INTERNAL API
@@ -16,116 +19,327 @@ import akka.util.ByteString
 private[http2] trait Http2Multiplexer {
   def pushControlFrame(frame: FrameEvent): Unit
   def registerSubStream(sub: Http2SubStream): Unit
+
+  /** Notifies the multiplexer that the peer decided to cancel the substream */
   def cancelSubStream(streamId: Int): Unit
   def updateWindow(streamId: Int, increment: Int): Unit
-  def updateFrameSize(newFrameSize: Int): Unit
+  def updateMaxFrameSize(newMaxFrameSize: Int): Unit
   def updateDefaultWindow(newDefaultWindow: Int): Unit
+  def updatePriority(priorityFrame: PriorityFrame): Unit
+
+  def reportTimings(): Unit
 }
+
 /**
  * INTERNAL API
  *
  * The current default multiplexer.
  */
 private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with StageLogging ⇒
-  def createMultiplexer(outlet: GenericOutlet[FrameEvent]): Http2Multiplexer =
-    new BufferedOutletExtended[FrameEvent](outlet) with Http2Multiplexer {
+  def createMultiplexer(outlet: GenericOutlet[FrameEvent], prioritizer: StreamPrioritizer): Http2Multiplexer =
+    new Http2Multiplexer with OutHandler with StateTimingSupport with LogSupport {
+      outlet.setHandler(this)
+
       class OutStream(
-        var inlet:              Option[SubSinkInlet[ByteString]],
-        var outboundWindowLeft: Int
-      )
+        val streamId:           Int,
+        private var maybeInlet: Option[SubSinkInlet[ByteString]],
+        var outboundWindowLeft: Int,
+        private var buffer:     ByteString                       = ByteString.empty,
+        var upstreamClosed:     Boolean                          = false,
+        var endStreamSent:      Boolean                          = false
+      ) extends InHandler {
+        private def inlet: SubSinkInlet[ByteString] = maybeInlet.get
+        def canSend = (buffer.nonEmpty && outboundWindowLeft > 0) || (upstreamClosed && !endStreamSent)
+
+        def shouldSendEndStreamNow: Boolean = upstreamClosed && !endStreamSent && buffer.isEmpty
+
+        def registerIncomingData(inlet: SubSinkInlet[ByteString]): Unit = {
+          require(!maybeInlet.isDefined)
+
+          this.maybeInlet = Some(inlet)
+          inlet.pull()
+          inlet.setHandler(this)
+        }
+
+        def nextFrame(maxBytesToSend: Int): DataFrame = {
+          val toTake = maxBytesToSend min buffer.size min outboundWindowLeft
+          val toSend = buffer.take(toTake)
+          require(toSend.nonEmpty)
+
+          outboundWindowLeft -= toTake
+          buffer = buffer.drop(toTake)
+
+          val endStream = shouldSendEndStreamNow
+
+          maybePull()
+
+          debug(s"[$streamId] sending ${toSend.size} bytes, endStream = $endStream")
+
+          endStreamSent = endStream
+          if (endStream) closeStream()
+
+          DataFrame(streamId, endStream, toSend)
+        }
+
+        private def maybePull(): Unit = {
+          // TODO: Check that buffer is not too much over the limit (which we might warn the user about)
+          //       The problem here is that backpressure will only work properly if batch elements like
+          //       ByteString have a reasonable size.
+          if (buffer.size < maxBytesToBufferPerSubstream && !inlet.hasBeenPulled && !inlet.isClosed) inlet.pull()
+        }
+
+        /** Closes the stream completely */
+        def closeStream(): Unit = {
+          upstreamClosed = true
+          endStreamSent = true
+          buffer = ByteString.empty
+          maybeInlet.foreach(_.cancel())
+          maybeInlet = None
+          outStreams.remove(streamId)
+        }
+
+        def cancelStream(): Unit = closeStream()
+        def bufferedBytes: Int = buffer.size
+
+        override def onPush(): Unit = {
+          val newData = inlet.grab()
+          buffer ++= newData
+
+          debug(s"[$streamId] buffered ${buffer.size} bytes")
+          maybePull()
+
+          // else wait for more data being drained
+          if (canSend) enqueueOutStream(this)
+        }
+
+        override def onUpstreamFinish(): Unit =
+          if (buffer.isEmpty) {
+            // push last frame immediately
+            closeStream()
+            pushControlFrame(DataFrame(streamId, endStream = true, ByteString.empty))
+          } else
+            upstreamClosed = true
+
+        override def onUpstreamFailure(ex: Throwable): Unit = {
+          log.error(ex, s"Substream $streamId failed with $ex")
+          closeStream() // RST_STREAM closes the stream
+          pushControlFrame(RstStreamFrame(streamId, Http2Protocol.ErrorCode.INTERNAL_ERROR))
+        }
+      }
 
       private var currentInitialWindow = Http2Protocol.InitialWindowSize
-      private var totalOutboundWindowLeft = Http2Protocol.InitialWindowSize
+      private var currentMaxFrameSize = Http2Protocol.InitialMaxFrameSize
+      private var connectionWindowLeft = Http2Protocol.InitialWindowSize
 
       private val outStreams = mutable.Map.empty[Int, OutStream]
 
-      def pushControlFrame(frame: FrameEvent): Unit = push(frame)
-      def registerSubStream(sub: Http2SubStream): Unit = {
+      override def pushControlFrame(frame: FrameEvent): Unit = state.pushControlFrame(frame)
+
+      override def registerSubStream(sub: Http2SubStream): Unit = {
         pushControlFrame(sub.initialHeaders)
+        sub.initialHeaders.priorityInfo.foreach(updatePriority)
         if (!sub.initialHeaders.endStream) { // if endStream is set, the source is never read
           val subIn = new SubSinkInlet[ByteString](s"substream-in-${sub.streamId}")
-          streamFor(sub.streamId).inlet = Some(subIn)
-
-          subIn.pull()
-          subIn.setHandler(new InHandler {
-            def onPush(): Unit = pushWithTrigger(DataFrame(sub.streamId, endStream = false, subIn.grab()), () ⇒
-              if (!subIn.isClosed) subIn.pull())
-
-            override def onUpstreamFinish(): Unit = pushControlFrame(DataFrame(sub.streamId, endStream = true, ByteString.empty))
-          })
+          val info = streamFor(sub.streamId)
+          info.registerIncomingData(subIn)
           sub.data.runWith(subIn.sink)(subFusingMaterializer)
         }
       }
-      def updateWindow(streamId: Int, increment: Int): Unit = {
+
+      override def updateWindow(streamId: Int, increment: Int): Unit =
         if (streamId == 0) {
-          totalOutboundWindowLeft += increment
-          debug(s"Updating outgoing connection window by $increment to $totalOutboundWindowLeft bufferedElements: ${buffer.size()}")
+          connectionWindowLeft += increment
+          debug(s"Updating outgoing connection window by $increment to $connectionWindowLeft")
+          state.connectionWindowAvailable()
         } else {
           updateWindowFor(streamId, increment)
-          debug(s"Updating window for $streamId by $increment to ${windowLeftFor(streamId)} bufferedElements: ${buffer.size()}")
+          debug(s"Updating window for $streamId by $increment to ${windowLeftFor(streamId)} buffered bytes: ${streamFor(streamId).bufferedBytes}")
         }
-        tryFlush()
-      }
 
-      def cancelSubStream(streamId: Int): Unit = outStreams(streamId).inlet.foreach(_.cancel())
-      def updateFrameSize(newFrameSize: Int): Unit = {} // ignored so far
-      def updateDefaultWindow(newDefaultWindow: Int): Unit = {
+      override def cancelSubStream(streamId: Int): Unit = streamFor(streamId).cancelStream()
+      override def updateMaxFrameSize(newMaxFrameSize: Int): Unit = currentMaxFrameSize = newMaxFrameSize
+      override def updateDefaultWindow(newDefaultWindow: Int): Unit = {
         val delta = newDefaultWindow - currentInitialWindow
 
         currentInitialWindow = newDefaultWindow
-        outStreams.values.foreach(_.outboundWindowLeft += delta)
+        outStreams.values.foreach(i ⇒ updateWindowFor(i.streamId, delta))
       }
+      override def updatePriority(info: PriorityFrame): Unit = prioritizer.updatePriority(info)
 
       private def streamFor(streamId: Int): OutStream = outStreams.get(streamId) match {
         case None ⇒
-          val newOne = new OutStream(None, currentInitialWindow)
+          val newOne = new OutStream(streamId, None, currentInitialWindow)
           outStreams += streamId → newOne
           newOne
         case Some(old) ⇒ old
       }
       private def windowLeftFor(streamId: Int): Int = streamFor(streamId).outboundWindowLeft
-      private def updateWindowFor(streamId: Int, increment: Int): Unit = streamFor(streamId).outboundWindowLeft += increment
+      private def updateWindowFor(streamId: Int, increment: Int): Unit = {
+        val info = streamFor(streamId)
+        info.outboundWindowLeft += increment
+        if (info.canSend) enqueueOutStream(info)
+      }
 
-      override def doPush(elem: ElementAndTrigger): Unit =
-        elem.element match {
-          case d @ DataFrame(streamId, _, payload) ⇒
-            val sendSize = totalOutboundWindowLeft min windowLeftFor(streamId) min payload.size
+      def enqueueOutStream(outStream: OutStream): Unit = state.enqueueOutStream(outStream)
 
-            def send(elem: ElementAndTrigger): Unit = {
-              super.doPush(elem)
-              totalOutboundWindowLeft -= elem.element.asInstanceOf[DataFrame].payload.size
-              updateWindowFor(streamId, -elem.element.asInstanceOf[DataFrame].payload.size)
-            }
+      override def onDownstreamFinish(): Unit = {
+        outStreams.values.foreach(_.cancelStream())
+        completeStage()
+      }
 
-            if (sendSize == payload.size) {
-              // send unchanged
-              send(elem)
+      var state: MultiplexerState = Idle
+      def onPull(): Unit = state.onPull()
+      private def become(nextState: MultiplexerState): Unit = {
+        if (nextState.name != state.name) recordStateChange(state.name, nextState.name)
 
-              debug(s"Pushed ${payload.size} bytes of data for stream $streamId total window left: $totalOutboundWindowLeft per stream window left: ${windowLeftFor(streamId)}")
-            } else if (sendSize > 0) {
-              // split up
-              val toSend = payload.take(sendSize)
-              val remaining = payload.drop(sendSize)
+        state = nextState
+      }
 
-              send(
-                elem.copy(
-                  element = d.copy(payload = toSend),
-                  trigger = () ⇒ buffer.add(elem.copy(d.copy(payload = remaining)))))
+      sealed trait MultiplexerState extends Product {
+        def name: String = productPrefix
 
-              debug(s"Couldn't send completely because not enough window was left. Sending partially. " +
-                s"Total size: ${payload.size} sent: $sendSize left: ${remaining.size} " +
-                s"connection level window: $totalOutboundWindowLeft per stream window: ${windowLeftFor(streamId)}")
-            } else {
-              debug(s"Couldn't send because no window left. Size: ${payload.size} total: $totalOutboundWindowLeft per stream: ${windowLeftFor(streamId)}")
-              // adding to end of the queue only works if there's only ever one frame per
-              // substream in the queue (which is the case since backpressure was introduced)
-              // TODO: we should try to find another stream to push data in this case
-              buffer.add(elem)
-            }
-          case _ ⇒
-            super.doPush(elem)
+        def onPull(): Unit
+        def pushControlFrame(frame: FrameEvent): Unit
+        def connectionWindowAvailable(): Unit
+        def enqueueOutStream(outStream: OutStream): Unit
+      }
+
+      // Multiplexer state machine
+      // Idle: No data to send, no demand from the network (i.e. we were not yet pulled)
+      // WaitingForData: Got demand from the network but no data to send
+      // WaitingForNetworkToSendControlFrames: Control frames (and maybe data frames) are queued but there is no network demand
+      // WaitingForNetworkToSendData: Data frames queued but no network demand
+      // WaitingForConnectionWindow: Data frames queued, demand from the network, but no connection-level window available
+
+      case object Idle extends MultiplexerState {
+        def onPull(): Unit = become(WaitingForData)
+        def pushControlFrame(frame: FrameEvent): Unit = become(WaitingForNetworkToSendControlFrames(frame :: Nil, immutable.TreeSet.empty))
+        def connectionWindowAvailable(): Unit = ()
+        def enqueueOutStream(outStream: OutStream): Unit = become(WaitingForNetworkToSendData(immutable.TreeSet(outStream.streamId)))
+      }
+
+      case object WaitingForData extends MultiplexerState {
+        def onPull(): Unit = throw new IllegalStateException(s"pull unexpected while waiting for data")
+        def pushControlFrame(frame: FrameEvent): Unit = {
+          outlet.push(frame)
+          become(Idle)
         }
+        def connectionWindowAvailable(): Unit = () // nothing to do, as there is no data to send
+        def enqueueOutStream(outStream: OutStream): Unit =
+          if (connectionWindowLeft == 0) become(WaitingForConnectionWindow(immutable.TreeSet(outStream.streamId)))
+          else {
+            require(outStream.canSend)
 
-      private def debug(msg: String): Unit = log.debug(msg)
+            val maxBytesToSend = currentMaxFrameSize min connectionWindowLeft
+            val frame = outStream.nextFrame(maxBytesToSend)
+            outlet.push(frame)
+            connectionWindowLeft -= frame.payload.size
+
+            if (outStream.canSend) // if we still can send, then do
+              become(WaitingForNetworkToSendData(immutable.TreeSet(outStream.streamId)))
+            else
+              become(Idle) // everything sent for now
+          }
+      }
+
+      /** Not yet pulled but data waiting to be sent */
+      case class WaitingForNetworkToSendControlFrames(controlFrameBuffer: immutable.Seq[FrameEvent], sendableOutstreams: immutable.Set[Int]) extends MultiplexerState {
+        require(controlFrameBuffer.nonEmpty)
+        def onPull(): Unit = controlFrameBuffer match {
+          case first +: remaining ⇒
+            outlet.push(first)
+            become {
+              if (remaining.isEmpty && sendableOutstreams.isEmpty) Idle
+              else if (remaining.isEmpty) WaitingForNetworkToSendData(sendableOutstreams)
+              else copy(remaining, sendableOutstreams)
+            }
+        }
+        def pushControlFrame(frame: FrameEvent): Unit = become(copy(controlFrameBuffer = controlFrameBuffer :+ frame))
+        def connectionWindowAvailable(): Unit = ()
+        def enqueueOutStream(outStream: OutStream): Unit =
+          if (!sendableOutstreams.contains(outStream.streamId))
+            become(copy(sendableOutstreams = sendableOutstreams + outStream.streamId))
+      }
+
+      abstract class WithSendableOutStreams extends MultiplexerState {
+        def sendableOutstreams: immutable.Set[Int]
+
+        protected def sendNext(): Unit = {
+          val chosenId = prioritizer.chooseSubstream(sendableOutstreams)
+          val outStream = streamFor(chosenId)
+          require(outStream.canSend)
+
+          val maxBytesToSend = currentMaxFrameSize min connectionWindowLeft
+          val frame = outStream.nextFrame(maxBytesToSend)
+          outlet.push(frame)
+          connectionWindowLeft -= frame.payload.size
+
+          if (outStream.canSend) // if we still can send, then do
+            become(WaitingForNetworkToSendData(sendableOutstreams))
+          else if (sendableOutstreams.size == 1)
+            // now empty
+            become(Idle)
+          else
+            become(WaitingForNetworkToSendData(sendableOutstreams.filterNot(_ == chosenId))) // TODO: use Set instead
+        }
+      }
+
+      case class WaitingForNetworkToSendData(sendableOutstreams: immutable.Set[Int]) extends WithSendableOutStreams {
+        require(sendableOutstreams.nonEmpty)
+        def onPull(): Unit =
+          if (connectionWindowLeft > 0) sendNext()
+          else // do nothing and wait for window first
+            become(WaitingForConnectionWindow(sendableOutstreams))
+
+        def pushControlFrame(frame: FrameEvent): Unit = become(WaitingForNetworkToSendControlFrames(frame :: Nil, sendableOutstreams))
+        def connectionWindowAvailable(): Unit = ()
+        def enqueueOutStream(outStream: OutStream): Unit =
+          if (!sendableOutstreams.contains(outStream.streamId))
+            become(copy(sendableOutstreams = sendableOutstreams + outStream.streamId))
+      }
+
+      /** Pulled and data is pending but no connection-level window available */
+      case class WaitingForConnectionWindow(sendableOutstreams: immutable.Set[Int]) extends WithSendableOutStreams {
+        require(sendableOutstreams.nonEmpty)
+        def onPull(): Unit = throw new IllegalStateException(s"pull unexpected while waiting for connection window")
+        def pushControlFrame(frame: FrameEvent): Unit = {
+          outlet.push(frame)
+          become(WaitingForNetworkToSendData(sendableOutstreams))
+        }
+        def connectionWindowAvailable(): Unit = sendNext()
+        def enqueueOutStream(outStream: OutStream): Unit =
+          if (!sendableOutstreams.contains(outStream.streamId))
+            become(copy(sendableOutstreams = sendableOutstreams + outStream.streamId))
+      }
+
+      private def maxBytesToBufferPerSubstream = 2 * currentMaxFrameSize // for now, let's buffer two frames per substream
+
+      def debug(msg: ⇒ String): Unit = log.debug(msg)
     }
+
+  private trait LogSupport {
+    def debug(msg: ⇒ String): Unit
+  }
+
+  private trait StateTimingSupport { self: LogSupport ⇒
+    var timings = Map.empty[String, Long].withDefaultValue(0L)
+    var lastTimestamp = System.nanoTime()
+
+    def recordStateChange(oldState: String, newState: String): Unit = {
+      val now = System.nanoTime()
+      val lasted = now - lastTimestamp
+      val name = oldState
+      timings = timings.updated(name, timings(name) + lasted)
+      lastTimestamp = now
+      debug(s"Changing state from $oldState to $newState")
+    }
+
+    /** Logs DEBUG level timing data for the output side of the multiplexer*/
+    def reportTimings(): Unit = {
+      val timingsReport = timings.toSeq.sortBy(_._1).map {
+        case (name, nanos) ⇒ f"${nanos / 1000000}%5d ms $name"
+      }.mkString("\n")
+      debug(s"Timing data for connection\n$timingsReport")
+    }
+  }
 }

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -90,7 +90,7 @@ class Http2ServerDemux extends GraphStage[BidiShape[Http2SubStream, FrameEvent, 
         outlet:   Option[BufferedOutlet[ByteString]]
       )
 
-      val multiplexer = createMultiplexer(frameOut)
+      val multiplexer = createMultiplexer(frameOut, StreamPrioritizer.first())
 
       override def preStart(): Unit = {
         pull(frameIn)
@@ -127,6 +127,9 @@ class Http2ServerDemux extends GraphStage[BidiShape[Http2SubStream, FrameEvent, 
           in match {
             case WindowUpdateFrame(streamId, increment) ⇒ multiplexer.updateWindow(streamId, increment)
 
+            case priorityInfo: PriorityFrame ⇒
+              multiplexer.updatePriority(priorityInfo)
+
             case e: StreamFrameEvent if !Http2Compliance.isClientInitiatedStreamId(e.streamId) ⇒
               pushGOAWAY(ErrorCode.PROTOCOL_ERROR, "Not a valid client initiated stream id! Was: " + e.streamId)
 
@@ -151,9 +154,7 @@ class Http2ServerDemux extends GraphStage[BidiShape[Http2SubStream, FrameEvent, 
 
               dispatchSubstream(Http2SubStream(frame, data))
 
-            case PriorityFrame(streamId, exclusiveFlag, streamDependency, weight) ⇒
-              // must be before the "unknown stream id" case, since can be sent eagerly (e.g. firefox does so)
-              debug(s"Received PriorityFrame for stream $streamId with ${if (exclusiveFlag) "exclusive " else "non-exclusive "} dependency on stream $streamDependency and weight $weight")
+              prioInfo.foreach(multiplexer.updatePriority)
 
             case e: StreamFrameEvent if !incomingStreams.contains(e.streamId) ⇒
               // if a stream is invalid we will GO_AWAY
@@ -192,7 +193,7 @@ class Http2ServerDemux extends GraphStage[BidiShape[Http2SubStream, FrameEvent, 
                     settingsAppliedOk = false
                   }
                 case Setting(Http2Protocol.SettingIdentifier.SETTINGS_MAX_FRAME_SIZE, value) ⇒
-                  multiplexer.updateFrameSize(value)
+                  multiplexer.updateMaxFrameSize(value)
                 case Setting(Http2Protocol.SettingIdentifier.SETTINGS_MAX_CONCURRENT_STREAMS, value) ⇒
                   debug(s"Setting max concurrent streams to $value (not enforced)")
                   maxConcurrentStreams = Some(value)

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+
+import akka.http.impl.engine.http2.util.AsciiTreeLayout
+
+import scala.collection.immutable
+import scala.collection.immutable.{ Seq, TreeMap, TreeSet }
+
+/** INTERNAL API */
+private[http2] trait PriorityNode {
+  def streamId: Int
+  def weight: Int
+  def dependency: PriorityNode
+  def children: immutable.Seq[PriorityNode]
+}
+
+/** INTERNAL API */
+private[http2] trait PriorityTree {
+  /**
+   * Returns a new priority tree containing the new or existing and updated stream.
+   */
+  def insertOrUpdate(streamId: Int, streamDependency: Int, weight: Int, exclusive: Boolean): PriorityTree
+
+  /**
+   * Returns the root node of the tree.
+   */
+  def rootNode: PriorityNode
+
+  /**
+   * Gives an ASCII representation of the tree.
+   */
+  def print: String
+}
+
+/** INTERNAL API */
+private[http2] object PriorityTree {
+  def apply(): PriorityTree = create(TreeMap(0 → RootNode))
+
+  private final val DefaultWeight = 16
+
+  private val RootNode = PriorityInfo(0, 0, DefaultWeight, TreeSet.empty)
+  private def create(nodes: TreeMap[Int, PriorityInfo]): PriorityTreeImpl =
+    new PriorityTreeImpl(nodes)
+
+  private class PriorityTreeImpl(nodes: TreeMap[Int, PriorityInfo]) extends PriorityTree {
+    def rootNode: PriorityNode = node(0)
+
+    def insertOrUpdate(streamId: Int, streamDependency: Int, weight: Int, exclusive: Boolean): PriorityTree =
+      if (nodes.isDefinedAt(streamId)) update(streamId, streamDependency, weight, exclusive)
+      else insert(streamId, streamDependency, weight, exclusive)
+
+    private def insert(streamId: Int, streamDependency: Int, weight: Int, exclusive: Boolean): PriorityTreeImpl = {
+      require(!nodes.isDefinedAt(streamId))
+      require(streamId != streamDependency)
+
+      if (nodes.isDefinedAt(streamDependency)) {
+        val dependencyInfo = nodes(streamDependency)
+        if (!exclusive)
+          insertNode(PriorityInfo(streamId, streamDependency, weight, TreeSet.empty))
+            .updateNode(streamDependency)(updateChildren(_ + streamId))
+        else
+          insertNode(PriorityInfo(streamId, streamDependency, weight, dependencyInfo.childrenIds))
+            .updateNode(streamDependency)(updateChildren(_ ⇒ TreeSet(streamId)))
+      } else
+        insertNode(PriorityInfo(streamDependency, 0, DefaultWeight, TreeSet.empty)) // try again after creating intermediate
+          .insert(streamId, streamDependency, weight, exclusive)
+    }
+    private def update(streamId: Int, newStreamDependency: Int, newWeight: Int, newlyExclusive: Boolean): PriorityTree = {
+      require(nodes.isDefinedAt(streamId))
+      require(streamId != newStreamDependency)
+
+      if (nodes.isDefinedAt(newStreamDependency)) {
+        val oldInfo = nodes(streamId)
+
+        if (!newlyExclusive && newStreamDependency == dependencyOf(streamId)) // no dependency changes -> simple
+          updateNode(streamId)(_.copy(weight = newWeight))
+        else if (!dependsTransitivelyOn(newStreamDependency, streamId)) {
+          remove(streamId)
+            .insert(streamId, newStreamDependency, newWeight, newlyExclusive)
+            .updateNode(streamId)(updateChildren(newChildren ⇒ newChildren ++ oldInfo.childrenIds))
+        } else {
+          this // FIXME: actually implement moving nodes down in a dependency chain
+        }
+      } else
+        insert(newStreamDependency, 0, DefaultWeight, exclusive = false) // try again after creating intermediate
+          .update(streamId, newStreamDependency, newWeight, newlyExclusive)
+    }
+
+    private def remove(streamId: Int): PriorityTreeImpl = {
+      require(nodes.isDefinedAt(streamId))
+      require(streamId != 0)
+
+      val info = nodes(streamId)
+      val dependencyInfo = nodes(info.streamDependency)
+
+      create(
+        (nodes - streamId) +
+          (info.streamDependency → dependencyInfo.copy(childrenIds = dependencyInfo.childrenIds - streamId)) ++
+          info.childrenIds.map(id ⇒
+            id → nodes(id).copy(streamDependency = info.streamDependency)
+          )
+      )
+    }
+
+    private def dependsTransitivelyOn(child: Int, parent: Int): Boolean = {
+      val realParent = dependencyOf(child)
+
+      (child != 0) && (
+        realParent == parent ||
+        dependsTransitivelyOn(realParent, parent))
+    }
+
+    private def dependencyOf(streamId: Int): Int = nodes(streamId).streamDependency
+
+    // lens-like "mutators"
+    private def updateNodes(updater: TreeMap[Int, PriorityInfo] ⇒ TreeMap[Int, PriorityInfo]): PriorityTreeImpl =
+      create(updater(nodes))
+    private def updateAll(updaters: (TreeMap[Int, PriorityInfo] ⇒ TreeMap[Int, PriorityInfo])*): PriorityTreeImpl =
+      updateNodes(nodes ⇒ updaters.foldLeft(nodes)((updater, state) ⇒ state(updater)))
+
+    private def updateNode(streamId: Int)(updater: PriorityInfo ⇒ PriorityInfo): PriorityTreeImpl =
+      updateNodes { nodes ⇒
+        nodes.updated(streamId, updater(nodes(streamId)))
+      }
+    private def updateChildren(updater: immutable.TreeSet[Int] ⇒ immutable.TreeSet[Int]): PriorityInfo ⇒ PriorityInfo = { old ⇒
+      old.copy(childrenIds = updater(old.childrenIds))
+    }
+    private def insertNode(newNode: PriorityInfo): PriorityTreeImpl =
+      updateNodes(_ + (newNode.streamId → newNode))
+
+    def print: String = {
+      def printNode(node: PriorityNode): String = s"${node.streamId} [weight: ${node.weight}]"
+
+      AsciiTreeLayout.toAscii[PriorityNode](rootNode, _.children, printNode)
+    }
+
+    private def node(_streamId: Int): PriorityNode = new PriorityNode {
+      def streamId: Int = _streamId
+      def weight: Int = nodes(streamId).weight
+      def dependency: PriorityNode = node(nodes(streamId).streamDependency)
+      def children: immutable.Seq[PriorityNode] = nodes(streamId).childrenIds.toVector.map(node)
+    }
+  }
+
+  private case class PriorityInfo(
+    streamId:         Int,
+    streamDependency: Int,
+    weight:           Int,
+    childrenIds:      immutable.TreeSet[Int]
+  )
+}

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
@@ -53,8 +53,8 @@ private[http2] object PriorityTree {
       else insert(streamId, streamDependency, weight, exclusive)
 
     private def insert(streamId: Int, streamDependency: Int, weight: Int, exclusive: Boolean): PriorityTreeImpl = {
-      require(!nodes.isDefinedAt(streamId))
-      require(streamId != streamDependency)
+      require(!nodes.isDefinedAt(streamId), s"Cannot insert node twice: $streamId")
+      require(streamId != streamDependency, s"Stream cannot depend on itself: $streamId")
 
       if (nodes.isDefinedAt(streamDependency)) {
         val dependencyInfo = nodes(streamDependency)
@@ -69,8 +69,8 @@ private[http2] object PriorityTree {
           .insert(streamId, streamDependency, weight, exclusive)
     }
     private def update(streamId: Int, newStreamDependency: Int, newWeight: Int, newlyExclusive: Boolean): PriorityTree = {
-      require(nodes.isDefinedAt(streamId))
-      require(streamId != newStreamDependency)
+      require(nodes.isDefinedAt(streamId), s"Not must exist to be updated: $streamId")
+      require(streamId != newStreamDependency, s"Stream cannot depend on itself: $streamId")
 
       if (nodes.isDefinedAt(newStreamDependency)) {
         val oldInfo = nodes(streamId)
@@ -90,8 +90,8 @@ private[http2] object PriorityTree {
     }
 
     private def remove(streamId: Int): PriorityTreeImpl = {
-      require(nodes.isDefinedAt(streamId))
-      require(streamId != 0)
+      require(nodes.isDefinedAt(streamId), s"Node must exist to be removed")
+      require(streamId != 0, "Cannot remove root node")
 
       val info = nodes(streamId)
       val dependencyInfo = nodes(info.streamDependency)

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/StreamPrioritizer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/StreamPrioritizer.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+
+import scala.collection.immutable
+
+/** The interface for pluggable stream prioritizers */
+private[http2] trait StreamPrioritizer {
+  /** Update priority information for a substream */
+  def updatePriority(priorityFrame: PriorityFrame): Unit
+
+  /** Choose a substream from a set of substream ids that have data available */
+  def chooseSubstream(streams: immutable.Set[Int]): Int
+}
+
+private[http2] object StreamPrioritizer {
+  /** A prioritizer that ignores priority information and just sends to the first stream */
+  def first(): StreamPrioritizer =
+    new StreamPrioritizer {
+      def updatePriority(priorityFrame: PriorityFrame): Unit = ()
+      def chooseSubstream(streams: Set[Int]): Int = streams.head
+    }
+
+  def usingPriorityTree(): StreamPrioritizer =
+    new StreamPrioritizer {
+      private var priorityTree = PriorityTree()
+
+      def updatePriority(info: PriorityFrame): Unit = {
+        priorityTree = priorityTree.insertOrUpdate(info.streamId, info.streamDependency, info.weight, info.exclusiveFlag)
+        //debug(s"Priority tree after update $info:\n${priorityTree.print}")
+      }
+
+      /** Choose a substream from a set of substream ids that have data available */
+      def chooseSubstream(streams: Set[Int]): Int = {
+        /**
+         * Chooses one of the children, returns the chosen stream id (which must be part of `streams` or
+         * -1 if no eligible stream was found in that part of the tree).
+         */
+        def chooseFromChildren(prioNode: PriorityNode): Int = {
+          if (streams.contains(prioNode.streamId)) prioNode.streamId
+          else {
+            def inner(children: Seq[PriorityNode]): Int =
+              if (children.nonEmpty) {
+                val chosen = children.maxBy(_.weight) // choose the one with highest prio first
+                val result = chooseFromChildren(chosen)
+                if (result != -1) result
+                else inner(children.filterNot(_ == chosen))
+              } else -1
+
+            inner(prioNode.children)
+          }
+        }
+        val result = chooseFromChildren(priorityTree.rootNode)
+        if (result == -1)
+          throw new RuntimeException(s"Couldn't find one of the streams [${streams.toSeq.sorted.mkString(", ")}] in priority tree\n${priorityTree.print}")
+
+        result
+      }
+    }
+}

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/util/AsciiTreeLayout.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/util/AsciiTreeLayout.scala
@@ -1,0 +1,54 @@
+/* sbt -- Simple Build Tool
+ * Copyright 2011 Mark Harrah, Eugene Yokota
+ *
+ * Copied from sbt 0.12 source code
+ */
+package akka.http.impl.engine.http2.util
+
+private[http2] object AsciiTreeLayout {
+  // [info] foo
+  // [info]   +-bar
+  // [info]   | +-baz
+  // [info]   |
+  // [info]   +-quux
+  def toAscii[A](
+    top:       A,
+    children:  A ⇒ Seq[A],
+    display:   A ⇒ String,
+    maxColumn: Int        = 80): String = {
+    val twoSpaces = " " + " " // prevent accidentally being converted into a tab
+    def limitLine(s: String): String =
+      if (s.length > maxColumn) s.slice(0, maxColumn - 2) + ".."
+      else s
+    def insertBar(s: String, at: Int): String =
+      if (at < s.length)
+        s.slice(0, at) +
+          (s(at).toString match {
+            case " " ⇒ "|"
+            case x   ⇒ x
+          }) +
+          s.slice(at + 1, s.length)
+      else s
+    def toAsciiLines(node: A, level: Int, parents: Set[A]): Vector[String] =
+      if (parents contains node) // cycle
+        Vector(limitLine((twoSpaces * level) + "#-" + display(node) + " (cycle)"))
+      else {
+        val line = limitLine((twoSpaces * level) + (if (level == 0) "" else "+-") + display(node))
+        val cs = Vector(children(node): _*)
+        val childLines = cs map {
+          toAsciiLines(_, level + 1, parents + node)
+        }
+        val withBar = childLines.zipWithIndex flatMap {
+          case (lines, pos) if pos < (cs.size - 1) ⇒ lines map {
+            insertBar(_, 2 * (level + 1))
+          }
+          case (lines, pos) ⇒
+            if (lines.last.trim != "") lines ++ Vector(twoSpaces * (level + 1))
+            else lines
+        }
+        line +: withBar
+      }
+
+    toAsciiLines(top, 0, Set.empty).mkString("\n")
+  }
+}

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -326,7 +326,7 @@ class Http2ServerSpec extends AkkaSpec("" + "akka.loglevel = debug")
         entityDataOut.expectCancellation()
       }
 
-      "send RST_STREAM when entity data stream fails" inPendingUntilFixed new WaitingForResponseDataSetup {
+      "send RST_STREAM when entity data stream fails" in new WaitingForResponseDataSetup {
         val data1 = ByteString("abcd")
         entityDataOut.sendNext(data1)
         expectDATA(TheStreamId, endStream = false, data1)
@@ -407,7 +407,7 @@ class Http2ServerSpec extends AkkaSpec("" + "akka.loglevel = debug")
         // we must get at least a bit of demand
         entityDataOut.sendNext(bytes(1000, 0x23))
       }
-      "give control frames priority over pending data frames" inPendingUntilFixed new WaitingForResponseDataSetup {
+      "give control frames priority over pending data frames" in new WaitingForResponseDataSetup {
         val responseDataChunk = bytes(1000, 0x42)
 
         // send data first but expect it to be queued because of missing demand

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/PriorityTreeSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/PriorityTreeSpec.scala
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+
+import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.{ MatchResult, Matcher }
+
+class PriorityTreeSpec extends WordSpec with Matchers {
+  "PriorityTree" should {
+    "contain only the root node if empty" in {
+      PriorityTree() should printLike(
+        """0 [weight: 16]"""
+      )
+    }
+
+    "insert a single non-exclusive node under the root node" in {
+      PriorityTree()
+        .insertOrUpdate(1, 0, 50, exclusive = false) should printLike(
+          """0 [weight: 16]
+            |  +-1 [weight: 50]
+            |""".stripMargin
+        )
+    }
+    "insert an exclusive node under the empty root node" in {
+      PriorityTree()
+        .insertOrUpdate(1, 0, 50, exclusive = true) should printLike(
+          """0 [weight: 16]
+            |  +-1 [weight: 50]
+            |""".stripMargin
+        )
+    }
+    "insert a node with an dependency" in {
+      PriorityTree()
+        .insertOrUpdate(1, 0, 50, exclusive = false)
+        .insertOrUpdate(3, 1, 42, exclusive = false) should printLike(
+          """0 [weight: 16]
+            |  +-1 [weight: 50]
+            |    +-3 [weight: 42]
+            |""".stripMargin
+        )
+    }
+    "insert an exclusive node under the root node with one existing sibling" in {
+      PriorityTree()
+        .insertOrUpdate(1, 0, 30, exclusive = false)
+        .insertOrUpdate(3, 0, 50, exclusive = true) should printLike(
+          """0 [weight: 16]
+            |  +-3 [weight: 50]
+            |    +-1 [weight: 30]
+            |""".stripMargin
+        )
+    }
+
+    "update the priority of a node" in {
+      PriorityTree()
+        .insertOrUpdate(1, 0, 50, exclusive = false)
+        .insertOrUpdate(3, 0, 25, exclusive = false)
+        .insertOrUpdate(1, 0, 133, exclusive = false) should printLike(
+          """0 [weight: 16]
+            |  +-1 [weight: 133]
+            |  +-3 [weight: 25]
+            |""".stripMargin
+        )
+    }
+    "update a node setting exclusivity for a node" in {
+      PriorityTree()
+        .insertOrUpdate(1, 0, 50, exclusive = false)
+        .insertOrUpdate(3, 0, 25, exclusive = false)
+        .insertOrUpdate(1, 0, 133, exclusive = true) should printLike(
+          """0 [weight: 16]
+          |  +-1 [weight: 133]
+          |    +-3 [weight: 25]
+          |""".stripMargin
+        )
+    }
+    "update the dependency of a non-exclusive node" in {
+      PriorityTree()
+        .insertOrUpdate(1, 0, 50, exclusive = false)
+        .insertOrUpdate(3, 0, 25, exclusive = false)
+        .insertOrUpdate(1, 3, 133, exclusive = false) should printLike(
+          """0 [weight: 16]
+          |  +-3 [weight: 25]
+          |    +-1 [weight: 133]
+          |""".stripMargin
+        )
+    }
+    "update the dependency of a non-exclusive node that had siblings" in {
+      val origin =
+        PriorityTree()
+          .insertOrUpdate(1, 0, 50, exclusive = false)
+          .insertOrUpdate(3, 0, 25, exclusive = false)
+          .insertOrUpdate(5, 0, 100, exclusive = false)
+
+      origin should printLike(
+        """0 [weight: 16]
+          |  +-1 [weight: 50]
+          |  +-3 [weight: 25]
+          |  +-5 [weight: 100]
+        """.stripMargin
+      )
+
+      origin
+        .insertOrUpdate(1, 3, 133, exclusive = false) should printLike(
+          """0 [weight: 16]
+            |  +-3 [weight: 25]
+            |  | +-1 [weight: 133]
+            |  |
+            |  +-5 [weight: 100]
+            |""".stripMargin
+        )
+    }
+    "update the dependency of an exclusive node" in {
+      val origin =
+        PriorityTree()
+          .insertOrUpdate(1, 0, 50, exclusive = false)
+          .insertOrUpdate(3, 1, 25, exclusive = false)
+
+      origin should printLike(
+        """0 [weight: 16]
+          |  +-1 [weight: 50]
+          |    +-3 [weight: 25]
+        """.stripMargin
+      )
+
+      origin // now moving up to be exclusive children of 0
+        .insertOrUpdate(3, 0, 133, exclusive = true) should printLike(
+          """0 [weight: 16]
+            |  +-3 [weight: 133]
+            |    +-1 [weight: 50]
+            |""".stripMargin
+        )
+    }
+    "update the dependency of a node with children non-exclusively" in {
+      val origin =
+        PriorityTree()
+          .insertOrUpdate(1, 0, 50, exclusive = false)
+          .insertOrUpdate(3, 1, 25, exclusive = false)
+          .insertOrUpdate(5, 0, 100, exclusive = false)
+
+      origin should printLike(
+        """0 [weight: 16]
+          |  +-1 [weight: 50]
+          |  | +-3 [weight: 25]
+          |  |
+          |  +-5 [weight: 100]
+        """.stripMargin
+      )
+
+      origin
+        .insertOrUpdate(1, 5, 23, exclusive = false) should printLike(
+          """0 [weight: 16]
+            |  +-5 [weight: 100]
+            |    +-1 [weight: 23]
+            |      +-3 [weight: 25]
+            |""".stripMargin
+        )
+    }
+    "update the dependency of a node with children exclusively" in {
+      val origin =
+        PriorityTree()
+          .insertOrUpdate(1, 0, 50, exclusive = false)
+          .insertOrUpdate(3, 1, 25, exclusive = false)
+          .insertOrUpdate(5, 0, 100, exclusive = false)
+          .insertOrUpdate(7, 5, 42, exclusive = false)
+
+      origin should printLike(
+        """0 [weight: 16]
+          |  +-1 [weight: 50]
+          |  | +-3 [weight: 25]
+          |  |
+          |  +-5 [weight: 100]
+          |    +-7 [weight: 42]
+        """.stripMargin
+      )
+
+      origin
+        .insertOrUpdate(1, 5, 23, exclusive = true) should printLike(
+          """0 [weight: 16]
+            |  +-5 [weight: 100]
+            |    +-1 [weight: 23]
+            |      +-3 [weight: 25]
+            |      +-7 [weight: 42]
+            |""".stripMargin
+        )
+    }
+    "update the dependency to a former children" in {
+      pending // a bit tricky
+      val origin =
+        PriorityTree()
+          .insertOrUpdate(1, 0, 50, exclusive = false)
+          .insertOrUpdate(3, 1, 25, exclusive = false)
+          .insertOrUpdate(5, 0, 100, exclusive = false)
+          .insertOrUpdate(7, 1, 33, exclusive = false)
+
+      origin should printLike(
+        """0 [weight: 16]
+          |  +-1 [weight: 50]
+          |  | +-3 [weight: 25]
+          |  | +-7 [weight: 33]
+          |  |
+          |  +-5 [weight: 100]
+        """.stripMargin
+      )
+
+      origin
+        .insertOrUpdate(1, 3, 23, exclusive = false) should printLike(
+          """0 [weight: 16]
+            |  +-3 [weight: 133]
+            |  | +-1 [weight: 50]
+            |  |   +-7 [weight: 33]
+            |  |
+            |  +-5 [weight: 100]
+            |""".stripMargin
+        )
+    }
+
+    "spec example 5.3.1" in pending
+    "spec example 5.3.3" in pending
+
+    "prune nodes" in pending
+
+    "fail when updating the root node" in pending
+    "fail when introducing a dependency on itself" in pending
+  }
+
+  def printLike(resultingTree: String): Matcher[PriorityTree] =
+    Matcher { tree ⇒
+      val WithPotentialEndOfLineWhiteSpace = """(.*?)\s*""".r
+      // The tree printer sometimes inserts blanks.
+      def trimLines(str: String): String =
+        str
+          .split('\n')
+          .map {
+            case WithPotentialEndOfLineWhiteSpace(line) ⇒ line
+          }
+          .mkString("\n")
+          .trim
+      val candidate = trimLines(tree.print)
+      val expected = trimLines(resultingTree)
+
+      MatchResult(
+        candidate === expected,
+        s"Does not render as\n$expected\nbut as\n$candidate",
+        "XXX"
+      )
+    }
+}


### PR DESCRIPTION
A first preview of the priority work:

 * a first version of the priority tree to implement the rules from the spec (it works and is somewhat simple but is probably rather slow)
 * a rewrite of the multiplexer with a proper state machine that sends control frames first and now has a single entry point for actually prioritizing substreams