### PR TITLE
Preserve the order of repeated parameters when retrieving query string as a multimap

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -574,6 +574,22 @@ object Uri {
         if (q.isEmpty) map else append(map.updated(q.key, q.value), q.tail)
       append(Map.empty, this)
     }
+
+    /**
+     * Returns this query as a map where keys can have multiple values. The parameter order is
+     * preserved, so that the following query:
+     *
+     * {{{
+     *   a=1&a=2&a=3&a=4&b=1
+     * }}}
+     *
+     * Will return a map like:
+     *
+     * {{{
+     *   "a" -> List(1, 2, 3, 4),
+     *   "b" -> List(1)
+     * }}}
+     */
     def toMultiMap: Map[String, List[String]] = {
       @tailrec def append(map: Map[String, List[String]], q: Query): Map[String, List[String]] =
         if (q.isEmpty) map else append(map.updated(q.key, map.getOrElse(q.key, Nil) :+ q.value), q.tail)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -576,7 +576,7 @@ object Uri {
     }
     def toMultiMap: Map[String, List[String]] = {
       @tailrec def append(map: Map[String, List[String]], q: Query): Map[String, List[String]] =
-        if (q.isEmpty) map else append(map.updated(q.key, q.value :: map.getOrElse(q.key, Nil)), q.tail)
+        if (q.isEmpty) map else append(map.updated(q.key, map.getOrElse(q.key, Nil) :+ q.value), q.tail)
       append(Map.empty, this)
     }
     override def newBuilder: mutable.Builder[(String, String), Query] = Query.newBuilder

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -405,9 +405,13 @@ class UriSpec extends WordSpec with Matchers {
       query.getAll("b") shouldEqual List("", "4", "2")
       query.getAll("d") shouldEqual Nil
       query.toMap shouldEqual Map("a" → "1", "b" → "", "c" → "3")
-      query.toMultiMap shouldEqual Map("a" → List("1"), "b" → List("", "4", "2"), "c" → List("3"))
+      query.toMultiMap shouldEqual Map("a" → List("1"), "b" → List("2", "4", ""), "c" → List("3"))
       query.toList shouldEqual List("a" → "1", "b" → "2", "c" → "3", "b" → "4", "b" → "")
       query.toSeq shouldEqual Seq("a" → "1", "b" → "2", "c" → "3", "b" → "4", "b" → "")
+    }
+    "preserve the order of repeated parameters when retrieving as a multimap" in {
+      val query = Query("a=1&b=1&b=2&b=3&b=4&c=1")
+      query.toMultiMap shouldEqual Map("a" → List("1"), "b" → List("1", "2", "3", "4"), "c" → List("1"))
     }
     "support conversion from list of name/value pairs" in {
       import Query._


### PR DESCRIPTION
While I couldn't find any saying in RFC3986, I think this is better than using the reverse order.

See playframework/playframework#7567