### PR TITLE
The scaladsl route seal example was leaking an actor system

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/RouteSealExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/RouteSealExampleSpec.scala
@@ -10,17 +10,20 @@ import docs.CompileOnlySpec
 
 class RouteSealExampleSpec extends RoutingSpec with Directives with CompileOnlySpec {
 
-  compileOnlySpec {
+  "seal route example" in compileOnlySpec {
     //#route-seal-example
     val route = respondWithHeader(RawHeader("special-header", "you always have this even in 404")) {
       Route.seal(
         get {
           pathSingleSlash {
-            complete { "Captain on the bridge!" }
+            complete {
+              "Captain on the bridge!"
+            }
           }
         }
       )
     }
     //#route-seal-example
   }
+
 }


### PR DESCRIPTION
Which in turn would hang the entire test suite