### PR TITLE
adds Cache-Control 'immutable' value

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
@@ -42,5 +42,5 @@ public final class CacheDirectives {
     public static CacheDirective S_MAXAGE(long deltaSeconds) {
         return new akka.http.scaladsl.model.headers.CacheDirectives.s$minusmaxage(deltaSeconds);
     }
-    public static final CacheDirective IMMUTABLE = akka.http.scaladsl.model.headers.CacheDirectives.immutable$.MODULE$;
+    public static final CacheDirective IMMUTABLE = akka.http.scaladsl.model.headers.CacheDirectives.getImmutable();
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
@@ -42,4 +42,5 @@ public final class CacheDirectives {
     public static CacheDirective S_MAXAGE(long deltaSeconds) {
         return new akka.http.scaladsl.model.headers.CacheDirectives.s$minusmaxage(deltaSeconds);
     }
+    public static final CacheDirective IMMUTABLE = akka.http.scaladsl.model.headers.CacheDirectives.immutable$.MODULE$;
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CacheControlHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CacheControlHeader.scala
@@ -28,6 +28,7 @@ private[parser] trait CacheControlHeader { this: Parser with CommonRules with Co
       | "must-revalidate" ~ push(`must-revalidate`)
       | "proxy-revalidate" ~ push(`proxy-revalidate`)
       | "s-maxage=" ~ `delta-seconds` ~> (`s-maxage`(_))
+      | "immutable" ~ push(`immutable`)
       | token ~ optional(ws('=') ~ word) ~> (CacheDirective.custom(_, _)))
 
   def `field-names` = rule { `quoted-tokens` | token ~> (Seq(_)) }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CacheControlHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CacheControlHeader.scala
@@ -7,6 +7,7 @@ package akka.http.impl.model.parser
 import akka.parboiled2.Parser
 import akka.http.scaladsl.model.headers._
 import CacheDirectives._
+import CacheDirectives.ImmutableCacheValue._
 
 private[parser] trait CacheControlHeader { this: Parser with CommonRules with CommonActions with StringBuilding ⇒
 

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CacheControlHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CacheControlHeader.scala
@@ -7,7 +7,6 @@ package akka.http.impl.model.parser
 import akka.parboiled2.Parser
 import akka.http.scaladsl.model.headers._
 import CacheDirectives._
-import CacheDirectives.ImmutableCacheValue._
 
 private[parser] trait CacheControlHeader { this: Parser with CommonRules with CommonActions with StringBuilding ⇒
 
@@ -29,7 +28,7 @@ private[parser] trait CacheControlHeader { this: Parser with CommonRules with Co
       | "must-revalidate" ~ push(`must-revalidate`)
       | "proxy-revalidate" ~ push(`proxy-revalidate`)
       | "s-maxage=" ~ `delta-seconds` ~> (`s-maxage`(_))
-      | "immutable" ~ push(`immutable`)
+      | "immutable" ~ push(immutableDirective)
       | token ~ optional(ws('=') ~ word) ~> (CacheDirective.custom(_, _)))
 
   def `field-names` = rule { `quoted-tokens` | token ~> (Seq(_)) }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
@@ -5,7 +5,7 @@
 package akka.http.scaladsl.model.headers
 
 import scala.annotation.{ varargs, tailrec }
-import scala.collection.immutable
+import scala.collection.{ immutable ⇒ colImmutable }
 import akka.http.impl.util._
 import akka.http.javadsl.{ model ⇒ jm }
 
@@ -29,7 +29,7 @@ object CacheDirective {
     CustomCacheDirective(name, content)
 
   sealed abstract class FieldNamesDirective extends Product with ValueRenderable {
-    def fieldNames: immutable.Seq[String]
+    def fieldNames: colImmutable.Seq[String]
     final def render[R <: Rendering](r: R): r.type =
       if (fieldNames.nonEmpty) {
         r ~~ productPrefix ~~ '=' ~~ '"'
@@ -68,7 +68,7 @@ object CacheDirectives {
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.1.4
   case object `no-cache` extends SingletonValueRenderable with RequestDirective with ResponseDirective {
-    def apply(fieldNames: String*): `no-cache` = new `no-cache`(immutable.Seq(fieldNames: _*))
+    def apply(fieldNames: String*): `no-cache` = new `no-cache`(colImmutable.Seq(fieldNames: _*))
   }
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.1.5
@@ -86,22 +86,25 @@ object CacheDirectives {
   case object `must-revalidate` extends SingletonValueRenderable with ResponseDirective
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.2.2
-  final case class `no-cache`(fieldNames: immutable.Seq[String]) extends FieldNamesDirective with ResponseDirective
+  final case class `no-cache`(fieldNames: colImmutable.Seq[String]) extends FieldNamesDirective with ResponseDirective
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.2.5
   case object `public` extends SingletonValueRenderable with ResponseDirective
+
+  // https://tools.ietf.org/wg/httpbis/draft-ietf-httpbis-immutable/
+  case object `immutable` extends SingletonValueRenderable with ResponseDirective
 
   /** Java API */
   def getPublic: ResponseDirective = `public`
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.2.6
-  final case class `private`(fieldNames: immutable.Seq[String]) extends FieldNamesDirective with ResponseDirective
+  final case class `private`(fieldNames: colImmutable.Seq[String]) extends FieldNamesDirective with ResponseDirective
   object `private` {
-    def apply(fieldNames: String*): `private` = new `private`(immutable.Seq(fieldNames: _*))
+    def apply(fieldNames: String*): `private` = new `private`(colImmutable.Seq(fieldNames: _*))
   }
 
   /** Java API */
-  @varargs def createPrivate(fieldNames: String*): ResponseDirective = new `private`(immutable.Seq(fieldNames: _*))
+  @varargs def createPrivate(fieldNames: String*): ResponseDirective = new `private`(colImmutable.Seq(fieldNames: _*))
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.2.7
   case object `proxy-revalidate` extends SingletonValueRenderable with ResponseDirective

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
@@ -113,14 +113,13 @@ object CacheDirectives {
     def render[R <: Rendering](r: R): r.type = r ~~ productPrefix ~~ '=' ~~ deltaSeconds
   }
 
-  /** Java API */
-  def getImmutable: ResponseDirective = ImmutableCacheValue.immutable
-
-  object ImmutableCacheValue {
-
-    /** https://tools.ietf.org/wg/httpbis/draft-ietf-httpbis-immutable */
-    @ApiMayChange
-    case object immutable extends SingletonValueRenderable with ResponseDirective
+  /** https://tools.ietf.org/wg/httpbis/draft-ietf-httpbis-immutable */
+  @ApiMayChange
+  case object immutableDirective extends SingletonValueRenderable with ResponseDirective {
+    private val valueBytes = "immutable".asciiBytes
+    override def render[R <: Rendering](r: R): r.type = r ~~ valueBytes
   }
 
+  /** Java API */
+  def getImmutable: ResponseDirective = immutableDirective
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
@@ -4,8 +4,10 @@
 
 package akka.http.scaladsl.model.headers
 
-import scala.annotation.{ varargs, tailrec }
-import scala.collection.{ immutable ⇒ colImmutable }
+import akka.annotation.ApiMayChange
+
+import scala.annotation.{ tailrec, varargs }
+import scala.collection.immutable
 import akka.http.impl.util._
 import akka.http.javadsl.{ model ⇒ jm }
 
@@ -29,7 +31,7 @@ object CacheDirective {
     CustomCacheDirective(name, content)
 
   sealed abstract class FieldNamesDirective extends Product with ValueRenderable {
-    def fieldNames: colImmutable.Seq[String]
+    def fieldNames: immutable.Seq[String]
     final def render[R <: Rendering](r: R): r.type =
       if (fieldNames.nonEmpty) {
         r ~~ productPrefix ~~ '=' ~~ '"'
@@ -68,7 +70,7 @@ object CacheDirectives {
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.1.4
   case object `no-cache` extends SingletonValueRenderable with RequestDirective with ResponseDirective {
-    def apply(fieldNames: String*): `no-cache` = new `no-cache`(colImmutable.Seq(fieldNames: _*))
+    def apply(fieldNames: String*): `no-cache` = new `no-cache`(immutable.Seq(fieldNames: _*))
   }
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.1.5
@@ -86,25 +88,22 @@ object CacheDirectives {
   case object `must-revalidate` extends SingletonValueRenderable with ResponseDirective
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.2.2
-  final case class `no-cache`(fieldNames: colImmutable.Seq[String]) extends FieldNamesDirective with ResponseDirective
+  final case class `no-cache`(fieldNames: immutable.Seq[String]) extends FieldNamesDirective with ResponseDirective
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.2.5
   case object `public` extends SingletonValueRenderable with ResponseDirective
-
-  // https://tools.ietf.org/wg/httpbis/draft-ietf-httpbis-immutable/
-  case object `immutable` extends SingletonValueRenderable with ResponseDirective
 
   /** Java API */
   def getPublic: ResponseDirective = `public`
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.2.6
-  final case class `private`(fieldNames: colImmutable.Seq[String]) extends FieldNamesDirective with ResponseDirective
+  final case class `private`(fieldNames: immutable.Seq[String]) extends FieldNamesDirective with ResponseDirective
   object `private` {
-    def apply(fieldNames: String*): `private` = new `private`(colImmutable.Seq(fieldNames: _*))
+    def apply(fieldNames: String*): `private` = new `private`(immutable.Seq(fieldNames: _*))
   }
 
   /** Java API */
-  @varargs def createPrivate(fieldNames: String*): ResponseDirective = new `private`(colImmutable.Seq(fieldNames: _*))
+  @varargs def createPrivate(fieldNames: String*): ResponseDirective = new `private`(immutable.Seq(fieldNames: _*))
 
   // http://tools.ietf.org/html/rfc7234#section-5.2.2.7
   case object `proxy-revalidate` extends SingletonValueRenderable with ResponseDirective
@@ -113,4 +112,15 @@ object CacheDirectives {
   final case class `s-maxage`(deltaSeconds: Long) extends ResponseDirective with ValueRenderable {
     def render[R <: Rendering](r: R): r.type = r ~~ productPrefix ~~ '=' ~~ deltaSeconds
   }
+
+  /** Java API */
+  def getImmutable: ResponseDirective = ImmutableCacheValue.immutable
+
+  object ImmutableCacheValue {
+
+    /** https://tools.ietf.org/wg/httpbis/draft-ietf-httpbis-immutable */
+    @ApiMayChange
+    case object immutable extends SingletonValueRenderable with ResponseDirective
+  }
+
 }

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -12,7 +12,6 @@ import akka.http.impl.util._
 import akka.http.scaladsl.model._
 import headers._
 import CacheDirectives._
-import CacheDirectives.ImmutableCacheValue._
 import MediaTypes._
 import MediaRanges._
 import HttpCharsets._
@@ -177,7 +176,7 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
       "Cache-Control: private=\"a,b\", no-cache" =!=
         `Cache-Control`(`private`("a", "b"), `no-cache`)
       "Cache-Control: private, immutable" =!=
-        `Cache-Control`(`private`(), immutable)
+        `Cache-Control`(`private`(), immutableDirective)
     }
 
     "Connection" in {

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -12,6 +12,7 @@ import akka.http.impl.util._
 import akka.http.scaladsl.model._
 import headers._
 import CacheDirectives._
+import CacheDirectives.ImmutableCacheValue._
 import MediaTypes._
 import MediaRanges._
 import HttpCharsets._
@@ -176,7 +177,7 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
       "Cache-Control: private=\"a,b\", no-cache" =!=
         `Cache-Control`(`private`("a", "b"), `no-cache`)
       "Cache-Control: private, immutable" =!=
-        `Cache-Control`(`private`(), `immutable`)
+        `Cache-Control`(`private`(), immutable)
     }
 
     "Connection" in {

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -175,6 +175,8 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
         `Cache-Control`(`no-cache`("Set-Cookie")).renderedTo("no-cache=\"Set-Cookie\"")
       "Cache-Control: private=\"a,b\", no-cache" =!=
         `Cache-Control`(`private`("a", "b"), `no-cache`)
+      "Cache-Control: private, immutable" =!=
+        `Cache-Control`(`private`(), `immutable`)
     }
 
     "Connection" in {


### PR DESCRIPTION
Hi,

after reading [this](https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/ ) a while ago I thought that the `immutable` Cache-Control value might be a good addition and so I created this PR.

Let me know what you think.

Best,
Matthias

See also
- https://bitsup.blogspot.de/2016/05/cache-control-immutable.html
- https://tools.ietf.org/wg/httpbis/draft-ietf-httpbis-immutable/