### PR TITLE
Avoid redirect loops when `redirectToNoTrailingSlashIfPresent` is used

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -441,6 +441,10 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
   "the `redirectToNoTrailingSlashIfPresent` directive" should {
     val route = redirectToNoTrailingSlashIfPresent(Found) { completeOk }
 
+    "pass if the path is a single slash" in {
+      Get("/") ~> route ~> check { response shouldEqual Ok }
+    }
+
     "pass if the request path already doesn't have a trailing slash" in {
       Get("/foo/bar") ~> route ~> check { response shouldEqual Ok }
     }
@@ -457,10 +461,6 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
       Get("/foo/bar/") ~>
         redirectToNoTrailingSlashIfPresent(MovedPermanently) { completeOk } ~>
         check { status shouldEqual MovedPermanently }
-    }
-
-    "not loop infinitely when the path is a single slash" in {
-      Get("/") ~> route ~> check { response shouldEqual Ok }
     }
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -423,7 +423,7 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
       Get("/foo/bar") ~> route ~> checkRedirectTo("/foo/bar/")
     }
 
-    "preserves the query and the frag when redirect" in {
+    "preserve the query and the frag when redirect" in {
       Get("/foo/bar?query#frag") ~> route ~> checkRedirectTo("/foo/bar/?query#frag")
     }
 
@@ -449,7 +449,7 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
       Get("/foo/bar/") ~> route ~> checkRedirectTo("/foo/bar")
     }
 
-    "preserves the query and the frag when redirect" in {
+    "preserve the query and the frag when redirect" in {
       Get("/foo/bar/?query#frag") ~> route ~> checkRedirectTo("/foo/bar?query#frag")
     }
 
@@ -457,6 +457,10 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
       Get("/foo/bar/") ~>
         redirectToNoTrailingSlashIfPresent(MovedPermanently) { completeOk } ~>
         check { status shouldEqual MovedPermanently }
+    }
+
+    "not loop infinitely when the path is a single slash" in {
+      Get("/") ~> route ~> check { response shouldEqual Ok }
     }
   }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
@@ -177,13 +177,11 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
   /**
    * If the request path ends with a slash, redirect to the same uri without trailing slash in the path.
    *
-   * '''Caveat''': [[pathSingleSlash]] directive will not match inside of this directive.
-   *
    * @group path
    */
   def redirectToNoTrailingSlashIfPresent(redirectionType: StatusCodes.Redirection): Directive0 =
     extractUri.flatMap { uri ⇒
-      if (uri.path.endsWithSlash) {
+      if (uri.path.endsWithSlash && uri.path != Path.SingleSlash) {
         val newPath = uri.path.reverse.tail.reverse
         val newUri = uri.withPath(newPath)
         redirect(newUri, redirectionType)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
@@ -177,6 +177,14 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
   /**
    * If the request path ends with a slash, redirect to the same uri without trailing slash in the path.
    *
+   * Note, however, that this directive doesn't apply to a URI consisting of just a single slash.
+   * HTTP does not support empty target paths, so that browsers will convert
+   * a URI such as `http://example.org` to `http://example.org/` adding the trailing slash.
+   *
+   * Redirecting the single slash path URI would lead to a redirection loop.
+   *
+   * '''Caveat''': [[pathSingleSlash]] directive will only match on the root path level inside of this directive.
+   *
    * @group path
    */
   def redirectToNoTrailingSlashIfPresent(redirectionType: StatusCodes.Redirection): Directive0 =


### PR DESCRIPTION
Fixes #878.

I'm not sure if it's the right way to do it - if you have any suggestions on how to make it better, please tell ;)