### PR TITLE
=doc Show scalatest and specs2 testkit examples using tabs

### DIFF
--- a/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
@@ -13,13 +13,14 @@ To use it include the following dependency:
 
 ## Usage
 
-Here is an example of what a simple test with the routing testkit might look like (using the built-in support for
-[scalatest](http://www.scalatest.org)):
+Here is an example of what a simple test with the routing testkit might look like using the built-in support for
+[scalatest](http://www.scalatest.org) and [specs2](http://etorreborre.github.io/specs2/):
 
-@@snip [FullTestKitExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/server/FullTestKitExampleSpec.scala) { #source-quote }
+ScalaTest
+:  @@snip [FullTestKitExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/server/FullTestKitExampleSpec.scala) { #source-quote }
 
-The testkit also supports testing routes with [specs2](http://etorreborre.github.io/specs2/). The equivalent of the above example can be found
-@github[here](docs/src/test/scala/docs/http/scaladsl/server/FullSpecs2TestKitExampleSpec.scala).
+specs2
+:  @@snip [FullSpecs2TestKitExampleSpec.scala](../../../../../test/scala/docs/http/scaladsl/server/FullSpecs2TestKitExampleSpec.scala) { #source-quote }
 
 The basic structure of a test built with the testkit is this (expression placeholder in all-caps):
 
@@ -87,7 +88,7 @@ You do this by wrapping your route with the `akka.http.scaladsl.server.Route.sea
 and translates them to the respective `HttpResponse`.
 
 Note that explicit call on the `akka.http.scaladsl.server.Route.seal` method is needed in test code, but in your application code it is not necessary.
-As described in @ref[Sealing a Route](routes.md#sealing-a-route), your application code only needs to bring 
+As described in @ref[Sealing a Route](routes.md#sealing-a-route), your application code only needs to bring
 implicit rejection and exception handlers in scope.
 
 ## Testing Route fragments

--- a/docs/src/test/scala/docs/http/scaladsl/server/FullSpecs2TestKitExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/FullSpecs2TestKitExampleSpec.scala
@@ -7,12 +7,11 @@ package docs.http.scaladsl.server
 // format: OFF
 
 //#source-quote
-
+import org.specs2.mutable.Specification
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.Specs2RouteTest
 import akka.http.scaladsl.server._
 import Directives._
-import org.specs2.mutable.Specification
 
 class FullSpecs2TestKitExampleSpec extends Specification with Specs2RouteTest {
 
@@ -23,9 +22,9 @@ class FullSpecs2TestKitExampleSpec extends Specification with Specs2RouteTest {
           "Captain on the bridge!"
         }
       } ~
-        path("ping") {
-          complete("PONG!")
-        }
+      path("ping") {
+        complete("PONG!")
+      }
     }
 
   "The service" should {


### PR DESCRIPTION
Makes it easier to see the two supported test frameworks. Adjust the
specs2 imports and formatting to make it similar to the ScalaTest
version.

Extracted from #1125

---
<img width="1139" alt="screen shot 2017-05-15 at 2 14 42 pm" src="https://cloud.githubusercontent.com/assets/8417/26057224/08fb42dc-3979-11e7-8a56-36b910713044.png">
