### PR TITLE
Change `Unmarshal#to` to use a default context #78

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshal.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshal.scala
@@ -16,5 +16,9 @@ class Unmarshal[A](val value: A) {
   /**
    * Unmarshals the value to the given Type using the in-scope Unmarshaller.
    */
-  def to[B](implicit um: Unmarshaller[A, B], ec: ExecutionContext, mat: Materializer): Future[B] = um(value)
+  def to[B](implicit um: Unmarshaller[A, B], ec: ExecutionContext = null, mat: Materializer): Future[B] = {
+    val context: ExecutionContext = if (ec == null) mat.executionContext else ec
+
+    um(value)(context, mat)
+  }
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshal.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshal.scala
@@ -15,6 +15,9 @@ object Unmarshal {
 class Unmarshal[A](val value: A) {
   /**
    * Unmarshals the value to the given Type using the in-scope Unmarshaller.
+   
+   * Uses the default materializer [[ExecutionContext]] if no implicit execution context is provided. 
+   * If you expect the marshalling to be heavy, it is suggested to provide a specialized context for those operations.
    */
   def to[B](implicit um: Unmarshaller[A, B], ec: ExecutionContext = null, mat: Materializer): Future[B] = {
     val context: ExecutionContext = if (ec == null) mat.executionContext else ec

--- a/docs/src/test/scala/docs/http/scaladsl/UnmarshalSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/UnmarshalSpec.scala
@@ -12,7 +12,7 @@ class UnmarshalSpec extends AkkaSpec {
   "use unmarshal" in {
     //#use-unmarshal
     import akka.http.scaladsl.unmarshalling.Unmarshal
-    import system.dispatcher // ExecutionContext
+    import system.dispatcher // Optional ExecutionContext (default from Materializer)
     implicit val materializer: Materializer = ActorMaterializer()
 
     import scala.concurrent.Await
@@ -28,4 +28,19 @@ class UnmarshalSpec extends AkkaSpec {
     //#use-unmarshal
   }
 
+  "use unmarshal without execution context" in {
+    import akka.http.scaladsl.unmarshalling.Unmarshal
+    implicit val materializer: Materializer = ActorMaterializer()
+
+    import scala.concurrent.Await
+    import scala.concurrent.duration._
+
+    val intFuture = Unmarshal("42").to[Int]
+    val int = Await.result(intFuture, 1.second) // don't block in non-test code!
+    int shouldEqual 42
+
+    val boolFuture = Unmarshal("off").to[Boolean]
+    val bool = Await.result(boolFuture, 1.second) // don't block in non-test code!
+    bool shouldBe false
+  }
 }


### PR DESCRIPTION
Attempt to fix issue #78

As per the corresponding Gitter discussion, this PR will make ```Unmarshall#to``` use the execution context provided by the Materializer if none is provided implicitly.