### PR TITLE
Remove duplicated info from index. Add akka-http-jackson mdoule in intro

### DIFF
--- a/docs/src/main/paradox/java/http/index.md
+++ b/docs/src/main/paradox/java/http/index.md
@@ -1,31 +1,6 @@
 <a id="http-java"></a>
 # Akka HTTP
 
-The Akka HTTP modules implement a full server- and client-side HTTP stack on top of *akka-actor* and *akka-stream*. It's
-not a web-framework but rather a more general toolkit for providing and consuming HTTP-based services. While interaction
-with a browser is of course also in scope it is not the primary focus of Akka HTTP.
-
-Akka HTTP follows a rather open design and many times offers several different API levels for "doing the same thing".
-You get to pick the API level of abstraction that is most suitable for your application.
-This means that, if you have trouble achieving something using a high-level API, there's a good chance that you can get
-it done with a low-level API, which offers more flexibility but might require you to write more application code.
-
-Akka HTTP is structured into several modules:
-
-akka-http-core
-: A complete, mostly low-level, server- and client-side implementation of HTTP (incl. WebSockets).
-Includes a model of all things HTTP.
-
-akka-http
-: Higher-level functionality, like (un)marshalling, (de)compression as well as a powerful DSL
-for defining HTTP-based APIs on the server-side
-
-akka-http-testkit
-: A test harness and set of utilities for verifying server-side service implementations
-
-akka-http-jackson
-: Predefined glue-code for (de)serializing custom types from/to JSON with [jackson](https://github.com/FasterXML/jackson)
-
 Akka HTTP API - @javadoc:[Javadoc](akka.http.javadsl.package-summary)
 
 @@toc { depth=3 }

--- a/docs/src/main/paradox/java/http/introduction.md
+++ b/docs/src/main/paradox/java/http/introduction.md
@@ -131,3 +131,6 @@ Details can be found in sections @ref[Low-Level Server-Side API](server-side/low
 
 akka-http-testkit
 : A test harness and set of utilities for verifying server-side service implementations
+
+akka-http-jackson
+: Predefined glue-code for (de)serializing custom types from/to JSON with [jackson](https://github.com/FasterXML/jackson)


### PR DESCRIPTION
Issue: ##863
Information under `index.html` for Java documentation is a partial duplication of `introduction.html`.
Remove duplicated text.
Add missing dependency under `introduction.html`