### PR TITLE
#1222 Correctly handle ContentType.withMissingCharset in ContentTypeRange

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
@@ -11,11 +11,13 @@ import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.impl.util.JavaMapping.Implicits._
 
 final case class ContentTypeRange(mediaRange: MediaRange, charsetRange: HttpCharsetRange) extends jm.ContentTypeRange with ValueRenderable {
-  def matches(contentType: jm.ContentType) =
-    contentType match {
-      case ContentType.Binary(mt)   ⇒ mediaRange.matches(mt)
-      case x: ContentType.NonBinary ⇒ mediaRange.matches(x.mediaType) && charsetRange.matches(x.charset)
+  def matches(contentType: jm.ContentType) = {
+    convertToScala(contentType) match {
+      case ContentType.Binary(mt)             ⇒ mediaRange.matches(mt)
+      case ContentType.WithMissingCharset(mt) ⇒ mediaRange.matches(mt)
+      case x: ContentType.NonBinary           ⇒ mediaRange.matches(x.mediaType) && charsetRange.matches(x.charset)
     }
+  }
 
   def render[R <: Rendering](r: R): r.type = charsetRange match {
     case HttpCharsetRange.`*` ⇒ r ~~ mediaRange

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -73,7 +73,13 @@ class UnmarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll wi
       ex.getMessage should include("Right failure: For input string")
       ex.getMessage should include("Left failure: For input string")
     }
+  }
 
+  "Unmarshaller.forContentTypes" - {
+    "forContentTypes should handle media ranges of types with missing charset" in {
+      val um = Unmarshaller.byteArrayUnmarshaller.forContentTypes(MediaTypes.`text/plain`)
+      Await.result(um(HttpEntity("Hello")), 1.second.dilated) should ===("Hello".getBytes)
+    }
   }
 
   override def afterAll() = TestKit.shutdownActorSystem(system)


### PR DESCRIPTION
This scenario was overlooked in #1141, because jm.ContentType isn't a
sealed trait (and can't be, because it is implemented in the scala DSL).

Fixes #1222.