### PR TITLE
Name root project 'akka-http-root'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ inThisBuild(Def.settings(
 ))
 
 lazy val root = Project(
-    id = "root",
+    id = "akka-http-root",
     base = file(".")
   )
   .enablePlugins(UnidocRoot, NoPublish, DeployRsync)


### PR DESCRIPTION
Used as default for the sbt prompt, IntelliJ project name, perhaps other things