### PR TITLE
Added SSE client timeout

### DIFF
--- a/akka-http/src/main/mima-filters/10.0.9.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.0.9.backwards.excludes
@@ -1,0 +1,4 @@
+
+# Provide timeout for SSE unmarshalling in #1279, ok because trait is marked @ApiMayChange
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.unmarshalling.sse.EventStreamUnmarshalling.fromEventStreamWithTimeout$default$1")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.unmarshalling.sse.EventStreamUnmarshalling.fromEventStreamWithTimeout")

--- a/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/sse/EventStreamUnmarshalling.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/sse/EventStreamUnmarshalling.scala
@@ -11,6 +11,7 @@ import akka.NotUsed
 import akka.http.javadsl.model.HttpEntity
 import akka.http.javadsl.model.sse.ServerSentEvent
 import akka.stream.javadsl.Source
+import akka.util.Timeout
 
 /**
  * Using `fromEventStream` lets a `HttpEntity` with a `text/event-stream` media type be unmarshalled to a source of
@@ -21,8 +22,31 @@ object EventStreamUnmarshalling {
   /**
    * Lets a `HttpEntity` with a `text/event-stream` media type be unmarshalled to a source of `ServerSentEvent`s.
    */
+  @deprecated("Use fromEventStreamWithTimeout", "10.0.10")
   val fromEventStream: Unmarshaller[HttpEntity, Source[ServerSentEvent, NotUsed]] =
     scaladsl.unmarshalling.sse.EventStreamUnmarshalling.fromEventStream
       .map(_.map(_.asInstanceOf[ServerSentEvent]).asJava)
       .asInstanceOf[Unmarshaller[HttpEntity, Source[ServerSentEvent, NotUsed]]]
+
+  /**
+   * Lets a `HttpEntity` with a `text/event-stream` media type be unmarshalled to a source of `ServerSentEvent`s.
+   *
+   * @param idleTimeout How long the connection should be allowed to be idle for before the connection is failed.
+   */
+  def fromEventStreamWithTimeout(idleTimeout: Timeout) = {
+    scaladsl.unmarshalling.sse.EventStreamUnmarshalling.fromEventStreamWithTimeout(idleTimeout)
+      .map(_.map(_.asInstanceOf[ServerSentEvent]).asJava)
+      .asInstanceOf[Unmarshaller[HttpEntity, Source[ServerSentEvent, NotUsed]]]
+  }
+
+  /**
+   * Lets a `HttpEntity` with a `text/event-stream` media type be unmarshalled to a source of `ServerSentEvent`s.
+   *
+   * Will shutdown the connection if the server doesn't send any events or heartbeats for 60 seconds.
+   */
+  def fromEventStreamWithTimeout() = {
+    scaladsl.unmarshalling.sse.EventStreamUnmarshalling.fromEventStreamWithTimeout
+      .map(_.map(_.asInstanceOf[ServerSentEvent]).asJava)
+      .asInstanceOf[Unmarshaller[HttpEntity, Source[ServerSentEvent, NotUsed]]]
+  }
 }


### PR DESCRIPTION
Fixes #1279

Note I made the timeout compulsory, even if a server doesn't send heartbeats, it is better to close the connection every so often and reconnect than to leak a connection when network partitions happen.

Binary and source compatability have been maintained.