### PR TITLE
Link to javadoc and scaladoc instead of files on GitHub

### DIFF
--- a/docs/src/main/paradox/java/http/client-side/client-https-support.md
+++ b/docs/src/main/paradox/java/http/client-side/client-https-support.md
@@ -9,7 +9,7 @@ the static method `ConnectionContext.https` which is defined like this:
 @@snip [ConnectionContext.scala](../../../../../../../akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala) { #https-context-creation }
 
 In addition to the `outgoingConnection`, `newHostConnectionPool` and `cachedHostConnectionPool` methods the
-@github[akka.http.javadsl.Http](/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala) extension also defines `outgoingConnectionHttps`, `newHostConnectionPoolHttps` and
+@javadoc[akka.http.javadsl.Http](akka.http.javadsl.Http) extension also defines `outgoingConnectionHttps`, `newHostConnectionPoolHttps` and
 `cachedHostConnectionPoolHttps`. These methods work identically to their counterparts without the `-Https` suffix,
 with the exception that all connections will always be encrypted.
 

--- a/docs/src/main/paradox/java/http/common/de-coding.md
+++ b/docs/src/main/paradox/java/http/common/de-coding.md
@@ -5,7 +5,7 @@ The [HTTP spec](http://tools.ietf.org/html/rfc7231#section-3.1.2.1) defines a `C
 
 Currently Akka HTTP supports the compression and decompression of HTTP requests and responses with the `gzip` or
 `deflate` encodings.
-The core logic for this lives in the @github[akka.http.scaladsl.coding](/akka-http/src/main/scala/akka/http/scaladsl/coding) package.
+The core logic for this lives in the @javadoc[akka.http.scaladsl.coding](akka.http.scaladsl.coding.package-summary) package.
 
 ## Server side
 

--- a/docs/src/main/paradox/java/http/common/http-model.md
+++ b/docs/src/main/paradox/java/http/common/http-model.md
@@ -327,7 +327,7 @@ or `Http.get(sys).superPool`, usually need the same settings, however the `serve
 <a id="registeringcustommediatypes-java"></a>
 ## Registering Custom Media Types
 
-Akka HTTP @github[predefines](/akka-http-core/src/main/java/akka/http/javadsl/model/MediaType.scala#L17) most commonly encountered media types and emits them in their well-typed form while parsing http messages.
+Akka HTTP @javadoc[predefines](akka.http.javadsl.model.MediaTypes) most commonly encountered media types and emits them in their well-typed form while parsing http messages.
 Sometimes you may want to define a custom media type and inform the parser infrastructure about how to handle these custom
 media types, e.g. that `application/custom` is to be treated as `NonBinary` with `WithFixedCharset`. To achieve this you
 need to register the custom media type in the server's settings by configuring `ParserSettings` like this:

--- a/docs/src/main/paradox/java/http/common/marshalling.md
+++ b/docs/src/main/paradox/java/http/common/marshalling.md
@@ -46,7 +46,7 @@ This is how `Marshalling` is defined:
 Akka HTTP already predefines a number of marshallers for the most common types.
 Specifically these are:
 
- * @github[PredefinedToEntityMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala)
+ * @javadoc[PredefinedToEntityMarshallers](akka.http.scaladsl.marshalling.PredefinedToEntityMarshallers)
     * `Array[Byte]`
     * `ByteString`
     * `Array[Char]`
@@ -54,7 +54,7 @@ Specifically these are:
     * `akka.http.scaladsl.model.FormData`
     * `akka.http.scaladsl.model.MessageEntity`
     * `T <: akka.http.scaladsl.model.Multipart`
- * @github[PredefinedToResponseMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala)
+ * @javadoc[PredefinedToResponseMarshallers](akka.http.scaladsl.marshalling.PredefinedToResponseMarshallers)
     * `T`, if a `ToEntityMarshaller[T]` is available
     * `HttpResponse`
     * `StatusCode`
@@ -62,12 +62,12 @@ Specifically these are:
     * `(Int, T)`, if a `ToEntityMarshaller[T]` is available
     * `(StatusCode, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
     * `(Int, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
- * @github[PredefinedToRequestMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala)
+ * @javadoc[PredefinedToRequestMarshallers](akka.http.scaladsl.marshalling.PredefinedToRequestMarshallers)
     * `HttpRequest`
     * `Uri`
     * `(HttpMethod, Uri, T)`, if a `ToEntityMarshaller[T]` is available
     * `(HttpMethod, Uri, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
- * @github[GenericMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala)
+ * @javadoc[GenericMarshallers](akka.http.scaladsl.marshalling.GenericMarshallers)
     * `Marshaller[Throwable, T]`
     * `Marshaller[Option[A], B]`, if a `Marshaller[A, B]` and an `EmptyValue[B]` is available
     * `Marshaller[Either[A1, A2], B]`, if a `Marshaller[A1, B]` and a `Marshaller[A2, B]` is available

--- a/docs/src/main/paradox/java/http/common/unmarshalling.md
+++ b/docs/src/main/paradox/java/http/common/unmarshalling.md
@@ -26,7 +26,7 @@ content negotiation which saves two additional layers of indirection that are re
 Akka HTTP already predefines a number of marshallers for the most common types.
 Specifically these are:
 
- * @github[PredefinedFromStringUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala)
+ * @javadoc[PredefinedFromStringUnmarshallers](akka.http.scaladsl.unmarshalling.PredefinedFromStringUnmarshallers)
     * `Byte`
     * `Short`
     * `Int`
@@ -34,13 +34,13 @@ Specifically these are:
     * `Float`
     * `Double`
     * `Boolean`
- * @github[PredefinedFromEntityUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala)
+ * @javadoc[PredefinedFromEntityUnmarshallers](akka.http.scaladsl.unmarshalling.PredefinedFromEntityUnmarshallers)
     * `Array[Byte]`
     * `ByteString`
     * `Array[Char]`
     * `String`
     * `akka.http.scaladsl.model.FormData`
- * @github[GenericUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/GenericUnmarshallers.scala)
+ * @javadoc[GenericUnmarshallers](akka.http.scaladsl.unmarshalling.GenericUnmarshallers)
     * `Unmarshaller[T, T]` (identity unmarshaller)
     * `Unmarshaller[Option[A], B]`, if an `Unmarshaller[A, B]` is available
     * `Unmarshaller[A, Option[B]]`, if an `Unmarshaller[A, B]` is available

--- a/docs/src/main/paradox/java/http/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/rejections.md
@@ -23,7 +23,7 @@ and handle any rejection.
 ## Predefined Rejections
 
 A rejection encapsulates a specific reason why a route was not able to handle a request. It is modeled as an object of
-type `Rejection`. Akka HTTP comes with a set of @github[predefined rejections](/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala), which are used by the many
+type `Rejection`. Akka HTTP comes with a set of @javadoc[predefined rejections](akka.http.javadsl.server.Rejections), which are used by the many
 @ref[predefined directives](directives/alphabetically.md#predefined-directives-java).
 
 Rejections are gathered up over the course of a Route evaluation and finally converted to `HttpResponse` replies by
@@ -33,7 +33,7 @@ the @ref[handleRejections](directives/execution-directives/handleRejections.md#h
 ## The RejectionHandler
 
 The @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections-java) directive delegates the actual job of converting a list of rejections to its argument, a
-@github[RejectionHandler](/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala), which is a partial function,
+@javadoc[RejectionHandler](akka.http.javadsl.server.RejectionHandler), which is a partial function,
 so it can choose whether it would like to handle the current set of rejections or not.
 Unhandled rejections will simply continue to flow through the route structure.
 

--- a/docs/src/main/paradox/java/http/server-side/low-level-server-side-api.md
+++ b/docs/src/main/paradox/java/http/server-side/low-level-server-side-api.md
@@ -49,7 +49,7 @@ the @ref[HTTP Model](../common/http-model.md#http-model-java) for more informati
 
 ## Starting and Stopping
 
-On the most basic level an Akka HTTP server is bound by invoking the `bind` method of the @github[akka.http.javadsl.Http](/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala)
+On the most basic level an Akka HTTP server is bound by invoking the `bind` method of the @javadoc[akka.http.javadsl.Http](akka.http.javadsl.Http)
 extension:
 
 @@snip [HttpServerExampleDocTest.java](../../../../../test/java/docs/http/javadsl/server/HttpServerExampleDocTest.java) { #binding-example }

--- a/docs/src/main/paradox/scala/http/client-side/client-https-support.md
+++ b/docs/src/main/paradox/scala/http/client-side/client-https-support.md
@@ -9,7 +9,7 @@ the static method `ConnectionContext.https` which is defined like this:
 @@snip [ConnectionContext.scala](../../../../../../../akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala) { #https-context-creation }
 
 In addition to the `outgoingConnection`, `newHostConnectionPool` and `cachedHostConnectionPool` methods the
-@github[akka.http.scaladsl.Http](/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala) extension also defines `outgoingConnectionHttps`, `newHostConnectionPoolHttps` and
+@scaladoc[akka.http.scaladsl.Http](akka.http.scaladsl.Http$) extension also defines `outgoingConnectionHttps`, `newHostConnectionPoolHttps` and
 `cachedHostConnectionPoolHttps`. These methods work identically to their counterparts without the `-Https` suffix,
 with the exception that all connections will always be encrypted.
 

--- a/docs/src/main/paradox/scala/http/common/de-coding.md
+++ b/docs/src/main/paradox/scala/http/common/de-coding.md
@@ -5,7 +5,7 @@ The [HTTP spec](http://tools.ietf.org/html/rfc7231#section-3.1.2.1) defines a `C
 
 Currently Akka HTTP supports the compression and decompression of HTTP requests and responses with the `gzip` or
 `deflate` encodings.
-The core logic for this lives in the @github[akka.http.scaladsl.coding](/akka-http/src/main/scala/akka/http/scaladsl/coding) package.
+The core logic for this lives in the @scaladoc[akka.http.scaladsl.coding](akka.http.scaladsl.coding.index) package.
 
 ## Server side
 

--- a/docs/src/main/paradox/scala/http/common/http-model.md
+++ b/docs/src/main/paradox/scala/http/common/http-model.md
@@ -340,7 +340,7 @@ usually need the same settings, however the `server` most likely has a very diff
 <a id="registeringcustommediatypes"></a>
 ## Registering Custom Media Types
 
-Akka HTTP @github[predefines](/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala#L297) most commonly encountered media types and emits them in their well-typed form while parsing http messages.
+Akka HTTP @scaladoc[predefines](akka.http.scaladsl.model.MediaTypes) most commonly encountered media types and emits them in their well-typed form while parsing http messages.
 Sometimes you may want to define a custom media type and inform the parser infrastructure about how to handle these custom
 media types, e.g. that `application/custom` is to be treated as `NonBinary` with `WithFixedCharset`. To achieve this you
 need to register the custom media type in the server's settings by configuring `ParserSettings` like this:

--- a/docs/src/main/paradox/scala/http/common/json-support.md
+++ b/docs/src/main/paradox/scala/http/common/json-support.md
@@ -9,7 +9,7 @@ Other JSON libraries are supported by the community. See [the list of current co
 
 ## spray-json Support
 
-The @github[SprayJsonSupport](/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala) trait provides a `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` for every type `T`
+The @scaladoc[SprayJsonSupport](akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport) trait provides a `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` for every type `T`
 that an implicit `spray.json.RootJsonReader` and/or `spray.json.RootJsonWriter` (respectively) is available for.
 
 To enable automatic support for (un)marshalling from and to JSON with [spray-json], add a library dependency onto:

--- a/docs/src/main/paradox/scala/http/common/marshalling.md
+++ b/docs/src/main/paradox/scala/http/common/marshalling.md
@@ -44,7 +44,7 @@ This is how `Marshalling` is defined:
 Akka HTTP already predefines a number of marshallers for the most common types.
 Specifically these are:
 
- * @github[PredefinedToEntityMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala)
+ * @scaladoc[PredefinedToEntityMarshallers](akka.http.scaladsl.marshalling.PredefinedToEntityMarshallers)
     * `Array[Byte]`
     * `ByteString`
     * `Array[Char]`
@@ -52,7 +52,7 @@ Specifically these are:
     * `akka.http.scaladsl.model.FormData`
     * `akka.http.scaladsl.model.MessageEntity`
     * `T <: akka.http.scaladsl.model.Multipart`
- * @github[PredefinedToResponseMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala)
+ * @scaladoc[PredefinedToResponseMarshallers](akka.http.scaladsl.marshalling.PredefinedToResponseMarshallers)
     * `T`, if a `ToEntityMarshaller[T]` is available
     * `HttpResponse`
     * `StatusCode`
@@ -60,12 +60,12 @@ Specifically these are:
     * `(Int, T)`, if a `ToEntityMarshaller[T]` is available
     * `(StatusCode, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
     * `(Int, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
- * @github[PredefinedToRequestMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala)
+ * @scaladoc[PredefinedToRequestMarshallers](akka.http.scaladsl.marshalling.PredefinedToRequestMarshallers)
     * `HttpRequest`
     * `Uri`
     * `(HttpMethod, Uri, T)`, if a `ToEntityMarshaller[T]` is available
     * `(HttpMethod, Uri, immutable.Seq[HttpHeader], T)`, if a `ToEntityMarshaller[T]` is available
- * @github[GenericMarshallers](/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala)
+ * @scaladoc[GenericMarshallers](akka.http.scaladsl.marshalling.GenericMarshallers)
     * `Marshaller[Throwable, T]`
     * `Marshaller[Option[A], B]`, if a `Marshaller[A, B]` and an `EmptyValue[B]` is available
     * `Marshaller[Either[A1, A2], B]`, if a `Marshaller[A1, B]` and a `Marshaller[A2, B]` is available

--- a/docs/src/main/paradox/scala/http/common/unmarshalling.md
+++ b/docs/src/main/paradox/scala/http/common/unmarshalling.md
@@ -24,7 +24,7 @@ content negotiation which saves two additional layers of indirection that are re
 Akka HTTP already predefines a number of marshallers for the most common types.
 Specifically these are:
 
- * @github[PredefinedFromStringUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala)
+ * @scaladoc[PredefinedFromStringUnmarshallers](akka.http.scaladsl.unmarshalling.PredefinedFromStringUnmarshallers)
     * `Byte`
     * `Short`
     * `Int`
@@ -32,13 +32,13 @@ Specifically these are:
     * `Float`
     * `Double`
     * `Boolean`
- * @github[PredefinedFromEntityUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala)
+ * @scaladoc[PredefinedFromEntityUnmarshallers](akka.http.scaladsl.unmarshalling.PredefinedFromEntityUnmarshallers)
     * `Array[Byte]`
     * `ByteString`
     * `Array[Char]`
     * `String`
     * `akka.http.scaladsl.model.FormData`
- * @github[GenericUnmarshallers](/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/GenericUnmarshallers.scala)
+ * @scaladoc[GenericUnmarshallers](akka.http.scaladsl.unmarshalling.GenericUnmarshallers)
     * `Unmarshaller[T, T]` (identity unmarshaller)
     * `Unmarshaller[Option[A], B]`, if an `Unmarshaller[A, B]` is available
     * `Unmarshaller[A, Option[B]]`, if an `Unmarshaller[A, B]` is available

--- a/docs/src/main/paradox/scala/http/common/xml-support.md
+++ b/docs/src/main/paradox/scala/http/common/xml-support.md
@@ -10,7 +10,7 @@ For XML Akka HTTP currently provides support for [Scala XML](https://github.com/
 
 ## Scala XML Support
 
-The @github[ScalaXmlSupport](/akka-http-marshallers-scala/akka-http-xml/src/main/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala) trait provides a `FromEntityUnmarshaller[NodeSeq]` and `ToEntityMarshaller[NodeSeq]` that
+The @scaladoc[ScalaXmlSupport](akka.http.scaladsl.marshallers.xml.ScalaXmlSupport) trait provides a `FromEntityUnmarshaller[NodeSeq]` and `ToEntityMarshaller[NodeSeq]` that
 you can use directly or build upon.
 
 In order to enable support for (un)marshalling from and to XML with [Scala XML](https://github.com/scala/scala-xml) `NodeSeq` you must add

--- a/docs/src/main/paradox/scala/http/low-level-server-side-api.md
+++ b/docs/src/main/paradox/scala/http/low-level-server-side-api.md
@@ -55,7 +55,7 @@ the @ref[HTTP Model](common/http-model.md#http-model-scala) for more information
 
 ## Starting and Stopping
 
-On the most basic level an Akka HTTP server is bound by invoking the `bind` method of the @github[akka.http.scaladsl.Http](/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala)
+On the most basic level an Akka HTTP server is bound by invoking the `bind` method of the @scaladoc[akka.http.scaladsl.Http](akka.http.scaladsl.Http$)
 extension:
 
 @@snip [HttpServerExampleSpec.scala](../../../../test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala) { #binding-example }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/decodeRequest.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/decodeRequest.md
@@ -11,4 +11,4 @@ Decompresses the incoming request if it is `gzip` or `deflate` compressed. Uncom
 
 ## Example
 
-@@snip [CodingDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/CodingDirectivesExamplesSpec.scala) { #"decodeRequest" }
+@@snip [CodingDirectivesExamplesSpec.scala](../../../../../../../test/scala/docs/http/scaladsl/server/directives/CodingDirectivesExamplesSpec.scala) { #decodeRequest }

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/requestEncodedWith.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/coding-directives/requestEncodedWith.md
@@ -9,4 +9,4 @@
 
 Passes the request to the inner route if the request is encoded with the argument encoding. Otherwise, rejects the request with an `UnacceptedRequestEncodingRejection(encoding)`.
 
-This directive is the @github[building block](/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala) for `decodeRequest` to reject unsupported encodings.
+This directive is the building block for @ref:[decodeRequest](decodeRequest.md) to reject unsupported encodings.

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/custom-directives.md
@@ -28,7 +28,7 @@ together in the @ref[BasicDirectives](basic-directives/index.md#basicdirectives)
 ## Transforming Directives
 
 The second option for creating new directives is to transform an existing one using one of the
-“transformation methods”, which are defined on the @github[Directive](/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala) class, the base class of all “regular” directives.
+“transformation methods”, which are defined on the @scaladoc[Directive](akka.http.scaladsl.server.Directive) class, the base class of all “regular” directives.
 
 Apart from the combinator operators (`|` and `&`) and the case-class extractor (`as[T]`)
 the following transformations are also defined on all `Directive` instances:

--- a/docs/src/main/paradox/scala/http/routing-dsl/exception-handling.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/exception-handling.md
@@ -5,7 +5,7 @@ Exceptions thrown during route execution bubble up through the route structure t
 @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions) directive or the top of your route structure.
 
 Similarly to the way that @ref[Rejections](rejections.md#rejections-scala) are handled the @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions) directive delegates the actual job
-of converting an exception to its argument, an @github[ExceptionHandler](/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala), which is defined like this:
+of converting an exception to its argument, an @scaladoc[ExceptionHandler](akka.http.scaladsl.server.ExceptionHandler), which is defined like this:
 
 ```scala
 trait ExceptionHandler extends PartialFunction[Throwable, Route]

--- a/docs/src/main/paradox/scala/http/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/rejections.md
@@ -23,7 +23,7 @@ and handle any rejection.
 ## Predefined Rejections
 
 A rejection encapsulates a specific reason why a route was not able to handle a request. It is modeled as an object of
-type `Rejection`. Akka HTTP comes with a set of @github[predefined rejections](/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala), which are used by the many
+type `Rejection`. Akka HTTP comes with a set of @scaladoc[predefined rejections](akka.http.scaladsl.server.Rejection), which are used by the many
 @ref[predefined directives](directives/alphabetically.md#predefined-directives).
 
 Rejections are gathered up over the course of a Route evaluation and finally converted to `HttpResponse` replies by
@@ -33,7 +33,7 @@ the @ref[handleRejections](directives/execution-directives/handleRejections.md#h
 ## The RejectionHandler
 
 The @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections) directive delegates the actual job of converting a list of rejections to its argument, a
-@github[RejectionHandler](/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala), which is defined like this:
+@scaladoc[RejectionHandler](akka.http.scaladsl.server.RejectionHandler), which is defined like this:
 
 ```scala
 trait RejectionHandler extends (immutable.Seq[Rejection] => Option[Route])

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CodingDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CodingDirectivesExamplesSpec.scala
@@ -69,6 +69,7 @@ class CodingDirectivesExamplesSpec extends RoutingSpec {
   val helloGzipped = compress("Hello", Gzip)
   val helloDeflated = compress("Hello", Deflate)
   "decodeRequest" in {
+    //#decodeRequest
     val route =
       decodeRequest {
         entity(as[String]) { content: String =>
@@ -86,6 +87,7 @@ class CodingDirectivesExamplesSpec extends RoutingSpec {
     Post("/", "hello uncompressed") ~> `Content-Encoding`(identity) ~> route ~> check {
       responseAs[String] shouldEqual "Request content: 'hello uncompressed'"
     }
+    //#decodeRequest
   }
   "decodeRequestWith-0" in {
     //#decodeRequestWith


### PR DESCRIPTION
Also fixes a broken snippet: http://doc.akka.io/docs/akka-http/10.0.7/scala/http/routing-dsl/directives/coding-directives/decodeRequest.html#decoderequest