### PR TITLE
Provide access to materialized value from websocket server https://gi…

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
@@ -5,16 +5,20 @@
 package akka.http.javadsl.model.ws
 
 import java.lang.{ Iterable ⇒ JIterable }
+
+import akka.annotation.DoNotInherit
 import akka.http.scaladsl.{ model ⇒ sm }
 import akka.http.javadsl.model._
 import akka.japi.Pair
 import akka.stream._
+
 import scala.concurrent.Future
 
 /**
  * A virtual header that WebSocket requests will contain. Use [[UpgradeToWebSocket.handleMessagesWith]] to
  * create a WebSocket handshake response and handle the WebSocket message stream with the given handler.
  */
+@DoNotInherit
 trait UpgradeToWebSocket extends sm.HttpHeader {
   /**
    * Returns the sequence of protocols the client accepts.

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
@@ -7,8 +7,9 @@ package akka.http.javadsl.model.ws
 import java.lang.{ Iterable ⇒ JIterable }
 import akka.http.scaladsl.{ model ⇒ sm }
 import akka.http.javadsl.model._
-
+import akka.japi.Pair
 import akka.stream._
+import scala.concurrent.Future
 
 /**
  * A virtual header that WebSocket requests will contain. Use [[UpgradeToWebSocket.handleMessagesWith]] to
@@ -48,4 +49,13 @@ trait UpgradeToWebSocket extends sm.HttpHeader {
    * The given subprotocol must be one of the ones offered by the client.
    */
   def handleMessagesWith(inSink: Graph[SinkShape[Message], _ <: Any], outSource: Graph[SourceShape[Message], _ <: Any], subprotocol: String): HttpResponse
+
+  /**
+   * Returns a response that can be used to answer a WebSocket handshake request, as well as a future materialized value.
+   * The connection will afterwards use the given handlerFlow to handle WebSocket messages from the client. The given
+   * subprotocol must be one of the ones offered by the client.
+   */
+  def handleMessagesWithMat[Mat](
+    handlerFlow: Graph[FlowShape[Message, Message], Mat],
+    subprotocol: String): Pair[HttpResponse, Future[Mat]]
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocket.scala
@@ -7,6 +7,9 @@ package akka.http.javadsl.model.ws
 import akka.stream.javadsl.Flow
 import akka.http.javadsl.model._
 import akka.http.impl.util.JavaMapping.Implicits._
+import akka.japi.Pair
+import akka.stream.{ FlowShape, Graph }
+import scala.concurrent.Future
 
 object WebSocket {
   /**
@@ -18,5 +21,22 @@ object WebSocket {
     request.asScala.header[UpgradeToWebSocket] match {
       case Some(header) ⇒ header.handleMessagesWith(handler)
       case None         ⇒ HttpResponse.create().withStatus(StatusCodes.BAD_REQUEST).withEntity("Expected WebSocket request")
+    }
+
+  /**
+   * If a given request is a WebSocket request a response accepting the request is returned using the given handler to
+   * handle the WebSocket message stream, as well as a future materialized value. If the request wasn't a WebSocket
+   * request a response with status code 400 is returned, as well as a failed future.
+   */
+  def handleWebSocketRequestWithMat[Mat](
+    request:     HttpRequest,
+    handler:     Graph[FlowShape[Message, Message], Mat],
+    subprotocol: String): Pair[HttpResponse, Future[Mat]] =
+    request.asScala.header[UpgradeToWebSocket] match {
+      case Some(header) ⇒ header.handleMessagesWithMat(handler, subprotocol)
+      case None ⇒ {
+        val httpResponse = HttpResponse.create().withStatus(StatusCodes.BAD_REQUEST).withEntity("Expected WebSocket request")
+        Pair(httpResponse, Future.failed(new IllegalStateException("Expected WebSocket request")))
+      }
     }
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
@@ -69,7 +69,7 @@ trait UpgradeToWebSocket extends jm.ws.UpgradeToWebSocket {
    */
   def handleMessagesWithMat[Mat](
     handlerFlow: Graph[FlowShape[Message, Message], Mat],
-    subprotocol: Option[String] = None): (HttpResponse, Future[Mat]) = {
+    subprotocol: Option[String]                          = None): (HttpResponse, Future[Mat]) = {
     val promise = Promise[Mat]
     val response = handleMessages(Flow.fromGraph(handlerFlow).mapMaterializedValue(mat ⇒ promise.success(mat)), subprotocol)
     (response, promise.future)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
@@ -5,14 +5,17 @@
 package akka.http.scaladsl.model.ws
 
 import java.lang.Iterable
+
 import scala.collection.immutable
 import akka.NotUsed
+import akka.annotation.DoNotInherit
 import akka.stream._
 import akka.http.impl.util.JavaMapping
 import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.scaladsl.model.HttpResponse
 import akka.japi.Pair
 import akka.stream.scaladsl.Flow
+
 import scala.concurrent.{ Future, Promise }
 
 /**
@@ -20,6 +23,7 @@ import scala.concurrent.{ Future, Promise }
  * enables a request handler to upgrade this connection to a WebSocket connection and
  * registers a WebSocket handler.
  */
+@DoNotInherit
 trait UpgradeToWebSocket extends jm.ws.UpgradeToWebSocket {
   /**
    * A sequence of protocols the client accepts.

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
@@ -11,6 +11,9 @@ import akka.stream._
 import akka.http.impl.util.JavaMapping
 import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.scaladsl.model.HttpResponse
+import akka.japi.Pair
+import akka.stream.scaladsl.Flow
+import scala.concurrent.{ Future, Promise }
 
 /**
  * A custom header that will be added to an WebSocket upgrade HttpRequest that
@@ -54,6 +57,24 @@ trait UpgradeToWebSocket extends jm.ws.UpgradeToWebSocket {
     subprotocol: Option[String]                   = None): HttpResponse =
     handleMessages(scaladsl.Flow.fromSinkAndSource(inSink, outSource), subprotocol)
 
+  /**
+   * The high-level interface to create a WebSocket server based on "messages".
+   *
+   * Returns a response to return in a request handler that will signal the
+   * low-level HTTP implementation to upgrade the connection to WebSocket and
+   * use the supplied handler to handle incoming WebSocket messages, as well as
+   * the future of the materialized value.
+   *
+   * Optionally, a subprotocol out of the ones requested by the client can be chosen.
+   */
+  def handleMessagesWithMat[Mat](
+    handlerFlow: Graph[FlowShape[Message, Message], Mat],
+    subprotocol: Option[String] = None): (HttpResponse, Future[Mat]) = {
+    val promise = Promise[Mat]
+    val response = handleMessages(Flow.fromGraph(handlerFlow).mapMaterializedValue(mat ⇒ promise.success(mat)), subprotocol)
+    (response, promise.future)
+  }
+
   import scala.collection.JavaConverters._
 
   /**
@@ -87,6 +108,24 @@ trait UpgradeToWebSocket extends jm.ws.UpgradeToWebSocket {
     outSource:   Graph[SourceShape[jm.ws.Message], _ <: Any],
     subprotocol: String): HttpResponse =
     handleMessages(createScalaFlow(inSink, outSource), subprotocol = Some(subprotocol))
+
+  /**
+   * Java API
+   */
+  def handleMessagesWithMat[Mat](handlerFlow: Graph[FlowShape[jm.ws.Message, jm.ws.Message], Mat]): Pair[jm.HttpResponse, Future[Mat]] = {
+    val tuple = handleMessagesWithMat(JavaMapping.toScala(handlerFlow))
+    Pair(tuple._1, tuple._2)
+  }
+
+  /**
+   * Java API
+   */
+  def handleMessagesWithMat[Mat](
+    handlerFlow: Graph[FlowShape[jm.ws.Message, jm.ws.Message], Mat],
+    subprotocol: String): Pair[jm.HttpResponse, Future[Mat]] = {
+    val tuple: (HttpResponse, Future[Mat]) = handleMessagesWithMat(JavaMapping.toScala(handlerFlow), subprotocol = Some(subprotocol))
+    Pair(tuple._1, tuple._2)
+  }
 
   private[this] def createScalaFlow(inSink: Graph[SinkShape[jm.ws.Message], _ <: Any], outSource: Graph[SourceShape[jm.ws.Message], _ <: Any]): Graph[FlowShape[Message, Message], NotUsed] =
     JavaMapping.toScala(scaladsl.Flow.fromSinkAndSourceMat(inSink, outSource)(scaladsl.Keep.none): Graph[FlowShape[jm.ws.Message, jm.ws.Message], NotUsed])

--- a/akka-http/src/main/mima-filters/10.0.6.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.0.6.backwards.excludes
@@ -7,3 +7,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.server.Ht
 
 # Path ignore trailing slash #880 (Trait is not expected to be implemented by third-parties)
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.PathDirectives.ignoreTrailingSlash")
+
+# handleMessagesWithMat method not meant to be extended by end users #1167
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.ws.UpgradeToWebSocket.handleMessagesWithMat")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ws.UpgradeToWebSocket.handleMessagesWithMat")


### PR DESCRIPTION
https://github.com/akka/akka-http/issues/1167

* Modify the Websocket object, as well as the UpgradeToWebSocket traits (Scala + Java DSLs) to
  return a future of the materialized view, along with the HttpResponse