### PR TITLE
Allow Content-Range to be used as a request header #932

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -427,7 +427,7 @@ object `Content-Range` extends ModeledCompanion[`Content-Range`] {
   def apply(byteContentRange: ByteContentRange): `Content-Range` = apply(RangeUnits.Bytes, byteContentRange)
 }
 final case class `Content-Range`(rangeUnit: RangeUnit, contentRange: ContentRange) extends jm.headers.ContentRange
-  with ResponseHeader {
+  with RequestResponseHeader {
   def renderValue[R <: Rendering](r: R): r.type = r ~~ rangeUnit ~~ ' ' ~~ contentRange
   protected def companion = `Content-Range`
 }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -97,6 +97,7 @@ class HeaderSpec extends FreeSpec with Matchers {
         `Content-Length`(2000),
         `Content-Disposition`(ContentDispositionTypes.inline),
         `Content-Encoding`(HttpEncodings.gzip),
+        `Content-Range`(ContentRange.Default(1, 20, None)),
         `Content-Type`(ContentTypes.`text/xml(UTF-8)`),
         Cookie("cookie", "with-chocolate"),
         Date(DateTime(2016, 2, 4, 9, 9, 0)),


### PR DESCRIPTION
Changes the type of `Content-Range` from `ResponseHeader` to `RequestResponseHeader`