### PR TITLE
Websocket illegal headers #1166 

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
@@ -1,0 +1,4 @@
+# Mima filters needed to check newer versions against 10.0.7
+
+# Added another parameter to HttpHeaderParser internal settings
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.engine.parsing.HttpHeaderParser#Settings.errorLoggingVerbosity")

--- a/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
@@ -1,7 +1,10 @@
 # Mima filters needed to check newer versions against 10.0.7
 
-# Added another parameter to HttpHeaderParser internal settings
+# Changed HttpHeaderParser signature and added extra settings
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.engine.parsing.HttpHeaderParser#Settings.errorLoggingVerbosity")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.parsing.HttpHeaderParser.apply$default$3")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.parsing.HttpHeaderParser.apply")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.engine.parsing.HttpHeaderParser#Settings.illegalHeaderWarnings")
 
 # Added a new method to this sealed trait
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.MediaType#WithOpenCharset.toContentTypeWithMissingCharset")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
@@ -54,7 +54,7 @@ private final class HttpsProxyGraphStage(targetHostName: String, targetPort: Int
     private var state: State = Starting
 
     lazy val parser = {
-      val p = new HttpResponseParser(settings.parserSettings, HttpHeaderParser(settings.parserSettings, log)()) {
+      val p = new HttpResponseParser(settings.parserSettings, HttpHeaderParser(settings.parserSettings, log)) {
         override def handleInformationalResponses = false
 
         override protected def parseMessage(input: ByteString, offset: Int): StateResult = {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -86,10 +86,7 @@ private[http] object OutgoingConnectionBlueprint {
       val responseParsingMerge = b.add {
         // the initial header parser we initially use for every connection,
         // will not be mutated, all "shared copy" parsers copy on first-write into the header cache
-        val rootParser = new HttpResponseParser(parserSettings, HttpHeaderParser(parserSettings, log) { info ⇒
-          if (parserSettings.illegalHeaderWarnings)
-            logParsingError(info withSummaryPrepended "Illegal response header", log, parserSettings.errorLoggingVerbosity)
-        })
+        val rootParser = new HttpResponseParser(parserSettings, HttpHeaderParser(parserSettings, log))
         new ResponseParsingMerge(rootParser)
       }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/BodyPartParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/BodyPartParser.scala
@@ -59,9 +59,7 @@ private[http] final class BodyPartParser(
   private[this] val boyerMoore = new BoyerMoore(needle)
 
   // TODO: prevent re-priming header parser from scratch
-  private[this] val headerParser = HttpHeaderParser(settings, log) { errorInfo ⇒
-    if (illegalHeaderWarnings) log.warning(errorInfo.withSummaryPrepended("Illegal multipart header").formatPretty)
-  }
+  private[this] val headerParser = HttpHeaderParser(settings, log)
 
   val in = Inlet[ByteString]("BodyPartParser.in")
   val out = Outlet[BodyPartParser.Output]("BodyPartParser.out")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -446,7 +446,7 @@ private[http] object HttpHeaderParser {
 
   def defaultIllegalHeaderHandler(settings: HttpHeaderParser.Settings, log: LoggingAdapter): ErrorInfo ⇒ Unit =
     if (settings.illegalHeaderWarnings)
-      info ⇒ logParsingError(info withSummaryPrepended "Illegal response header", log, settings.errorLoggingVerbosity)
+      info ⇒ logParsingError(info withSummaryPrepended "Illegal header", log, settings.errorLoggingVerbosity)
     else
       (_: ErrorInfo) ⇒ _ // Does exactly what the label says - nothing
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -441,8 +441,8 @@ private[http] object HttpHeaderParser {
     "Cache-Control: no-cache",
     "Expect: 100-continue")
 
-  def apply(settings: HttpHeaderParser.Settings, log: LoggingAdapter)(onIllegalHeader: ErrorInfo ⇒ Unit = defaultIllegalHeaderHandler(settings, log)) =
-    prime(unprimed(settings, log, onIllegalHeader))
+  def apply(settings: HttpHeaderParser.Settings, log: LoggingAdapter) =
+    prime(unprimed(settings, log, defaultIllegalHeaderHandler(settings, log)))
 
   def defaultIllegalHeaderHandler(settings: HttpHeaderParser.Settings, log: LoggingAdapter): ErrorInfo ⇒ Unit =
     if (settings.illegalHeaderWarnings)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -449,7 +449,6 @@ private[http] object HttpHeaderParser {
         case IllegalResponseHeaderValueProcessingMode.Error ⇒ info ⇒ throw IllegalHeaderException(info)
         case IllegalResponseHeaderValueProcessingMode.Warn ⇒ info ⇒ logParsingError(info withSummaryPrepended "Illegal response header", log, settings.errorLoggingVerbosity)
         case IllegalResponseHeaderValueProcessingMode.Ignore ⇒ _ ⇒ // Does exactly what the label says - nothing
-        case _ ⇒ ??? //TODO what would be the appropriate way to handle an unexpected value here?
       }
     }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -208,11 +208,7 @@ private[http] object HttpServerBluePrint {
 
     // the initial header parser we initially use for every connection,
     // will not be mutated, all "shared copy" parsers copy on first-write into the header cache
-    val rootParser = new HttpRequestParser(parserSettings, rawRequestUriHeader,
-      HttpHeaderParser(parserSettings, log) { info ⇒
-        if (parserSettings.illegalHeaderWarnings)
-          logParsingError(info withSummaryPrepended "Illegal request header", log, parserSettings.errorLoggingVerbosity)
-      })
+    val rootParser = new HttpRequestParser(parserSettings, rawRequestUriHeader, HttpHeaderParser(parserSettings, log))
 
     def establishAbsoluteUri(requestOutput: RequestOutput): RequestOutput = requestOutput match {
       case start: RequestStart ⇒

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
@@ -19,7 +19,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpMethods, HttpResponse }
 import akka.http.scaladsl.model.headers.Host
 import akka.http.impl.engine.parsing.HttpMessageParser.StateResult
-import akka.http.impl.engine.parsing.ParserOutput.{ NeedMoreData, RemainingBytes, ResponseStart }
+import akka.http.impl.engine.parsing.ParserOutput.{ MessageStartError, NeedMoreData, RemainingBytes, ResponseStart }
 import akka.http.impl.engine.parsing.{ HttpHeaderParser, HttpResponseParser, ParserOutput }
 import akka.http.impl.engine.rendering.{ HttpRequestRendererFactory, RequestRenderingContext }
 import akka.http.impl.engine.ws.Handshake.Client.NegotiatedWebSocketSettings
@@ -103,6 +103,8 @@ object WebSocketClientBlueprint {
                     result.success(InvalidUpgradeResponse(response, s"WebSocket server at $uri returned $problem"))
                     failStage(new IllegalArgumentException(s"WebSocket upgrade did not finish because of '$problem'"))
                 }
+              case MessageStartError(statusCode, errorInfo) ⇒
+                throw new IllegalStateException(s"Message failed with status code $statusCode; Error info: $errorInfo")
               case other ⇒
                 throw new IllegalStateException(s"unexpected element of type ${other.getClass}")
             }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
@@ -62,7 +62,7 @@ object WebSocketClientBlueprint {
         new GraphStageLogic(shape) with InHandler with OutHandler {
           // a special version of the parser which only parses one message and then reports the remaining data
           // if some is available
-          val parser = new HttpResponseParser(settings.parserSettings, HttpHeaderParser(settings.parserSettings, log)()) {
+          val parser = new HttpResponseParser(settings.parserSettings, HttpHeaderParser(settings.parserSettings, log)) {
             var first = true
             override def handleInformationalResponses = false
             override protected def parseMessage(input: ByteString, offset: Int): StateResult = {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -1,6 +1,6 @@
 /**
-  * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
-  */
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
 
 package akka.http.impl.engine.parsing
 
@@ -268,9 +268,8 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends WordS
   }
 
   def createParserSettings(
-                            actorSystem:                              ActorSystem,
-                            illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode = IllegalResponseHeaderValueProcessingMode.Error
-                          ): ParserSettings =
+    actorSystem:                              ActorSystem,
+    illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode = IllegalResponseHeaderValueProcessingMode.Error): ParserSettings =
     ParserSettings(actorSystem)
       .withIllegalResponseHeaderValueProcessingMode(illegalResponseHeaderValueProcessingMode)
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -195,7 +195,6 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends WordS
       noException should be thrownBy parseLine(s"Server: something; something${newLine}x")
     }
 
-    // TODO this test is almost identical to the test above, but has a different setup - what do?
     "continue parsing even if a header contains an invalid value when illegalResponseHeaderValueProcessingMode is set to Ignore" in new TestSetup(testSetupMode = TestSetupMode.Default, createParserSettings(system, illegalResponseHeaderValueProcessingMode = IllegalResponseHeaderValueProcessingMode.Ignore)) {
       noException should be thrownBy parseLine(s"Server: something; something${newLine}x")
     }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
- */
+  * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+  */
 
 package akka.http.impl.engine.parsing
 
@@ -146,8 +146,8 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends WordS
       val newLineWithHyphen = if (newLine == "\r\n") """\r-\n""" else """\n"""
       check {
         s""" ┌─f-a-n-c-y---p-a-n-t-s-:-(Fancy-Pants)- -f-o-o-${newLineWithHyphen}- *Fancy-Pants: foo
-          |-h-e-l-l-o-:- -b-o-b- 'Hello
-          |""" → parser.formatTrie
+           |-h-e-l-l-o-:- -b-o-b- 'Hello
+           |""" → parser.formatTrie
       }
       ixA shouldEqual ixB
       headerA shouldEqual RawHeader("Fancy-Pants", "foo")
@@ -267,8 +267,10 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends WordS
     case object Default extends TestSetupMode // creates a test setup using the default HttpHeaderParser.apply()
   }
 
-  def createParserSettings(actorSystem:                              ActorSystem,
-                           illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode = IllegalResponseHeaderValueProcessingMode.Error): ParserSettings =
+  def createParserSettings(
+                            actorSystem:                              ActorSystem,
+                            illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode = IllegalResponseHeaderValueProcessingMode.Error
+                          ): ParserSettings =
     ParserSettings(actorSystem)
       .withIllegalResponseHeaderValueProcessingMode(illegalResponseHeaderValueProcessingMode)
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -187,18 +187,6 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends WordS
         "HTTP header value exceeds the configured limit of 1000 characters"
     }
 
-    "produce an error when illegalResponseHeaderValueProcessingMode set to Error and a header contains illegal value" in new TestSetup(testSetupMode = TestSetupMode.Default, createParserSettings(system, illegalResponseHeaderValueProcessingMode = IllegalResponseHeaderValueProcessingMode.Error)) {
-      the[IllegalHeaderException] thrownBy parseLine(s"Server: something; something${newLine}x")
-    }
-
-    "continue parsing even if a header contains an invalid value when illegalResponseHeaderValueProcessingMode is set to Warn" in new TestSetup(testSetupMode = TestSetupMode.Default, createParserSettings(system, illegalResponseHeaderValueProcessingMode = IllegalResponseHeaderValueProcessingMode.Warn)) {
-      noException should be thrownBy parseLine(s"Server: something; something${newLine}x")
-    }
-
-    "continue parsing even if a header contains an invalid value when illegalResponseHeaderValueProcessingMode is set to Ignore" in new TestSetup(testSetupMode = TestSetupMode.Default, createParserSettings(system, illegalResponseHeaderValueProcessingMode = IllegalResponseHeaderValueProcessingMode.Ignore)) {
-      noException should be thrownBy parseLine(s"Server: something; something${newLine}x")
-    }
-
     "continue parsing raw headers even if the overall cache value capacity is reached" in new TestSetup() {
       val randomHeaders = Stream.continually {
         val name = nextRandomString(nextRandomAlphaNumChar, nextRandomInt(4, 16))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -477,36 +477,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
           |
           |""" should parseToError(422: StatusCode, ErrorInfo("TRACE requests must not have an entity"))
       }
-
-      "with additional fields in headers" in new Test {
-        """GET / HTTP/1.1
-          |Host: x; dummy
-          |
-          |""" should parseToError(
-          BadRequest,
-          ErrorInfo("Illegal 'host' header: Invalid input ' ', expected 'EOI', ':', UPPER_ALPHA, lower-reg-name-char or pct-encoded (line 1, column 3)", "x; dummy\n  ^"))
-
-        """GET / HTTP/1.1
-          |Content-length: 3; dummy
-          |
-          |""" should parseToError(
-          BadRequest,
-          ErrorInfo("Illegal `Content-Length` header value"))
-
-        """GET / HTTP/1.1
-          |Connection:keep-alive; dummy
-          |
-          |""" should parseToError(
-          BadRequest,
-          ErrorInfo("Illegal 'connection' header: Invalid input ';', expected tchar, OWS, listSep or 'EOI' (line 1, column 11)", "keep-alive; dummy\n          ^"))
-
-        """GET / HTTP/1.1
-          |Transfer-Encoding: chunked; dummy
-          |
-          |""" should parseToError(
-          BadRequest,
-          ErrorInfo("Illegal 'transfer-encoding' header: Invalid input ';', expected OWS, listSep or 'EOI' (line 1, column 8)", "chunked; dummy\n       ^"))
-      }
+      
     }
   }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -302,7 +302,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
 
     "support `rawRequestUriHeader` setting" in new Test {
       override protected def newParser: HttpRequestParser =
-        new HttpRequestParser(parserSettings, rawRequestUriHeader = true, headerParser = HttpHeaderParser(parserSettings, system.log)())
+        new HttpRequestParser(parserSettings, rawRequestUriHeader = true, headerParser = HttpHeaderParser(parserSettings, system.log))
 
       """GET /f%6f%6fbar?q=b%61z HTTP/1.1
         |Host: ping
@@ -477,7 +477,6 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
           |
           |""" should parseToError(422: StatusCode, ErrorInfo("TRACE requests must not have an entity"))
       }
-      
     }
   }
 
@@ -555,7 +554,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
         .awaitResult(awaitAtMost)
 
     protected def parserSettings: ParserSettings = ParserSettings(system)
-    protected def newParser = new HttpRequestParser(parserSettings, false, HttpHeaderParser(parserSettings, system.log)())
+    protected def newParser = new HttpRequestParser(parserSettings, false, HttpHeaderParser(parserSettings, system.log))
 
     private def compactEntity(entity: RequestEntity): Future[RequestEntity] =
       entity match {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -323,7 +323,7 @@ abstract class ResponseParserSpec(mode: String, newLine: String) extends FreeSpe
     protected def parserSettings: ParserSettings = ParserSettings(system)
 
     def newParserStage(requestMethod: HttpMethod = GET) = {
-      val parser = new HttpResponseParser(parserSettings, HttpHeaderParser(parserSettings, system.log)())
+      val parser = new HttpResponseParser(parserSettings, HttpHeaderParser(parserSettings, system.log))
       parser.setContextForNextResponse(HttpResponseParser.ResponseContext(requestMethod, None))
 
       // Note that this GraphStage mutates the HttpMessageParser instance, use with caution.

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -79,10 +79,7 @@ object Http2Blueprint {
     // This is master header parser, every other usage should do .createShallowCopy()
     // HttpHeaderParser is not thread safe and should not be called concurrently,
     // the internal trie, however, has built-in protection and will do copy-on-write
-    val masterHttpHeaderParser = HttpHeaderParser(parserSettings, log) { info ⇒
-      if (parserSettings.illegalHeaderWarnings)
-        logParsingError(info withSummaryPrepended "Illegal request header", log, parserSettings.errorLoggingVerbosity)
-    }
+    val masterHttpHeaderParser = HttpHeaderParser(parserSettings, log)
     BidiFlow.fromFlows(
       Flow[HttpResponse].map(ResponseRendering.renderResponse(settings, log)),
       Flow[Http2SubStream].via(StreamUtils.statefulAttrsMap { attrs ⇒


### PR DESCRIPTION
Attempted fix to issue #1166. 

Changed HttpHeaderParser such that by default illegal header value handling depends on the configured IllegalResponseHeaderValueProcessingMode.

A couple of problems:

First, I'm not sure how I should handle an unexpected value [here](https://github.com/disblader/akka-http/blob/websocket-illegal-headers/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala#L452). Is there an exception that implementors generally use for these kinds of situations?

Secondly, I'm pretty bad with scalatest and I ended up in [this situation](https://github.com/disblader/akka-http/blob/websocket-illegal-headers/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala#L194-L201) where I have identical tests with different setups and I'm not sure if that's fine or not? 
