### PR TITLE
Fix #1134: Create representation of Content-Type with missing charset

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
@@ -1,0 +1,4 @@
+# Mima filters needed to check newer versions against 10.0.7
+
+# Added a new method to this sealed trait
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.MediaType#WithOpenCharset.toContentTypeWithMissingCharset")

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
@@ -25,12 +25,10 @@ private[parser] trait ContentTypeHeader { this: Parser with CommonRules with Com
       case Nil ⇒
         val parameters = if (builder eq null) Map.empty[String, String] else builder.result()
         getMediaType(main, sub, charset.isDefined, parameters) match {
-          case x: MediaType.Binary           ⇒ ContentType.Binary(x)
-          case x: MediaType.WithFixedCharset ⇒ ContentType.WithFixedCharset(x)
-          case x: MediaType.WithOpenCharset ⇒
-            // if we have an open charset media-type but no charset parameter we default to UTF-8
-            val cs = if (charset.isDefined) charset.get else HttpCharsets.`UTF-8`
-            ContentType.WithCharset(x, cs)
+          case x: MediaType.Binary                               ⇒ ContentType.Binary(x)
+          case x: MediaType.WithFixedCharset                     ⇒ ContentType.WithFixedCharset(x)
+          case x: MediaType.WithOpenCharset if charset.isDefined ⇒ ContentType.WithCharset(x, charset.get)
+          case x: MediaType.WithOpenCharset if charset.isEmpty   ⇒ ContentType.WithMissingCharset(x)
         }
 
       case Seq(("charset", value), tail @ _*) ⇒

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ContentType.scala
@@ -5,30 +5,35 @@ package akka.http.javadsl.model
 
 import java.util.Optional
 
+// Has to be defined in Scala even though it's JavaDSL because of:
+// https://issues.scala-lang.org/browse/SI-9621
+object ContentType {
+  /** Represents a content-type which we know not to contain text (will never have a charset) */
+  trait Binary extends ContentType
+
+  /** Represents a content-type which we know to contain text, and has a specified charset. */
+  trait NonBinary extends ContentType {
+    def charset: HttpCharset
+  }
+
+  /**
+   * Represents a content-type which we know to contain text, and would be better off having a charset,
+   * but the client hasn't provided that. For example, "text/xml" without a charset parameter.
+   */
+  trait WithMissingCharset extends ContentType
+
+  /** Represents a content-type which we know to contain text, where the charset always has the same predefined value. */
+  trait WithFixedCharset extends NonBinary
+
+  /** Represents a content-type which we know to contain text, and the charset is known at runtime. */
+  trait WithCharset extends NonBinary
+}
+
 /**
  * Represents an Http content-type. A content-type consists of a media-type and an optional charset.
  *
  * See [[ContentTypes]] for convenience access to often used values.
  */
-// Has to be defined in Scala even though it's JavaDSL because of:
-// https://issues.scala-lang.org/browse/SI-9621
-object ContentType {
-
-  trait Binary extends ContentType {
-  }
-
-  trait NonBinary extends ContentType {
-    def charset: HttpCharset
-  }
-
-  trait WithFixedCharset extends NonBinary {
-  }
-
-  trait WithCharset extends NonBinary {
-  }
-
-}
-
 trait ContentType {
   /**
    * The media-type of this content-type.

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/MediaType.scala
@@ -13,6 +13,9 @@ package akka.http.javadsl.model
 object MediaType {
 
   trait Binary extends MediaType {
+    /**
+     * Turns the media type into a content type.
+     */
     def toContentType: ContentType.Binary
   }
 
@@ -20,11 +23,26 @@ object MediaType {
   }
 
   trait WithFixedCharset extends NonBinary {
+    /**
+     * Turns the media type into a content type with a fixed, known charset.
+     */
     def toContentType: ContentType.WithFixedCharset
   }
 
   trait WithOpenCharset extends NonBinary {
+    /**
+     * Turns the media type into a content type with the given charset.
+     */
     def toContentType(charset: HttpCharset): ContentType.WithCharset
+    /**
+     * Turns the media type into a content type without specifying a charset.
+     *
+     * This is generally NOT what you want, since you're hiding the actual character encoding of your content, making
+     * decoding it possibly ambiguous.
+     *
+     * Consider using toContentType(charset: HttpCharset) instead.
+     */
+    def toContentTypeWithMissingCharset: ContentType.WithMissingCharset
   }
 
   trait Multipart extends Binary {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -22,7 +22,7 @@ import akka.stream.scaladsl._
 import akka.stream.stage._
 import akka.stream._
 import akka.{ Done, NotUsed, stream }
-import akka.http.scaladsl.model.ContentType.{ Binary, NonBinary }
+import akka.http.scaladsl.model.ContentType.{ Binary, NonBinary, WithMissingCharset }
 import akka.http.scaladsl.util.FastFuture
 import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.impl.util.{ JavaMapping, StreamUtils }
@@ -341,6 +341,8 @@ object HttpEntity {
     override def toString = {
       val dataAsString = contentType match {
         case _: Binary ⇒
+          data.toString()
+        case _: WithMissingCharset ⇒
           data.toString()
         case nb: NonBinary ⇒
           try {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -219,20 +219,44 @@ object MediaType {
       customWithFixedCharset(mainType, subType, charset, fileExtensions, params)
 
     /**
+     * Turns the media type into a content type with a fixed, known charset.
+     *
      * JAVA API
      */
     def toContentType: ContentType.WithFixedCharset = ContentType(this)
   }
 
   sealed abstract class WithOpenCharset extends NonBinary with jm.MediaType.WithOpenCharset {
+    /**
+     * Turns the media type into a content type without specifying a charset.
+     *
+     * This is generally NOT what you want, since you're hiding the actual character encoding of your content, making
+     * decoding it possibly ambiguous.
+     *
+     * Consider using toContentType(charset: HttpCharset) instead.
+     */
+    def withMissingCharset: ContentType.WithMissingCharset = ContentType.WithMissingCharset(this)
     def withCharset(charset: HttpCharset): ContentType.WithCharset = ContentType(this, charset)
     def withParams(params: Map[String, String]): WithOpenCharset with MediaType =
       customWithOpenCharset(mainType, subType, fileExtensions, params)
 
     /**
+     * Turns the media type into a content type with the given charset.
+     *
      * JAVA API
      */
     def toContentType(charset: jm.HttpCharset): ContentType.WithCharset = withCharset(charset.asScala)
+    /**
+     * Turns the media type into a content type without specifying a charset.
+     *
+     * This is generally NOT what you want, since you're hiding the actual character encoding of your content, making
+     * decoding it possibly ambiguous.
+     *
+     * Consider using toContentType(charset: HttpCharset) instead.
+     *
+     * JAVA API
+     */
+    def toContentTypeWithMissingCharset: ContentType.WithMissingCharset = withMissingCharset
   }
 
   sealed abstract class NonMultipartWithOpenCharset(val value: String, val mainType: String, val subType: String,

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -208,6 +208,8 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
         `Content-Type`(`application/json`)
       "Content-Type: text/plain; charset=utf8" =!=
         `Content-Type`(ContentType(`text/plain`, `UTF-8`)).renderedTo("text/plain; charset=UTF-8")
+      "Content-Type: text/plain" =!=
+        `Content-Type`(ContentType.WithMissingCharset(MediaTypes.`text/plain`)).renderedTo("text/plain")
       "Content-Type: text/xml2; version=3; charset=windows-1252" =!=
         `Content-Type`(MediaType.customWithOpenCharset("text", "xml2", params = Map("version" → "3"))
           withCharset HttpCharsets.getForKey("windows-1252").get)

--- a/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
@@ -100,7 +100,7 @@ class HttpModelIntegrationSpec extends WordSpec with Matchers with BeforeAndAfte
       // example simple model of an HTTP response.
 
       val textHeaders: Seq[(String, String)] = Seq(
-        "Content-Type" → "text/plain",
+        "Content-Type" → "text/plain;charset=UTF-8",
         "Content-Length" → "3",
         "X-Greeting" → "Hello")
       val byteArrayBody: Array[Byte] = "foo".getBytes

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -49,7 +49,7 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
         Unmarshal(HttpEntity(
           `multipart/mixed` withBoundary "XYZABC",
           ByteString("""--XYZABC
-                       |Content-type: text/xml
+                       |Content-type: text/xml; charset=UTF-8
                        |Age: 12
                        |--XYZABC--""".stripMarginWithNewline("\r\n")))).to[Multipart.General] should haveParts(
           Multipart.General.BodyPart.Strict(HttpEntity.empty(ContentTypes.`text/xml(UTF-8)`), List(Age(12))))
@@ -257,12 +257,12 @@ class MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAf
         `multipart/byteranges` withBoundary "12345",
         ByteString("""--12345
                      |Content-Range: bytes 0-2/26
-                     |Content-Type: text/plain
+                     |Content-Type: text/plain; charset=UTF-8
                      |
                      |ABC
                      |--12345
                      |Content-Range: bytes 23-25/26
-                     |Content-Type: text/plain
+                     |Content-Type: text/plain; charset=UTF-8
                      |
                      |XYZ
                      |--12345--""".stripMarginWithNewline("\r\n")))).to[Multipart.ByteRanges] should haveParts(

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -24,6 +24,9 @@ class UnmarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll wi
     "stringUnmarshaller should unmarshal `text/plain` content in UTF-8 to Strings" in {
       Unmarshal(HttpEntity("Hällö")).to[String] should evaluateTo("Hällö")
     }
+    "stringUnmarshaller should assume UTF-8 for textual content type with missing charset" in {
+      Unmarshal(HttpEntity(MediaTypes.`text/plain`.withMissingCharset, "Hällö".getBytes("UTF-8"))).to[String] should evaluateTo("Hällö")
+    }
     "charArrayUnmarshaller should unmarshal `text/plain` content in UTF-8 to char arrays" in {
       Unmarshal(HttpEntity("árvíztűrő ütvefúrógép")).to[Array[Char]] should evaluateTo("árvíztűrő ütvefúrógép".toCharArray)
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshal.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshal.scala
@@ -48,7 +48,7 @@ class Marshal[A](val value: A) {
       val bestMarshal = {
         if (supportedAlternatives.nonEmpty) {
           ctn.pickContentType(supportedAlternatives).flatMap {
-            case best @ (_: ContentType.Binary | _: ContentType.WithFixedCharset) ⇒
+            case best @ (_: ContentType.Binary | _: ContentType.WithFixedCharset | _: ContentType.WithMissingCharset) ⇒
               marshallings collectFirst { case Marshalling.WithFixedContentType(`best`, marshal) ⇒ marshal }
             case best @ ContentType.WithCharset(bestMT, bestCS) ⇒
               marshallings collectFirst {

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
@@ -94,7 +94,7 @@ trait PredefinedToResponseMarshallers extends LowPriorityToResponseMarshallerImp
           val bestMarshallingPerElement = availableMarshallingsPerElement mapConcat { marshallings ⇒
             // pick the Marshalling that matches our EntityStreamingSupport
             (s.contentType match {
-              case best @ (_: ContentType.Binary | _: ContentType.WithFixedCharset) ⇒
+              case best @ (_: ContentType.Binary | _: ContentType.WithFixedCharset | _: ContentType.WithMissingCharset) ⇒
                 marshallings collectFirst { case Marshalling.WithFixedContentType(`best`, marshal) ⇒ marshal }
 
               case best @ ContentType.WithCharset(bestMT, bestCS) ⇒
@@ -137,7 +137,7 @@ trait LowPriorityToResponseMarshallerImplicits {
           val bestMarshallingPerElement = availableMarshallingsPerElement mapConcat { marshallings ⇒
             // pick the Marshalling that matches our EntityStreamingSupport
             val selectedMarshallings = (s.contentType match {
-              case best @ (_: ContentType.Binary | _: ContentType.WithFixedCharset) ⇒
+              case best @ (_: ContentType.Binary | _: ContentType.WithFixedCharset | _: ContentType.WithMissingCharset) ⇒
                 marshallings collectFirst { case Marshalling.WithFixedContentType(`best`, marshal) ⇒ marshal }
 
               case best @ ContentType.WithCharset(bestMT, bestCS) ⇒

--- a/docs/src/main/paradox/release-notes.md
+++ b/docs/src/main/paradox/release-notes.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## 10.0.8
+
+### Ability to express textual content types with missing character set
+
+Akka-http has a strongly typed media type / content type system, and knows at compile time about which media types
+are supposed to express a character set attribute, e.g. `text/plain; charset=UTF-8`. Before this release, akka would
+silently assume UTF-8 for `ContentType` instances of media types with a missing `charset` attribute.
+
+From now on, content types missing a charset can be both parsed and expressed directly, using the new 
+`ContentType.WithMissingCharset` trait/class. 
+
+- For incoming Content-Type headers with values missing a charset, such as `text/plain`, the header 
+  `ContentType` will be represented as `WithMissingCharset`, rather than assuming an UTF-8 charset 
+  (which could have been a wrong guess).
+- If you need to create such a content type programmatically, use e.g. ```MediaTypes.`text/plain`.withMissingCharset```
+  (scala) or `MediaTypes.TEXT_PLAIN.toContentTypeWithMissingCharset()` (java).
+
+*Note to scala users*: If you have `match` statements across `ContentType`, keep an eye out for new compiler hints. You need
+to decide what what to do in case you get a content type with a missing character set, by adding a 
+`ContentType.WithMissingCharset` case. 
+
 ## 10.0.7
 
 ### New Seed Templates for Akka HTTP Apps


### PR DESCRIPTION
The text/xml content-type (and possibly others) is best used with a
charset parameter, and akka inforces this on the type level. That's
great practice, but _incoming_ requests can certainly have a
Content-Type header of "text/xml" without a charset. Akka currently
just blindly adds "UTF-8", which is incorrect and a potential problem.

This commit adds a specific type to the ContentType hierarchy to represent
"a media type that should have had a charset but didn't".