### PR TITLE
Provide routes method in HttpApp #953

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
@@ -18,7 +18,7 @@ public class MinimalHttpApp extends HttpApp {
   CompletableFuture<Done> bindingPromise = new CompletableFuture<>();
 
   @Override
-  protected Route route() {
+  protected Route routes() {
     return route(path("foo", () ->
         complete("bar")
       ),

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
@@ -31,7 +31,7 @@ class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
     val shutdownPromise = Promise[Done]()
     val bindingPromise = Promise[Done]()
 
-    override protected def route: Route =
+    override protected def routes: Route =
       path("foo") {
         complete("bar")
       } ~

--- a/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
@@ -73,7 +73,7 @@ public abstract class HttpApp extends AllDirectives {
 
     CompletionStage<ServerBinding> bindingFuture = Http
       .get(theSystem)
-      .bindAndHandle(routes().flow(theSystem, materializer), // uses the deprecated method to have an easy migration.
+      .bindAndHandle(routes().flow(theSystem, materializer),
         ConnectHttp.toHost(host, port),
         settings,
         theSystem.log(),

--- a/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
@@ -73,7 +73,7 @@ public abstract class HttpApp extends AllDirectives {
 
     CompletionStage<ServerBinding> bindingFuture = Http
       .get(theSystem)
-      .bindAndHandle(route().flow(theSystem, materializer), // uses the deprecated method to have an easy migration.
+      .bindAndHandle(routes().flow(theSystem, materializer), // uses the deprecated method to have an easy migration.
         ConnectHttp.toHost(host, port),
         settings,
         theSystem.log(),
@@ -161,19 +161,7 @@ public abstract class HttpApp extends AllDirectives {
 
   /**
    * Override to implement the route that will be served by this http server.
-   * @deprecated This method is deprecated please use `routes` instead.
    */
-  @Deprecated
-  protected Route route() {
-    return routes();
-  }
-
-
-  /**
-   * Override to implement the route that will be served by this http server.
-   */
-  protected Route routes() {
-    throw new RuntimeException("Please override `routes` to provide the route that will be served by this http server");
-  }
+  protected abstract Route routes();
 
 }

--- a/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
@@ -73,7 +73,7 @@ public abstract class HttpApp extends AllDirectives {
 
     CompletionStage<ServerBinding> bindingFuture = Http
       .get(theSystem)
-      .bindAndHandle(route().flow(theSystem, materializer),
+      .bindAndHandle(route().flow(theSystem, materializer), // uses the deprecated method to have an easy migration.
         ConnectHttp.toHost(host, port),
         settings,
         theSystem.log(),
@@ -161,8 +161,19 @@ public abstract class HttpApp extends AllDirectives {
 
   /**
    * Override to implement the route that will be served by this http server.
+   * @deprecated This method is deprecated please use `routes` instead.
    */
-  protected abstract Route route();
+  @Deprecated
+  protected Route route() {
+    return routes();
+  }
 
+
+  /**
+   * Override to implement the route that will be served by this http server.
+   */
+  protected Route routes() {
+    throw new RuntimeException("Please override `routes` to provide the route that will be served by this http server");
+  }
 
 }

--- a/akka-http/src/main/mima-filters/10.0.6.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.0.6.backwards.excludes
@@ -1,0 +1,4 @@
+# Provide routes method in HttpApp #953
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.server.HttpApp.routes")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.HttpApp.routes")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.server.HttpApp.route")

--- a/akka-http/src/main/mima-filters/10.0.6.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.0.6.backwards.excludes
@@ -1,4 +1,4 @@
-# Provide routes method in HttpApp #953
+# Provide routes method in HttpApp #953 Rename of method is OK as class is `@ApiMayChange`
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.server.HttpApp.routes")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.HttpApp.routes")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.server.HttpApp.route")

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -70,7 +70,7 @@ abstract class HttpApp extends Directives {
     implicit val executionContext = theSystem.dispatcher
 
     val bindingFuture = Http().bindAndHandle(
-      handler = route, // uses the deprecated method to have an easy migration.
+      handler = routes, // uses the deprecated method to have an easy migration.
       interface = host,
       port = port,
       settings = settings)
@@ -146,14 +146,7 @@ abstract class HttpApp extends Directives {
   }
 
   /**
-   * Override to implement the route that will be served by this http server.
-   * @deprecated This method is deprecated please use `routes` instead
-   */
-  @deprecated("This method is deprecated please use `routes` instead", since = "10.0.6")
-  protected def route: Route = routes
-
-  /**
    * Override to implement the routes that will be served by this http server.
    */
-  protected def routes: Route = throw new RuntimeException("Please override `routes` to provide the route that will be served by this http server")
+  protected def routes: Route
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -70,7 +70,7 @@ abstract class HttpApp extends Directives {
     implicit val executionContext = theSystem.dispatcher
 
     val bindingFuture = Http().bindAndHandle(
-      handler = routes, // uses the deprecated method to have an easy migration.
+      handler = routes,
       interface = host,
       port = port,
       settings = settings)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -70,7 +70,7 @@ abstract class HttpApp extends Directives {
     implicit val executionContext = theSystem.dispatcher
 
     val bindingFuture = Http().bindAndHandle(
-      handler = route,
+      handler = route, // uses the deprecated method to have an easy migration.
       interface = host,
       port = port,
       settings = settings)
@@ -147,7 +147,13 @@ abstract class HttpApp extends Directives {
 
   /**
    * Override to implement the route that will be served by this http server.
+   * @deprecated This method is deprecated please use `routes` instead
    */
-  protected def route: Route
+  @deprecated("This method is deprecated please use `routes` instead", since = "10.0.6")
+  protected def route: Route = routes
 
+  /**
+   * Override to implement the routes that will be served by this http server.
+   */
+  protected def routes: Route = throw new RuntimeException("Please override `routes` to provide the route that will be served by this http server")
 }

--- a/docs/src/main/paradox/java/http/migration-guide/index.md
+++ b/docs/src/main/paradox/java/http/migration-guide/index.md
@@ -7,5 +7,6 @@
 
 * [migration-from-old-http-javadsl](migration-from-old-http-javadsl.md)
 * [migration-guide-2.4.x-10.0.x](migration-guide-2.4.x-10.0.x.md)
+* [migration-within-10.0.x-Api-May-Change](migration-within-10.0.x-Api-May-Change.md)
 
 @@@

--- a/docs/src/main/paradox/java/http/migration-guide/migration-within-10.0.x-Api-May-Change.md
+++ b/docs/src/main/paradox/java/http/migration-guide/migration-within-10.0.x-Api-May-Change.md
@@ -2,10 +2,14 @@
 
 ## General Notes
 Akka HTTP is binary backwards compatible within for all version within the 10.0.x range. However, there are a set of APIs
-that are marked with the special annotation `@ApiMayChange` where this binary backwards compatibility is not guaranteed.
-See @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers) in the Akka documentation for further information.
+that are marked with the special annotation `@ApiMayChange` which are exempt from this rule, in order to allow them to be 
+evolved more freely until stabilising them, by removing this annotation.
+See @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers) for further information.
 
-## Akka HTTP 10.0.x -> 10.0.6
+This migration guide aims to help developers who use these bleeding-edge APIs to migrate between their evolving versions
+within patch releases.
+
+## Akka HTTP 10.0.6 -> 10.0.7
 
 ### `AkkaHttp#route` has been renamed to `AkkaHttp#routes`
 

--- a/docs/src/main/paradox/java/http/migration-guide/migration-within-10.0.x-Api-May-Change.md
+++ b/docs/src/main/paradox/java/http/migration-guide/migration-within-10.0.x-Api-May-Change.md
@@ -1,0 +1,14 @@
+# Migration Guide within Akka HTTP 10.0.x
+
+## General Notes
+Akka HTTP is binary backwards compatible within for all version within the 10.0.x range. However, there are a set of APIs
+that are marked with the special annotation `@ApiMayChange` where this binary backwards compatibility is not guaranteed.
+See @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers) in the Akka documentation for further information.
+
+## Akka HTTP 10.0.x -> 10.0.6
+
+### `AkkaHttp#route` has been renamed to `AkkaHttp#routes`
+
+In order to provide a more descriptive name, `AkkaHttp#route` has been renamed to `AkkaHttp#routes`. The previous name
+might have led to some confusion by wrongly implying that only one route could be returned in that method.
+To migrate to 10.0.6, you must rename the old `route` method to `routes`.

--- a/docs/src/main/paradox/java/http/routing-dsl/HttpApp.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/HttpApp.md
@@ -12,7 +12,7 @@ in the Akka documentation.
 ## Introduction
 
 The objective of `HttpApp` is to help you start an HTTP server with just a few lines of code.
-This is accomplished just by extending `HttpApp` and implementing the `route()` method.
+This is accomplished just by extending `HttpApp` and implementing the `routes()` method.
 If desired, `HttpApp` provides different hook methods that can be overridden to change its default behavior.
 
 ## Minimal Example

--- a/docs/src/main/paradox/scala/http/migration-guide/index.md
+++ b/docs/src/main/paradox/scala/http/migration-guide/index.md
@@ -7,5 +7,6 @@
 
 * [migration-from-spray](migration-from-spray.md)
 * [migration-guide-2.4.x-10.0.x](migration-guide-2.4.x-10.0.x.md)
+* [migration-within-10.0.x-Api-May-Change](migration-within-10.0.x-Api-May-Change.md)
 
 @@@

--- a/docs/src/main/paradox/scala/http/migration-guide/migration-within-10.0.x-Api-May-Change.md
+++ b/docs/src/main/paradox/scala/http/migration-guide/migration-within-10.0.x-Api-May-Change.md
@@ -2,10 +2,14 @@
 
 ## General Notes
 Akka HTTP is binary backwards compatible within for all version within the 10.0.x range. However, there are a set of APIs
-that are marked with the special annotation `@ApiMayChange` where this binary backwards compatibility is not guaranteed.
-See @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers) in the Akka documentation for further information.
+that are marked with the special annotation `@ApiMayChange` which are exempt from this rule, in order to allow them to be 
+evolved more freely until stabilising them, by removing this annotation.
+See @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers) for further information.
 
-## Akka HTTP 10.0.x -> 10.0.6
+This migration guide aims to help developers who use these bleeding-edge APIs to migrate between their evolving versions
+within patch releases.
+
+## Akka HTTP 10.0.6 -> 10.0.7
 
 ### `AkkaHttp#route` has been renamed to `AkkaHttp#routes`
 

--- a/docs/src/main/paradox/scala/http/migration-guide/migration-within-10.0.x-Api-May-Change.md
+++ b/docs/src/main/paradox/scala/http/migration-guide/migration-within-10.0.x-Api-May-Change.md
@@ -1,0 +1,14 @@
+# Migration Guide within Akka HTTP 10.0.x
+
+## General Notes
+Akka HTTP is binary backwards compatible within for all version within the 10.0.x range. However, there are a set of APIs
+that are marked with the special annotation `@ApiMayChange` where this binary backwards compatibility is not guaranteed.
+See @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers) in the Akka documentation for further information.
+
+## Akka HTTP 10.0.x -> 10.0.6
+
+### `AkkaHttp#route` has been renamed to `AkkaHttp#routes`
+
+In order to provide a more descriptive name, `AkkaHttp#route` has been renamed to `AkkaHttp#routes`. The previous name
+might have led to some confusion by wrongly implying that only one route could be returned in that method.
+To migrate to 10.0.6, you must rename the old `route` method to `routes`.

--- a/docs/src/main/paradox/scala/http/routing-dsl/HttpApp.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/HttpApp.md
@@ -12,7 +12,7 @@ in the Akka documentation.
 ## Introduction
 
 The objective of `HttpApp` is to help you start an HTTP server with just a few lines of code.
-This is accomplished just by extending `HttpApp` and implementing the `route()` method.
+This is accomplished just by extending `HttpApp` and implementing the `routes()` method.
 If desired, `HttpApp` provides different hook methods that can be overridden to change its default behavior.
 
 ## Minimal Example

--- a/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
@@ -43,7 +43,7 @@ public class HttpAppExampleTest extends JUnitSuite {
     // Server definition
     class MinimalHttpApp extends HttpApp {
       @Override
-      protected Route route() {
+      protected Route routes() {
         return path("hello", () ->
           get(() ->
             complete("<h1>Say hello to akka-http</h1>")
@@ -79,7 +79,7 @@ public class HttpAppExampleTest extends JUnitSuite {
     class SelfDestroyingHttpApp extends HttpApp {
 
       @Override
-      protected Route route() {
+      protected Route routes() {
         return path("hello", () ->
           get(() ->
               complete("<h1>Say hello to akka-http</h1>")
@@ -114,7 +114,7 @@ public class HttpAppExampleTest extends JUnitSuite {
     class FailBindingOverrideHttpApp extends HttpApp {
 
       @Override
-      protected Route route() {
+      protected Route routes() {
         return path("hello", () ->
           get(() ->
             complete("<h1>Say hello to akka-http</h1>")
@@ -157,7 +157,7 @@ public class HttpAppExampleTest extends JUnitSuite {
     class PostShutdownOverrideHttpApp extends HttpApp {
 
       @Override
-      protected Route route() {
+      protected Route routes() {
         return path("hello", () ->
           get(() ->
             complete("<h1>Say hello to akka-http</h1>")

--- a/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
@@ -17,7 +17,7 @@ class HttpAppExampleSpec extends WordSpec with Matchers
 
     // Server definition
     object WebServer extends HttpApp {
-      def route: Route =
+      override def routes: Route =
         path("hello") {
           get {
             complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
@@ -40,7 +40,7 @@ class HttpAppExampleSpec extends WordSpec with Matchers
 
     // Server definition
     object WebServer extends HttpApp {
-      def route: Route =
+      override def routes: Route =
         path("hello") {
           get {
             complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
@@ -63,7 +63,7 @@ class HttpAppExampleSpec extends WordSpec with Matchers
 
     // Server definition
     object WebServer extends HttpApp {
-      def route: Route =
+      override def routes: Route =
         path("hello") {
           get {
             complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
@@ -96,7 +96,7 @@ class HttpAppExampleSpec extends WordSpec with Matchers
 
     // Server definition
     object WebServer extends HttpApp {
-      def route: Route =
+      override def routes: Route =
         path("hello") {
           get {
             complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
@@ -123,7 +123,7 @@ class HttpAppExampleSpec extends WordSpec with Matchers
 
     // Server definition
     object WebServer extends HttpApp {
-      def route: Route =
+      override def routes: Route =
         path("hello") {
           get {
             complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
@@ -151,7 +151,7 @@ class HttpAppExampleSpec extends WordSpec with Matchers
 
     // Server definition
     class WebServer extends HttpApp {
-      def route: Route =
+      override def routes: Route =
         path("hello") {
           get {
             complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))


### PR DESCRIPTION
Issue: #953
Provide routes method in HttpApp
Deprecate route mothod in HttpApp
Use the new method in tests and docs
Update docs
HttpApp still uses the route method internally to ease the update