### PR TITLE
Drop use of .taskValue from sbt generators

### DIFF
--- a/akka-http2-support/build.sbt
+++ b/akka-http2-support/build.sbt
@@ -34,4 +34,4 @@ resourceGenerators in Test += Def.task {
     }
   }
   Seq(h2spec)
-}.taskValue
+}

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -14,7 +14,7 @@ object Version {
   def versionSettings: Seq[Setting[_]] = inConfig(Compile)(Seq(
     resourceGenerators += generateVersion(resourceManaged, _ / "akka-http-version.conf",
       """|akka.http.version = "%s"
-         |""").taskValue,
+         |"""),
     sourceGenerators += generateVersion(sourceManaged, _ / "akka" / "http" / "Version.scala",
       """|package akka.http
          |
@@ -31,7 +31,7 @@ object Version {
          |    }
          |  }
          |}
-         |""").taskValue
+         |""")
   ))
 
   def generateVersion(dir: SettingKey[File], locate: File => File, template: String) = Def.task[Seq[File]] {


### PR DESCRIPTION
The upgrade to sbt 0.13.15 allows us to drop use of `.taskValue` for
generators.