### PR TITLE
Move MiMa issue loading from file to sbt mima plugin

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.0.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.0.backwards.excludes
@@ -1,7 +1,7 @@
 # Mima filters needed to check newer versions against 10.0.0
 
 # Internal class change
-FilterAnyProblemStartingWith("akka.http.impl.util.One2OneBidiFlow")
+ProblemFilters.exclude[Problem]("akka.http.impl.util.One2OneBidiFlow*")
 
 # Removal of internal MapError since present as method on Flow in Akka 2.4.16
 ProblemFilters.exclude[MissingClassProblem]("akka.http.impl.util.MapError")

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -8,23 +8,12 @@ import sbt.Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 
-import scala.io.Source
-import scala.util.{Failure, Success, Try}
-
 object MiMa extends AutoPlugin {
 
   override def requires = MimaPlugin
   override def trigger = allRequirements
 
-  val mimaFiltersDirectory = settingKey[File]("Directory containing mima filters.")
-
   override val projectSettings = Seq(
-    mimaFiltersDirectory := (sourceDirectory in Compile).value / "mima-filters",
-    mimaBackwardIssueFilters ++= {
-      val directory = mimaFiltersDirectory.value
-      if (directory.exists) loadMimaIgnoredProblems(directory, ".backwards.excludes", streams.value.log)
-      else Map.empty
-    },
     mimaPreviousArtifacts :=
       // manually maintained list of previous versions to make sure all incompatibilities are found
       // even if so far no files have been been created in this project's mima-filters directory
@@ -41,69 +30,4 @@ object MiMa extends AutoPlugin {
       )
         .map((version: String) => organization.value %% name.value % version)
   )
-
-  case class FilterAnyProblem(name: String) extends com.typesafe.tools.mima.core.ProblemFilter {
-    import com.typesafe.tools.mima.core._
-    override def apply(p: Problem): Boolean = p match {
-      case t: TemplateProblem => t.ref.fullName != name && t.ref.fullName != (name + '$')
-      case m: MemberProblem => m.ref.owner.fullName != name && m.ref.owner.fullName != (name + '$')
-    }
-  }
-
-  case class FilterAnyProblemStartingWith(start: String) extends com.typesafe.tools.mima.core.ProblemFilter {
-    import com.typesafe.tools.mima.core._
-    override def apply(p: Problem): Boolean = p match {
-      case t: TemplateProblem => !t.ref.fullName.startsWith(start)
-      case m: MemberProblem => !m.ref.owner.fullName.startsWith(start)
-    }
-  }
-
-  import com.typesafe.tools.mima.core._
-  def loadMimaIgnoredProblems(directory: File, fileExtension: String, logger: Logger): Map[String, Seq[ProblemFilter]] = {
-    val FilterAnyProblemPattern = """FilterAnyProblem\("([^"]+)"\)""".r
-    val FilterAnyProblemStartingWithPattern = """FilterAnyProblemStartingWith\("([^"]+)"\)""".r
-    val ExclusionPattern = """ProblemFilters\.exclude\[([^\]]+)\]\("([^"]+)"\)""".r
-
-    def findFiles(): Seq[File] = directory.listFiles().filter(_.getName endsWith fileExtension)
-    def parseFile(file: File): Either[Seq[Throwable], (String, Seq[ProblemFilter])] = {
-      val version = file.getName.dropRight(fileExtension.size)
-
-      def parseLine(text: String, line: Int): Try[ProblemFilter] =
-        Try {
-          text match {
-            case ExclusionPattern(className, target) => ProblemFilters.exclude(className, target)
-            case FilterAnyProblemPattern(target) => FilterAnyProblem(target)
-            case FilterAnyProblemStartingWithPattern(target) => FilterAnyProblemStartingWith(target)
-            case x => throw new RuntimeException(s"Couldn't parse '$x'")
-          }
-        }.transform(Success(_), ex => Failure(new ParsingException(file, line, ex)))
-
-      val (excludes, failures) =
-        Source.fromFile(file)
-          .getLines()
-          .zipWithIndex
-          .filterNot { case (str, line) => str.trim.isEmpty || str.trim.startsWith("#") }
-          .map((parseLine _).tupled)
-          .partition(_.isSuccess)
-
-      if (failures.isEmpty) Right(version -> excludes.map(_.get).toSeq)
-      else Left(failures.map(_.failed.get).toSeq)
-    }
-
-    require(directory.exists(), s"Mima filter directory did not exist: ${directory.getAbsolutePath}")
-    val (mappings, failures) =
-      findFiles()
-        .map(parseFile)
-        .partition(_.isRight)
-
-    if (failures.isEmpty) mappings.map(_.right.get).toMap
-    else {
-      failures.flatMap(_.left.get).foreach(ex => logger.error(ex.getMessage))
-
-      throw new RuntimeException(s"Loading Mima filters failed with ${failures.size} failures.")
-    }
-  }
-
-  case class ParsingException(file: File, line: Int, ex: Throwable) extends RuntimeException(s"Error while parsing $file, line $line: ${ex.getMessage}", ex)
 }
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16-RC1
+sbt.version=0.13.16

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16-RC1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ resolvers += Resolver.bintrayIvyRepo("2m", "sbt-plugin-releases")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.3.8")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.14")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.15")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "1.1.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.1")


### PR DESCRIPTION
*This PR uses a not yet released feature (https://github.com/typesafehub/migration-manager/pull/174) from sbt MiMa plugin where it is able to load mima filters from files like in akka-http.*

*EDIT: it now uses a new version of MiMa 0.1.15 and can be merged.*

Sbt MiMa now knows how to load issue filters from file. Also there is now support for wildcards in FQCN in filter definitions, so no custom filters needed anymore.