### PR TITLE
Fix #1172: Move rejection handler into the example App object

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -21,31 +21,33 @@ object MyRejectionHandler {
   import StatusCodes._
   import Directives._
 
-  implicit def myRejectionHandler =
-    RejectionHandler.newBuilder()
-      .handle { case MissingCookieRejection(cookieName) =>
-        complete(HttpResponse(BadRequest, entity = "No cookies, no service!!!"))
-      }
-      .handle { case AuthorizationFailedRejection =>
-        complete((Forbidden, "You're out of your depth!"))
-      }
-      .handle { case ValidationRejection(msg, _) =>
-        complete((InternalServerError, "That wasn't valid! " + msg))
-      }
-      .handleAll[MethodRejection] { methodRejections =>
-        val names = methodRejections.map(_.supported.name)
-        complete((MethodNotAllowed, s"Can't do that! Supported: ${names mkString " or "}!"))
-      }
-      .handleNotFound { complete((NotFound, "Not here!")) }
-      .result()
-
   object MyApp extends App {
+    implicit def myRejectionHandler =
+      RejectionHandler.newBuilder()
+        .handle { case MissingCookieRejection(cookieName) =>
+          complete(HttpResponse(BadRequest, entity = "No cookies, no service!!!"))
+        }
+        .handle { case AuthorizationFailedRejection =>
+          complete((Forbidden, "You're out of your depth!"))
+        }
+        .handle { case ValidationRejection(msg, _) =>
+          complete((InternalServerError, "That wasn't valid! " + msg))
+        }
+        .handleAll[MethodRejection] { methodRejections =>
+          val names = methodRejections.map(_.supported.name)
+          complete((MethodNotAllowed, s"Can't do that! Supported: ${names mkString " or "}!"))
+        }
+        .handleNotFound { complete((NotFound, "Not here!")) }
+        .result()
+
     implicit val system = ActorSystem()
     implicit val materializer = ActorMaterializer()
 
     val route: Route =
       // ... some route structure
+      //#custom-handler-example
       null // hide
+      //#custom-handler-example
 
     Http().bindAndHandle(route, "localhost", 8080)
   }


### PR DESCRIPTION
The code listing shown in Customizing Rejection Handling can't be
compiled as is, because the implicit def is defined outside any class or
object. Move it into the MyApp object so it compiles stand-alone.

<img width="813" alt="screen shot 2017-06-02 at 9 40 10 am" src="https://cloud.githubusercontent.com/assets/8417/26715856/8b519f22-4777-11e7-9942-2575baa50748.png">

