### PR TITLE
As mentioned in #106, parsers should also accept LF end of line as good as CRLF.

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -463,6 +463,7 @@ private[http] object HttpHeaderParser {
     insertInGoodOrder(specializedHeaderValueParsers)()
     insertInGoodOrder(predefinedHeaders.sorted)()
     parser.insert(ByteString("\r\n"), EmptyHeader)()
+    parser.insert(ByteString("\n"), EmptyHeader)()
     parser
   }
 
@@ -522,6 +523,9 @@ private[http] object HttpHeaderParser {
         case '\r' if byteChar(input, ix + 1) == '\n' ⇒
           if (WSP(byteChar(input, ix + 2))) scanHeaderValue(hhp, input, start, limit, log, mode)(appended(' '), ix + 3)
           else (if (sb != null) sb.toString else asciiString(input, start, ix), ix + 2)
+        case '\n' ⇒
+          if (WSP(byteChar(input, ix + 1))) scanHeaderValue(hhp, input, start, limit, log, mode)(appended(' '), ix + 2)
+          else (if (sb != null) sb.toString else asciiString(input, start, ix), ix + 1)
         case c ⇒
           var nix = ix + 1
           val nsb =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -242,6 +242,7 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
           case c if CharacterClasses.HEXDIG(c) ⇒ parseSize(cursor + 1, size * 16 + CharUtils.hexValue(c))
           case ';' if cursor > offset ⇒ parseChunkExtensions(size.toInt, cursor + 1)()
           case '\r' if cursor > offset && byteChar(input, cursor + 1) == '\n' ⇒ parseChunkBody(size.toInt, "", cursor + 2)
+          case '\n' if cursor > offset ⇒ parseChunkBody(size.toInt, "", cursor + 1)
           case c ⇒ failEntityStream(s"Illegal character '${escape(c)}' in chunk start")
         }
       } else failEntityStream(s"HTTP chunk size exceeds the configured limit of ${settings.maxChunkSize} bytes")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
@@ -73,6 +73,8 @@ private[http] final class HttpRequestParser(
       cursor = parseProtocol(input, cursor)
       if (byteChar(input, cursor) == '\r' && byteChar(input, cursor + 1) == '\n')
         parseHeaderLines(input, cursor + 2)
+      else if (byteChar(input, cursor) == '\n')
+        parseHeaderLines(input, cursor + 1)
       else onBadProtocol
     }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
@@ -89,11 +89,12 @@ private[http] class HttpResponseParser(protected val settings: ParserSettings, p
       @tailrec def skipReason(idx: Int): Int =
         if (idx - startIdx <= maxResponseReasonLength)
           if (byteChar(input, idx) == '\r' && byteChar(input, idx + 1) == '\n') idx + 2
+          else if (byteChar(input, idx) == '\n') idx + 1
           else skipReason(idx + 1)
         else throw new ParsingException("Response reason phrase exceeds the configured limit of " +
           maxResponseReasonLength + " characters")
       skipReason(startIdx)
-    } else if (byteChar(input, cursor + 3) == '\r' && byteChar(input, cursor + 4) == '\n') {
+    } else if (byteChar(input, cursor + 3) == '\n' || byteChar(input, cursor + 3) == '\r' && byteChar(input, cursor + 4) == '\n') {
       throw new ParsingException("Status code misses trailing space")
     } else badStatusCode
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/SpecializedHeaderValueParsers.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/SpecializedHeaderValueParsers.scala
@@ -26,6 +26,7 @@ private object SpecializedHeaderValueParsers {
         else if (DIGIT(c)) recurse(ix + 1, result * 10 + c - '0')
         else if (WSP(c)) recurse(ix + 1, result)
         else if (c == '\r' && byteChar(input, ix + 1) == '\n') (`Content-Length`(result), ix + 2)
+        else if (c == '\n') (`Content-Length`(result), ix + 1)
         else fail("Illegal `Content-Length` header value")
       }
       recurse()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ContentLengthHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ContentLengthHeaderParserSpec.scala
@@ -9,9 +9,9 @@ import akka.util.ByteString
 import akka.http.scaladsl.model.headers.`Content-Length`
 import akka.http.impl.engine.parsing.SpecializedHeaderValueParsers.ContentLengthParser
 
-class ContentLengthHeaderParserSpec extends WordSpec with Matchers {
+abstract class ContentLengthHeaderParserSpec(mode: String, newLine: String) extends WordSpec with Matchers {
 
-  "specialized ContentLength parser" should {
+  s"specialized ContentLength parser (mode: $mode)" should {
     "accept zero" in {
       parse("0") shouldEqual 0L
     }
@@ -30,8 +30,12 @@ class ContentLengthHeaderParserSpec extends WordSpec with Matchers {
   }
 
   def parse(bigint: String): Long = {
-    val (`Content-Length`(length), _) = ContentLengthParser(null, ByteString(bigint + "\r\n").compact, 0, _ ⇒ ())
+    val (`Content-Length`(length), _) = ContentLengthParser(null, ByteString(bigint + newLine).compact, 0, _ ⇒ ())
     length
   }
 
 }
+
+class ContentLengthHeaderParserCRLFSpec extends ContentLengthHeaderParserSpec("CRLF", "\r\n")
+
+class ContentLengthHeaderParserLFSpec extends ContentLengthHeaderParserSpec("LF", "\n")

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -31,7 +31,7 @@ import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.util.FastFuture._
 import akka.testkit.TestKit
 
-class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
+abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec with Matchers with BeforeAndAfterAll {
   val testConf: Config = ConfigFactory.parseString("""
     akka.event-handlers = ["akka.testkit.TestEventListener"]
     akka.loglevel = WARNING
@@ -44,7 +44,7 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
   val BOLT = HttpMethod.custom("BOLT", safe = false, idempotent = true, requestEntityAcceptance = Expected)
   implicit val materializer = ActorMaterializer()
 
-  "The request parsing logic should" - {
+  s"The request parsing logic should (mode: $mode)" - {
     "properly parse a request" - {
       "with no headers and no body" in new Test {
         """GET / HTTP/1.0
@@ -275,8 +275,8 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
 
         val x = NotEnoughDataException
         val numChunks = 12000 // failed starting from 4000 with sbt started with `-Xss2m`
-        val oneChunk = "1\r\nz\n"
-        val manyChunks = (oneChunk * numChunks) + "0\r\n"
+        val oneChunk = s"1${newLine}z\n"
+        val manyChunks = (oneChunk * numChunks) + s"0${newLine}"
 
         val parser = newParser
         val result = multiParse(newParser)(Seq(prep(start + manyChunks)))
@@ -596,8 +596,12 @@ class RequestParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
       data.limit(100000).runWith(Sink.seq)
         .fast.recover { case _: NoSuchElementException ⇒ Nil }
 
-    def prep(response: String) = response.stripMarginWithNewline("\r\n")
+    def prep(response: String) = response.stripMarginWithNewline(newLine)
   }
 
   def source[T](elems: T*): Source[T, NotUsed] = Source(elems.toList)
 }
+
+class RequestParserCRLFSpec extends RequestParserSpec("CRLF", "\r\n")
+
+class RequestParserLFSpec extends RequestParserSpec("LF", "\n")

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -31,7 +31,7 @@ import ParserOutput._
 import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import akka.testkit.TestKit
 
-class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
+abstract class ResponseParserSpec(mode: String, newLine: String) extends FreeSpec with Matchers with BeforeAndAfterAll {
   val testConf: Config = ConfigFactory.parseString("""
     akka.event-handlers = ["akka.testkit.TestEventListener"]
     akka.loglevel = WARNING
@@ -42,7 +42,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
   implicit val materializer = ActorMaterializer()
   val ServerOnTheMove = StatusCodes.custom(331, "Server on the move")
 
-  "The response parsing logic should" - {
+  s"The response parsing logic should (mode: $mode)" - {
     "properly parse" - {
 
       // http://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -85,7 +85,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
       }
 
       "a response with a missing reason phrase" in new Test {
-        "HTTP/1.1 200 \r\nContent-Length: 0\r\n\r\n" should parseTo(HttpResponse(OK))
+        s"HTTP/1.1 200 ${newLine}Content-Length: 0${newLine}${newLine}" should parseTo(HttpResponse(OK))
         closeAfterResponseCompletion shouldEqual Seq(false)
       }
 
@@ -229,7 +229,7 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
 
     "reject a response with" - {
       "HTTP version 1.2" in new Test {
-        Seq("HTTP/1.2 200 OK\r\n") should generalMultiParseTo(Left(MessageStartError(
+        Seq(s"HTTP/1.2 200 OK${newLine}") should generalMultiParseTo(Left(MessageStartError(
           400: StatusCode, ErrorInfo("The server-side HTTP version is not supported"))))
       }
 
@@ -239,12 +239,12 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
       }
 
       "a too-long response status reason" in new Test {
-        Seq("HTTP/1.1 204 12345678", "90123456789012\r\n") should generalMultiParseTo(Left(
+        Seq("HTTP/1.1 204 12345678", s"90123456789012${newLine}") should generalMultiParseTo(Left(
           MessageStartError(400: StatusCode, ErrorInfo("Response reason phrase exceeds the configured limit of 21 characters"))))
       }
 
       "with a missing reason phrase and no trailing space" in new Test {
-        Seq("HTTP/1.1 200\r\nContent-Length: 0\r\n\r\n") should generalMultiParseTo(Left(MessageStartError(
+        Seq(s"HTTP/1.1 200${newLine}Content-Length: 0${newLine}${newLine}") should generalMultiParseTo(Left(MessageStartError(
           400: StatusCode, ErrorInfo("Status code misses trailing space"))))
       }
     }
@@ -366,8 +366,12 @@ class ResponseParserSpec extends FreeSpec with Matchers with BeforeAndAfterAll {
         .fast.map(source(_: _*))
         .fast.recover { case _: NoSuchElementException ⇒ source() }
 
-    def prep(response: String) = response.stripMarginWithNewline("\r\n")
+    def prep(response: String) = response.stripMarginWithNewline(newLine)
 
     def source[T](elems: T*): Source[T, NotUsed] = Source(elems.toList)
   }
 }
+
+class ResponseParserCRLFSpec extends ResponseParserSpec("CRLF", "\r\n")
+
+class ResponseParserLFSpec extends ResponseParserSpec("LF", "\n")


### PR DESCRIPTION
* Add tests verifying `\n` alongside `\r\n` in all modified parsers
* Duplicate specs to test either with `\r\n` and with `\n` (force to test in both cases for future developments)