### PR TITLE
=docs add discouragement to use withoutSizeLimit in docs #814

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/MiscDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/MiscDirectives.scala
@@ -75,6 +75,10 @@ abstract class MiscDirectives extends MethodDirectives {
    * Disables the size limit (configured by `akka.http.parsing.max-content-length` by default) checking on the incoming
    * [[akka.http.javadsl.model.HttpRequest]] entity.
    * Can be useful when handling arbitrarily large data uploads in specific parts of your routes.
+   *
+   * @note  Usage of `withoutSizeLimit` is not recommended as it turns off the too large payload protection. Therefore,
+   *        we highly encourage using `withSizeLimit` instead, providing it with a value high enough to successfully
+   *        handle the route in need of big entities.
    */
   def withoutSizeLimit(inner: Supplier[Route]): Route = RouteAdapter {
     D.withoutSizeLimit { inner.get.delegate }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala
@@ -91,6 +91,10 @@ trait MiscDirectives {
    * [[HttpRequest]] entity.
    * Can be useful when handling arbitrarily large data uploads in specific parts of your routes.
    *
+   * @note  Usage of `withoutSizeLimit` is not recommended as it turns off the too large payload protection. Therefore,
+   *        we highly encourage using `withSizeLimit` instead, providing it with a value high enough to successfully
+   *        handle the route in need of big entities.
+   *
    * @group misc
    */
   def withoutSizeLimit: Directive0 = MiscDirectives._withoutSizeLimit

--- a/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/withoutSizeLimit.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/directives/misc-directives/withoutSizeLimit.md
@@ -9,6 +9,12 @@ The whole mechanism of entity size checking is intended to prevent certain Denia
 So suggested setup is to have `akka.http.parsing.max-content-length` relatively low and use `withoutSizeLimit`
 directive just for endpoints for which size verification should not be performed.
 
+@@@ warning { title="Caution" }
+Usage of `withoutSizeLimit` is not recommended as it turns off the too large payload protection. Therefore, we highly 
+encourage using `withSizeLimit` instead, providing it with a value high enough to successfully handle the 
+route in need of big entities.
+@@@
+
 See also @ref[withSizeLimit](withSizeLimit.md#withsizelimit-java) for setting request entity size limit.
 
 ## Example

--- a/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/withoutSizeLimit.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/directives/misc-directives/withoutSizeLimit.md
@@ -13,6 +13,12 @@ The whole mechanism of entity size checking is intended to prevent certain Denia
 So suggested setup is to have `akka.http.parsing.max-content-length` relatively low and use `withoutSizeLimit`
 directive just for endpoints for which size verification should not be performed.
 
+@@@ warning { title="Caution" }
+Usage of `withoutSizeLimit` is not recommended as it turns off the too large payload protection. Therefore, we highly 
+encourage using `withSizeLimit` instead, providing it with a value high enough to successfully handle the 
+route in need of big entities.
+@@@
+
 See also @ref[withSizeLimit](withSizeLimit.md#withsizelimit) for setting request entity size limit.
 
 ## Example


### PR DESCRIPTION
Issue: #814
Add Warning and note on Scala/Java Doc so people see the risks of using withoutSizeLimit