### PR TITLE
Update to Akka 2.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import scala.language.implicitConversions
 object Dependencies {
   import DependencyHelpers._
 
-  val akkaVersion = "2.4.17"
+  val akkaVersion = "2.5.0"
   val junitVersion = "4.12"
   val h2specVersion = "1.5.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"


### PR DESCRIPTION
Checked locally if there's any issues while digging through emails and PRs.
Seems passes locally.

Do we want to do this in a 10.1.0 bump?
Might be good to just signal that "minor akka version changed" even though no other changes required.

Only reason to get this out soon seems to be that someone reported an incompatibility when mixing 10.0.5 with 2.5 hm... 