### PR TITLE
Use media type parameters in content negotiation (#963)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaRange.scala
@@ -92,7 +92,9 @@ object MediaRange {
     override def isText = mediaType.isText
     override def isVideo = mediaType.isVideo
     def matches(mediaType: MediaType) =
-      this.mediaType.mainType == mediaType.mainType && this.mediaType.subType == mediaType.subType
+      this.mediaType.mainType == mediaType.mainType &&
+        this.mediaType.subType == mediaType.subType &&
+        this.mediaType.params.forall { case (key, value) ⇒ mediaType.params.get(key).contains(value) }
     def withParams(params: Map[String, String]) = copy(mediaType = mediaType.withParams(params))
     def withQValue(qValue: Float) = copy(qValue = qValue)
     def render[R <: Rendering](r: R): r.type = if (qValue < 1.0f) r ~~ mediaType ~~ ";q=" ~~ qValue else r ~~ mediaType

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaRange.scala
@@ -57,7 +57,8 @@ object MediaRange {
   private final case class Custom(mainType: String, params: Map[String, String], qValue: Float)
     extends MediaRange with ValueRenderable {
     require(0.0f <= qValue && qValue <= 1.0f, "qValue must be >= 0 and <= 1.0")
-    def matches(mediaType: MediaType) = mainType == "*" || mediaType.mainType == mainType
+    def matches(mediaType: MediaType) = (mainType == "*" || mediaType.mainType == mainType) &&
+      this.params.forall { case (key, value) ⇒ mediaType.params.get(key).contains(value) }
     def withParams(params: Map[String, String]) = custom(mainType, params, qValue)
     def withQValue(qValue: Float) = if (qValue != this.qValue) custom(mainType, params, qValue) else this
     def render[R <: Rendering](r: R): r.type = {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -226,6 +226,8 @@ object MediaType {
 
   sealed abstract class WithOpenCharset extends NonBinary with jm.MediaType.WithOpenCharset {
     def withCharset(charset: HttpCharset): ContentType.WithCharset = ContentType(this, charset)
+    def withParams(params: Map[String, String]): WithOpenCharset with MediaType =
+      customWithOpenCharset(mainType, subType, fileExtensions, params)
 
     /**
      * JAVA API
@@ -236,8 +238,6 @@ object MediaType {
   sealed abstract class NonMultipartWithOpenCharset(val value: String, val mainType: String, val subType: String,
                                                     val fileExtensions: List[String]) extends WithOpenCharset {
     def params: Map[String, String] = Map.empty
-    def withParams(params: Map[String, String]): WithOpenCharset with MediaType =
-      customWithOpenCharset(mainType, subType, fileExtensions, params)
   }
 
   final class Multipart(subType: String, _params: Map[String, String])
@@ -278,8 +278,8 @@ object MediaTypes extends ObjectRegistry[(String, String), MediaType] {
     register(mediaType.mainType.toRootLowerCase → mediaType.subType.toRootLowerCase, mediaType)
   }
 
-  import MediaType._  
-  
+  import MediaType._
+
   /////////////////////////// PREDEFINED MEDIA-TYPE DEFINITION ////////////////////////////
   // format: OFF
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
@@ -147,9 +147,14 @@ class ContentNegotiationSpec extends FreeSpec with Matchers {
       accept(`text/html` withParams Map("level" → "1"), `text/html` withParams Map("format" → "flowed")) should select(`text/html` withParams Map("level" → "1") withCharset `UTF-8`)
     }
 
-    /** when both acceptable media types are equally specific, we must select the one with the highest qValue */
+    /** when both acceptable media types are available as separate marshallers and equally specific, we must select the one with the highest qValue */
     "Accept: text/html;level=1;q=0.4, text/html;format=flowed;q=0.7" test { accept ⇒
       accept(`text/html` withParams Map("level" → "1"), `text/html` withParams Map("format" → "flowed")) should select(`text/html` withParams Map("format" → "flowed") withCharset `UTF-8`)
+    }
+
+    /** when there's 2 equally specific matching media types for the available marshaller, we should choose the one with the highest qValue */
+    "Accept: text/html;level=1;q=0.4, text/html;format=flowed;q=1, text/html;q=0.7" test { accept ⇒
+      accept(`text/html` withParams Map("level" → "1", "format" → "flowed"), `text/html`) should select(`text/html` withParams Map("level" → "1", "format" → "flowed") withCharset `UTF-8`)
     }
 
     // https://tools.ietf.org/html/rfc7231#section-5.3.2

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
@@ -152,6 +152,11 @@ class ContentNegotiationSpec extends FreeSpec with Matchers {
       accept(`text/html` withParams Map("level" → "1"), `text/html` withParams Map("format" → "flowed")) should select(`text/html` withParams Map("format" → "flowed") withCharset `UTF-8`)
     }
 
+    /** when both acceptable media types are available as separate marshallers and equally specific, we must select the one with the highest qValue */
+    "Accept: text/*;level=1;q=0.4, text/*;format=flowed;q=0.7" test { accept ⇒
+      accept(`text/html` withParams Map("level" → "1"), `text/html` withParams Map("format" → "flowed")) should select(`text/html` withParams Map("format" → "flowed") withCharset `UTF-8`)
+    }
+
     /** when there's 2 equally specific matching media types for the available marshaller, we should choose the one with the highest qValue */
     "Accept: text/html;level=1;q=0.4, text/html;format=flowed;q=1, text/html;q=0.7" test { accept ⇒
       accept(`text/html` withParams Map("level" → "1", "format" → "flowed"), `text/html`) should select(`text/html` withParams Map("level" → "1", "format" → "flowed") withCharset `UTF-8`)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
@@ -22,9 +22,9 @@ final class MediaTypeNegotiator(requestHeaders: Seq[HttpHeader]) {
       Accept(mediaRanges) ← requestHeaders
       range ← mediaRanges
     } yield range).sortBy { // `sortBy` is stable, i.e. upholds the original order on identical keys
-      case x if x.isWildcard     ⇒ 2f // most general, needs to come last
-      case MediaRange.One(_, qv) ⇒ -qv // most specific, needs to come first
-      case _                     ⇒ 1f // simple range like `image/*`
+      case x if x.isWildcard   ⇒ 2f // most general, needs to come last
+      case one: MediaRange.One ⇒ -one.params.size // most specific, needs to come first
+      case _                   ⇒ 1f // simple range like `image/*`
     }.toList
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
@@ -23,7 +23,7 @@ final class MediaTypeNegotiator(requestHeaders: Seq[HttpHeader]) {
       range ← mediaRanges
     } yield range).sortBy { // `sortBy` is stable, i.e. upholds the original order on identical weights
       case x if x.isWildcard   ⇒ 2f // most general, needs to come last
-      case one: MediaRange.One ⇒ -one.params.size // most specific, needs to come first
+      case one: MediaRange.One ⇒ -(2 * one.params.size + one.qValue) // most specific, needs to come first
       case _                   ⇒ 1f // simple range like `image/*`
     }.toList
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
@@ -21,7 +21,7 @@ final class MediaTypeNegotiator(requestHeaders: Seq[HttpHeader]) {
     (for {
       Accept(mediaRanges) ← requestHeaders
       range ← mediaRanges
-    } yield range).sortBy { // `sortBy` is stable, i.e. upholds the original order on identical keys
+    } yield range).sortBy { // `sortBy` is stable, i.e. upholds the original order on identical weights
       case x if x.isWildcard   ⇒ 2f // most general, needs to come last
       case one: MediaRange.One ⇒ -one.params.size // most specific, needs to come first
       case _                   ⇒ 1f // simple range like `image/*`

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
@@ -22,9 +22,9 @@ final class MediaTypeNegotiator(requestHeaders: Seq[HttpHeader]) {
       Accept(mediaRanges) ← requestHeaders
       range ← mediaRanges
     } yield range).sortBy { // `sortBy` is stable, i.e. upholds the original order on identical weights
-      case x if x.isWildcard   ⇒ 2f // most general, needs to come last
-      case one: MediaRange.One ⇒ -(2 * one.params.size + one.qValue) // most specific, needs to come first
-      case _                   ⇒ 1f // simple range like `image/*`
+      case x if x.isWildcard   ⇒ (2, -x.params.size, -x.qValue)
+      case one: MediaRange.One ⇒ (0, -one.params.size, -one.qValue) // most specific, needs to come first
+      case range               ⇒ (1, -range.params.size, -range.qValue) // simple range like `image/*`
     }.toList
 
   /**


### PR DESCRIPTION
https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1 describes how to interpret the Accept header during content negotiation.

Notably, it specifies "The media type quality factor associated with a given type is determined by finding the media range with the highest precedence which matches that type", and then gives some examples.

'matching' is implemented in akka-http in `MediaRange::matches`, but for `MediaRange.One` fails to take into account parameters.

'precedence' is implemented in akka-http when determining the sorting of `acceptedMediaRanges` in `MediaTypeNegotiator`, but for non-wildcard media types sorts by the qValue instead of by the number of parameters.