### PR TITLE
Remove references to old HttpApp from docs #1041

### DIFF
--- a/docs/src/main/paradox/java/http/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/testkit.md
@@ -20,8 +20,8 @@ To see the testkit in action consider the following simple calculator app servic
 
 @@snip [MyAppService.java](../../../../../test/java/docs/http/javadsl/server/testkit/MyAppService.java) { #simple-app }
 
-The app extends from `HttpApp` which brings all of the directives into scope. Method `createRoute`
-needs to be implemented to return the complete route of the app.
+`MyAppService` extends from `AllDirectives` which brings all of the directives into scope. We define a method called `createRoute`
+that provides the routes to serve to `bindAndHandle`.
 
 Here's how you would test that service:
 

--- a/docs/src/main/paradox/java/http/server-side-https-support.md
+++ b/docs/src/main/paradox/java/http/server-side-https-support.md
@@ -55,7 +55,7 @@ Once you have obtained the server certificate, using it is as simple as preparin
 and either setting it as the default one to be used by all servers started by the given `Http` extension
 or passing it in explicitly when binding the server.
 
-The below example shows how setting up HTTPS works when using the `akka.http.javadsl.server.HttpApp` convenience class.
+The below example shows how setting up HTTPS works.
 Firstly you will create and configure an instance of `akka.http.javadsl.HttpsConnectionContext` :
 
 @@snip [SimpleServerApp.java](../../../../../../akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java) { #https-http-config }

--- a/docs/src/test/java/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
@@ -26,7 +26,6 @@ public class HighLevelServerBindFailureExample {
     final ActorSystem system = ActorSystem.create();
     final ActorMaterializer materializer = ActorMaterializer.create(system);
 
-    // HttpApp.bindRoute expects a route being provided by HttpApp.createRoute
     final HighLevelServerExample app = new HighLevelServerExample();
     final Route route = app.createRoute();
 

--- a/docs/src/test/java/docs/http/javadsl/server/HighLevelServerExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HighLevelServerExample.java
@@ -28,7 +28,6 @@ public class HighLevelServerExample extends AllDirectives {
     // boot up server using the route as defined below
     ActorSystem system = ActorSystem.create();
 
-    // HttpApp.bindRoute expects a route being provided by HttpApp.createRoute
     final HighLevelServerExample app = new HighLevelServerExample();
 
     final Http http = Http.get(system);


### PR DESCRIPTION
Issue: #1041
Remove mentions to old Spray HttpApp from docs.
Keep them for migration notes