### PR TITLE
Provide Rejection Documentation #593

### DIFF
--- a/docs/src/main/paradox/java/http/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/rejections.md
@@ -1,10 +1,8 @@
 <a id="rejections-java"></a>
 # Rejections
 
-TODO update to Java APIs
-
-In the chapter about constructing @ref[Routes](routes.md#routes-java) the `~` operator was introduced, which connects two routes in a way
-that allows a second route to get a go at a request if the first route "rejected" it. The concept of "rejections" is
+In the chapter about constructing @ref[Routes](routes.md#routes-java) the `RouteDirectives.route()` method was introduced, which connects two or more routes in a way
+that allows the next specified route to get a go at a request if the first route "rejected" it. The concept of "rejections" is
 used by Akka HTTP for maintaining a more functional overall architecture and in order to be able to properly
 handle all kinds of error scenarios.
 
@@ -19,13 +17,13 @@ another route that can complete it. If there are more rejections all of them wil
 
 If the request cannot be completed by (a branch of) the route structure an enclosing @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections-java) directive
 can be used to convert a set of rejections into an `HttpResponse` (which, in most cases, will be an error response).
-`Route.seal` internally wraps its argument route with the @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections-java) directive in order to "catch"
+`Route.seal()` internally wraps its argument route with the @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections-java) directive in order to "catch"
 and handle any rejection.
 
 ## Predefined Rejections
 
 A rejection encapsulates a specific reason why a route was not able to handle a request. It is modeled as an object of
-type `Rejection`. Akka HTTP comes with a set of @github[predefined rejections](/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala), which are used by the many
+type `Rejection`. Akka HTTP comes with a set of @github[predefined rejections](/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala), which are used by the many
 @ref[predefined directives](directives/alphabetically.md#predefined-directives-java).
 
 Rejections are gathered up over the course of a Route evaluation and finally converted to `HttpResponse` replies by
@@ -35,18 +33,12 @@ the @ref[handleRejections](directives/execution-directives/handleRejections.md#h
 ## The RejectionHandler
 
 The @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections-java) directive delegates the actual job of converting a list of rejections to its argument, a
-@github[RejectionHandler](/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala), which is defined like this:
-
-```scala
-trait RejectionHandler extends (immutable.Seq[Rejection] => Option[Route])
-```
-
-Since a `RejectionHandler` returns an `Option[Route]` it can choose whether it would like to handle the current set
-of rejections or not. If it returns `None` the rejections will simply continue to flow through the route structure.
+@github[RejectionHandler](/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala), which is a partial function,
+so it can choose whether it would like to handle the current set of rejections or not.
+Unhandled rejections will simply continue to flow through the route structure.
 
 The default `RejectionHandler` applied by the top-level glue code that turns a `Route` into a
-`Flow` or async handler function for the @ref[low-level API](../server-side/low-level-server-side-api.md#http-low-level-server-side-api-java) (via
-`Route.handlerFlow` or `Route.asyncHandler`) will handle *all* rejections that reach it.
+`Flow` or async handler function for the @ref[low-level API](../server-side/low-level-server-side-api.md#http-low-level-server-side-api-java) will handle *all* rejections that reach it.
 
 ## Rejection Cancellation
 
@@ -55,7 +47,7 @@ them. This is because some route structure produce several "reasons" why a reque
 
 Take this route structure for example:
 
-TODO missing sample
+@@snip [RejectionHandlerExamplesTest.java](../../../../../test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java) { #example1 }
 
 For uncompressed POST requests this route structure would initially yield two rejections:
 
@@ -66,14 +58,13 @@ gzip-compressed requests here)
 In reality the route even generates one more rejection, a `TransformationRejection` produced by the @ref[post](directives/method-directives/post.md#post-java)
 directive. It "cancels" all other potentially existing *MethodRejections*, since they are invalid after the
 @ref[post](directives/method-directives/post.md#post) directive allowed the request to pass (after all, the route structure *can* deal with POST requests).
-These types of rejection cancellations are resolved *before* a `RejectionHandler` sees the rejection list.
-So, for the example above the `RejectionHandler` will be presented with only a single-element rejection list,
-containing nothing but the `UnsupportedRequestEncodingRejection`.
+These types of rejection cancellations are resolved *before* a `RejectionHandler` is called with any rejection.
+So, for the example above the `RejectionHandler` will be presented with only one single rejection, the `UnsupportedRequestEncodingRejection`.
 
 <a id="empty-rejections-java"></a>
 ## Empty Rejections
 
-Since rejections are passed around in a list (or rather immutable `Seq`) you might ask yourself what the semantics of
+Internally rejections stored in a list (or rather immutable `Seq`), so you might ask yourself what the semantics of
 an empty rejection list are. In fact, empty rejection lists have well defined semantics. They signal that a request was
 not handled because the respective resource could not be found. Akka HTTP reserves the special status of "empty
 rejection" to this most common failure a service is likely to produce.
@@ -86,28 +77,28 @@ So, for example, if the @ref[path](directives/path-directives/path.md#path-java)
 If you'd like to customize the way certain rejections are handled you'll have to write a custom
 [RejectionHandler](#the-rejectionhandler). Here is an example:
 
-TODO missing sample
+@@snip [RejectionHandlerExamplesTest.java](../../../../../test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java) { #custom-handler-example-java }
 
-The easiest way to construct a `RejectionHandler` is via the `RejectionHandler.Builder` that Akka HTTP provides.
+The easiest way to construct a `RejectionHandler` is via the `RejectionHandlerBuilder` class that Akka HTTP provides.
 After having created a new `Builder` instance with `RejectionHandler.newBuilder()`
 you can attach handling logic for certain types of rejections through three helper methods:
 
-handle
-: Handles certain rejections with the given partial function. The partial function simply produces a `Route` which is
+handle(Class<T>, Function<T, Route>)
+: Handles the provided type of rejections with the given function. The provided function simply produces a `Route` which is
 run when the rejection is "caught". This makes the full power of the Routing DSL available for defining rejection
 handlers and even allows for recursing back into the main route structure if required.
 
-handleAll[T <: Rejection]
+handleAll<T extends Rejection>(Class<T>, Function<List<T>, Route>)
 : Handles all rejections of a certain type at the same time. This is useful for cases where your need access to more
 than the first rejection of a certain type, e.g. for producing the error message to an unsupported request method.
 
-handleNotFound
+handleNotFound(Route)
 : As described [above](#empty-rejections) "Resource Not Found" is special as it is represented with an empty
 rejection set. The `handleNotFound` helper let's you specify the "recovery route" for this case.
 
 
 Even though you could handle several different rejection types in a single partial function supplied to `handle`
-it is recommended to split these up into distinct `handle` attachments instead.
+by "listening" to the `Rejection.class`, it is recommended to split these up into distinct `handle` attachments instead.
 This way the priority between rejections is properly defined via the order of your `handle` clauses rather than the
 (sometimes hard to predict or control) order of rejections in the rejection set.
 
@@ -122,6 +113,19 @@ itself.
 
 The second case allows you to restrict the applicability of your handler to certain branches of your route structure.
 
+### Customising rejection HTTP Responses
+
+It is also possible to customise just the responses that are returned by a defined rejection handler.
+This can be useful for example if you like the rejection messages and status codes of the default handler,
+however you'd like to wrap those responses in JSON or some other content type.
+
+Please note that since those are not 200 responses, a different content type than the one that was sent in
+a client's `Accept` header *is* legal. Thus the default handler renders such rejections as `text/plain`.
+
+In order to customise the HTTP Responses of an existing handler you can call the 
+`mapRejectionResponse` method on such handler as shown in the example below:
+
+@@snip [RejectionHandlerExamplesTest.java](../../../../../test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java) { #example-json }
 
 #### Adding the unmatched route in handleNotFound
 
@@ -129,6 +133,6 @@ Since rejection handlers are routes themselves, it is possible to do anything yo
 For example you may want to include the path which was not found in the response to the client, this is as simple as 
 using the `extractUnmatchedPath` and completing the route with it.
 
-@@snip [RejectionHandlerExamplesSpec.scala](../../../../../test/java/docs/http/javadsl/server/directives/ExecutionDirectivesExamplesTest.java) { #handleNotFoundWithDefails }
+@@snip [ExecutionDirectivesExamplesTest.java](../../../../../test/java/docs/http/javadsl/server/directives/ExecutionDirectivesExamplesTest.java) { #handleNotFoundWithDefails }
 
 If you want to add even more information you can obtain the full request by using `extractRequest` as well.

--- a/docs/src/main/paradox/scala/http/routing-dsl/source-streaming-support.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/source-streaming-support.md
@@ -125,4 +125,4 @@ Refer to the below, complete, example showcasing how to configure a custom marsh
 the entity streaming's support content type to be compatible. This is an area that would benefit from additional type-safety,
 which we hope to add in a future release.
 
-@@snip [JsonStreamingFullExamples.scala](../../../../../test/java/docs/http/scaladsl/server/JsonStreamingFullExamples.scala) { #custom-content-type }
+@@snip [JsonStreamingFullExamples.scala](../../../../../test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala) { #custom-content-type }

--- a/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.http.javadsl.server;
+
+import akka.http.javadsl.coding.Coder;
+import akka.http.javadsl.model.ContentTypes;
+import akka.http.javadsl.model.HttpEntity;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.AuthorizationFailedRejection;
+import akka.http.javadsl.server.MethodRejection;
+import akka.http.javadsl.server.MissingCookieRejection;
+import akka.http.javadsl.server.RejectionHandler;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.server.ValidationRejection;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+
+public class RejectionHandlerExamplesTest extends JUnitRouteTest {
+
+  @Test
+  public void compileOnlySpec() throws Exception {
+    // just making sure for it to be really compiled / run even if empty
+  }
+
+  void example1() {
+    //#example1
+    final Route route = path("order", () ->
+      route(
+        get(() ->
+          complete("Received GET")
+        ),
+        post(() ->
+          decodeRequestWith(Coder.Gzip, () ->
+            complete("Received compressed POST")
+          )
+        )
+      ));
+    //#example1
+  }
+
+  void customRejectionHandler() {
+    //#custom-handler-example-java
+    final RejectionHandler rejectionHandler = RejectionHandler.newBuilder()
+      .handle(MissingCookieRejection.class, rej ->
+        complete(StatusCodes.BAD_REQUEST, "No cookies, no service!!!")
+      )
+      .handle(AuthorizationFailedRejection.class, rej ->
+        complete(StatusCodes.FORBIDDEN, "You're out of your depth!")
+      )
+      .handle(ValidationRejection.class, rej ->
+        complete(StatusCodes.INTERNAL_SERVER_ERROR, "That wasn't valid! " + rej.message())
+      )
+      .handleAll(MethodRejection.class, rejections -> {
+        String supported = rejections.stream()
+          .map(rej -> rej.supported().name())
+          .collect(Collectors.joining(" or "));
+        return complete(StatusCodes.METHOD_NOT_ALLOWED, "Can't do that! Supported: " + supported + "!");
+      })
+      .handleNotFound(complete(StatusCodes.NOT_FOUND, "Not here!"))
+      .build();
+
+    // Route that will be bound to the Http
+    final Route wrapped = handleRejections(rejectionHandler,
+      this::getRoute); // Some route structure for this Server
+    //#custom-handler-example-java
+  }
+
+  Route getRoute() {
+    return null;
+  }
+
+  @Test
+  public void customRejectionResponse() {
+    //#example-json
+    final RejectionHandler rejectionHandler = RejectionHandler.defaultHandler()
+      .mapRejectionResponse(response -> {
+        if (response.entity() instanceof HttpEntity.Strict) {
+          // since all Akka default rejection responses are Strict this will handle all rejections
+          String message = ((HttpEntity.Strict) response.entity()).getData().utf8String()
+            .replaceAll("\"", "\\\"");
+          // we create a new copy the response in order to keep all headers and status code,
+          // replacing the original entity with a custom message as hand rolled JSON you could the
+          // entity using your favourite marshalling library (e.g. spray json or anything else)
+          return response.withEntity(ContentTypes.APPLICATION_JSON,
+            "{\"rejection\": \"" + message + "\"}");
+        } else {
+          // pass through all other types of responses
+          return response;
+        }
+      });
+
+    Route route = handleRejections(rejectionHandler, () ->
+      path("hello", () ->
+        complete("Hello there")
+      ));
+
+    // tests:
+    testRoute(route)
+      .run(HttpRequest.GET("/nope"))
+      .assertStatusCode(StatusCodes.NOT_FOUND)
+      .assertContentType(ContentTypes.APPLICATION_JSON)
+      .assertEntity("{\"rejection\": \"The requested resource could not be found.\"}");
+
+    Route anotherOne = handleRejections(rejectionHandler, () ->
+      validate(() -> false, "Whoops, bad request!", () ->
+        complete("Hello there")
+    ));
+
+    // tests:
+    testRoute(anotherOne)
+      .run(HttpRequest.GET("/hello"))
+      .assertStatusCode(StatusCodes.BAD_REQUEST)
+      .assertContentType(ContentTypes.APPLICATION_JSON)
+      .assertEntity("{\"rejection\": \"Whoops, bad request!\"}");
+    //#example-json
+  }
+
+}

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -117,17 +117,17 @@ class RejectionHandlerExamplesSpec extends RoutingSpec {
           complete("Hello there")
         }
       )
-      
-    //#example-json
+
+    // tests:
     Get("/nope") ~> route ~> check {
       status should === (StatusCodes.NotFound)
       contentType should === (ContentTypes.`application/json`)
       responseAs[String] should ===("""{"rejection": "The requested resource could not be found."}""")
     }
+    //#example-json
   }
   
   "example-3-custom-rejection-http-response" in {
-    //#example-json
     import akka.http.scaladsl.model._
     import akka.http.scaladsl.server.RejectionHandler
 
@@ -144,20 +144,23 @@ class RejectionHandlerExamplesSpec extends RoutingSpec {
             
           case x => x // pass through all other types of responses
         }
-    
-    val route =
+
+    //#example-json
+
+    val anotherRoute =
       Route.seal(
         validate(check = false, "Whoops, bad request!") {
           complete("Hello there") 
         }
       )
-      
-    //#example-json
-    Get("/hello") ~> route ~> check {
+
+    // tests:
+    Get("/hello") ~> anotherRoute ~> check {
       status should === (StatusCodes.BadRequest)
       contentType should === (ContentTypes.`application/json`)
       responseAs[String] should ===("""{"rejection": "Whoops, bad request!"}""")
     }
+    //#example-json
   }
 
   "test custom handler example" in {


### PR DESCRIPTION
Issue: #593
* Extend `RejectionHandler` to have `mapRejectionResponse`
* Add tests for it
* Documenation for Rejections adapted to Java APIs
* Fix code example for Scala docs