### PR TITLE
Mention Giter8 templates in the introduction

### DIFF
--- a/docs/src/main/paradox/java/http/introduction.md
+++ b/docs/src/main/paradox/java/http/introduction.md
@@ -39,6 +39,15 @@ Mind that Akka HTTP comes in two modules: `akka-http` and `akka-http-core`. Beca
 depends on `akka-http-core` you don't need to bring the latter explicitly. Still you may need to this in case you rely
 solely on the low-level API; make sure the Scala version is a recent release of version `2.11` or `2.12`.
 
+Alternatively, you can bootstrap a new sbt project with Akka HTTP already
+configured using the [Giter8](http://www.foundweekends.org/giter8/) template:
+```sh
+sbt -Dsbt.version=0.13.15 new https://github.com/akka/akka-http-java-seed.g8
+```
+More instructions can be found in the [template
+project](https://github.com/akka/akka-http-java-seed.g8). Note, requires
+sbt version 0.13.13 or newer.
+
 ## Routing DSL for HTTP servers
 
 The high-level, routing API of Akka HTTP provides a DSL to describe HTTP "routes" and how they should be handled.

--- a/docs/src/main/paradox/release-notes.md
+++ b/docs/src/main/paradox/release-notes.md
@@ -4,13 +4,13 @@
 
 ### New Seed Templates for Akka HTTP Apps
 
-We prepared new seed templates for starting out with Akka HTTP using the [Java DSL](https://github.com/akka/akka-http-java-seed.g8) 
-as well as [Scala DSL](https://github.com/akka/akka-http-scala-seed.g8). By using the `sbt new` command one can now easily get a 
+We prepared new seed templates for starting out with Akka HTTP using the [Java DSL](https://github.com/akka/akka-http-java-seed.g8)
+as well as [Scala DSL](https://github.com/akka/akka-http-scala-seed.g8). By using the `sbt new` command one can now easily get a
 small sample project to easily get started with your first Akka HTTP app. More instructions on the seed template pages.
 
 ### New Path Directive `ignoreTrailingSlash`
 
-Akka HTTP treats differently by default a route that ends with slash (`/`) than one that doesn't. From this version on, 
+Akka HTTP treats differently by default a route that ends with slash (`/`) than one that doesn't. From this version on,
 users who don't want to have this distinction, can use a new Path Directive called `ignoreTrailingSlash`.
 This route, will retry its inner route with and without a trailing slash. If you want to know more about this feature,
 please check the documentation pages for @ref[Scala](scala/http/routing-dsl/directives/path-directives/ignoreTrailingSlash.md)
@@ -22,7 +22,7 @@ and @ref[Java](java/http/routing-dsl/directives/path-directives/ignoreTrailingSl
 
 ##### akka-http
  * Added new Path Directive `ignoreTrailingSlash` ([#880](https://github.com/akka/akka-http/issues/880))
- * Prepared new seed templates for Akka HTTP apps (for both [Java DSL](https://github.com/akka/akka-http-java-seed.g8) and [Scala](https://github.com/akka/akka-http-scala-seed.g8)) ([1137](https://github.com/akka/akka-http/issues/1137) & [1055](https://github.com/akka/akka-http/issues/1055))
+ * Prepared new seed templates for Akka HTTP apps (for both [Java DSL](https://github.com/akka/akka-http-java-seed.g8) and [Scala DSL](https://github.com/akka/akka-http-scala-seed.g8)) ([1137](https://github.com/akka/akka-http/issues/1137) & [1055](https://github.com/akka/akka-http/issues/1055))
 
 ## 10.0.6
 
@@ -125,7 +125,7 @@ This is the fifth maintenance release of the Akka HTTP 10.0 series. It is primar
 
 ### Compatibility notes
 
-This version of Akka HTTP must be used with Akka in version at-least 2.4.17, however it is also compatible with Akka 2.5, which has just released its Release Candidate 1. 
+This version of Akka HTTP must be used with Akka in version at-least 2.4.17, however it is also compatible with Akka 2.5, which has just released its Release Candidate 1.
 
 
 ## 10.0.4

--- a/docs/src/main/paradox/scala/http/introduction.md
+++ b/docs/src/main/paradox/scala/http/introduction.md
@@ -39,6 +39,14 @@ Mind that Akka HTTP comes in two modules: `akka-http` and `akka-http-core`. Beca
 depends on `akka-http-core` you don't need to bring the latter explicitly. Still you may need to this in case you rely
 solely on the low-level API; make sure the Scala version is a recent release of version `2.11` or `2.12`.
 
+Alternatively, you can bootstrap a new sbt project with Akka HTTP already
+configured using the [Giter8](http://www.foundweekends.org/giter8/) template:
+```sh
+sbt -Dsbt.version=0.13.15 new https://github.com/akka/akka-http-scala-seed.g8
+```
+More instructions can be found on the [template
+project](https://github.com/akka/akka-http-scala-seed.g8). Note, requires
+sbt version 0.13.13 or newer.
 
 ## Routing DSL for HTTP servers
 


### PR DESCRIPTION
Point to the new g8 seed templates as a way to bootstrap a new Akka HTTP
sbt project.

As discussed in #1150.

---

Motivated by https://github.com/akka/akka-http/pull/1150#issuecomment-303685068

/cc @ktoso @jlprat 