### PR TITLE
Allow '=' in query param values in relaxed mode (Fix #1120)

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
@@ -2,3 +2,7 @@
 
 # Added a new method to this sealed trait
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.MediaType#WithOpenCharset.toContentTypeWithMissingCharset")
+
+# akka.http.impl.model.parser.CharacterClasses is private[http].
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.model.parser.CharacterClasses.relaxed-query-char")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.model.parser.CharacterClasses.strict-query-char")

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CharacterClasses.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CharacterClasses.scala
@@ -43,12 +43,14 @@ private[http] object CharacterClasses {
   val `pchar-base-nc` = unreserved ++ `sub-delims` ++ '@'
   val `pchar-base` = `pchar-base-nc` ++ ':' // pchar without percent
   val `query-fragment-char` = `pchar-base` ++ "/?"
-  val `strict-query-char` = `query-fragment-char` -- "&=;"
-  val `strict-query-char-np` = `strict-query-char` -- '+'
+  val `strict-query-key-char` = `query-fragment-char` -- "&=;"
+  val `strict-query-value-char` = `query-fragment-char` -- "&=;"
+  val `strict-query-char-np` = `strict-query-value-char` -- '+'
 
   val `relaxed-fragment-char` = VCHAR -- '%'
   val `relaxed-path-segment-char` = VCHAR -- "%/?#"
-  val `relaxed-query-char` = VCHAR -- "%&=#"
+  val `relaxed-query-key-char` = VCHAR -- "%&=#"
+  val `relaxed-query-value-char` = VCHAR -- "%&#"
   val `raw-query-char` = VCHAR -- '#'
   val `scheme-char` = ALPHA ++ DIGIT ++ '+' ++ '-' ++ '.'
 

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
@@ -121,11 +121,11 @@ public class UriTest extends JUnitSuite {
   @Test(expected = IllegalUriException.class)
   public void testIllegalQuery() {
     //#illegal-query
-    Uri.create("?a=b=c").query();
+    Uri.create("?a%b=c").query();
     //IllegalUriException(
-    //  "Illegal query: Invalid input '=', expected '+', query-char, 'EOI', '&' or pct-encoded (line 1, column 4)",
-    //  "a=b=c\n" +
-    //  "   ^"
+    //  " Illegal query: Invalid input '=', expected HEXDIG (line 1, column 4): a%b=c",
+    //  "a%b=c\n" +
+    //  " ^"
     //)
     //#illegal-query
   }
@@ -264,24 +264,13 @@ public class UriTest extends JUnitSuite {
     //#query-relaxed-mode-success
     assertEquals(Query.create(Pair.create("a^", "b")), relaxed("a^=b"));
     assertEquals(Query.create(Pair.create("a;", "b")), relaxed("a;=b"));
+    assertEquals(Query.create(Pair.create("a", "b=c")), relaxed("a=b=c"));
     //#query-relaxed-mode-success
   }
 
   //#query-relaxed-mode-exception-1
   @Test(expected = IllegalUriException.class)
   public void testRelaxedModeException1() {
-    //double '=' in query string is invalid, even in relaxed mode
-    relaxed("a=b=c");
-    //IllegalUriException(
-    //  "Illegal query: Invalid input '=', expected '+', query-char, 'EOI', '&' or pct-encoded (line 1, column 4)",
-    //  "a=b=c\n" +
-    //  "   ^")
-  }
-  //#query-relaxed-mode-exception-1
-
-  //#query-relaxed-mode-exception-2
-  @Test(expected = IllegalUriException.class)
-  public void testRelaxedModeException2() {
     //following '%', it should be percent encoding (HEXDIG), but "%b=" is not a valid percent encoding
     //still invalid even in relaxed mode
     relaxed("a%b=c");
@@ -290,6 +279,6 @@ public class UriTest extends JUnitSuite {
     //  "a%b=c\n" +
     //  "   ^")
   }
-  //#query-relaxed-mode-exception-2
+  //#query-relaxed-mode-exception-1
 
 }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -382,16 +382,10 @@ class UriSpec extends WordSpec with Matchers {
       //#query-relaxed-mode-success
       relaxed("a^=b") shouldEqual ("a^", "b") +: Query.Empty
       relaxed("a;=b") shouldEqual ("a;", "b") +: Query.Empty
+      relaxed("a=b=c") shouldEqual ("a", "b=c") +: Query.Empty
       //#query-relaxed-mode-success
 
       //#query-relaxed-mode-exception
-      //double '=' in query string is invalid, even in relaxed mode
-      the[IllegalUriException] thrownBy relaxed("a=b=c") shouldBe {
-        IllegalUriException(
-          "Illegal query: Invalid input '=', expected '+', query-char, 'EOI', '&' or pct-encoded (line 1, column 4)",
-          "a=b=c\n" +
-            "   ^")
-      }
       //following '%', it should be percent encoding (HEXDIG), but "%b=" is not a valid percent encoding
       //still invalid even in relaxed mode
       the[IllegalUriException] thrownBy relaxed("a%b=c") shouldBe {
@@ -615,14 +609,6 @@ class UriSpec extends WordSpec with Matchers {
             "            ^")
       }
       //#illegal-cases-immediate-exception
-
-      // illegal query
-      the[IllegalUriException] thrownBy Uri("?a=b=c").query() shouldBe {
-        IllegalUriException(
-          "Illegal query: Invalid input '=', expected '+', query-char, 'EOI', '&' or pct-encoded (line 1, column 4)",
-          "a=b=c\n" +
-            "   ^")
-      }
     }
 
     // http://tools.ietf.org/html/rfc3986#section-5.4

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
@@ -33,9 +33,14 @@ public class ParameterDirectivesTest extends JUnitRouteTest {
       .assertEntity("john");
 
     route
+        .run(HttpRequest.create().withUri("/abc?stringParam=a%b"))
+        .assertStatusCode(400)
+        .assertEntity("The request content was malformed:\nThe request's query string is invalid: stringParam=a%b");
+
+    route
       .run(HttpRequest.create().withUri("/abc?stringParam=a=b"))
-      .assertStatusCode(400)
-      .assertEntity("The request content was malformed:\nThe request's query string is invalid: stringParam=a=b");
+      .assertStatusCode(200)
+      .assertEntity("a=b");
   }
 
   @Test

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -50,11 +50,11 @@ class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Insi
         }
       }
       "cause a MalformedRequestContentRejection on invalid query strings" in {
-        Get("/?amount=1=") ~> {
+        Get("/?amount=1%2") ~> {
           parameter("amount".as[Int].?) { echoComplete }
         } ~> check {
           inside(rejection) {
-            case MalformedRequestContentRejection("The request's query string is invalid: amount=1=", _) ⇒
+            case MalformedRequestContentRejection("The request's query string is invalid: amount=1%2", _) ⇒
           }
         }
       }

--- a/docs/src/main/paradox/java/http/common/uri-model.md
+++ b/docs/src/main/paradox/java/http/common/uri-model.md
@@ -132,8 +132,6 @@ However, even with the `Relaxed` mode, there are still invalid special character
 
 @@snip [UriTest.java](../../../../../../../akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java) { #query-relaxed-mode-exception-1 }
 
-@@snip [UriTest.java](../../../../../../../akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java) { #query-relaxed-mode-exception-2 }
-
 Other than specifying the `mode` in the parameters, like when using directives, you can specify the `mode` in your configuration as follows.
 
 ```


### PR DESCRIPTION
* Create new character class for query value chars and use this in relaxed mode
* Update relevant tests and examples to reflect this change

Fixes #1120