### PR TITLE
+htc #916 add pluggable Transport API to switch out client-side transport layer

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.4.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.4.backwards.excludes
@@ -4,3 +4,10 @@ ProblemFilters.exclude[MissingTypesProblem]("akka.http.impl.engine.client.PoolIn
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.impl.engine.client.PoolSlot.apply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.client.PoolFlow.apply")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.engine.client.PoolGateway#GatewayIdentifier.name")
+
+# Added new member to ConnectionPoolSettings which shouldn't be implemented by user classes, #916
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.transport")
+
+# changes to internal classes, #916
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.copy")

--- a/akka-http-core/src/main/mima-filters/10.0.4.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.4.backwards.excludes
@@ -11,3 +11,4 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.setting
 # changes to internal classes, #916
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.apply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.util.JavaMapping.flowMapping")

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ClientTransport.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ClientTransport.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.javadsl
+
+import java.net.InetSocketAddress
+import java.util.Optional
+import java.util.concurrent.CompletionStage
+
+import akka.actor.ActorSystem
+import akka.stream.javadsl.Flow
+import akka.util.ByteString
+import akka.http.javadsl.settings.ClientConnectionSettings
+import akka.http.impl.util.JavaMapping
+import JavaMapping._
+import JavaMapping.Implicits._
+import akka.http.{ javadsl, scaladsl }
+
+import scala.concurrent.Future
+
+abstract class ClientTransport { outer ⇒
+  def connectTo(host: String, port: Int, system: ActorSystem): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]]
+}
+
+object ClientTransport {
+  def TCP(localAddress: Optional[InetSocketAddress], settings: ClientConnectionSettings): ClientTransport =
+    scaladsl.ClientTransport.TCP(localAddress.asScala, settings.asScala).asJava
+
+  def fromScala(scalaTransport: scaladsl.ClientTransport): ClientTransport =
+    scalaTransport match {
+      case j: JavaWrapper ⇒ j.delegate
+      case x              ⇒ new ScalaWrapper(x)
+    }
+  def toScala(javaTransport: ClientTransport): scaladsl.ClientTransport =
+    javaTransport match {
+      case s: ScalaWrapper ⇒ s.delegate
+      case x               ⇒ new JavaWrapper(x)
+    }
+
+  private class ScalaWrapper(val delegate: scaladsl.ClientTransport) extends ClientTransport {
+    def connectTo(host: String, port: Int, system: ActorSystem): akka.stream.javadsl.Flow[ByteString, ByteString, CompletionStage[javadsl.OutgoingConnection]] = {
+      import system.dispatcher
+      JavaMapping.toJava(delegate.connectTo(host, port)(system))
+    }
+  }
+  private class JavaWrapper(val delegate: ClientTransport) extends scaladsl.ClientTransport {
+    def connectTo(host: String, port: Int)(implicit system: ActorSystem): akka.stream.scaladsl.Flow[ByteString, ByteString, Future[scaladsl.Http.OutgoingConnection]] = {
+      import system.dispatcher
+      JavaMapping.toScala(delegate.connectTo(host, port, system))
+    }
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -709,8 +709,8 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     delegate.createDefaultClientHttpsContext()
 
   private def adaptTupleFlow[T, Mat](scalaFlow: stream.scaladsl.Flow[(scaladsl.model.HttpRequest, T), (Try[scaladsl.model.HttpResponse], T), Mat]): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], Mat] = {
-    implicit val _ = JavaMapping.identity[T]
-    JavaMapping.toJava(scalaFlow)(JavaMapping.flowMapping[Pair[HttpRequest, T], (scaladsl.model.HttpRequest, T), Pair[Try[HttpResponse], T], (Try[scaladsl.model.HttpResponse], T), Mat])
+    implicit def id[X] = JavaMapping.identity[X]
+    JavaMapping.toJava(scalaFlow)(JavaMapping.flowMapping[Pair[HttpRequest, T], (scaladsl.model.HttpRequest, T), Pair[Try[HttpResponse], T], (Try[scaladsl.model.HttpResponse], T), Mat, Mat])
   }
 
   private def adaptOutgoingFlow[T, Mat](scalaFlow: stream.scaladsl.Flow[scaladsl.model.HttpRequest, scaladsl.model.HttpResponse, Future[scaladsl.Http.OutgoingConnection]]): Flow[HttpRequest, HttpResponse, CompletionStage[OutgoingConnection]] =

--- a/akka-http-core/src/main/scala/akka/http/javadsl/OutgoingConnection.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/OutgoingConnection.scala
@@ -8,7 +8,7 @@ import java.net.InetSocketAddress
 
 import akka.http.scaladsl
 
-class OutgoingConnection private[http] (delegate: scaladsl.Http.OutgoingConnection) {
+class OutgoingConnection private[http] (val delegate: scaladsl.Http.OutgoingConnection) {
   /**
    * The local address of this connection.
    */

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -4,23 +4,30 @@
 package akka.http.javadsl.settings
 
 import akka.actor.ActorSystem
+import akka.annotation.DoNotInherit
 import akka.http.impl.settings.ConnectionPoolSettingsImpl
+import akka.http.impl.util.JavaMapping
 import com.typesafe.config.Config
 
 import scala.concurrent.duration.Duration
 import akka.http.impl.util.JavaMapping.Implicits._
+import akka.http.javadsl.ClientTransport
 
 /**
  * Public API but not intended for subclassing
  */
+@DoNotInherit
 abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSettingsImpl ⇒
-  def getMaxConnections: Int
-  def getMinConnections: Int
-  def getMaxRetries: Int
-  def getMaxOpenRequests: Int
-  def getPipeliningLimit: Int
-  def getIdleTimeout: Duration
-  def getConnectionSettings: ClientConnectionSettings
+  def getMaxConnections: Int = maxConnections
+  def getMinConnections: Int = minConnections
+  def getMaxRetries: Int = maxRetries
+  def getMaxOpenRequests: Int = maxOpenRequests
+  def getPipeliningLimit: Int = pipeliningLimit
+  def getIdleTimeout: Duration = idleTimeout
+  def getConnectionSettings: ClientConnectionSettings = connectionSettings
+
+  /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
+  def getTransport: ClientTransport = transport.asJava
 
   // ---
 
@@ -30,6 +37,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue)
   def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue)
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala)
+  def withTransport(newValue: ClientTransport): ConnectionPoolSettings = self.copy(transport = newValue.asScala)
 }
 
 object ConnectionPoolSettings extends SettingsCompanion[ConnectionPoolSettings] {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ClientTransport.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ClientTransport.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl
+
+import java.net.InetSocketAddress
+
+import akka.actor.ActorSystem
+import akka.annotation.ApiMayChange
+import akka.http.scaladsl.Http.OutgoingConnection
+import akka.http.scaladsl.settings.ClientConnectionSettings
+import akka.stream.scaladsl.{ Flow, Tcp }
+import akka.util.ByteString
+
+import scala.concurrent.Future
+
+/**
+ * Abstraction to allow the creation of alternative transports to run HTTP on.
+ */
+@ApiMayChange
+trait ClientTransport {
+  def connectTo(host: String, port: Int)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[OutgoingConnection]]
+}
+
+object ClientTransport {
+  def TCP(localAddress: Option[InetSocketAddress], settings: ClientConnectionSettings): ClientTransport =
+    new TCPTransport(localAddress, settings)
+
+  private case class TCPTransport(localAddress: Option[InetSocketAddress], settings: ClientConnectionSettings) extends ClientTransport {
+    def connectTo(host: String, port: Int)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[OutgoingConnection]] =
+      // The InetSocketAddress representing the remote address must be created unresolved because akka.io.TcpOutgoingConnection will
+      // not attempt DNS resolution if the InetSocketAddress is already resolved. That behavior is problematic when it comes to
+      // connection pools since it means that new connections opened by the pool in the future can end up using a stale IP address.
+      // By passing an unresolved InetSocketAddress instead, we ensure that DNS resolution is performed for every new connection.
+      Tcp().outgoingConnection(InetSocketAddress.createUnresolved(host, port), localAddress,
+        settings.socketOptions, halfClose = true, settings.connectingTimeout, settings.idleTimeout)
+        .mapMaterializedValue(_.map(tcpConn ⇒ OutgoingConnection(tcpConn.localAddress, tcpConn.remoteAddress))(system.dispatcher))
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ClientTransport.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ClientTransport.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
  * Abstraction to allow the creation of alternative transports to run HTTP on.
  */
 @ApiMayChange
-trait ClientTransport {
+trait ClientTransport { outer ⇒
   def connectTo(host: String, port: Int)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[OutgoingConnection]]
 }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -27,16 +27,6 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
   def transport: ClientTransport
 
-  /* JAVA APIs */
-
-  final override def getConnectionSettings: js.ClientConnectionSettings = connectionSettings
-  final override def getPipeliningLimit: Int = pipeliningLimit
-  final override def getIdleTimeout: Duration = idleTimeout
-  final override def getMaxConnections: Int = maxConnections
-  final override def getMinConnections: Int = minConnections
-  final override def getMaxOpenRequests: Int = maxOpenRequests
-  final override def getMaxRetries: Int = maxRetries
-
   // ---
 
   // overrides for more precise return type

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -3,8 +3,10 @@
  */
 package akka.http.scaladsl.settings
 
+import akka.annotation.DoNotInherit
 import akka.http.impl.settings.ConnectionPoolSettingsImpl
 import akka.http.javadsl.{ settings ⇒ js }
+import akka.http.scaladsl.ClientTransport
 import com.typesafe.config.Config
 
 import scala.concurrent.duration.Duration
@@ -12,6 +14,7 @@ import scala.concurrent.duration.Duration
 /**
  * Public API but not intended for subclassing
  */
+@DoNotInherit
 abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: ConnectionPoolSettingsImpl ⇒
   def maxConnections: Int
   def minConnections: Int
@@ -20,6 +23,9 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   def pipeliningLimit: Int
   def idleTimeout: Duration
   def connectionSettings: ClientConnectionSettings
+
+  /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
+  def transport: ClientTransport
 
   /* JAVA APIs */
 
@@ -42,6 +48,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
 
   // overloads for idiomatic Scala use
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue)
+  def withTransport(newTransport: ClientTransport): ConnectionPoolSettings = self.copy(transport = newTransport)
 }
 
 object ConnectionPoolSettings extends SettingsCompanion[ConnectionPoolSettings] {


### PR DESCRIPTION
For now, this is basically a refactoring of how the client-side graph is put together.

I had this already lying around for a while half-finished. Thought I could just finish it.

Java APIs are still missing.

Refs #916.