### PR TITLE
=htc #851 fix leaking AbsorbCancellation

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.3.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.3.backwards.excludes
@@ -1,0 +1,10 @@
+# Added new method to interface to be extended only internally.
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ServerSettings#Timeouts.withLingerTimeout")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ServerSettings#Timeouts.lingerTimeout")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ServerSettings#Timeouts.withLingerTimeout")
+
+# internal class
+ProblemFilters.exclude[MissingTypesProblem]("akka.http.impl.settings.ServerSettingsImpl$Timeouts$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl#Timeouts.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl#Timeouts.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl#Timeouts.this")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -37,6 +37,19 @@ akka.http {
     # The time period within which the TCP binding process must be completed.
     bind-timeout = 1s
 
+    # The time period the HTTP server implementation will keep a connection open after
+    # all data has been delivered to the network layer. This setting is similar to the SO_LINGER socket option
+    # but does not only include the OS-level socket but also covers the Akka IO / Akka Streams network stack.
+    # The setting is an extra precaution that prevents clients from keeping open a connection that is
+    # already considered completed from the server side.
+    #
+    # If the network level buffers (including the Akka Stream / Akka IO networking stack buffers)
+    # contains more data than can be transferred to the client in the given time when the server-side considers
+    # to be finished with this connection, the client may encounter a connection reset.
+    #
+    # Set to 'infinite' to disable automatic connection closure (which will risk to leak connections).
+    linger-timeout = 1 min
+
     # The maximum number of concurrently accepted connections when using the
     # `Http().bindAndHandle` methods.
     #

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
@@ -54,10 +54,12 @@ object ServerSettingsImpl extends SettingsCompanion[ServerSettingsImpl]("akka.ht
   final case class Timeouts(
     idleTimeout:    Duration,
     requestTimeout: Duration,
-    bindTimeout:    FiniteDuration) extends ServerSettings.Timeouts {
+    bindTimeout:    FiniteDuration,
+    lingerTimeout:  Duration) extends ServerSettings.Timeouts {
     require(idleTimeout > Duration.Zero, "idleTimeout must be infinite or > 0")
     require(requestTimeout > Duration.Zero, "requestTimeout must be infinite or > 0")
     require(bindTimeout > Duration.Zero, "bindTimeout must be > 0")
+    require(lingerTimeout > Duration.Zero, "lingerTimeout must be infinite or > 0")
   }
 
   def fromSubConfig(root: Config, c: Config) = new ServerSettingsImpl(
@@ -65,7 +67,8 @@ object ServerSettingsImpl extends SettingsCompanion[ServerSettingsImpl]("akka.ht
     Timeouts(
       c getPotentiallyInfiniteDuration "idle-timeout",
       c getPotentiallyInfiniteDuration "request-timeout",
-      c getFiniteDuration "bind-timeout"),
+      c getFiniteDuration "bind-timeout",
+      c getPotentiallyInfiniteDuration "linger-timeout"),
     c getInt "max-connections",
     c getInt "pipelining-limit",
     c getBoolean "remote-address-header",
@@ -85,8 +88,4 @@ object ServerSettingsImpl extends SettingsCompanion[ServerSettingsImpl]("akka.ht
       },
     Randoms.SecureRandomInstances, // can currently only be overridden from code
     ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing")))
-
-  //  def apply(optionalSettings: Option[ServerSettings])(implicit actorRefFactory: ActorRefFactory): ServerSettings =
-  //    optionalSettings getOrElse apply(actorSystem)
-
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
@@ -11,6 +11,7 @@ import akka.http.javadsl.model.headers.Host
 import akka.http.javadsl.model.headers.Server
 import akka.io.Inet.SocketOption
 import akka.http.impl.util.JavaMapping.Implicits._
+import akka.http.scaladsl.settings
 import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
@@ -63,11 +64,13 @@ object ServerSettings extends SettingsCompanion[ServerSettings] {
     def idleTimeout: Duration
     def requestTimeout: Duration
     def bindTimeout: FiniteDuration
+    def lingerTimeout: Duration
 
     // ---
-    def withIdleTimeout(newValue: Duration): ServerSettings.Timeouts = self.copy(idleTimeout = newValue)
-    def withRequestTimeout(newValue: Duration): ServerSettings.Timeouts = self.copy(requestTimeout = newValue)
-    def withBindTimeout(newValue: FiniteDuration): ServerSettings.Timeouts = self.copy(bindTimeout = newValue)
+    def withIdleTimeout(newValue: Duration): Timeouts = self.copy(idleTimeout = newValue)
+    def withRequestTimeout(newValue: Duration): Timeouts = self.copy(requestTimeout = newValue)
+    def withBindTimeout(newValue: FiniteDuration): Timeouts = self.copy(bindTimeout = newValue)
+    def withLingerTimeout(newValue: Duration): Timeouts = self.copy(lingerTimeout = newValue)
 
     /** INTERNAL API */
     protected def self = this.asInstanceOf[ServerSettingsImpl.Timeouts]

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -111,12 +111,7 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
           incoming.flow
             // Prevent cancellation from the Http implementation to reach the TCP streams to prevent
             // completion / cancellation race towards TCP streams. See #459.
-            //
-            // This could create a potential resource leak, if, e.g. because of a bug, the HTTP implementation doesn't
-            // close the write-side of the connection at the same time as it cancels the read side and if the client
-            // never closes the connection after or while reading the response. Fortunately, this will be handled by
-            // the idle-timeout which will forcibly close the connection after a defined amount of inactivity.
-            .via(StreamUtils.absorbCancellation)
+            .via(StreamUtils.delayCancellation(settings.lingerTimeout))
         incoming.copy(flow = newFlow)
       }
   }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -18,7 +18,7 @@ import com.typesafe.config.Config
 import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.compat.java8.OptionConverters
-import scala.concurrent.duration.{ FiniteDuration, Duration }
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.language.implicitConversions
 
 /**
@@ -90,9 +90,10 @@ object ServerSettings extends SettingsCompanion[ServerSettings] {
   trait Timeouts extends akka.http.javadsl.settings.ServerSettings.Timeouts {
     // ---
     // override for more specific return types
-    override def withIdleTimeout(newValue: Duration): ServerSettings.Timeouts = self.copy(idleTimeout = newValue)
-    override def withRequestTimeout(newValue: Duration): ServerSettings.Timeouts = self.copy(requestTimeout = newValue)
-    override def withBindTimeout(newValue: FiniteDuration): ServerSettings.Timeouts = self.copy(bindTimeout = newValue)
+    override def withIdleTimeout(newValue: Duration): Timeouts = self.copy(idleTimeout = newValue)
+    override def withRequestTimeout(newValue: Duration): Timeouts = self.copy(requestTimeout = newValue)
+    override def withBindTimeout(newValue: FiniteDuration): Timeouts = self.copy(bindTimeout = newValue)
+    override def withLingerTimeout(newValue: Duration): Timeouts = self.copy(lingerTimeout = newValue)
   }
 
   implicit def timeoutsShortcut(s: ServerSettings): Timeouts = s.timeouts

--- a/docs/src/main/paradox/java/http/common/timeouts.md
+++ b/docs/src/main/paradox/java/http/common/timeouts.md
@@ -58,6 +58,20 @@ The request timeout can be configured at run-time for a given route using the an
 The bind timeout is the time period within which the TCP binding process must be completed (using any of the `Http().bind*` methods).
 It can be configured using the `akka.http.server.bind-timeout` setting.
 
+### Linger timeout
+
+The linger timeout is the time period the HTTP server implementation will keep a connection open after
+all data has been delivered to the network layer. This setting is similar to the SO_LINGER socket option
+but does not only include the OS-level socket but also covers the Akka IO / Akka Streams network stack.
+The setting is an extra precaution that prevents clients from keeping open a connection that is
+already considered completed from the server side.
+
+If the network level buffers (including the Akka Stream / Akka IO networking stack buffers)
+contains more data than can be transferred to the client in the given time when the server-side considers
+to be finished with this connection, the client may encounter a connection reset.
+
+Set to `infinite` to disable automatic connection closure (which will risk to leak connections).
+
 ## Client timeouts
 
 ### Connecting timeout

--- a/docs/src/main/paradox/scala/http/common/timeouts.md
+++ b/docs/src/main/paradox/scala/http/common/timeouts.md
@@ -25,7 +25,7 @@ akka.http.host-connection-pool.client.idle-timeout
 ```
 
 @@@ note
-For the connection pooled client side the idle period is counted only when the pool has no pending requests waiting.
+For the client side connection pool, the idle period is counted only when the pool has no pending requests waiting.
 @@@
 
 ## Server timeouts
@@ -57,6 +57,20 @@ The request timeout can be configured at run-time for a given route using the an
 
 The bind timeout is the time period within which the TCP binding process must be completed (using any of the `Http().bind*` methods).
 It can be configured using the `akka.http.server.bind-timeout` setting.
+
+### Linger timeout
+
+The linger timeout is the time period the HTTP server implementation will keep a connection open after
+all data has been delivered to the network layer. This setting is similar to the SO_LINGER socket option
+but does not only include the OS-level socket but also covers the Akka IO / Akka Streams network stack.
+The setting is an extra precaution that prevents clients from keeping open a connection that is
+already considered completed from the server side.
+
+If the network level buffers (including the Akka Stream / Akka IO networking stack buffers)
+contains more data than can be transferred to the client in the given time when the server-side considers
+to be finished with this connection, the client may encounter a connection reset.
+
+Set to `infinite` to disable automatic connection closure (which will risk to leak connections).
 
 ## Client timeouts
 


### PR DESCRIPTION
Under circumstances that I could not reproduce so far,
the AbsorbCancellation stage introduced in #459 may keep the graph running
if data was already buffered but never read. The reason is that the stage
so far requires completion to reach the stage after cancellation was
absorbed which might be blocked by incoming elements that were never
pulled.

The solution is two-fold. After cancellation:

 1) pull in and ignore all incoming elements to eventually fetch completion
 2) complete the stage after a configurable time

In the HTTP use case, we delay the cancellation by no more than the time specified
in the new linger-timeout setting.