### PR TITLE
HttpResponseParser - add parsing for status codes without reason (#1251)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
@@ -108,6 +108,7 @@ private[http] class HttpResponseParser(protected val settings: ParserSettings, p
           maxResponseReasonLength + " characters")
       skipReason(startIdx)
     } else if (isNewLine(cursor + 3)) {
+      parseStatusCode()
       // Status format with no reason phrase and no trailing space accepted, diverging from the spec
       // See https://github.com/akka/akka-http/pull/989
       skipNewLine(cursor + 3)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -85,12 +85,12 @@ abstract class ResponseParserSpec(mode: String, newLine: String) extends FreeSpe
       }
 
       "a response with a missing reason phrase" in new Test {
-        s"HTTP/1.1 200 ${newLine}Content-Length: 0${newLine}${newLine}" should parseTo(HttpResponse(OK))
+        s"HTTP/1.1 404 ${newLine}Content-Length: 0${newLine}${newLine}" should parseTo(HttpResponse(NotFound))
         closeAfterResponseCompletion shouldEqual Seq(false)
       }
 
       "a response with no reason phrase and no trailing space" in new Test {
-        s"""HTTP/1.1 200${newLine}Content-Length: 0${newLine}${newLine}""".stripMargin should parseTo(HEAD, HttpResponse())
+        s"""HTTP/1.1 404${newLine}Content-Length: 0${newLine}${newLine}""".stripMargin should parseTo(HEAD, HttpResponse(NotFound))
         closeAfterResponseCompletion shouldEqual Seq(false)
       }
 


### PR DESCRIPTION
Fixed #1251 and updated tests to use non-default status code 