### PR TITLE
Issue #1271 - Provide Dilated Timeouts for Java Testkit.

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/RouteTest.scala
@@ -22,6 +22,7 @@ import akka.http.scaladsl.server.{ ExceptionHandler, Route ⇒ ScalaRoute }
 import akka.http.scaladsl.settings.RoutingSettings
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.Materializer
+import akka.testkit.TestDuration
 
 /**
  * A base class to create route tests for testing libraries. An implementation needs to provide
@@ -34,7 +35,7 @@ abstract class RouteTest extends AllDirectives with WSTestRequestBuilding {
   implicit def materializer: Materializer
   implicit def executionContext: ExecutionContextExecutor = system.dispatcher
 
-  protected def awaitDuration: FiniteDuration = 3.seconds
+  protected def awaitDuration: FiniteDuration = 3.seconds.dilated
 
   protected def defaultHostInfo: DefaultHostInfo = DefaultHostInfo(Host.create("example.com"), false)
 


### PR DESCRIPTION
Fix for #1271.