### PR TITLE
Fix akka-docs extref to expand the akka version sbt setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,7 +160,7 @@ lazy val docs = project("docs")
         case akka.Doc.BinVer(_) => ""
         case _                  => "cross CrossVersion.full"
       }),
-      "extref.akka-docs.base_url" -> s"http://doc.akka.io/docs/akka/${Dependencies.akkaVersion}/%s",
+      "extref.akka-docs.base_url" -> s"http://doc.akka.io/docs/akka/${Dependencies.akkaVersion.value}/%s",
       "javadoc.akka.http.base_url" -> {
         val v = if (isSnapshot.value) "current" else version.value
         s"http://doc.akka.io/japi/akka-http/$v"


### PR DESCRIPTION
The regression was introduced in ffd69f87ac1a18a393fff28be285ef7989cd2c32.