### PR TITLE
Handle failure while parsing the URI in parameter extraction #1043

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
@@ -35,7 +35,7 @@ public class ParameterDirectivesTest extends JUnitRouteTest {
     route
       .run(HttpRequest.create().withUri("/abc?stringParam=a=b"))
       .assertStatusCode(400)
-      .assertEntity("The request content was malformed:\nThe request's query string is invalid");
+      .assertEntity("The request content was malformed:\nThe request's query string is invalid: Illegal query: Invalid input '=', expected '+', query-char, 'EOI', '&' or pct-encoded (line 1, column 14): stringParam=a=b\n             ^");
   }
 
   @Test

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
@@ -35,7 +35,7 @@ public class ParameterDirectivesTest extends JUnitRouteTest {
     route
       .run(HttpRequest.create().withUri("/abc?stringParam=a=b"))
       .assertStatusCode(400)
-      .assertEntity("The request content was malformed:\nThe request's query string is invalid: Illegal query: Invalid input '=', expected '+', query-char, 'EOI', '&' or pct-encoded (line 1, column 14): stringParam=a=b\n             ^");
+      .assertEntity("The request content was malformed:\nThe request's query string is invalid: stringParam=a=b");
   }
 
   @Test

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
@@ -31,6 +31,11 @@ public class ParameterDirectivesTest extends JUnitRouteTest {
       .run(HttpRequest.create().withUri("/abc?stringParam=john"))
       .assertStatusCode(200)
       .assertEntity("john");
+
+    route
+      .run(HttpRequest.create().withUri("/abc?stringParam=a=b"))
+      .assertStatusCode(400)
+      .assertEntity("The request content was malformed:\nThe request's query string is invalid");
   }
 
   @Test

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -54,7 +54,7 @@ class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Insi
           parameter("amount".as[Int].?) { echoComplete }
         } ~> check {
           inside(rejection) {
-            case MalformedRequestContentRejection("The request's query string is invalid: Illegal query: Invalid input '=', expected '+', query-char, 'EOI', '&' or pct-encoded (line 1, column 9): amount=1=\n        ^", _) ⇒
+            case MalformedRequestContentRejection("The request's query string is invalid: amount=1=", _) ⇒
           }
         }
       }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -49,6 +49,15 @@ class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Insi
           }
         }
       }
+      "cause a MalformedRequestContentRejection on invalid query strings" in {
+        Get("/?amount=1=") ~> {
+          parameter("amount".as[Int].?) { echoComplete }
+        } ~> check {
+          inside(rejection) {
+            case MalformedRequestContentRejection("The request's query string is invalid", _) ⇒
+          }
+        }
+      }
     }
     "supply chaining of unmarshallers" in {
       case class UserId(id: Int)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -54,7 +54,7 @@ class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Insi
           parameter("amount".as[Int].?) { echoComplete }
         } ~> check {
           inside(rejection) {
-            case MalformedRequestContentRejection("The request's query string is invalid", _) ⇒
+            case MalformedRequestContentRejection("The request's query string is invalid: Illegal query: Invalid input '=', expected '+', query-char, 'EOI', '&' or pct-encoded (line 1, column 9): amount=1=\n        ^", _) ⇒
           }
         }
       }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -127,7 +127,7 @@ object ParameterDirectives extends ParameterDirectives {
         import ctx.materializer
         Try(ctx.request.uri.query()) match {
           case Success(query) ⇒ handleParamResult(paramName, fsou(query.get(paramName)))
-          case Failure(t)     ⇒ reject(MalformedRequestContentRejection("The request's query string is invalid", t))
+          case Failure(t)     ⇒ reject(MalformedRequestContentRejection(s"The request's query string is invalid: ${t.getMessage}", t))
         }
       }
     implicit def forString(implicit fsu: FSU[String]): ParamDefAux[String, Directive1[String]] =

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -127,7 +127,7 @@ object ParameterDirectives extends ParameterDirectives {
         import ctx.materializer
         Try(ctx.request.uri.query()) match {
           case Success(query) ⇒ handleParamResult(paramName, fsou(query.get(paramName)))
-          case Failure(t)     ⇒ reject(MalformedRequestContentRejection(s"The request's query string is invalid: ${t.getMessage}", t))
+          case Failure(t)     ⇒ reject(MalformedRequestContentRejection(s"The request's query string is invalid: ${ctx.request.uri.rawQueryString.getOrElse("")}", t))
         }
       }
     implicit def forString(implicit fsu: FSU[String]): ParamDefAux[String, Directive1[String]] =

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -9,7 +9,7 @@ import akka.http.javadsl.server.directives.CorrespondsTo
 
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success }
+import scala.util.{ Failure, Success, Try }
 import akka.http.scaladsl.common._
 import akka.http.impl.util._
 
@@ -125,7 +125,10 @@ object ParameterDirectives extends ParameterDirectives {
       extractRequestContext flatMap { ctx ⇒
         import ctx.executionContext
         import ctx.materializer
-        handleParamResult(paramName, fsou(ctx.request.uri.query().get(paramName)))
+        Try(ctx.request.uri.query()) match {
+          case Success(query) ⇒ handleParamResult(paramName, fsou(query.get(paramName)))
+          case Failure(t)     ⇒ reject(MalformedRequestContentRejection("The request's query string is invalid", t))
+        }
       }
     implicit def forString(implicit fsu: FSU[String]): ParamDefAux[String, Directive1[String]] =
       extractParameter[String, String] { string ⇒ filter(string, fsu) }


### PR DESCRIPTION
This changes the behaviour so that rather than throwing an exception leading to an Internal Server Error, instead we reject with a `MalformedRequestContentRejection`. This is used instead of `MalformedQueryParameterRejection` as the parse failure doesn't give us information about the query parameter that led to the parse failure.

I hope the tests are sufficient, but I'm more than happy to add more if desired.