### PR TITLE
=htc #1110 Parse RFC 1123 dates with single digit day and double digit year

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
@@ -88,13 +88,13 @@ private[parser] trait CommonRules { this: Parser with StringBuilding ⇒
 
   def date1 = rule { day ~ `date-sep` ~ month ~ `date-sep` ~ year }
 
-  def day = rule { digit2 }
+  def day = rule { digit2 | digit }
 
   def month = rule(
     "Jan" ~ push(1) | "Feb" ~ push(2) | "Mar" ~ push(3) | "Apr" ~ push(4) | "May" ~ push(5) | "Jun" ~ push(6) | "Jul" ~ push(7) |
       "Aug" ~ push(8) | "Sep" ~ push(9) | "Oct" ~ push(10) | "Nov" ~ push(11) | "Dec" ~ push(12))
 
-  def year = rule { digit4 }
+  def year = rule { digit4 | digit2 ~> (y ⇒ if (y <= 69) y + 2000 else y + 1900) }
 
   def `time-of-day` = rule { hour ~ ':' ~ minute ~ ':' ~ second }
   def hour = rule { digit2 }

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -312,6 +312,10 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
 
     "If-Modified-Since" in {
       "If-Modified-Since: Wed, 13 Jul 2011 08:12:31 GMT" =!= `If-Modified-Since`(DateTime(2011, 7, 13, 8, 12, 31))
+      "If-Modified-Since: Tue, 09 May 2017 18:49:57 GMT" =!= `If-Modified-Since`(DateTime(2017, 5, 9, 18, 49, 57))
+      "If-Modified-Since: Tue, 9 May 2017 18:49:57 GMT" =!=> "Tue, 09 May 2017 18:49:57 GMT"
+      "If-Modified-Since: Tue, 9 May 17 18:49:57 GMT" =!=> "Tue, 09 May 2017 18:49:57 GMT"
+      "If-Modified-Since: Sat, 09 May 70 18:49:57 GMT" =!=> "Sat, 09 May 1970 18:49:57 GMT"
       "If-Modified-Since: 0" =!= `If-Modified-Since`(DateTime.MinValue).renderedTo("Wed, 01 Jan 1800 00:00:00 GMT")
     }
 


### PR DESCRIPTION
RFC 1123 Section 5.2.14 defines the grammar for dates as:

    date = 1*2DIGIT month 2*4DIGIT