### PR TITLE
[WIP] Potential marshaller improvements

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala
@@ -99,7 +99,7 @@ class EntityStreamingSpec extends RoutingSpec {
   }
 
   "csv-example" in {
-    implicit val tweetAsCsv = Marshaller.strict[Tweet, ByteString] { t ⇒
+    implicit val tweetAsCsv = Marshaller.strictDynamic[Tweet, ByteString] { t ⇒
       Marshalling.WithFixedContentType(ContentTypes.`text/csv(UTF-8)`, () ⇒ {
         val txt = t.txt.replaceAll(",", ".")
         val uid = t.uid
@@ -203,13 +203,10 @@ class EntityStreamingSpec extends RoutingSpec {
     }
   }
   "render a JSON Source of raw Strings if String => JsValue is provided" in {
-    implicit val stringFormat = Marshaller[String, ByteString] { ec ⇒ s ⇒
-      Future.successful {
-        List(Marshalling.WithFixedContentType(ContentTypes.`application/json`, () ⇒
-          ByteString("\"" + s + "\"")) // "raw string" to be rendered as json element in our stream must be enclosed by ""
-        )
-      }
-    }
+    implicit val stringFormat =
+      Marshaller.withFixedContentType[String, ByteString](ContentTypes.`application/json`)(
+        s ⇒ ByteString("\"" + s + "\"") // "raw string" to be rendered as json element in our stream must be enclosed by ""
+      )
 
     implicit val jsonStreamingSupport =
       EntityStreamingSupport.json()

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -7,7 +7,8 @@ package akka.http.scaladsl.server.directives
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
 import org.scalatest.FreeSpec
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.duration._
 import akka.testkit.EventFilter
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport._
 import akka.http.scaladsl.marshalling._
@@ -108,6 +109,30 @@ class RouteDirectivesSpec extends FreeSpec with GenericRoutingSpec {
       Get().withHeaders(Accept(MediaTypes.`text/plain`)) ~> Route.seal(route) ~> check {
         status shouldEqual StatusCodes.NotAcceptable
       }
+    }
+    "avoid marshalling too eagerly for multi-marshallers" in {
+      case class MyClass(value: String)
+
+      implicit val superMarshaller = {
+        val jsonMarshaller =
+          Marshaller.stringMarshaller(MediaTypes.`application/json`)
+            .compose[MyClass] { mc ⇒
+              println(s"jsonMarshaller marshall $mc")
+              mc.value
+            }
+        val textMarshaller = Marshaller.stringMarshaller(MediaTypes.`text/html`)
+          .compose[MyClass] { mc ⇒
+            println(s"textMarshaller marshall $mc")
+            throw new IllegalArgumentException(s"Unexpected value $mc")
+          }
+
+        Marshaller.oneOf(jsonMarshaller, textMarshaller)
+      }
+      val request =
+        HttpRequest(uri = "/test")
+          .withHeaders(Accept(MediaTypes.`application/json`))
+      val response = Await.result(Marshal(MyClass("test")).toResponseFor(request), 1.second)
+      response.status shouldEqual StatusCodes.OK
     }
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -117,16 +117,19 @@ class RouteDirectivesSpec extends FreeSpec with GenericRoutingSpec {
         val jsonMarshaller =
           Marshaller.stringMarshaller(MediaTypes.`application/json`)
             .compose[MyClass] { mc ⇒
+              //Thread.dumpStack()
               println(s"jsonMarshaller marshall $mc")
+              Thread.dumpStack()
               mc.value
             }
         val textMarshaller = Marshaller.stringMarshaller(MediaTypes.`text/html`)
           .compose[MyClass] { mc ⇒
             println(s"textMarshaller marshall $mc")
+            Thread.dumpStack()
             throw new IllegalArgumentException(s"Unexpected value $mc")
           }
 
-        Marshaller.oneOf(jsonMarshaller, textMarshaller)
+        Marshaller.oneOf(textMarshaller, jsonMarshaller)
       }
       val request =
         HttpRequest(uri = "/test")

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala
@@ -11,10 +11,10 @@ import FastFuture._
 
 trait GenericMarshallers extends LowPriorityToResponseMarshallerImplicits {
 
-  implicit def throwableMarshaller[T]: Marshaller[Throwable, T] = Marshaller(_ ⇒ FastFuture.failed)
+  implicit def throwableMarshaller[T]: Marshaller[Throwable, T] = Marshaller.dynamic(_ ⇒ FastFuture.failed)
 
   implicit def optionMarshaller[A, B](implicit m: Marshaller[A, B], empty: EmptyValue[B]): Marshaller[Option[A], B] =
-    Marshaller { implicit ec ⇒
+    Marshaller.dynamic { implicit ec ⇒
       {
         case Some(value) ⇒ m(value)
         case None        ⇒ FastFuture.successful(Marshalling.Opaque(() ⇒ empty.emptyValue) :: Nil)
@@ -22,7 +22,7 @@ trait GenericMarshallers extends LowPriorityToResponseMarshallerImplicits {
     }
 
   implicit def eitherMarshaller[A1, A2, B](implicit m1: Marshaller[A1, B], m2: Marshaller[A2, B]): Marshaller[Either[A1, A2], B] =
-    Marshaller { implicit ec ⇒
+    Marshaller.dynamic { implicit ec ⇒
       {
         case Left(a1)  ⇒ m1(a1)
         case Right(a2) ⇒ m2(a2)
@@ -30,10 +30,10 @@ trait GenericMarshallers extends LowPriorityToResponseMarshallerImplicits {
     }
 
   implicit def futureMarshaller[A, B](implicit m: Marshaller[A, B]): Marshaller[Future[A], B] =
-    Marshaller(implicit ec ⇒ _.fast.flatMap(m(_)))
+    Marshaller.dynamic(implicit ec ⇒ _.fast.flatMap(m(_)))
 
   implicit def tryMarshaller[A, B](implicit m: Marshaller[A, B]): Marshaller[Try[A], B] =
-    Marshaller { implicit ec ⇒
+    Marshaller.dynamic { implicit ec ⇒
       {
         case Success(value) ⇒ m(value)
         case Failure(error) ⇒ FastFuture.failed(error)

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
@@ -4,8 +4,6 @@
 
 package akka.http.scaladsl.marshalling
 
-import akka.http.scaladsl.marshalling.Marshalling.Opaque
-
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 import akka.http.scaladsl.model._
@@ -16,9 +14,6 @@ import akka.http.scaladsl.util.FastFuture._
 sealed abstract class Marshaller[-A, +B] {
 
   def apply(value: A)(implicit ec: ExecutionContext): Future[List[Marshalling[B]]]
-
-  def map[C](f: B ⇒ C): Marshaller[A, C] =
-    Marshaller(implicit ec ⇒ value ⇒ this(value).fast map (_ map (_ map f)))
 
   /**
    * Reuses this Marshaller's logic to produce a new Marshaller from another type `C` which overrides
@@ -38,7 +33,7 @@ sealed abstract class Marshaller[-A, +B] {
    * If the wrapping is illegal the [[scala.concurrent.Future]] produced by the resulting marshaller will contain a [[RuntimeException]].
    */
   def wrapWithEC[C, D >: B](newMediaType: MediaType)(f: ExecutionContext ⇒ C ⇒ A)(implicit cto: ContentTypeOverrider[D]): Marshaller[C, D] =
-    Marshaller { implicit ec ⇒ value ⇒
+    Marshaller.dynamic { implicit ec ⇒ value ⇒
       import Marshalling._
       this(f(ec)(value)).fast map {
         _ map {
@@ -69,11 +64,11 @@ sealed abstract class Marshaller[-A, +B] {
       }
     }
 
-  def compose[C](f: C ⇒ A): Marshaller[C, B] =
-    Marshaller(implicit ec ⇒ c ⇒ apply(f(c)))
+  def map[C](f: B ⇒ C): Marshaller[A, C] = wrapInAndOut(a ⇒ (a, f))
+  def compose[C](f: C ⇒ A): Marshaller[C, B] = wrapInAndOut(c ⇒ (f(c), identity))
 
-  def composeWithEC[C](f: ExecutionContext ⇒ C ⇒ A): Marshaller[C, B] =
-    Marshaller(implicit ec ⇒ c ⇒ apply(f(ec)(c)))
+  // TODO: an asynchronous version of this method would be nice but that cannot be implemented without making Marshalling asynchronous itself
+  def wrapInAndOut[A0, B1](f: A0 ⇒ (A, B ⇒ B1)): Marshaller[A0, B1]
 }
 
 //#marshaller-creation
@@ -86,18 +81,24 @@ object Marshaller
   /**
    * Creates a [[Marshaller]] from the given function.
    */
-  def apply[A, B](f: ExecutionContext ⇒ A ⇒ Future[List[Marshalling[B]]]): Marshaller[A, B] =
+  def dynamic[A, B](f: ExecutionContext ⇒ A ⇒ Future[List[Marshalling[B]]]): Marshaller[A, B] =
     new Marshaller[A, B] {
       def apply(value: A)(implicit ec: ExecutionContext) =
         try f(ec)(value)
         catch { case NonFatal(e) ⇒ FastFuture.failed(e) }
+
+      def wrapInAndOut[A0, B1](f: A0 ⇒ (A, B ⇒ B1)): Marshaller[A0, B1] =
+        Marshaller.dynamic[A0, B1] { implicit ec ⇒ a0 ⇒
+          val (a, f2) = f(a0)
+          apply(a).fast map (_ map (_ map f2))
+        }
     }
 
   /**
    * Helper for creating a [[Marshaller]] using the given function.
    */
-  def strict[A, B](f: A ⇒ Marshalling[B]): Marshaller[A, B] =
-    Marshaller { _ ⇒ a ⇒ FastFuture.successful(f(a) :: Nil) }
+  def strictDynamic[A, B](f: A ⇒ Marshalling[B]): Marshaller[A, B] =
+    dynamic { _ ⇒ a ⇒ FastFuture.successful(f(a) :: Nil) }
 
   /**
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
@@ -109,7 +110,7 @@ object Marshaller
    * changed in later versions of Akka HTTP.
    */
   def oneOf[A, B](marshallers: Marshaller[A, B]*): Marshaller[A, B] =
-    Marshaller { implicit ec ⇒ a ⇒ FastFuture.sequence(marshallers.map(_(a))).fast.map(_.flatten.toList) }
+    dynamic { implicit ec ⇒ a ⇒ FastFuture.sequence(marshallers.map(_(a))).fast.map(_.flatten.toList) }
 
   /**
    * Helper for creating a "super-marshaller" from a number of values and a function producing "sub-marshallers"
@@ -126,47 +127,63 @@ object Marshaller
   /**
    * Helper for creating a synchronous [[Marshaller]] to content with a fixed charset from the given function.
    */
-  def withFixedContentType[A, B](contentType: ContentType)(marshal: A ⇒ B): Marshaller[A, B] = {
-    val f1 = (value: A) ⇒ Marshalling.WithFixedContentType(contentType, () ⇒ marshal(value))
-    val f2 = (_: ExecutionContext) ⇒ (a: A) ⇒ FastFuture.successful(f1(a) :: Nil)
-    new Marshaller[A, B] {
-      def apply(value: A)(implicit ec: ExecutionContext) =
-        try f2(ec)(value)
-        catch { case NonFatal(e) ⇒ FastFuture.failed(e) }
+  def withFixedContentType[A, B](contentType: ContentType)(marshal: A ⇒ B): Marshaller[A, B] =
+    new FixedContentTypeMarshaller(contentType, marshal)
 
-      override def compose[C](f: C ⇒ A): Marshaller[C, B] =
-        Marshaller.withFixedContentType(contentType)(marshal compose f)
-    }
+  final class FixedContentTypeMarshaller[A, B](contentType: ContentType, marshal: A ⇒ B) extends Marshaller[A, B] {
+    def apply(value: A)(implicit ec: ExecutionContext) =
+      try FastFuture.successful(Marshalling.WithFixedContentType(contentType, () ⇒ marshal(value)) :: Nil)
+      catch { case NonFatal(e) ⇒ FastFuture.failed(e) }
+
+    def wrapInAndOut[A0, B1](f: A0 ⇒ (A, B ⇒ B1)): Marshaller[A0, B1] =
+      new FixedContentTypeMarshaller[A0, B1](contentType, { a0 ⇒
+        val (a, f2) = f(a0)
+        f2(marshal(a))
+      })
   }
 
   /**
    * Helper for creating a synchronous [[Marshaller]] to content with a negotiable charset from the given function.
    */
-  def withOpenCharset[A, B](mediaType: MediaType.WithOpenCharset)(marshal: (A, HttpCharset) ⇒ B): Marshaller[A, B] = {
-    val f1 = (value: A) ⇒ Marshalling.WithOpenCharset(mediaType, charset ⇒ marshal(value, charset))
-    val f2 = (_: ExecutionContext) ⇒ (a: A) ⇒ FastFuture.successful(f1(a) :: Nil)
-    new Marshaller[A, B] {
-      def apply(value: A)(implicit ec: ExecutionContext) =
-        try f2(ec)(value)
-        catch { case NonFatal(e) ⇒ FastFuture.failed(e) }
+  def withOpenCharset[A, B](mediaType: MediaType.WithOpenCharset)(marshal: (A, HttpCharset) ⇒ B): Marshaller[A, B] =
+    new OpenCharsetMarshaller(mediaType, marshal)
 
-      override def compose[C](f: C ⇒ A): Marshaller[C, B] =
-        Marshaller.withOpenCharset(mediaType)((c: C, hc: HttpCharset) ⇒ marshal(f(c), hc))
-    }
+  final class OpenCharsetMarshaller[A, B](mediaType: MediaType.WithOpenCharset, marshal: (A, HttpCharset) ⇒ B) extends Marshaller[A, B] {
+    def apply(value: A)(implicit ec: ExecutionContext) =
+      try FastFuture.successful(Marshalling.WithOpenCharset(mediaType, charset ⇒ marshal(value, charset)) :: Nil)
+      catch { case NonFatal(e) ⇒ FastFuture.failed(e) }
+
+    def wrapInAndOut[A0, B1](f: A0 ⇒ (A, B ⇒ B1)): Marshaller[A0, B1] =
+      new OpenCharsetMarshaller[A0, B1](mediaType, { (a0, charset) ⇒
+        val (a, f2) = f(a0)
+        f2(marshal(a, charset))
+      })
   }
 
   /**
    * Helper for creating a synchronous [[Marshaller]] to non-negotiable content from the given function.
    */
   def opaque[A, B](marshal: A ⇒ B): Marshaller[A, B] =
-    strict { value ⇒ Marshalling.Opaque(() ⇒ marshal(value)) }
+    new OpaqueMarshaller(marshal)
+
+  final class OpaqueMarshaller[A, B](marshal: A ⇒ B) extends Marshaller[A, B] {
+    def apply(value: A)(implicit ec: ExecutionContext) =
+      try FastFuture.successful(Marshalling.Opaque(() ⇒ marshal(value)) :: Nil)
+      catch { case NonFatal(e) ⇒ FastFuture.failed(e) }
+
+    def wrapInAndOut[A0, B1](f: A0 ⇒ (A, B ⇒ B1)): Marshaller[A0, B1] =
+      new OpaqueMarshaller[A0, B1]({ a0 ⇒
+        val (a, f2) = f(a0)
+        f2(marshal(a))
+      })
+  }
 
   /**
    * Helper for creating a [[Marshaller]] combined of the provided `marshal` function
    * and an implicit Marshaller which is able to produce the required final type.
    */
   def combined[A, B, C](marshal: A ⇒ B)(implicit m2: Marshaller[B, C]): Marshaller[A, C] =
-    Marshaller[A, C] { ec ⇒ a ⇒ m2.compose(marshal).apply(a)(ec) }
+    dynamic[A, C] { ec ⇒ a ⇒ m2.compose(marshal).apply(a)(ec) }
 }
 //#marshaller-creation
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
@@ -13,7 +13,7 @@ import akka.http.scaladsl.model._
 
 trait MultipartMarshallers {
   implicit def multipartMarshaller[T <: Multipart](implicit log: LoggingAdapter = DefaultNoLogging): ToEntityMarshaller[T] =
-    Marshaller strict { value ⇒
+    Marshaller strictDynamic { value ⇒
       val boundary = randomBoundary()
       val mediaType = value.mediaType withBoundary boundary
       Marshalling.WithFixedContentType(mediaType.toContentType, () ⇒ value.toEntity(boundary, log))

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala
@@ -51,7 +51,7 @@ trait PredefinedToEntityMarshallers extends MultipartMarshallers {
     Marshaller.withOpenCharset(`application/x-www-form-urlencoded`) { _ toEntity _ }
 
   implicit val MessageEntityMarshaller: ToEntityMarshaller[MessageEntity] =
-    Marshaller strict { value ⇒ Marshalling.WithFixedContentType(value.contentType, () ⇒ value) }
+    Marshaller strictDynamic { value ⇒ Marshalling.WithFixedContentType(value.contentType, () ⇒ value) }
 }
 
 object PredefinedToEntityMarshallers extends PredefinedToEntityMarshallers

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
@@ -14,15 +14,15 @@ trait PredefinedToRequestMarshallers {
   implicit val fromRequest: TRM[HttpRequest] = Marshaller.opaque(identity)
 
   implicit def fromUri: TRM[Uri] =
-    Marshaller strict { uri ⇒ Marshalling.Opaque(() ⇒ HttpRequest(uri = uri)) }
+    Marshaller.opaque(uri ⇒ HttpRequest(uri = uri))
 
   implicit def fromMethodAndUriAndValue[S, T](implicit mt: ToEntityMarshaller[T]): TRM[(HttpMethod, Uri, T)] =
     fromMethodAndUriAndHeadersAndValue[T] compose { case (m, u, v) ⇒ (m, u, Nil, v) }
 
   implicit def fromMethodAndUriAndHeadersAndValue[T](implicit mt: ToEntityMarshaller[T]): TRM[(HttpMethod, Uri, immutable.Seq[HttpHeader], T)] =
-    Marshaller(implicit ec ⇒ {
-      case (m, u, h, v) ⇒ mt(v).fast map (_ map (_ map (HttpRequest(m, u, h, _))))
-    })
+    mt.wrapInAndOut {
+      case (m, u, h, v) ⇒ (v, HttpRequest(m, u, h, _))
+    }
 }
 
 object PredefinedToRequestMarshallers extends PredefinedToRequestMarshallers

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ToResponseMarshallable.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ToResponseMarshallable.scala
@@ -26,5 +26,5 @@ object ToResponseMarshallable {
     }
 
   implicit val marshaller: ToResponseMarshaller[ToResponseMarshallable] =
-    Marshaller { implicit ec ⇒ marshallable ⇒ marshallable.marshaller(marshallable.value) }
+    Marshaller.dynamic { implicit ec ⇒ marshallable ⇒ marshallable.marshaller(marshallable.value) }
 }


### PR DESCRIPTION
Based on @raboof's #1019, I went a step further to clean up marshaller constructors and apply the optimizations from #1019 also to other code paths. So far it's only a (binary incompatible) experiment.

In the medium term, it might make sense to make an ADT out of the classes introduced here (`DynamicMarshaller`, `FixedContentTypeMarshaller`, `OpenCharsetMarshaller`, and `OpaqueMarshaller`). That would allow us to further optimize the common simple combinations.