### PR TITLE
=htc #936 Fix NPE when access static Java constant fields

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
@@ -37,5 +37,5 @@ public abstract class RemoteAddress {
      *             Will be removed in Akka HTTP 11.x, use {@link RemoteAddresses#UNKNOWN} instead.
      */
     @Deprecated
-    public static final RemoteAddress UNKNOWN = RemoteAddresses.UNKNOWN;
+    public static final RemoteAddress UNKNOWN = akka.http.scaladsl.model.RemoteAddress.Unknown$.MODULE$;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRange.java
@@ -20,5 +20,5 @@ public abstract class EntityTagRange {
      *             Will be removed in Akka HTTP 11.x, use {@link EntityTagRanges#ALL} instead.
      */
     @Deprecated
-    public static final EntityTagRange ALL = EntityTagRanges.ALL;
+    public static final EntityTagRange ALL = akka.http.scaladsl.model.headers.EntityTagRange.$times$.MODULE$;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRange.java
@@ -25,5 +25,5 @@ public abstract class HttpEncodingRange {
      *             Will be removed in Akka HTTP 11.x, use {@link HttpEncodingRanges#ALL} instead.
      */
     @Deprecated
-    public static final HttpEncodingRange ALL = HttpEncodingRanges.ALL;
+    public static final HttpEncodingRange ALL = akka.http.scaladsl.model.headers.HttpEncodingRange.$times$.MODULE$;
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
@@ -23,5 +23,5 @@ public abstract class HttpOriginRange {
    * Will be removed in Akka HTTP 11.x, use {@link HttpEncodingRanges#ALL} instead.
    */
   @Deprecated
-  public static final HttpOriginRange ALL = HttpOriginRanges.ALL;
+  public static final HttpOriginRange ALL = akka.http.scaladsl.model.headers.HttpOriginRange.$times$.MODULE$;
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/RemoteAddress.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/RemoteAddress.scala
@@ -32,6 +32,9 @@ object RemoteAddress {
     def render[R <: Rendering](r: R): r.type = r ~~ "unknown"
 
     def isUnknown = true
+
+    JavaInitialization.initializeStaticFieldWith(
+      this, classOf[jm.RemoteAddress].getField("UNKNOWN"))
   }
 
   final case class IP(ip: InetAddress, port: Option[Int] = None) extends RemoteAddress {
@@ -55,8 +58,4 @@ object RemoteAddress {
     require(bytes.length == 4 || bytes.length == 16)
     try IP(InetAddress.getByAddress(bytes)) catch { case _: UnknownHostException ⇒ Unknown }
   }
-
-  JavaInitialization.initializeStaticFieldWith(
-    Unknown, classOf[jm.RemoteAddress].getField("UNKNOWN"))
-
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/EntityTag.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/EntityTag.scala
@@ -34,14 +34,14 @@ object EntityTagRange {
 
   case object `*` extends EntityTagRange {
     def render[R <: Rendering](r: R): r.type = r ~~ '*'
+
+    JavaInitialization.initializeStaticFieldWith(
+      this, classOf[jm.headers.EntityTagRange].getField("ALL"))
   }
 
   final case class Default(tags: immutable.Seq[EntityTag]) extends EntityTagRange {
     require(tags.nonEmpty, "tags must not be empty")
     def render[R <: Rendering](r: R): r.type = r ~~ tags
   }
-
-  JavaInitialization.initializeStaticFieldWith(
-    `*`, classOf[jm.headers.EntityTagRange].getField("ALL"))
 
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpEncoding.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpEncoding.scala
@@ -29,7 +29,10 @@ object HttpEncodingRange {
     def withQValue(qValue: Float) =
       if (qValue == 1.0f) `*` else if (qValue != this.qValue) `*`(qValue.toFloat) else this
   }
-  object `*` extends `*`(1.0f)
+  object `*` extends `*`(1.0f) {
+    JavaInitialization.initializeStaticFieldWith(
+      this, classOf[jm.headers.HttpEncodingRange].getField("ALL"))
+  }
 
   final case class One(encoding: HttpEncoding, qValue: Float) extends HttpEncodingRange {
     require(0.0f <= qValue && qValue <= 1.0f, "qValue must be >= 0 and <= 1.0")
@@ -40,10 +43,6 @@ object HttpEncodingRange {
 
   implicit def apply(encoding: HttpEncoding): HttpEncodingRange = apply(encoding, 1.0f)
   def apply(encoding: HttpEncoding, qValue: Float): HttpEncodingRange = One(encoding, qValue)
-
-  JavaInitialization.initializeStaticFieldWith(
-    `*`, classOf[jm.headers.HttpEncodingRange].getField("ALL"))
-
 }
 
 final case class HttpEncoding private[http] (value: String) extends jm.headers.HttpEncoding with LazyValueBytesRenderable with WithQValue[HttpEncodingRange] {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpOrigin.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpOrigin.scala
@@ -26,6 +26,9 @@ object HttpOriginRange {
   case object `*` extends HttpOriginRange {
     def matches(origin: HttpOrigin) = true
     def render[R <: Rendering](r: R): r.type = r ~~ '*'
+
+    JavaInitialization.initializeStaticFieldWith(
+      this, classOf[jm.headers.HttpOriginRange].getField("ALL"))
   }
 
   def apply(origins: HttpOrigin*): Default = Default(immutable.Seq(origins: _*))
@@ -34,9 +37,6 @@ object HttpOriginRange {
     def matches(origin: HttpOrigin): Boolean = origins contains origin
     def render[R <: Rendering](r: R): r.type = r ~~ origins
   }
-
-  JavaInitialization.initializeStaticFieldWith(
-    `*`, classOf[jm.headers.HttpOriginRange].getField("ALL"))
 
 }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LanguageRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LanguageRange.scala
@@ -39,7 +39,10 @@ object LanguageRange {
     def withQValue(qValue: Float) =
       if (qValue == 1.0f) `*` else if (qValue != this.qValue) `*`(qValue.toFloat) else this
   }
-  object `*` extends `*`(1.0f)
+  object `*` extends `*`(1.0f) {
+    JavaInitialization.initializeStaticFieldWith(
+      `*`, classOf[jm.headers.LanguageRange].getField("ALL"))
+  }
 
   final case class One(language: Language, qValue: Float) extends LanguageRange {
     require(0.0f <= qValue && qValue <= 1.0f, "qValue must be >= 0 and <= 1.0")
@@ -54,10 +57,6 @@ object LanguageRange {
 
   implicit def apply(language: Language): LanguageRange = apply(language, 1.0f)
   def apply(language: Language, qValue: Float): LanguageRange = One(language, qValue)
-
-  JavaInitialization.initializeStaticFieldWith(
-    `*`, classOf[jm.headers.LanguageRange].getField("ALL"))
-
 }
 
 final case class Language(primaryTag: String, subTags: immutable.Seq[String])

--- a/akka-http-core/src/test/scala/akka/http/javadsl/JavaInitializationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/JavaInitializationSpec.scala
@@ -8,12 +8,59 @@ import org.scalatest.{ Matchers, WordSpec }
 
 class JavaInitializationSpec extends WordSpec with Matchers {
 
-  "LanguageRange" should {
-
-    "initializes the right field" in {
-      akka.http.scaladsl.model.headers.LanguageRange.`*` // first we touch the scala one, it should force init the Java one
-      val _ = akka.http.javadsl.model.headers.LanguageRange.ALL // touching this one should not fail
-      akka.http.javadsl.model.headers.LanguageRanges.ALL // this is recommended and should work well too
+  implicit class HeaderCheck[T](self: T) {
+    def =!=(expected: String) = {
+      self should !==(null)
+      self.toString shouldBe expected
     }
   }
+
+  "EntityTagRange" should {
+    "initializes the right field" in {
+      akka.http.scaladsl.model.headers.EntityTagRange.`*` =!= "*"
+      akka.http.javadsl.model.headers.EntityTagRanges.ALL =!= "*"
+      akka.http.javadsl.model.headers.EntityTagRange.ALL =!= "*"
+    }
+  }
+
+  "HttpEncodingRange" should {
+    "initializes the right field" in {
+      akka.http.scaladsl.model.headers.HttpEncodingRange.`*` =!= "*"
+      akka.http.javadsl.model.headers.HttpEncodingRanges.ALL =!= "*"
+      akka.http.javadsl.model.headers.HttpEncodingRange.ALL =!= "*"
+    }
+  }
+
+  "HttpEntity" should {
+    "initializes the right field" in {
+      akka.http.scaladsl.model.HttpEntity.Empty =!= "HttpEntity.Strict(none/none,ByteString())"
+      akka.http.javadsl.model.HttpEntity.EMPTY =!= "HttpEntity.Strict(none/none,ByteString())"
+      akka.http.javadsl.model.HttpEntities.EMPTY =!= "HttpEntity.Strict(none/none,ByteString())"
+    }
+  }
+
+  "HttpOriginRange" should {
+    "initializes the right field" in {
+      akka.http.scaladsl.model.headers.HttpOriginRange.`*` =!= "*"
+      akka.http.javadsl.model.headers.HttpOriginRange.ALL =!= "*"
+      akka.http.javadsl.model.headers.HttpOriginRanges.ALL =!= "*"
+    }
+  }
+
+  "LanguageRange" should {
+    "initializes the right field" in {
+      akka.http.scaladsl.model.headers.LanguageRange.`*` =!= "*" // first we touch the scala one, it should force init the Java one
+      akka.http.javadsl.model.headers.LanguageRange.ALL =!= "*" // touching this one should not fail
+      akka.http.javadsl.model.headers.LanguageRanges.ALL =!= "*" // this is recommended and should work well too
+    }
+  }
+
+  "RemoteAddress" should {
+    "initializes the right field" in {
+      akka.http.scaladsl.model.RemoteAddress.Unknown =!= "unknown"
+      akka.http.javadsl.model.RemoteAddress.UNKNOWN =!= "unknown"
+      akka.http.javadsl.model.RemoteAddresses.UNKNOWN =!= "unknown"
+    }
+  }
+
 }


### PR DESCRIPTION
The workaround added in 34bd3d9f1b50ac133896b9e73b47d9408a2bd033 to
ensure static fields in Java model classes inherited from Scala models
are initialized properly put the runtime patching on the enclosing Scala
object, however, it also changed the Java classes to redirect static
fields to the new API, which meant that the initialization hook was
never called.

To fix this problem move the initialization to the Scala object
referenced from the Java static field.

---

Note, it is possible to further clean up use of `JavaInitialization` and for example remove it from `HttpEntity.Empty` since it is defined as a `val` instead of `object`.