### PR TITLE
=httst Improve test reliability for HttpApp #1121 #1061

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
@@ -17,18 +17,16 @@ public class MinimalHttpApp extends HttpApp {
   CompletableFuture<Done> shutdownTrigger = new CompletableFuture<>();
   CompletableFuture<Done> bindingPromise = new CompletableFuture<>();
 
+
+  public void shutdown() {
+    shutdownTrigger.complete(Done.getInstance());
+  }
+    
   @Override
   protected Route routes() {
-    return route(path("foo", () ->
+    return path("foo", () ->
         complete("bar")
-      ),
-      path("shutdown", () -> {
-        if (shutdownTrigger.complete(Done.getInstance())) {
-          return complete("Shutdown request accepted");
-        } else {
-          return complete("Shutdown is already in progress");
-        }
-      }));
+      );
   }
 
   @Override

--- a/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
@@ -50,9 +50,11 @@ class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
 
       minimal.bindingPromise.get(5, TimeUnit.SECONDS)
 
-      // Requesting the server to shutdown
-      callAndVerify(host, port, "shutdown")
+      // Checking server is up and running
+      callAndVerify(host, port, "foo")
 
+      // Requesting the server to shutdown
+      minimal.shutdown()
       Await.ready(server, Duration(1, TimeUnit.SECONDS))
       server.isCompleted should ===(true)
 
@@ -66,8 +68,11 @@ class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
 
       minimal.bindingPromise.get(5, TimeUnit.SECONDS)
 
+      // Checking server is up and running
+      callAndVerify(host, port, "foo")
+
       // Requesting the server to shutdown
-      callAndVerify(host, port, "shutdown")
+      minimal.shutdown()
 
       Await.ready(server, Duration(1, TimeUnit.SECONDS))
       server.isCompleted should ===(true)
@@ -82,8 +87,11 @@ class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
 
       minimal.bindingPromise.get(5, TimeUnit.SECONDS)
 
+      // Checking server is up and running
+      callAndVerify(host, port, "foo")
+
       // Requesting the server to shutdown
-      callAndVerify(host, port, "shutdown")
+      minimal.shutdown()
 
       Await.ready(server, Duration(1, TimeUnit.SECONDS))
       server.isCompleted should ===(true)
@@ -106,14 +114,17 @@ class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
       minimal.binding().localAddress.getPort should ===(port)
       minimal.binding().localAddress.getAddress.getHostAddress should ===(host)
 
+      // Checking server is up and running
+      callAndVerify(host, port, "foo")
+
       // Requesting the server to shutdown
-      callAndVerify(host, port, "shutdown")
+      minimal.shutdown()
       Await.ready(server, Duration(1, TimeUnit.SECONDS))
       server.isCompleted should ===(true)
 
     }
 
-    "let get notified" when {
+    "notify" when {
 
       "shutting down" in withSneaky { (sneaky, host, port) ⇒
 
@@ -125,8 +136,11 @@ class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
 
         sneaky.bindingPromise.get(5, TimeUnit.SECONDS)
 
+        // Checking server is up and running
+        callAndVerify(host, port, "foo")
+
         // Requesting the server to shutdown
-        callAndVerify(host, port, "shutdown")
+        sneaky.shutdown()
         Await.ready(server, Duration(1, TimeUnit.SECONDS))
         server.isCompleted should ===(true)
         eventually {
@@ -145,8 +159,11 @@ class HttpAppSpec extends AkkaSpec with RequestBuilding with Eventually {
 
         sneaky.postBindingCalled.get() should ===(true)
 
+        // Checking server is up and running
+        callAndVerify(host, port, "foo")
+
         // Requesting the server to shutdown
-        callAndVerify(host, port, "shutdown")
+        sneaky.shutdown()
         Await.ready(server, Duration(1, TimeUnit.SECONDS))
         server.isCompleted should ===(true)
 


### PR DESCRIPTION
Issues: #1121 #1061
Refactor test to avoid race condition between serving a request and shutting down the server itself.
Now, server is shutdown independently from serving a request.