### PR TITLE
Fix 10.0.x migration guide

### DIFF
--- a/docs/src/main/paradox/java/http/introduction.md
+++ b/docs/src/main/paradox/java/http/introduction.md
@@ -35,9 +35,9 @@ Akka HTTP is provided in a separate jar file, to use it make sure to include the
 
 Dependency declarations for other build tools (like Gradle or Maven) can be found [here](http://akka.io/docs/#akka-http).
 
-Mind that `akka-http` comes in two modules: `akka-http` and `akka-http-core`. Because `akka-http`
+Mind that Akka HTTP comes in two modules: `akka-http` and `akka-http-core`. Because `akka-http`
 depends on `akka-http-core` you don't need to bring the latter explicitly. Still you may need to this in case you rely
-solely on low-level API.
+solely on the low-level API; make sure the Scala version is a recent release of version `2.11` or `2.12`.
 
 ## Routing DSL for HTTP servers
 
@@ -51,7 +51,7 @@ will be sent back as a HTTP OK with the string as response body.
 
 Transforming request and response bodies between over-the-wire formats and objects to be used in your application is
 done separately from the route declarations, in marshallers, which are pulled in implicitly using the "magnet" pattern.
-This means that you can `complete` a request with any kind of object a as long as there is an implicit marshaller
+This means that you can `complete` a request with any kind of object as long as there is an implicit marshaller
 available in scope.
 
 JSON support is possible in `akka-http` by the use of Jackson, an external artifact (see @ref[JSON Support](common/json-support.md#json-support-via-jackson)

--- a/docs/src/main/paradox/java/http/migration-guide/index.md
+++ b/docs/src/main/paradox/java/http/migration-guide/index.md
@@ -7,6 +7,6 @@
 
 * [migration-from-old-http-javadsl](migration-from-old-http-javadsl.md)
 * [migration-guide-2.4.x-10.0.x](migration-guide-2.4.x-10.0.x.md)
-* [migration-within-10.0.x-Api-May-Change](migration-within-10.0.x-Api-May-Change.md)
+* [migration-guide-10.0.x](migration-guide-10.0.x.md)
 
 @@@

--- a/docs/src/main/paradox/java/http/migration-guide/migration-guide-10.0.x.md
+++ b/docs/src/main/paradox/java/http/migration-guide/migration-guide-10.0.x.md
@@ -2,7 +2,7 @@
 
 ## General Notes
 Akka HTTP is binary backwards compatible within for all version within the 10.0.x range. However, there are a set of APIs
-that are marked with the special annotation `@ApiMayChange` which are exempt from this rule, in order to allow them to be 
+that are marked with the special annotation `@ApiMayChange` which are exempt from this rule, in order to allow them to be
 evolved more freely until stabilising them, by removing this annotation.
 See @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers) for further information.
 
@@ -11,8 +11,8 @@ within patch releases.
 
 ## Akka HTTP 10.0.6 -> 10.0.7
 
-### `AkkaHttp#route` has been renamed to `AkkaHttp#routes`
+### `HttpApp#route` has been renamed to `HttpApp#routes`
 
-In order to provide a more descriptive name, `AkkaHttp#route` has been renamed to `AkkaHttp#routes`. The previous name
+In order to provide a more descriptive name, `HttpApp#route` has been renamed to `HttpApp#routes`. The previous name
 might have led to some confusion by wrongly implying that only one route could be returned in that method.
 To migrate to 10.0.6, you must rename the old `route` method to `routes`.

--- a/docs/src/main/paradox/scala/http/introduction.md
+++ b/docs/src/main/paradox/scala/http/introduction.md
@@ -35,9 +35,9 @@ Akka HTTP is provided in a separate jar file, to use it make sure to include the
 
 Dependency declarations for other build tools (like Gradle or Maven) can be found [here](http://akka.io/docs/#akka-http).
 
-Mind that `akka-http` comes in two modules: `akka-http` and `akka-http-core`. Because `akka-http`
+Mind that Akka HTTP comes in two modules: `akka-http` and `akka-http-core`. Because `akka-http`
 depends on `akka-http-core` you don't need to bring the latter explicitly. Still you may need to this in case you rely
-solely on low-level API; make sure the scala version should be a recent release of version `2.11` or `2.12`.
+solely on the low-level API; make sure the Scala version is a recent release of version `2.11` or `2.12`.
 
 
 ## Routing DSL for HTTP servers
@@ -52,7 +52,7 @@ will be sent back as a HTTP OK with the string as response body.
 
 Transforming request and response bodies between over-the-wire formats and objects to be used in your application is
 done separately from the route declarations, in marshallers, which are pulled in implicitly using the "magnet" pattern.
-This means that you can `complete` a request with any kind of object a as long as there is an implicit marshaller
+This means that you can `complete` a request with any kind of object as long as there is an implicit marshaller
 available in scope.
 
 Default marshallers are provided for simple objects like String or ByteString, and you can define your own for example

--- a/docs/src/main/paradox/scala/http/migration-guide/index.md
+++ b/docs/src/main/paradox/scala/http/migration-guide/index.md
@@ -7,6 +7,6 @@
 
 * [migration-from-spray](migration-from-spray.md)
 * [migration-guide-2.4.x-10.0.x](migration-guide-2.4.x-10.0.x.md)
-* [migration-within-10.0.x-Api-May-Change](migration-within-10.0.x-Api-May-Change.md)
+* [migration-guide-10.0.x](migration-guide-10.0.x.md)
 
 @@@

--- a/docs/src/main/paradox/scala/http/migration-guide/migration-guide-10.0.x.md
+++ b/docs/src/main/paradox/scala/http/migration-guide/migration-guide-10.0.x.md
@@ -2,7 +2,7 @@
 
 ## General Notes
 Akka HTTP is binary backwards compatible within for all version within the 10.0.x range. However, there are a set of APIs
-that are marked with the special annotation `@ApiMayChange` which are exempt from this rule, in order to allow them to be 
+that are marked with the special annotation `@ApiMayChange` which are exempt from this rule, in order to allow them to be
 evolved more freely until stabilising them, by removing this annotation.
 See @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binary-compatibility-rules.html#The_@DoNotInherit_and_@ApiMayChange_markers) for further information.
 
@@ -11,8 +11,8 @@ within patch releases.
 
 ## Akka HTTP 10.0.6 -> 10.0.7
 
-### `AkkaHttp#route` has been renamed to `AkkaHttp#routes`
+### `HttpApp#route` has been renamed to `HttpApp#routes`
 
-In order to provide a more descriptive name, `AkkaHttp#route` has been renamed to `AkkaHttp#routes`. The previous name
+In order to provide a more descriptive name, `HttpApp#route` has been renamed to `HttpApp#routes`. The previous name
 might have led to some confusion by wrongly implying that only one route could be returned in that method.
 To migrate to 10.0.6, you must rename the old `route` method to `routes`.

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
@@ -170,7 +170,7 @@ A `Directive[(String)]` extracts one String value (like the hostName directive).
 type Directive1[T] = Directive[Tuple1[T]]
 ```
 
-A Directive[(Int, String)] extracts an `Int` value and a `String` value
+A `Directive[(Int, String)]` extracts an `Int` value and a `String` value
 (like a `parameters('a.as[Int], 'b.as[String])` directive).
 
 Keeping extractions as `Tuples` has a lot of advantages, mainly great flexibility


### PR DESCRIPTION
Change `AkkaHttp` to `HttpApp` in the migration guide. I also took the liberty to rename the file to better match the others, the title remains the same.