### PR TITLE
[WIP] #360 Allow Java-implemented ContentTypeResolver

### DIFF
--- a/akka-http/src/main/java/akka/http/javadsl/server/directives/ContentTypeResolver.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/directives/ContentTypeResolver.java
@@ -1,0 +1,29 @@
+package akka.http.javadsl.server.directives;
+
+import akka.http.javadsl.model.ContentType;
+
+/**
+ * Implement this interface to provide a custom mapping from a file name to a [[akka.http.javadsl.model.ContentType]].
+ */
+@FunctionalInterface
+public interface ContentTypeResolver {
+    ContentType resolve(String fileName);
+
+    /**
+     * Returns a Scala DSL representation of this content type resolver
+     */
+    default akka.http.scaladsl.server.directives.ContentTypeResolver asScala() {
+        ContentTypeResolver delegate = this;
+        return new akka.http.scaladsl.server.directives.ContentTypeResolver() {
+            @Override
+            public ContentType resolve(String fileName) {
+                return delegate.resolve(fileName);
+            }
+            
+            @Override
+            public akka.http.scaladsl.model.ContentType apply(String fileName) {
+                return (akka.http.scaladsl.model.ContentType) delegate.resolve(fileName);
+            }
+        };
+    }
+}

--- a/akka-http/src/main/java/akka/http/javadsl/server/directives/ContentTypeResolver.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/directives/ContentTypeResolver.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 package akka.http.javadsl.server.directives;
 
 import akka.http.javadsl.model.ContentType;

--- a/akka-http/src/main/mima-filters/10.0.5.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.0.5.backwards.excludes
@@ -1,0 +1,6 @@
+# Mima filters needed to check newer versions against 10.0.5
+
+# Java content type resolvers could not be created in this version, so this class was never used.
+# In later versions, java content type resolvers can be created directly ,without going through
+# RoutingJavaMapping.
+ProblemFilters.exclude[MissingClassProblem]("akka.http.javadsl.server.RoutingJavaMapping$convertContentTypeResolver$")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
@@ -52,7 +52,6 @@ private[http] object RoutingJavaMapping {
   implicit object convertEntityStreamingSupport extends Inherited[EntityStreamingSupport, scommon.EntityStreamingSupport]
 
   implicit object convertDirectoryRenderer extends Inherited[jdirectives.DirectoryRenderer, sdirectives.FileAndResourceDirectives.DirectoryRenderer]
-  implicit object convertContentTypeResolver extends Inherited[jdirectives.ContentTypeResolver, sdirectives.ContentTypeResolver]
   implicit object convertDirectoryListing extends Inherited[jdirectives.DirectoryListing, sdirectives.DirectoryListing]
 
   //  implicit object javaToScalaMediaType extends Inherited[javadsl.model.MediaType, scaladsl.model.MediaType]

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FileAndResourceDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FileAndResourceDirectives.scala
@@ -15,13 +15,6 @@ import akka.http.javadsl.model.RequestEntity
 import akka.http.javadsl.server.{ Route, RoutingJavaMapping }
 import akka.http.scaladsl.server.{ Directives ⇒ D }
 
-/**
- * Implement this interface to provide a custom mapping from a file name to a [[akka.http.javadsl.model.ContentType]].
- */
-trait ContentTypeResolver {
-  def resolve(fileName: String): ContentType
-}
-
 abstract class DirectoryListing {
   def getPath: String
   def isRoot: Boolean


### PR DESCRIPTION
Resolves https://github.com/akka/akka-http/issues/360 .

The JavaMapping class assumes that all Java interfaces have
factory methods that only instantiate their Scala subclasses
from the scala DSL. That's not the case for ContentTypeResolver,
which is only a Java interface and a Scala trait. It's intended
to be implemented as a lambda / function.

However, when doing that from Java, the Scala trait is not
instantiated, upsetting the JavaMapping magic.

This commit changes ContentTypeResolver to no longer use the
JavaMapping conversion, but rather convert explicitly. By making
it a Java 8 functional interface, it can now be directly
implemented as a lambda. Binary compatibility is hopefully
unaffected, since the default method isn't slapped on until
actual Java implementations (which couldn't exist until now).