### PR TITLE
Do not throw if promise is completed #1034

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -17,7 +17,7 @@ import akka.http.scaladsl.settings.ServerSettings
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
+import scala.concurrent.{ Await, ExecutionContext, Future, Promise, blocking }
 import scala.io.StdIn
 import scala.util.{ Failure, Success, Try }
 
@@ -137,8 +137,10 @@ abstract class HttpApp extends Directives {
       promise.trySuccess(Done)
     }
     Future {
-      if (StdIn.readLine("Press RETURN to stop...\n") != null)
-        promise.success(Done)
+      blocking {
+        if (StdIn.readLine("Press RETURN to stop...\n") != null)
+          promise.trySuccess(Done)
+      }
     }
     promise.future
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -134,7 +134,7 @@ abstract class HttpApp extends Directives {
   protected def waitForShutdownSignal(system: ActorSystem)(implicit ec: ExecutionContext): Future[Done] = {
     val promise = Promise[Done]()
     sys.addShutdownHook {
-      promise.success(Done)
+      promise.trySuccess(Done)
     }
     Future {
       if (StdIn.readLine("Press RETURN to stop...\n") != null)


### PR DESCRIPTION
Issue: #1034
Do not throw if promise is already completed when called by the JVM shutdown hook