### PR TITLE
Use whenTerminated instead of deprecated isTerminated #827

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
@@ -59,7 +59,7 @@ class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
 
       Await.ready(server, Duration(1, TimeUnit.SECONDS))
       server.isCompleted should ===(true)
-      system.isTerminated should ===(false)
+      system.whenTerminated.isCompleted should ===(false)
     }
 
     "provide binding if available" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
@@ -82,7 +82,7 @@ class HttpAppSpec extends AkkaSpec with Directives with RequestBuilding with Eve
       callAndVerify(host, port, "shutdown")
       Await.ready(server, Duration(1, TimeUnit.SECONDS))
       server.isCompleted should ===(true)
-      system.isTerminated should ===(false)
+      system.whenTerminated.isCompleted should ===(false)
     }
 
     "provide binding if available" in {


### PR DESCRIPTION
Issue: #827 
Replace deprecated (and soon to be removed) `isTerminated` in `HttpAppSpec` with `whenTerminated`