### PR TITLE
=htc use ByteArrayRendering for response rendering

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.5.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.5.backwards.excludes
@@ -2,3 +2,6 @@
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage#MessageTransformations.transformEntityDataBytes")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpResponse.encoding")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.transformEntityDataBytes")
+
+# Internal API changes
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.impl.engine.rendering.RenderSupport.renderByteStrings")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
@@ -65,9 +65,9 @@ private object RenderSupport {
     } else r // don't render
   }
 
-  def renderByteStrings(r: ByteStringRendering, entityBytes: ⇒ Source[ByteString, Any],
+  def renderByteStrings(header: ByteString, entityBytes: ⇒ Source[ByteString, Any],
                         skipEntity: Boolean = false): Source[ByteString, Any] = {
-    val messageStart = Source.single(r.get)
+    val messageStart = Source.single(header)
     val messageBytes =
       if (!skipEntity) (messageStart ++ entityBytes).mapMaterializedValue(_ ⇒ ())
       else CancelSecond(messageStart, entityBytes)

--- a/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
@@ -294,6 +294,9 @@ private[http] class ByteArrayRendering(sizeHint: Int) extends Rendering {
     size = neededSize.toInt
     oldSize
   }
+
+  def remainingCapacity: Int = array.length - size
+  def asByteString: ByteString = ByteString.ByteString1(array, 0, size)
 }
 
 /**


### PR DESCRIPTION
Small scale buffer copies are faster than fine-grained chained ByteStrings.