### PR TITLE
Complete directives take `ResponseEntity` as a parameter instead of `RequestEntity`

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -17,6 +17,7 @@ import akka.http.impl.model.JavaUri
 import akka.http.javadsl.model.HttpHeader
 import akka.http.javadsl.model.HttpResponse
 import akka.http.javadsl.model.RequestEntity
+import akka.http.javadsl.model.ResponseEntity
 import akka.http.javadsl.model.StatusCode
 import akka.http.javadsl.model.Uri
 import akka.http.javadsl.server.{ RoutingJavaMapping, Rejection, Route }
@@ -112,7 +113,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
   /**
    * Completes the request using the given status code, headers, and response entity.
    */
-  def complete(status: StatusCode, headers: java.lang.Iterable[HttpHeader], entity: RequestEntity) = RouteAdapter {
+  def complete(status: StatusCode, headers: java.lang.Iterable[HttpHeader], entity: ResponseEntity) = RouteAdapter {
     D.complete(scaladsl.model.HttpResponse(status = status.asScala, entity = entity.asScala, headers = Util.immutableSeq(headers).map(_.asScala))) // TODO avoid the map()
   }
 
@@ -126,7 +127,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
   /**
    * Completes the request using the given status code and response entity.
    */
-  def complete(status: StatusCode, entity: RequestEntity) = RouteAdapter {
+  def complete(status: StatusCode, entity: ResponseEntity) = RouteAdapter {
     D.complete(scaladsl.model.HttpResponse(status = status.asScala, entity = entity.asScala))
   }
 
@@ -147,7 +148,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
   /**
    * Completes the request as HTTP 200 OK, adding the given headers and response entity.
    */
-  def complete(headers: java.lang.Iterable[HttpHeader], entity: RequestEntity) = RouteAdapter {
+  def complete(headers: java.lang.Iterable[HttpHeader], entity: ResponseEntity) = RouteAdapter {
     D.complete(scaladsl.model.HttpResponse(headers = headers.asScala.toVector.map(_.asScala), entity = entity.asScala)) // TODO can we avoid the map() ?
   }
 
@@ -162,7 +163,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
   /**
    * Completes the request as HTTP 200 OK with the given value as response entity.
    */
-  def complete(entity: RequestEntity) = RouteAdapter {
+  def complete(entity: ResponseEntity) = RouteAdapter {
     D.complete(scaladsl.model.HttpResponse(entity = entity.asScala))
   }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -118,6 +118,13 @@ abstract class RouteDirectives extends RespondWithDirectives {
   }
 
   /**
+   * Completes the request using the given status code, headers, and response entity.
+   */
+  @deprecated("This directive is for binary compatibility only", "10.0.6")
+  def complete(status: StatusCode, headers: java.lang.Iterable[HttpHeader], entity: RequestEntity): RouteAdapter =
+    complete(status, headers, entity.asInstanceOf[ResponseEntity])
+
+  /**
    * Completes the request using the given status code, marshalling the given value as response entity.
    */
   def complete[T](status: StatusCode, value: T, marshaller: Marshaller[T, RequestEntity]) = RouteAdapter {
@@ -130,6 +137,12 @@ abstract class RouteDirectives extends RespondWithDirectives {
   def complete(status: StatusCode, entity: ResponseEntity) = RouteAdapter {
     D.complete(scaladsl.model.HttpResponse(status = status.asScala, entity = entity.asScala))
   }
+
+  /**
+   * Completes the request using the given status code and response entity.
+   */
+  @deprecated("This directive is for binary compatibility only", "10.0.6")
+  def complete(status: StatusCode, entity: RequestEntity): RouteAdapter = complete(status, entity.asInstanceOf[ResponseEntity])
 
   /**
    * Completes the request using the given status code and the given body as UTF-8.
@@ -153,6 +166,13 @@ abstract class RouteDirectives extends RespondWithDirectives {
   }
 
   /**
+   * Completes the request as HTTP 200 OK, adding the given headers and response entity.
+   */
+  @deprecated("This directive is for binary compatibility only", "10.0.6")
+  def complete(headers: java.lang.Iterable[HttpHeader], entity: RequestEntity): RouteAdapter =
+    complete(headers, entity.asInstanceOf[ResponseEntity])
+
+  /**
    * Completes the request as HTTP 200 OK, marshalling the given value as response entity.
    */
   @CorrespondsTo("complete")
@@ -166,6 +186,12 @@ abstract class RouteDirectives extends RespondWithDirectives {
   def complete(entity: ResponseEntity) = RouteAdapter {
     D.complete(scaladsl.model.HttpResponse(entity = entity.asScala))
   }
+
+  /**
+   * Completes the request as HTTP 200 OK with the given value as response entity.
+   */
+  @deprecated("This directive is for binary compatibility only", "10.0.6")
+  def complete(entity: RequestEntity): RouteAdapter = complete(entity.asInstanceOf[ResponseEntity])
 
   // --- manual "magnet" for Scala Future ---
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -121,8 +121,9 @@ abstract class RouteDirectives extends RespondWithDirectives {
    * Completes the request using the given status code, headers, and response entity.
    */
   @deprecated("This directive is for binary compatibility only", "10.0.6")
-  def complete(status: StatusCode, headers: java.lang.Iterable[HttpHeader], entity: RequestEntity): RouteAdapter =
-    complete(status, headers, entity.asInstanceOf[ResponseEntity])
+  def complete(status: StatusCode, headers: java.lang.Iterable[HttpHeader], entity: RequestEntity): RouteAdapter = {
+    complete(status, headers, entity: ResponseEntity)
+  }
 
   /**
    * Completes the request using the given status code, marshalling the given value as response entity.
@@ -142,7 +143,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
    * Completes the request using the given status code and response entity.
    */
   @deprecated("This directive is for binary compatibility only", "10.0.6")
-  def complete(status: StatusCode, entity: RequestEntity): RouteAdapter = complete(status, entity.asInstanceOf[ResponseEntity])
+  def complete(status: StatusCode, entity: RequestEntity): RouteAdapter = complete(status, entity: ResponseEntity)
 
   /**
    * Completes the request using the given status code and the given body as UTF-8.
@@ -170,7 +171,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
    */
   @deprecated("This directive is for binary compatibility only", "10.0.6")
   def complete(headers: java.lang.Iterable[HttpHeader], entity: RequestEntity): RouteAdapter =
-    complete(headers, entity.asInstanceOf[ResponseEntity])
+    complete(headers, entity: ResponseEntity)
 
   /**
    * Completes the request as HTTP 200 OK, marshalling the given value as response entity.
@@ -191,7 +192,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
    * Completes the request as HTTP 200 OK with the given value as response entity.
    */
   @deprecated("This directive is for binary compatibility only", "10.0.6")
-  def complete(entity: RequestEntity): RouteAdapter = complete(entity.asInstanceOf[ResponseEntity])
+  def complete(entity: RequestEntity): RouteAdapter = complete(entity: ResponseEntity)
 
   // --- manual "magnet" for Scala Future ---
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -120,7 +120,6 @@ abstract class RouteDirectives extends RespondWithDirectives {
   /**
    * Completes the request using the given status code, headers, and response entity.
    */
-  @deprecated("This directive is for binary compatibility only", "10.0.6")
   def complete(status: StatusCode, headers: java.lang.Iterable[HttpHeader], entity: RequestEntity): RouteAdapter = {
     complete(status, headers, entity: ResponseEntity)
   }
@@ -142,7 +141,6 @@ abstract class RouteDirectives extends RespondWithDirectives {
   /**
    * Completes the request using the given status code and response entity.
    */
-  @deprecated("This directive is for binary compatibility only", "10.0.6")
   def complete(status: StatusCode, entity: RequestEntity): RouteAdapter = complete(status, entity: ResponseEntity)
 
   /**
@@ -169,7 +167,6 @@ abstract class RouteDirectives extends RespondWithDirectives {
   /**
    * Completes the request as HTTP 200 OK, adding the given headers and response entity.
    */
-  @deprecated("This directive is for binary compatibility only", "10.0.6")
   def complete(headers: java.lang.Iterable[HttpHeader], entity: RequestEntity): RouteAdapter =
     complete(headers, entity: ResponseEntity)
 
@@ -191,7 +188,6 @@ abstract class RouteDirectives extends RespondWithDirectives {
   /**
    * Completes the request as HTTP 200 OK with the given value as response entity.
    */
-  @deprecated("This directive is for binary compatibility only", "10.0.6")
   def complete(entity: RequestEntity): RouteAdapter = complete(entity: ResponseEntity)
 
   // --- manual "magnet" for Scala Future ---


### PR DESCRIPTION
Issue: 641
`complete` directives take `ResponseEntity` as a parameter instead of `RequestEntity`

I think in next steps `Marshaller[T, RequestEntity]` should be replaced by `Marshaller[T, ResponseEntity]`. But it requires #642 first. 