### PR TITLE
Remove a few compilation warnings #856

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -3,27 +3,22 @@
  */
 package akka.http.javadsl.server.directives
 
-import java.util.function.{ Function ⇒ JFunction }
-import java.util.{ List ⇒ JList, Map ⇒ JMap }
-
 import akka.NotUsed
 import akka.http.javadsl.common.EntityStreamingSupport
 import akka.http.javadsl.marshalling.Marshaller
 import akka.http.javadsl.model.{ HttpEntity, _ }
 import akka.http.javadsl.server.Route
 import akka.http.javadsl.unmarshalling.Unmarshaller
-import akka.http.scaladsl.marshalling.{ Marshalling, ToByteStringMarshaller, ToResponseMarshallable }
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.server.{ Directives ⇒ D }
 import akka.stream.javadsl.Source
 import akka.util.ByteString
 
-import scala.reflect.ClassTag
-
 /** EXPERIMENTAL API */
 abstract class FramedEntityStreamingDirectives extends TimeoutDirectives {
 
-  import akka.http.javadsl.server.RoutingJavaMapping._
   import akka.http.javadsl.server.RoutingJavaMapping.Implicits._
+  import akka.http.javadsl.server.RoutingJavaMapping._
 
   @CorrespondsTo("asSourceOf")
   def entityAsSourceOf[T](um: Unmarshaller[ByteString, T], support: EntityStreamingSupport,
@@ -39,7 +34,7 @@ abstract class FramedEntityStreamingDirectives extends TimeoutDirectives {
   def completeWithSource[T, M](source: Source[T, M])(implicit m: Marshaller[T, ByteString], support: EntityStreamingSupport): Route = RouteAdapter {
     import akka.http.scaladsl.marshalling.PredefinedToResponseMarshallers._
     val mm = m.map(ByteStringAsEntityFn).asScalaCastOutput[akka.http.scaladsl.model.RequestEntity]
-    val mmm = fromEntityStreamingSupportAndEntityMarshaller[T, M](support.asScala, mm)
+    val mmm = fromEntityStreamingSupportAndEntityMarshaller[T, M](support.asScala, mm, null)
     val response = ToResponseMarshallable(source.asScala)(mmm)
     D.complete(response)
   }
@@ -50,7 +45,7 @@ abstract class FramedEntityStreamingDirectives extends TimeoutDirectives {
     import akka.http.scaladsl.marshalling.PredefinedToResponseMarshallers._
     // don't try this at home:
     val mm = m.asScalaCastOutput[akka.http.scaladsl.model.RequestEntity].map(_.httpEntity.asInstanceOf[akka.http.scaladsl.model.RequestEntity])
-    implicit val mmm = fromEntityStreamingSupportAndEntityMarshaller[T, M](support.asScala, mm)
+    implicit val mmm = fromEntityStreamingSupportAndEntityMarshaller[T, M](support.asScala, mm, null)
     val response = ToResponseMarshallable(source.asScala)
     D.complete(response)
   }

--- a/akka-parsing/src/main/scala/akka/parboiled2/DynamicRuleDispatch.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/DynamicRuleDispatch.scala
@@ -17,7 +17,7 @@
 package akka.parboiled2
 
 import scala.collection.immutable
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox
 import akka.shapeless.HList
 
 /**
@@ -52,7 +52,7 @@ object DynamicRuleDispatch {
 
   ///////////////////// INTERNAL ////////////////////////
 
-  def __create[P <: Parser, L <: HList](c: Context)(ruleNames: c.Expr[String]*)(implicit P: c.WeakTypeTag[P], L: c.WeakTypeTag[L]): c.Expr[(DynamicRuleDispatch[P, L], immutable.Seq[String])] = {
+  def __create[P <: Parser, L <: HList](c: whitebox.Context)(ruleNames: c.Expr[String]*)(implicit P: c.WeakTypeTag[P], L: c.WeakTypeTag[L]): c.Expr[(DynamicRuleDispatch[P, L], immutable.Seq[String])] = {
     import c.universe._
     val names: Array[String] = ruleNames.map {
       _.tree match {
@@ -71,7 +71,7 @@ object DynamicRuleDispatch {
             else if (c > 0) ${rec(start, mid - 1)}
             else {
               val p = handler.parser
-              p.__run[$L](p.${newTermName(name).encodedName.toTermName})(handler)
+              p.__run[$L](p.${TermName(name).encodedName.toTermName})(handler)
             }"""
       } else q"handler.ruleNotFound(ruleName)"
 

--- a/akka-parsing/src/main/scala/akka/parboiled2/support/OpTreeContext.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/support/OpTreeContext.scala
@@ -538,7 +538,7 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
             case x ⇒ c.abort(argTree.pos, "Unexpected `run` argument: " + show(argTree))
           }
 
-        actionBody(c.resetLocalAttrs(argTree))
+        actionBody(c.untypecheck(argTree))
       }
 
       rrTree match {
@@ -564,8 +564,8 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
     def render(wrapped: Boolean): Tree =
       block(hlTree match {
         case q"support.this.HListable.fromUnit"       ⇒ argTree
-        case q"support.this.HListable.fromHList[$t]"  ⇒ q"valueStack.pushAll(${c.resetLocalAttrs(argTree)})"
-        case q"support.this.HListable.fromAnyRef[$t]" ⇒ q"valueStack.push(${c.resetLocalAttrs(argTree)})"
+        case q"support.this.HListable.fromHList[$t]"  ⇒ q"valueStack.pushAll(${c.untypecheck(argTree)})"
+        case q"support.this.HListable.fromAnyRef[$t]" ⇒ q"valueStack.push(${c.untypecheck(argTree)})"
         case x                                        ⇒ c.abort(hlTree.pos, "Unexpected HListable: " + show(x))
       }, q"true")
   }
@@ -638,7 +638,7 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
           case Block(statements, res) ⇒ block(statements, actionBody(res))
 
           case x @ (Ident(_) | Select(_, _)) ⇒
-            val valNames: List[TermName] = argTypes.indices.map { i ⇒ newTermName("value" + i) }(collection.breakOut)
+            val valNames: List[TermName] = argTypes.indices.map { i ⇒ TermName("value" + i) }(collection.breakOut)
             val args = valNames map Ident.apply
             block(popToVals(valNames), q"__push($x(..$args))")
 
@@ -652,7 +652,7 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
             block(popToVals(args.map(_.name)), rewrite(body))
         }
 
-      actionBody(c.resetLocalAttrs(actionTree))
+      actionBody(c.untypecheck(actionTree))
     }
   }
 
@@ -672,7 +672,7 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
           case x ⇒ c.abort(x.pos, "Illegal runSubParser expr: " + show(x))
         }
 
-      val q"($arg ⇒ $body)" = c.resetLocalAttrs(fTree)
+      val q"($arg ⇒ $body)" = c.untypecheck(fTree)
       rewrite(arg.name, body)
     }
   }

--- a/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
@@ -14,7 +14,7 @@ class HttpAppExampleSpec extends WordSpec with Matchers
     import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
     import akka.http.scaladsl.server.HttpApp
     import akka.http.scaladsl.server.Route
-    
+
     // Server definition
     object WebServer extends HttpApp {
       def route: Route =


### PR DESCRIPTION
Mostly taking care of easy cases like deprecated methods that have known
alternatives.

The most noticeable change is the use of
```ctx.internal.enclosingOwner``` in the parboiled2 parser macro

I had be happy to dig deeper if some changes require more refactoring that first thought.