### PR TITLE
Fix weird MediaType parsing (Don't panic its only a weird media range)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptHeader.scala
@@ -32,8 +32,11 @@ private[parser] trait AcceptHeader { this: Parser with CommonRules with CommonAc
     }
   }
 
+  // this specific ordering PREVENTS that next rule is allowed to parse `*/xyz` as a valid media range
   def `media-range-def` = rule {
-    "*/*" ~ push("*") ~ push("*") | `type` ~ '/' ~ ('*' ~ !tchar ~ push("*") | subtype) | '*' ~ push("*") ~ push("*")
+    "*/*" ~ push("*") ~ push("*") |
+      '*' ~ push("*") ~ push("*") |
+      `type` ~ '/' ~ ('*' ~ !tchar ~ push("*") | subtype)
   }
 }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.server.directives
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.{ Accept, RawHeader }
+import akka.http.scaladsl.server.IntegrationRoutingSpec
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+/**
+ * Has to excercise the entire stack, tgus an IntegrationRoutingSpec (not reproducable using just RouteTest).
+ */
+class IllegalHeadersIntegrationSpec extends IntegrationRoutingSpec {
+
+  "Illegal content type in request" should {
+    val route = extractRequest { req ⇒
+      complete(s"Accept:${req.header[Accept]}, byName:${req.headers.find(_.is("accept"))}")
+    }
+
+    // see: https://github.com/akka/akka-http/issues/1072
+    "not StackOverflow but be rejected properly" in {
+      val theIllegalHeader = RawHeader("Accept", "*/xml")
+      Get().addHeader(theIllegalHeader) ~!> route ~!> { response ⇒
+        import response._
+
+        status should ===(StatusCodes.OK)
+        val responseString = Await.result(response.entity.toStrict(1.second), 2.seconds).data.utf8String
+        responseString should ===("Accept:None, byName:Some(accept: */xml)")
+      }
+    }
+  }
+
+}

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContext.scala
@@ -4,19 +4,23 @@
 
 package akka.http.scaladsl.server
 
-import scala.concurrent.{ Future, ExecutionContextExecutor }
+import akka.annotation.DoNotInherit
+
+import scala.concurrent.{ ExecutionContextExecutor, Future }
 import akka.stream.Materializer
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
-
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.settings.{ RoutingSettings, ParserSettings }
+import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 
 /**
+ * This class is not meant to be extended by user code.
+ *
  * Immutable object encapsulating the context of an [[akka.http.scaladsl.model.HttpRequest]]
  * as it flows through a akka-http Route structure.
  */
+@DoNotInherit
 trait RequestContext {
 
   /** The request this context represents. Modelled as a `val` so as to enable an `import ctx.request._`. */

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
@@ -122,4 +122,7 @@ private[http] class RequestContextImpl(
     routingSettings:  RoutingSettings          = settings,
     parserSettings:   ParserSettings           = parserSettings) =
     new RequestContextImpl(request, unmatchedPath, executionContext, materializer, log, routingSettings, parserSettings)
+
+  override def toString: String =
+    s"""RequestContext($request, $unmatchedPath, [more settings])"""
 }


### PR DESCRIPTION
Resolves in 2 parts https://github.com/akka/akka-http/issues/1072

One is to avoid infinite retrying by refining what a real wildcard actually is.
Two is to ignore weird media types in the form of `*/wat`