### PR TITLE
Improve HttpApp usability #873 #875

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
@@ -42,6 +42,22 @@ class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
 
   "HttpApp Java" should {
 
+    "start only with host and port" in withMinimal { (minimal, host, port) ⇒
+
+      val server = Future {
+        minimal.startServer(host, port)
+      }
+
+      minimal.bindingPromise.get(5, TimeUnit.SECONDS)
+
+      // Requesting the server to shutdown
+      callAndVerify(host, port, "shutdown")
+
+      Await.ready(server, Duration(1, TimeUnit.SECONDS))
+      server.isCompleted should ===(true)
+
+    }
+
     "start without ActorSystem" in withMinimal { (minimal, host, port) ⇒
 
       val server = Future {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.util.Try
 
-class HttpAppSpec extends AkkaSpec with Directives with RequestBuilding with Eventually {
+class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
   import system.dispatcher
 
   class MinimalApp extends HttpApp {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
@@ -89,6 +89,19 @@ class HttpAppSpec extends AkkaSpec with Directives with RequestBuilding with Eve
 
   "HttpApp" should {
 
+    "start only with host and port" in withMinimal { (minimal, host, port) ⇒
+      val server = Future {
+        minimal.startServer(host, port)
+      }
+
+      Await.result(minimal.bindingPromise.future, Duration(5, TimeUnit.SECONDS))
+
+      // Requesting the server to shutdown
+      callAndVerify(host, port, "shutdown")
+      Await.ready(server, Duration(1, TimeUnit.SECONDS))
+      server.isCompleted should ===(true)
+    }
+
     "start without ActorSystem" in withMinimal { (minimal, host, port) ⇒
 
       val server = Future {

--- a/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
@@ -11,6 +11,7 @@ import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.settings.ServerSettings;
 import akka.stream.ActorMaterializer;
+import com.typesafe.config.ConfigFactory;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -32,6 +33,14 @@ public abstract class HttpApp extends AllDirectives {
    * Holds a reference to the {@link ActorSystem} used to start this server. Stopping this system will interfere with the proper functioning condition of the server.
    */
   protected AtomicReference<ActorSystem> systemReference = new AtomicReference<>();
+
+  /**
+   * Start a server on the specified host and port.
+   * Note that this method is blocking.
+   */
+  public void startServer(String host, int port) throws ExecutionException, InterruptedException {
+      startServer(host, port, ServerSettings.create(ConfigFactory.load()));
+  }
 
   /**
    * Start a server on the specified host and port, using provided settings.

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -13,6 +13,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.stream.ActorMaterializer
 import akka.http.scaladsl.settings.ServerSettings
+import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContext, Future }
@@ -32,6 +33,14 @@ trait HttpApp {
    * [[ActorSystem]] used to start this server. Stopping this system will interfere with the proper functioning condition of the server.
    */
   protected val systemReference = new AtomicReference[ActorSystem]()
+
+  /**
+   * Start a server on the specified host and port.
+   * Note that this method is blocking
+   */
+  def startServer(host: String, port: Int): Unit = {
+    startServer(host, port, ServerSettings(ConfigFactory.load))
+  }
 
   /**
    * Start a server on the specified host and port, using provided settings.

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -26,7 +26,7 @@ import scala.util.{ Failure, Success, Try }
  * It offers additional hooks to modify the default behavior.
  */
 // @akka.annotation.ApiMayChange // FIXME replace with real annotation once Akka dependency bumped
-trait HttpApp {
+trait HttpApp extends Directives {
 
   private val serverBinding = new AtomicReference[ServerBinding]()
   /**

--- a/docs/src/main/paradox/java/http/routing-dsl/HttpApp.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/HttpApp.md
@@ -19,10 +19,10 @@ If desired, `HttpApp` provides different hook methods that can be overridden to 
 
 The following example shows how to start a server:
 
-@@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #imports #minimal-routing-example }
+@@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #minimal-imports #minimal-routing-example }
 
 Firstly we define a `class` that extends `HttpApp` and we just implement the routes this server will handle.
-After that, we can start a server just by providing a `host`, `port` and `ServerProperties`. Calling `startServer` blocks the current thread until the server is signaled for termination.
+After that, we can start a server just by providing a `host` and a `port`. Calling `startServer` blocks the current thread until the server is signaled for termination.
 The default behavior of `HttpApp` is to start a server, and shut it down after `ENTER` is pressed. When the call to `startServer` returns the server is properly shut down.
 
 ## Reacting to Bind Failures
@@ -35,6 +35,14 @@ Here you can see an example server that overrides the `postHttpBindingFailure` h
 @@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #imports #bindingError }
 
 So if the port `80` would be already taken by another app, the call to `startServer` returns immediately and the `postHttpBindingFailure` hook will be called.
+
+## Providing your own Server Settings
+
+`HttpApp` reads the default `ServerSettings` when one is not provided.
+In case you want to provide different settings, you can simply pass it to `startServer` as illustrated in the following example:
+
+@@snip [HttpAppExampleTest.java](../../../../../test/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #imports #with-settings-routing-example }
+
 
 ## Providing your own Actor System
 

--- a/docs/src/main/paradox/scala/http/routing-dsl/HttpApp.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/HttpApp.md
@@ -22,7 +22,7 @@ The following example shows how to start a server:
 @@snip [HttpAppExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala) { #minimal-routing-example }
 
 Firstly we define an `object` (it can also be a `class`) that extends `HttpApp` and we just implement the routes this server will handle.
-After that, we can start a server just by providing a `host`, `port` and `ServerProperties`. Calling `startServer` blocks the current thread until the server is signaled for termination.
+After that, we can start a server just by providing a `host` and a `port`. Calling `startServer` blocks the current thread until the server is signaled for termination.
 The default behavior of `HttpApp` is to start a server, and shut it down after `ENTER` is pressed. When the call to `startServer` returns the server is properly shut down.
 
 ## Reacting to Bind Failures
@@ -35,6 +35,14 @@ Here you can see an example server that overrides the `postHttpBindingFailure` h
 @@snip [HttpAppExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala) { #failed-binding-example }
 
 So if the port `80` would be already taken by another app, the call to `startServer` returns immediately and the `postHttpBindingFailure` hook will be called.
+
+## Providing your own Server Settings
+
+`HttpApp` reads the default `ServerSettings` when one is not provided.
+In case you want to provide different settings, you can simply pass it to `startServer` as illustrated in the following example:
+
+@@snip [HttpAppExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala) { #with-settings-routing-example }
+
 
 ## Providing your own Actor System
 

--- a/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
@@ -1,10 +1,12 @@
 package docs.http.javadsl.server;
 
 //#imports
+//#minimal-imports
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.http.javadsl.server.HttpApp;
 import akka.http.javadsl.server.Route;
+//#minimal-imports
 import akka.http.javadsl.settings.ServerSettings;
 import com.typesafe.config.ConfigFactory;
 //#imports
@@ -16,8 +18,10 @@ import scala.concurrent.duration.Duration;
 import scala.runtime.BoxedUnit;
 //#selfClosing
 //#imports
+//#minimal-imports
 import java.util.Optional;
 import java.util.concurrent.*;
+//#minimal-imports
 //#imports
 //#selfClosing
 
@@ -55,10 +59,18 @@ public class HttpAppExampleTest extends JUnitSuite {
     //#minimal-routing-example
     // Starting the server
     final MinimalHttpApp myServer = new MinimalHttpApp();
-    myServer.startServer("localhost", 8080, ServerSettings.create(ConfigFactory.load()));
+    myServer.startServer("localhost", 8080);
     //#minimal-routing-example
   }
 
+
+  void withSettingsServer() throws ExecutionException, InterruptedException {
+    //#with-settings-routing-example
+    // Starting the server
+    final MinimalHttpApp myServer = new MinimalHttpApp();
+    myServer.startServer("localhost", 8080, ServerSettings.create(ConfigFactory.load()));
+    //#with-settings-routing-example
+  }
 
   static
   //#serverTerminationSignal

--- a/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
@@ -12,7 +12,6 @@ class HttpAppExampleSpec extends WordSpec with Matchers
   "minimal-routing-example" in compileOnlySpec {
     //#minimal-routing-example
     import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
-    import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.HttpApp
     import akka.http.scaladsl.server.Route
     
@@ -34,7 +33,6 @@ class HttpAppExampleSpec extends WordSpec with Matchers
   "with-settings-routing-example" in compileOnlySpec {
     //#with-settings-routing-example
     import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
-    import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.HttpApp
     import akka.http.scaladsl.server.Route
     import akka.http.scaladsl.settings.ServerSettings
@@ -58,7 +56,6 @@ class HttpAppExampleSpec extends WordSpec with Matchers
   "failed-binding" in compileOnlySpec {
     //#failed-binding-example
     import akka.http.scaladsl.model._
-    import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.HttpApp
     import akka.http.scaladsl.server.Route
     import akka.http.scaladsl.settings.ServerSettings
@@ -88,7 +85,6 @@ class HttpAppExampleSpec extends WordSpec with Matchers
     import akka.Done
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model._
-    import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.HttpApp
     import akka.pattern
     import akka.http.scaladsl.server.Route
@@ -121,7 +117,6 @@ class HttpAppExampleSpec extends WordSpec with Matchers
     //#with-actor-system
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model._
-    import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.HttpApp
     import akka.http.scaladsl.server.Route
     import akka.http.scaladsl.settings.ServerSettings
@@ -148,7 +143,6 @@ class HttpAppExampleSpec extends WordSpec with Matchers
     import akka.Done
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model._
-    import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.HttpApp
     import akka.http.scaladsl.server.Route
     import akka.http.scaladsl.settings.ServerSettings

--- a/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
@@ -15,6 +15,28 @@ class HttpAppExampleSpec extends WordSpec with Matchers
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.HttpApp
     import akka.http.scaladsl.server.Route
+    
+    // Server definition
+    object WebServer extends HttpApp {
+      def route: Route =
+        path("hello") {
+          get {
+            complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
+          }
+        }
+    }
+
+    // Starting the server
+    WebServer.startServer("localhost", 8080)
+    //#minimal-routing-example
+  }
+
+  "with-settings-routing-example" in compileOnlySpec {
+    //#with-settings-routing-example
+    import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
+    import akka.http.scaladsl.server.Directives._
+    import akka.http.scaladsl.server.HttpApp
+    import akka.http.scaladsl.server.Route
     import akka.http.scaladsl.settings.ServerSettings
     import com.typesafe.config.ConfigFactory
 
@@ -30,7 +52,7 @@ class HttpAppExampleSpec extends WordSpec with Matchers
 
     // Starting the server
     WebServer.startServer("localhost", 8080, ServerSettings(ConfigFactory.load))
-    //#minimal-routing-example
+    //#with-settings-routing-example
   }
 
   "failed-binding" in compileOnlySpec {


### PR DESCRIPTION
Issue: #873 and #875
Provide start server with only host and port
Update docu
Make `HttpApp` for Scala API extend `Directives` (like Java one does)