### PR TITLE
Replace FileInputStream and FileOutputStream, #1037

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/TestUtils.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/TestUtils.scala
@@ -4,13 +4,14 @@
 
 package akka.http.scaladsl
 
-import java.io.{ FileOutputStream, File }
+import java.io.File
+import java.nio.file.Files
 import java.net.InetSocketAddress
 import java.nio.channels.ServerSocketChannel
 
 object TestUtils {
   def writeAllText(text: String, file: File): Unit = {
-    val fos = new FileOutputStream(file)
+    val fos = Files.newOutputStream(file.toPath)
     try {
       fos.write(text.getBytes("UTF-8"))
     } finally fos.close()

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -4,7 +4,8 @@
 
 package akka.http.scaladsl.server.directives
 
-import java.io.{ File, FileInputStream }
+import java.io.File
+import java.nio.file.Files
 
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.{ MissingFormFieldRejection, RoutingSpec }
@@ -147,7 +148,7 @@ class FileUploadDirectivesSpec extends RoutingSpec {
   }
 
   private def read(file: File): String = {
-    val in = new FileInputStream(file)
+    val in = Files.newInputStream(file.toPath)
     try {
       val buffer = new Array[Byte](1024)
       in.read(buffer)


### PR DESCRIPTION
* because they use finalize that is not gc friendly
* they were only used in tests, but good to stay away from them
  anyway

Refs #1037