### PR TITLE
=htc #1102 allow r.header[ModeledCustomHeader] to work

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ModeledCustomHeader.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ModeledCustomHeader.java
@@ -10,7 +10,7 @@ import akka.util.Helpers;
 /**
  * Support class for building user-defined custom headers defined by implementing `name` and `value`.
  * By implementing a {@link ModeledCustomHeader} along with {@link ModeledCustomHeaderFactory} instead of {@link CustomHeader} directly,
- * convenience methods that allow parsing this user-defined header from {@link akka.http.javadsl.model.HttpHeader}  are
+ * convenience methods that allow parsing this user-defined header from {@link akka.http.javadsl.model.HttpHeader} are
  * available to use.
  */
 public abstract class ModeledCustomHeader extends CustomHeader {


### PR DESCRIPTION
This allows #1102 to work in Scala, we use a similar trick elsewhere already (when javadsl uses directives to find a header by type, but it turns out it is a scala custom modeled one).

Though this will not work in JavaDSL, I think there we should do something else I guess.
The JavaDSL style also recommends `BlaBla / BlaBlaFactory` nowadays so it's hard to find that factory - we should ask for it explicitly (bad API), or instead provide `getHeader(partial function)`  I think (slightly better and consistent with how routing looks for java), WDYT?