### PR TITLE
+h2 #1088 include RemoteAddress in ALPN switched to server

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.6.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.6.backwards.excludes
@@ -14,3 +14,12 @@ ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.engine.par
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.impl.engine.parsing.ParserOutput#StrictEntityCreator.this")
 ProblemFilters.exclude[MissingTypesProblem]("akka.http.impl.engine.parsing.ParserOutput$StrictEntityCreator$")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.impl.engine.parsing.ParserOutput#StrictEntityCreator.apply")
+
+# Remote-Address for HTTP/2
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.impl.engine.server.HttpAttributes.remoteAddress")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.impl.engine.server.HttpAttributes#RemoteAddress.this")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.impl.engine.server.HttpAttributes#RemoteAddress.copy")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.impl.engine.server.HttpAttributes#RemoteAddress.apply")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.engine.server.HttpAttributes#RemoteAddress.address")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.engine.server.HttpAttributes#RemoteAddress.copy$default$1")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.engine.server.HttpAttributes#RemoteAddress.address")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
@@ -18,9 +18,9 @@ import akka.stream.Attributes
 private[akka] object HttpAttributes {
   import Attributes._
 
-  private[akka] final case class RemoteAddress(address: Option[InetSocketAddress]) extends Attribute
+  private[akka] final case class RemoteAddress(address: InetSocketAddress) extends Attribute
 
-  private[akka] def remoteAddress(address: Option[InetSocketAddress]) =
+  private[akka] def remoteAddress(address: InetSocketAddress) =
     Attributes(RemoteAddress(address))
 
   private[akka] val empty =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -97,7 +97,8 @@ private[http] object HttpServerBluePrint {
     override val shape: FlowShape[RequestOutput, HttpRequest] = FlowShape.of(in, out)
 
     override def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with InHandler with OutHandler {
-      val remoteAddress = inheritedAttributes.get[HttpAttributes.RemoteAddress].flatMap(_.address)
+      val remoteAddress = inheritedAttributes.get[HttpAttributes.RemoteAddress].map(_.address)
+
       var downstreamPullWaiting = false
       var completionDeferred = false
       var entitySource: SubSourceOutlet[RequestOutput] = _
@@ -120,6 +121,7 @@ private[http] object HttpServerBluePrint {
       override def onPush(): Unit = grab(in) match {
         case RequestStart(method, uri, protocol, hdrs, entityCreator, _, _) ⇒
           val effectiveMethod = if (method == HttpMethods.HEAD && settings.transparentHeadRequests) HttpMethods.GET else method
+
           val effectiveHeaders =
             if (settings.remoteAddressHeader && remoteAddress.isDefined)
               headers.`Remote-Address`(RemoteAddress(remoteAddress.get)) +: hdrs

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -6,6 +6,8 @@ package akka.http.impl.util
 
 import akka.NotUsed
 import akka.actor.Cancellable
+import akka.annotation.InternalApi
+import akka.event.Logging
 import akka.stream._
 import akka.stream.impl.fusing.GraphInterpreter
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
@@ -214,6 +216,15 @@ private[http] object StreamUtils {
       i ⇒ f(i) :: Nil
     }
 
+  /**
+   * Lifts the streams attributes into an element and passes them to the function for each passed through element.
+   * Similar idea than [[FlowOps.statefulMapConcat]] but for a simple map.
+   *
+   * The result of `Attributes => (T => U)` is cached, and only the `T => U` function will be invoked afterwards for each element.
+   */
+  def statefulAttrsMap[T, U](functionConstructor: Attributes ⇒ T ⇒ U): Flow[T, U, NotUsed] =
+    Flow[T].via(ExposeAttributes[T, U](functionConstructor))
+
   trait ScheduleSupport { self: GraphStageLogic ⇒
     /**
      * Schedule a block to be run once after the given duration in the context of this graph stage.
@@ -279,4 +290,21 @@ private[http] class EnhancedByteStringSource[Mat](val byteStringStream: Source[B
     byteStringStream.runFold(ByteString.empty)(_ ++ _)
   def utf8String(implicit materializer: Materializer, ec: ExecutionContext): Future[String] =
     join.map(_.utf8String)
+}
+
+/** INTERNAL API */
+@InternalApi private[http] case class ExposeAttributes[T, U](functionConstructor: Attributes ⇒ T ⇒ U)
+  extends GraphStage[FlowShape[T, U]] {
+
+  val in = Inlet[T]("ExposeAttributes.in")
+  val out = Outlet[U]("ExposeAttributes.out")
+  override val shape = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes) = new GraphStageLogic(shape) with InHandler with OutHandler {
+    val f = functionConstructor(inheritedAttributes)
+    override def onPush(): Unit = push(out, f(grab(in)))
+    override def onPull(): Unit = pull(in)
+
+    setHandlers(in, out, this)
+  }
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -124,7 +124,7 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
     .map(tcpBinding ⇒ ServerBinding(tcpBinding.localAddress)(() ⇒ tcpBinding.unbind()))(mat.executionContext)
 
   private def prepareAttributes(settings: ServerSettings, remoteAddress: InetSocketAddress) =
-    if (settings.remoteAddressHeader) HttpAttributes.remoteAddress(Some(remoteAddress))
+    if (settings.remoteAddressHeader) HttpAttributes.remoteAddress(remoteAddress)
     else HttpAttributes.empty
 
   /**

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -893,7 +893,7 @@ class HttpServerSpec extends AkkaSpec(
       // with remote ip before flow is materialized, rather than from the blueprint apply method
       override def modifyServer(server: ServerLayer): ServerLayer = {
         BidiFlow.fromGraph(StreamUtils.fuseAggressive(server).withAttributes(
-          HttpAttributes.remoteAddress(Some(new InetSocketAddress(theAddress, 8080)))
+          HttpAttributes.remoteAddress(new InetSocketAddress(theAddress, 8080))
         ))
       }
 

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/AlpnSwitch.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/AlpnSwitch.scala
@@ -3,9 +3,11 @@
  */
 package akka.http.impl.engine.http2
 
+import java.net.InetSocketAddress
 import javax.net.ssl.SSLException
 
 import akka.NotUsed
+import akka.http.impl.engine.server.HttpAttributes
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.stream.TLSProtocol.{ SessionBytes, SessionTruncated, SslTlsInbound, SslTlsOutbound }
 import akka.stream.scaladsl.{ BidiFlow, Flow, GraphDSL, Keep, Sink, Source }
@@ -77,6 +79,7 @@ object AlpnSwitch {
             connect(serverRequestIn, requestOut)
 
             serverImplementation
+              .addAttributes(inheritedAttributes) // propagate attributes to "real" server (such as HttpAttributes)
               .join(networkSide)
               .join(userSide)
               .run()(interpreter.subFusingMaterializer)

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -6,10 +6,15 @@ package akka.http.impl.engine.http2
 
 import akka.annotation.InternalApi
 import akka.http.impl.engine.parsing.HttpHeaderParser
+import akka.http.impl.engine.server.HttpAttributes
+import akka.http.scaladsl.model
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.`Remote-Address`
 import akka.http.scaladsl.model.http2.Http2StreamIdHeader
+import akka.http.scaladsl.settings.ServerSettings
+import akka.stream.Attributes
 import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import akka.util.{ ByteString, OptionVal }
 
 import scala.annotation.tailrec
 import scala.collection.immutable.VectorBuilder
@@ -19,69 +24,79 @@ import scala.collection.immutable.VectorBuilder
  */
 @InternalApi
 private[http2] object RequestParsing {
-  def parseRequest(httpHeaderParser: HttpHeaderParser)(subStream: Http2SubStream): HttpRequest = {
-    @tailrec
-    def rec(
-      remainingHeaders: Seq[(String, String)],
-      method:           HttpMethod                = null,
-      scheme:           String                    = null,
-      authority:        Uri.Authority             = Uri.Authority.Empty,
-      path:             String                    = null,
-      contentType:      ContentType               = ContentTypes.`application/octet-stream`,
-      contentLength:    Long                      = -1,
-      headers:          VectorBuilder[HttpHeader] = new VectorBuilder[HttpHeader]
-    ): HttpRequest =
-      if (remainingHeaders.isEmpty) {
-        // 8.1.2.3: these pseudo header fields are mandatory for a request
-        checkRequiredField(":scheme", scheme)
-        checkRequiredField(":method", method)
-        checkRequiredField(":path", path)
 
-        headers += Http2StreamIdHeader(subStream.streamId)
+  def parseRequest(httpHeaderParser: HttpHeaderParser, serverSettings: ServerSettings, attributes: Attributes): Http2SubStream ⇒ HttpRequest = {
+    val remoteAddressHeader: Option[`Remote-Address`] =
+      if (serverSettings.remoteAddressHeader) {
+        attributes.get[HttpAttributes.RemoteAddress].map(remote ⇒ model.headers.`Remote-Address`(RemoteAddress(remote.address)))
+        // in order to avoid searching all the time for the attribute, we need to guard it with the setting condition
+      } else None // no need to emit the remote address header
 
-        val entity =
-          if (subStream.data == Source.empty || contentLength == 0) HttpEntity.Empty
-          else if (contentLength > 0) HttpEntity.Default(contentType, contentLength, subStream.data)
-          else HttpEntity.Chunked.fromData(contentType, subStream.data)
+    { subStream ⇒
+      @tailrec
+      def rec(
+        remainingHeaders: Seq[(String, String)],
+        method:           HttpMethod                = null,
+        scheme:           String                    = null,
+        authority:        Uri.Authority             = Uri.Authority.Empty,
+        path:             String                    = null,
+        contentType:      ContentType               = ContentTypes.`application/octet-stream`,
+        contentLength:    Long                      = -1,
+        headers:          VectorBuilder[HttpHeader] = new VectorBuilder[HttpHeader]
+      ): HttpRequest =
+        if (remainingHeaders.isEmpty) {
+          // 8.1.2.3: these pseudo header fields are mandatory for a request
+          checkRequiredField(":scheme", scheme)
+          checkRequiredField(":method", method)
+          checkRequiredField(":path", path)
 
-        val uri = Uri(scheme, authority).withPath(Uri.Path(path))
-        HttpRequest(
-          method, uri, headers.result(), entity, HttpProtocols.`HTTP/2.0`
-        )
-      } else remainingHeaders.head match {
-        case (":scheme", value) ⇒
-          rec(remainingHeaders.tail, method, value, authority, path, contentType, contentLength, headers)
-        case (":method", value) ⇒
-          val m = HttpMethods.getForKey(value).getOrElse(malformedRequest(s"Unknown HTTP method: '$value'"))
-          rec(remainingHeaders.tail, m, scheme, authority, path, contentType, contentLength, headers)
-        case (":path", path) ⇒
-          rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers)
-        case (":authority", value) ⇒
-          val authority = Uri.Authority.parse(value)
-          rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers)
+          headers += Http2StreamIdHeader(subStream.streamId)
+          if (remoteAddressHeader.isDefined) headers += remoteAddressHeader.get
 
-        case ("content-type", ct) ⇒
-          val contentType = ContentType.parse(ct).right.getOrElse(malformedRequest(s"Invalid content-type: '$ct'"))
-          rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers)
+          val entity =
+            if (subStream.data == Source.empty || contentLength == 0) HttpEntity.Empty
+            else if (contentLength > 0) HttpEntity.Default(contentType, contentLength, subStream.data)
+            else HttpEntity.Chunked.fromData(contentType, subStream.data)
 
-        case ("content-length", length) ⇒
-          val contentLength = length.toLong
-          rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers)
+          val uri = Uri(scheme, authority).withPath(Uri.Path(path))
+          HttpRequest(
+            method, uri, headers.result(), entity, HttpProtocols.`HTTP/2.0`
+          )
+        } else remainingHeaders.head match {
+          case (":scheme", value) ⇒
+            rec(remainingHeaders.tail, method, value, authority, path, contentType, contentLength, headers)
+          case (":method", value) ⇒
+            val m = HttpMethods.getForKey(value).getOrElse(malformedRequest(s"Unknown HTTP method: '$value'"))
+            rec(remainingHeaders.tail, m, scheme, authority, path, contentType, contentLength, headers)
+          case (":path", path) ⇒
+            rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers)
+          case (":authority", value) ⇒
+            val authority = Uri.Authority.parse(value)
+            rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers)
 
-        case (name, value) ⇒
-          // FIXME: later modify by adding HttpHeaderParser.parseHttp2Header that would use (name, value) pair directly
-          //        or use a separate, simpler, parser for Http2
-          // FIXME: add correctness checks (e.g. duplicated content-length) modeled after ones in HttpMessageParser
+          case ("content-type", ct) ⇒
+            val contentType = ContentType.parse(ct).right.getOrElse(malformedRequest(s"Invalid content-type: '$ct'"))
+            rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers)
 
-          // The odd-looking 'x' below is a by-product of how current parser and HTTP/1.1 work.
-          // Without '\r\n\x' (x being any additional byte) parsing will fail. See HttpHeaderParserSpec for examples.
-          val concHeaderLine = name + ": " + value + "\r\nx"
+          case ("content-length", length) ⇒
+            val contentLength = length.toLong
+            rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers)
 
-          httpHeaderParser.parseHeaderLine(ByteString(concHeaderLine))()
-          rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers += httpHeaderParser.resultHeader)
-      }
+          case (name, value) ⇒
+            // FIXME: later modify by adding HttpHeaderParser.parseHttp2Header that would use (name, value) pair directly
+            //        or use a separate, simpler, parser for Http2
+            // FIXME: add correctness checks (e.g. duplicated content-length) modeled after ones in HttpMessageParser
 
-    rec(subStream.initialHeaders.keyValuePairs)
+            // The odd-looking 'x' below is a by-product of how current parser and HTTP/1.1 work.
+            // Without '\r\n\x' (x being any additional byte) parsing will fail. See HttpHeaderParserSpec for examples.
+            val concHeaderLine = name + ": " + value + "\r\nx"
+
+            httpHeaderParser.parseHeaderLine(ByteString(concHeaderLine))()
+            rec(remainingHeaders.tail, method, scheme, authority, path, contentType, contentLength, headers += httpHeaderParser.resultHeader)
+        }
+
+      rec(subStream.initialHeaders.keyValuePairs)
+    }
   }
 
   def checkRequiredField(name: String, value: AnyRef): Unit =


### PR DESCRIPTION
Quick impl of https://github.com/akka/akka-http/issues/1088

We forgot to propagate headers to the ALPN "switched to" server graph.
This is not cleaned up, impled quickly before leaving home today, if you have suggestions where to "pass around" the headers let me know, I marked some TODOs. The Parsing is a method now, now a GraphStage so it has to get it passed in (it can't just reach for the attributes), I don't mind this style I guess, but wonder if there would be a cleaner way

Resolves https://github.com/akka/akka-http/issues/1088