### PR TITLE
Revamp SPI / API of ClientTransport infrastructure to fix #1012 and to simplify API

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
@@ -2,3 +2,15 @@
 
 # Added a new method to this sealed trait
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.MediaType#WithOpenCharset.toContentTypeWithMissingCharset")
+
+# Move settings implementations to Java superclass, ClientConnectionSettings are marked @DoNotInherit
+ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.getConnectingTimeout")
+ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.getParserSettings")
+ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.getIdleTimeout")
+ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.getSocketOptions")
+ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.getLogUnencryptedNetworkBytes")
+ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.getUserAgentHeader")
+ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.getWebsocketRandomFactory")
+ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.getRequestHeaderSizeHint")
+
+# Incompatible SPI / API changes for ClientTransport which is marked @ApiMayChange

--- a/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.7.backwards.excludes
@@ -14,3 +14,23 @@ ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientCon
 ProblemFilters.exclude[FinalMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.getRequestHeaderSizeHint")
 
 # Incompatible SPI / API changes for ClientTransport which is marked @ApiMayChange
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.ClientTransport#ScalaWrapper.connectTo")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.ClientTransport#JavaWrapper.connectTo")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.ClientTransport.TCP")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.ClientTransport.connectTo")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.ClientTransport.connectTo")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.ClientTransport.connectTo")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.ClientTransport.connectTo")
+ProblemFilters.exclude[MissingTypesProblem]("akka.http.scaladsl.ClientTransport$TCPTransport$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.ClientTransport#TCPTransport.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.ClientTransport#TCPTransport.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.ClientTransport.TCP")
+ProblemFilters.exclude[MissingClassProblem]("akka.http.scaladsl.ClientTransport$TCPTransport")
+
+# Internal classes
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ClientConnectionSettingsImpl.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ClientConnectionSettingsImpl.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ClientConnectionSettingsImpl.apply")
+
+# Added new setting to @DoNotInherit class
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ClientConnectionSettings.localAddress")

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
@@ -4,6 +4,7 @@
 
 package akka.http.impl.settings
 
+import java.net.InetSocketAddress
 import java.util.Random
 
 import akka.annotation.InternalApi
@@ -28,7 +29,8 @@ private[akka] final case class ClientConnectionSettingsImpl(
   logUnencryptedNetworkBytes: Option[Int],
   websocketRandomFactory:     () ⇒ Random,
   socketOptions:              immutable.Seq[SocketOption],
-  parserSettings:             ParserSettings)
+  parserSettings:             ParserSettings,
+  localAddress:               Option[InetSocketAddress])
   extends akka.http.scaladsl.settings.ClientConnectionSettings {
 
   require(connectingTimeout >= Duration.Zero, "connectingTimeout must be >= 0")
@@ -48,6 +50,7 @@ object ClientConnectionSettingsImpl extends SettingsCompanion[ClientConnectionSe
       logUnencryptedNetworkBytes = LogUnencryptedNetworkBytes(c getString "log-unencrypted-network-bytes"),
       websocketRandomFactory = Randoms.SecureRandomInstances, // can currently only be overridden from code
       socketOptions = SocketOptionSettings.fromSubConfig(root, c.getConfig("socket-options")),
-      parserSettings = ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing")))
+      parserSettings = ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing")),
+      localAddress = None)
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -34,7 +34,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
     idleTimeout:        Duration,
     connectionSettings: ClientConnectionSettings) =
     this(maxConnections, minConnections, maxRetries, maxOpenRequests, pipeliningLimit, idleTimeout, connectionSettings,
-      ClientTransport.TCP(None, connectionSettings))
+      ClientTransport.TCP)
 
   require(maxConnections > 0, "max-connections must be > 0")
   require(minConnections >= 0, "min-connections must be >= 0")

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
@@ -3,6 +3,7 @@
  */
 package akka.http.javadsl.settings
 
+import java.net.InetSocketAddress
 import java.util.function.Supplier
 import java.util.{ Optional, Random }
 
@@ -36,6 +37,7 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   final val getWebsocketRandomFactory: Supplier[Random] = new Supplier[Random] {
     override def get(): Random = websocketRandomFactory()
   }
+  final def getLocalAddress: Optional[InetSocketAddress] = OptionConverters.toJava(localAddress)
 
   // ---
 
@@ -47,7 +49,7 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ClientConnectionSettings = self.copy(websocketRandomFactory = () ⇒ newValue.get())
   def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ClientConnectionSettings = self.copy(socketOptions = newValue.asScala.toList)
   def withParserSettings(newValue: ParserSettings): ClientConnectionSettings = self.copy(parserSettings = newValue.asScala)
-
+  def withLocalAddress(newValue: Optional[InetSocketAddress]): ClientConnectionSettings = self.copy(localAddress = OptionConverters.toScala(newValue))
 }
 
 object ClientConnectionSettings extends SettingsCompanion[ClientConnectionSettings] {

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
@@ -3,6 +3,7 @@
  */
 package akka.http.javadsl.settings
 
+import java.util.function.Supplier
 import java.util.{ Optional, Random }
 
 import akka.actor.ActorSystem
@@ -23,14 +24,18 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
  */
 @DoNotInherit
 abstract class ClientConnectionSettings private[akka] () { self: ClientConnectionSettingsImpl ⇒
-  def getUserAgentHeader: Optional[UserAgent]
-  def getConnectingTimeout: FiniteDuration
-  def getIdleTimeout: Duration
-  def getRequestHeaderSizeHint: Int
-  def getWebsocketRandomFactory: java.util.function.Supplier[Random]
-  def getSocketOptions: java.lang.Iterable[SocketOption]
-  def getParserSettings: ParserSettings
-  def getLogUnencryptedNetworkBytes: Optional[Int]
+  /* JAVA APIs */
+
+  final def getConnectingTimeout: FiniteDuration = connectingTimeout
+  final def getParserSettings: ParserSettings = parserSettings
+  final def getIdleTimeout: Duration = idleTimeout
+  final def getSocketOptions: java.lang.Iterable[SocketOption] = socketOptions.asJava
+  final def getUserAgentHeader: Optional[UserAgent] = OptionConverters.toJava(userAgentHeader)
+  final def getLogUnencryptedNetworkBytes: Optional[Int] = OptionConverters.toJava(logUnencryptedNetworkBytes)
+  final def getRequestHeaderSizeHint: Int = requestHeaderSizeHint
+  final val getWebsocketRandomFactory: Supplier[Random] = new Supplier[Random] {
+    override def get(): Random = websocketRandomFactory()
+  }
 
   // ---
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
@@ -3,23 +3,17 @@
  */
 package akka.http.scaladsl.settings
 
-import java.lang.Iterable
-import java.util.{ Optional, Random }
-import java.util.function.Supplier
+import java.util.Random
 
 import akka.annotation.DoNotInherit
 import akka.http.impl.util._
 import akka.http.impl.settings.ClientConnectionSettingsImpl
-import akka.http.javadsl.model.headers.UserAgent
-import akka.http.javadsl.{ settings ⇒ js }
 import akka.http.scaladsl.model.headers.`User-Agent`
 import akka.io.Inet.SocketOption
 import com.typesafe.config.Config
 
 import scala.collection.immutable
-import scala.compat.java8.OptionConverters
 import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.collection.JavaConverters._
 
 /**
  * Public API but not intended for subclassing
@@ -34,19 +28,6 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   def socketOptions: immutable.Seq[SocketOption]
   def parserSettings: ParserSettings
   def logUnencryptedNetworkBytes: Option[Int]
-
-  /* JAVA APIs */
-
-  final override def getConnectingTimeout: FiniteDuration = connectingTimeout
-  final override def getParserSettings: js.ParserSettings = parserSettings
-  final override def getIdleTimeout: Duration = idleTimeout
-  final override def getSocketOptions: Iterable[SocketOption] = socketOptions.asJava
-  final override def getUserAgentHeader: Optional[UserAgent] = OptionConverters.toJava(userAgentHeader)
-  final override def getLogUnencryptedNetworkBytes: Optional[Int] = OptionConverters.toJava(logUnencryptedNetworkBytes)
-  final override def getRequestHeaderSizeHint: Int = requestHeaderSizeHint
-  final override def getWebsocketRandomFactory: Supplier[Random] = new Supplier[Random] {
-    override def get(): Random = websocketRandomFactory()
-  }
 
   // ---
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
@@ -3,6 +3,7 @@
  */
 package akka.http.scaladsl.settings
 
+import java.net.InetSocketAddress
 import java.util.Random
 
 import akka.annotation.DoNotInherit
@@ -28,6 +29,7 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   def socketOptions: immutable.Seq[SocketOption]
   def parserSettings: ParserSettings
   def logUnencryptedNetworkBytes: Option[Int]
+  def localAddress: Option[InetSocketAddress]
 
   // ---
 
@@ -42,6 +44,15 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   def withLogUnencryptedNetworkBytes(newValue: Option[Int]): ClientConnectionSettings = self.copy(logUnencryptedNetworkBytes = newValue)
   def withSocketOptions(newValue: immutable.Seq[SocketOption]): ClientConnectionSettings = self.copy(socketOptions = newValue)
   def withParserSettings(newValue: ParserSettings): ClientConnectionSettings = self.copy(parserSettings = newValue)
+  def withLocalAddress(newValue: Option[InetSocketAddress]): ClientConnectionSettings = self.copy(localAddress = newValue)
+
+  /**
+   * Returns a new instance with the given local address set if the given override is `Some(address)`, otherwise
+   * return this instance unchanged.
+   */
+  def withLocalAddressOverride(overrideLocalAddressOption: Option[InetSocketAddress]): ClientConnectionSettings =
+    if (overrideLocalAddressOption.isDefined) withLocalAddress(overrideLocalAddressOption)
+    else this
 }
 
 object ClientConnectionSettings extends SettingsCompanion[ClientConnectionSettings] {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -6,12 +6,10 @@ package akka.http.scaladsl.settings
 import java.util.Random
 import java.util.function.Supplier
 
-import akka.actor.ActorSystem
 import akka.annotation.DoNotInherit
 import akka.http.impl.util._
 import akka.http.impl.settings.ServerSettingsImpl
 import akka.http.impl.util.JavaMapping.Implicits._
-import akka.http.javadsl.settings.{ PreviewServerSettings, ServerSettings }
 import akka.http.javadsl.{ settings ⇒ js }
 import akka.http.scaladsl.model.headers.Host
 import akka.http.scaladsl.model.headers.Server

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
@@ -6,6 +6,7 @@ package akka.http.impl.engine.ws
 
 import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.annotation.InternalApi
 import akka.stream.scaladsl.Sink
 import akka.stream.testkit.TestSubscriber
 import akka.util.ByteString
@@ -13,7 +14,9 @@ import akka.util.ByteString
 import scala.annotation.tailrec
 import scala.concurrent.duration.FiniteDuration
 
-trait ByteStringSinkProbe {
+/** INTERNAL API */
+@InternalApi
+private[http] trait ByteStringSinkProbe {
   def sink: Sink[ByteString, NotUsed]
 
   def expectBytes(length: Int): ByteString
@@ -34,7 +37,9 @@ trait ByteStringSinkProbe {
   def cancel(): Unit
 }
 
-object ByteStringSinkProbe {
+/** INTERNAL API */
+@InternalApi
+private[http] object ByteStringSinkProbe {
   def apply()(implicit system: ActorSystem): ByteStringSinkProbe =
     new ByteStringSinkProbe {
       val probe = TestSubscriber.probe[ByteString]()
@@ -69,8 +74,10 @@ object ByteStringSinkProbe {
         assert(got == expected, s"expected ${expected.length} bytes '$expected' but got ${got.length} bytes '$got'")
       }
 
-      def expectUtf8EncodedString(string: String): Unit =
-        expectBytes(ByteString(string, "utf8"))
+      def expectUtf8EncodedString(expectedString: String): Unit = {
+        val data = expectBytes(expectedString.getBytes("utf8").length).utf8String
+        assert(data == expectedString, s"expected '$expectedString' but got '$data'")
+      }
 
       def expectSubscriptionAndComplete(): Unit = probe.expectSubscriptionAndComplete()
       def expectComplete(): Unit = probe.expectComplete()


### PR DESCRIPTION
This was inspired by part of @ktoso's fix in #1014 but goes a bit further to simplify the transport API.

A transport is now a static constant function value that gets passed
all parameters at connection time.

That fixes #1012 where client connection settings were both kept redundantly
inside the transport and inside the settings.

It's now also possible to specify the localAddress inside the settings. Methods
in the Http entrypoint that allow specifying the localAddress explicitly will
override whatever was given in the settings. In the future we'd like to
get rid of all those parameters to simplify entrypoint signatures in Http.

There is a basic disadvantage of passing `ClientConnectionSettings` to the `connectTo` method which is that whatever settings future `ClientTransport` come up with, they have to be put into those `ClientConnectionSettings`, so this might become an even bigger grab bag than it is right now.

Fixes #1012.