### PR TITLE
Make Response parser more relaxed on reason message #981

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -89,6 +89,11 @@ abstract class ResponseParserSpec(mode: String, newLine: String) extends FreeSpe
         closeAfterResponseCompletion shouldEqual Seq(false)
       }
 
+      "a response with no reason phrase and no trailing space" in new Test {
+        s"""HTTP/1.1 200${newLine}Content-Length: 0${newLine}${newLine}""".stripMargin should parseTo(HEAD, HttpResponse())
+        closeAfterResponseCompletion shouldEqual Seq(false)
+      }
+
       "a response funky `Transfer-Encoding` header" in new Test {
         override def parserSettings: ParserSettings =
           super.parserSettings.withCustomStatusCodes(ServerOnTheMove)
@@ -241,11 +246,6 @@ abstract class ResponseParserSpec(mode: String, newLine: String) extends FreeSpe
       "a too-long response status reason" in new Test {
         Seq("HTTP/1.1 204 12345678", s"90123456789012${newLine}") should generalMultiParseTo(Left(
           MessageStartError(400: StatusCode, ErrorInfo("Response reason phrase exceeds the configured limit of 21 characters"))))
-      }
-
-      "with a missing reason phrase and no trailing space" in new Test {
-        Seq(s"HTTP/1.1 200${newLine}Content-Length: 0${newLine}${newLine}") should generalMultiParseTo(Left(MessageStartError(
-          400: StatusCode, ErrorInfo("Status code misses trailing space"))))
       }
     }
   }


### PR DESCRIPTION
Proposal for issue #981 that will allow to parse a non-standard
Http Response which does not contain a status message.

Example: 'HTTP/1.1 400' instead of 'HTTP/1.1 400 Bad Request'