### PR TITLE
Copy-paste/naming error fixed

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
@@ -142,8 +142,8 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with PredefinedFromStr
   "mapped-repeated" in {
     //#mapped-repeated
     val route =
-      parameters('color, 'distance.as[Int].*) { (color, cities) =>
-        cities.toList match {
+      parameters('color, 'distance.as[Int].*) { (color, distances) =>
+        distances.toList match {
           case Nil             => complete(s"The color is '$color' and there are no distances.")
           case distance :: Nil => complete(s"The color is '$color' and the distance is $distance.")
           case multiple        => complete(s"The color is '$color' and the distances are ${multiple.mkString(", ")}.")


### PR DESCRIPTION
renames in `Repeated, deserialized parameter` example
city -> distance
cities -> distances