### PR TITLE
Add extra test to narrow down failure #443

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -305,6 +305,13 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
       "Host: 127.0.0.1" =!= Host("127.0.0.1")
     }
 
+    "If-Match dispatching" in {
+      // https://github.com/akka/akka-http/issues/443 Check dispatching for "if-match" does not throw "RuleNotFound"
+      import scala.util._
+      val Failure(cause) = Try(HeaderParser.dispatch(null, "if-match"))
+      cause.getClass should be(classOf[NullPointerException])
+    }
+
     "If-Match" in {
       """If-Match: *""" =!= `If-Match`.`*`
       """If-Match: "938fz3f83z3z38z"""" =!= `If-Match`(EntityTag("938fz3f83z3z38z"))


### PR DESCRIPTION
I agree with Johannes that the only code path to this failure is when the
parboiled dispatcher would throw `RuleNotFoundException`, but don't see how
this could be nondeterministic. To further narrow this down I added a test that
fails specifically in that case, should be interesting to see if that one also
fails (and whether they fail together).

Refs #443 