### PR TITLE
Update versions in FIXMEs and TODOs

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntities.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntities.java
@@ -43,7 +43,7 @@ public final class HttpEntities {
     }
 
     /**
-     * @deprecated Will be removed in Akka 3.x, use {@link #create(ContentType, Path)} instead.
+     * @deprecated Will be removed in Akka HTTP 11.x, use {@link #create(ContentType, Path)} instead.
      */
     @Deprecated
     public static UniversalEntity create(ContentType contentType, File file) {
@@ -55,7 +55,7 @@ public final class HttpEntities {
     }
 
     /**
-     * @deprecated Will be removed in Akka 3.x, use {@link #create(ContentType, Path, int)} instead.
+     * @deprecated Will be removed in Akka HTTP 11.x, use {@link #create(ContentType, Path, int)} instead.
      */
     @Deprecated
     public static UniversalEntity create(ContentType contentType, File file, int chunkSize) {

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
@@ -50,10 +50,9 @@ public interface HttpEntity {
     /**
      * The empty entity.
      *
-     * @deprecated Will be removed in Akka 3.x, use {@link HttpEntities#EMPTY} instead.
+     * @deprecated Will be removed in Akka HTTP 11.x, use {@link HttpEntities#EMPTY} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 10.0
     HttpEntity.Strict EMPTY = HttpEntities.EMPTY;
 
     /**

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -145,7 +145,7 @@ public interface HttpMessage {
         /**
          * Returns a copy of Self message with a new entity.
          *
-         * @deprecated Will be removed in Akka 3.x, use {@link #withEntity(ContentType, Path)} instead.
+         * @deprecated Will be removed in Akka HTTP 11.x, use {@link #withEntity(ContentType, Path)} instead.
          */
         @Deprecated
         Self withEntity(ContentType type, File file);

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethod.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethod.java
@@ -50,6 +50,6 @@ public abstract class HttpMethod {
     /**
      * Java API: Returns the entity acceptance level for this method.
      */
-    // TODO: Rename it to requestEntityAcceptance() in Akka 10.0
+    // TODO: Rename it to requestEntityAcceptance() in Akka HTTP 11.0
     public abstract akka.http.javadsl.model.RequestEntityAcceptance getRequestEntityAcceptance();
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethods.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethods.java
@@ -37,7 +37,7 @@ public final class HttpMethods {
     /**
      * Create a custom method type.
      */
-    // TODO: Rename it to custom() in Akka 10.0
+    // TODO: Rename it to custom() in Akka HTTP 11.0
     public static HttpMethod createCustom(String value, boolean safe, boolean idempotent, akka.http.javadsl.model.RequestEntityAcceptance requestEntityAcceptance) {
         //This cast is safe as implementation of RequestEntityAcceptance only exists in Scala
         akka.http.scaladsl.model.RequestEntityAcceptance scalaRequestEntityAcceptance

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
@@ -34,9 +34,8 @@ public abstract class RemoteAddress {
     /**
      * @deprecated because of troublesome initialisation order (with regards to scaladsl class implementing this class).
      *             In some edge cases this field could end up containing a null value.
-     *             Will be removed in Akka 3.x, use {@link RemoteAddresses#UNKNOWN} instead.
+     *             Will be removed in Akka HTTP 11.x, use {@link RemoteAddresses#UNKNOWN} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 10.0
     public static final RemoteAddress UNKNOWN = RemoteAddresses.UNKNOWN;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRange.java
@@ -17,9 +17,8 @@ public abstract class EntityTagRange {
     /**
      * @deprecated because of troublesome initialisation order (with regards to scaladsl class implementing this class).
      *             In some edge cases this field could end up containing a null value.
-     *             Will be removed in Akka 3.x, use {@link EntityTagRanges#ALL} instead.
+     *             Will be removed in Akka HTTP 11.x, use {@link EntityTagRanges#ALL} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 10.0
     public static final EntityTagRange ALL = EntityTagRanges.ALL;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRange.java
@@ -22,9 +22,8 @@ public abstract class HttpEncodingRange {
     /**
      * @deprecated because of troublesome initialisation order (with regards to scaladsl class implementing this class).
      *             In some edge cases this field could end up containing a null value.
-     *             Will be removed in Akka 3.x, use {@link HttpEncodingRanges#ALL} instead.
+     *             Will be removed in Akka HTTP 11.x, use {@link HttpEncodingRanges#ALL} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 10.0
     public static final HttpEncodingRange ALL = HttpEncodingRanges.ALL;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
@@ -20,9 +20,8 @@ public abstract class HttpOriginRange {
   /**
    * @deprecated because of troublesome initialisation order (with regards to scaladsl class implementing this class).
    * In some edge cases this field could end up containing a null value.
-   * Will be removed in Akka 3.x, use {@link HttpEncodingRanges#ALL} instead.
+   * Will be removed in Akka HTTP 11.x, use {@link HttpEncodingRanges#ALL} instead.
    */
   @Deprecated
-  // FIXME: Remove in Akka 10.0
   public static final HttpOriginRange ALL = HttpOriginRanges.ALL;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LanguageRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LanguageRange.java
@@ -14,9 +14,8 @@ public interface LanguageRange {
     /**
      * @deprecated because of troublesome initialisation order (with regards to scaladsl class implementing this class).
      *             In some edge cases this field could end up containing a null value.
-     *             Will be removed in Akka 3.x, use {@link LanguageRanges#ALL} instead.
+     *             Will be removed in Akka HTTP 11.x, use {@link LanguageRanges#ALL} instead.
      */
     @Deprecated
-    // FIXME: Remove in Akka 10.0
     public static final LanguageRange ALL = LanguageRanges.ALL;
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/JavaInitialization.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/JavaInitialization.scala
@@ -9,7 +9,7 @@ import akka.util.Unsafe
 /**
  * Provides workarounds around JavaDSL initialisation edge cases.
  *
- * FIXME: Exists only to fix JavaDSL init problem: #19162. Remove in Akka 3.x when "ALL" static fields moved
+ * FIXME: Exists only to fix JavaDSL init problem: #19162. Remove in Akka HTTP 11.x when "ALL" static fields moved
  */
 private[akka] object JavaInitialization {
 

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -167,5 +167,3 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
       }
   }
 }
-
-//FIXME: trait Specs2RouteTest extends RouteTest with Specs2Interface

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
@@ -42,7 +42,7 @@ private[http] object RoutingJavaMapping {
   implicit object Rejection extends Inherited[javadsl.server.Rejection, scaladsl.server.Rejection]
 
   implicit object RequestContext extends JavaMapping[javadsl.server.RequestContext, scaladsl.server.RequestContext] {
-    // TODO make it inhierit
+    // TODO make it inherit
     //    extends Inherited[javadsl.server.RequestContext, scaladsl.server.RequestContext]
     override def toScala(javaObject: javadsl.server.RequestContext): scaladsl.server.RequestContext = javaObject.delegate
     override def toJava(scalaObject: scaladsl.server.RequestContext): javadsl.server.RequestContext = javadsl.server.RequestContext.wrap(scalaObject)

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -118,7 +118,7 @@ object UnidocRoot extends AutoPlugin {
     javacOptions in (JavaUnidoc, unidoc) ++= Seq("-Xdoclint:none"),
     // genjavadoc needs to generate synthetic methods since the java code uses them
     scalacOptions += "-P:genjavadoc:suppressSynthetic=false",
-    // FIXME: see #18056
+    // FIXME: see https://github.com/akka/akka-http/issues/230
     sources in(JavaUnidoc, unidoc) ~= (_.filterNot(_.getPath.contains("Access$minusControl$minusAllow$minusOrigin")))
   )).getOrElse(Nil)
 
@@ -148,7 +148,7 @@ object Unidoc extends AutoPlugin {
       javacOptions in doc += "-Xdoclint:none",
       scalacOptions in Compile += "-P:genjavadoc:fabricateParams=true",
       unidocGenjavadocVersion in Global := "0.10",
-      // FIXME: see #18056
+      // FIXME: see https://github.com/akka/akka-http/issues/230
       sources in(Genjavadoc, doc) ~= (_.filterNot(_.getPath.contains("Access$minusControl$minusAllow$minusOrigin")))
     )
   ).getOrElse(Seq.empty)


### PR DESCRIPTION
Update FIXMEs referring to Akka 3.x and Akka HTTP 10.x to refer to Akka
HTTP 11.x.

---

I suggest we also create a 11.x milestone ticket to ensure we remember to remove and rename related methods.