### PR TITLE
=htc #945 in StreamUtils.delayCancellation cancel timeout if stage was stopped otherwise

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.4.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.4.backwards.excludes
@@ -12,3 +12,7 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.setting
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.apply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.copy")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.util.JavaMapping.flowMapping")
+
+# changes to internal classes, #945
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.util.StreamUtils#ScheduleSupport.scheduleOnce")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.util.StreamUtils#ScheduleSupport.scheduleOnce")


### PR DESCRIPTION
Before, the timeout kept referencing the stage which kept the whole
GraphInterpreter and indirectly the ActorGraphInterpreter referenced. The memory
was only freed after the timeout had triggered.

Fixes #945.