### PR TITLE
=htt #1222 improve test case to test fixed behavior

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
@@ -11,13 +11,12 @@ import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.impl.util.JavaMapping.Implicits._
 
 final case class ContentTypeRange(mediaRange: MediaRange, charsetRange: HttpCharsetRange) extends jm.ContentTypeRange with ValueRenderable {
-  def matches(contentType: jm.ContentType) = {
+  def matches(contentType: jm.ContentType) =
     convertToScala(contentType) match {
       case ContentType.Binary(mt)             ⇒ mediaRange.matches(mt)
       case ContentType.WithMissingCharset(mt) ⇒ mediaRange.matches(mt)
       case x: ContentType.NonBinary           ⇒ mediaRange.matches(x.mediaType) && charsetRange.matches(x.charset)
     }
-  }
 
   def render[R <: Rendering](r: R): r.type = charsetRange match {
     case HttpCharsetRange.`*` ⇒ r ~~ mediaRange
@@ -70,13 +69,13 @@ object ContentType {
   }
 
   /** Represents a content-type which we know to contain text, where the charset always has the same predefined value. */
-  final case class WithFixedCharset(val mediaType: MediaType.WithFixedCharset)
+  final case class WithFixedCharset(mediaType: MediaType.WithFixedCharset)
     extends jm.ContentType.WithFixedCharset with NonBinary {
     def charset = mediaType.charset
   }
 
   /** Represents a content-type which we know to contain text, and the charset is known at runtime. */
-  final case class WithCharset(val mediaType: MediaType.WithOpenCharset, val charset: HttpCharset)
+  final case class WithCharset(mediaType: MediaType.WithOpenCharset, charset: HttpCharset)
     extends jm.ContentType.WithCharset with NonBinary {
 
     private[http] override def render[R <: Rendering](r: R): r.type =

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -76,9 +76,9 @@ class UnmarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll wi
   }
 
   "Unmarshaller.forContentTypes" - {
-    "forContentTypes should handle media ranges of types with missing charset" in {
-      val um = Unmarshaller.byteArrayUnmarshaller.forContentTypes(MediaTypes.`text/plain`)
-      Await.result(um(HttpEntity("Hello")), 1.second.dilated) should ===("Hello".getBytes)
+    "should handle media ranges of types with missing charset by assuming UTF-8 charset when matching" in {
+      val um = Unmarshaller.stringUnmarshaller.forContentTypes(MediaTypes.`text/plain`)
+      Await.result(um(HttpEntity(MediaTypes.`text/plain`.withMissingCharset, "Hêllö".getBytes("utf-8"))), 1.second.dilated) should ===("Hêllö")
     }
   }
 


### PR DESCRIPTION
Follow up for #1223 to actually test the behavior that the unmarshaller will match a `WithMissingCharset` content-type and assume UTF-8.

/cc @jypma 