### PR TITLE
[WIP] #1017 make marshaller composition more lazy

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -7,7 +7,8 @@ package akka.http.scaladsl.server.directives
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import org.scalatest.FreeSpec
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.duration._
 import akka.testkit.EventFilter
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport._
 import akka.http.scaladsl.marshalling._
@@ -108,6 +109,30 @@ class RouteDirectivesSpec extends FreeSpec with GenericRoutingSpec {
       Get().withHeaders(Accept(MediaTypes.`text/plain`)) ~> Route.seal(route) ~> check {
         status shouldEqual StatusCodes.NotAcceptable
       }
+    }
+    "avoid marshalling too eagerly for multi-marshallers" in {
+      case class MyClass(value: String)
+
+      implicit val superMarshaller = {
+        val jsonMarshaller =
+          Marshaller.stringMarshaller(MediaTypes.`application/json`)
+            .compose[MyClass] { mc ⇒
+              println(s"jsonMarshaller marshall $mc")
+              mc.value
+            }
+        val textMarshaller = Marshaller.stringMarshaller(MediaTypes.`text/html`)
+          .compose[MyClass] { mc ⇒
+            println(s"textMarshaller marshall $mc")
+            throw new IllegalArgumentException(s"Unexpected value $mc")
+          }
+
+        Marshaller.oneOf(jsonMarshaller, textMarshaller)
+      }
+      val request =
+        HttpRequest(uri = "/test")
+          .withHeaders(Accept(MediaTypes.`application/json`))
+      val response = Await.result(Marshal(MyClass("test")).toResponseFor(request), 1.second)
+      response.status shouldEqual StatusCodes.OK
     }
   }
 


### PR DESCRIPTION
When using `Marshalling.oneOf`, in some situations each marshaller is actually executed before picking the most suitable result.

While indeed we can't avoid allocating a `Marshalling` for each `Marshaller` (that would need a wider overhaul as described in #243), the actual marshalling can still be lazy at that point (https://github.com/akka/akka-http/blob/master/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala#L168).

It seems `Marshaller.compose` is forcing the early evaluation. This PR appears to confirm that, though it isn't obvious we can work that through without performing the ugly hacks in here.