### PR TITLE
Add release step to communicate merge halt before releasing

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,20 +1,20 @@
 ## Releasing
-
-1. Add a release notes entry in docs/src/main/paradox/release-notes.md. As a helper run
+1. Communicate that a release is about to be released in [Gitter Akka Dev Channel](https://gitter.im/akka/dev), so that no new Pull Requests are merged
+2. Add a release notes entry in docs/src/main/paradox/release-notes.md. As a helper run
 `scripts/commits-for-release-notes.sh <last-version-tag>` which will output a list of commits grouped by submodule.
-2. Once the release notes have been merged, create a [new release](https://github.com/akka/akka-http/releases/new) with the next tag version (e.g. `v13.3.7`), title and release description including notable changes mentioning external contributors.
-3. Travis CI will start a [CI build](https://travis-ci.org/akka/akka-http/builds) for the new tag and publish artifacts to Bintray and will sync them to Maven Central.
-4. Checkout the newly created tag and run `sbt -Dakka.genjavadoc.enabled=true "++2.12.2 deployRsync repo.akka.io"` to deploy API and reference documentation.
-5. Go to https://bintray.com/akka/maven/com.typesafe.akka:akka-http_2.11 and select the just released version
-6. Go to the Maven Central tab and sync with Sonatype
+3. Once the release notes have been merged, create a [new release](https://github.com/akka/akka-http/releases/new) with the next tag version (e.g. `v13.3.7`), title and release description including notable changes mentioning external contributors.
+4. Travis CI will start a [CI build](https://travis-ci.org/akka/akka-http/builds) for the new tag and publish artifacts to Bintray and will sync them to Maven Central.
+5. Checkout the newly created tag and run `sbt -Dakka.genjavadoc.enabled=true "++2.12.2 deployRsync repo.akka.io"` to deploy API and reference documentation.
+6. Go to https://bintray.com/akka/maven/com.typesafe.akka:akka-http_2.11 and select the just released version
+7. Go to the Maven Central tab and sync with Sonatype
    - (Optional, should happen automatically if selected in Bintray) Log in to Sonatype to Close the staging repository
    - Run a test against the staging repository to make sure the release went well, for examply by using https://github.com/akka/akka-http-scala-seed.g8 and adding the sonatype staging repo with `resolvers += "Staging Repo" at "https://oss.sonatype.org/content/repositories/comtypesafe-xxx"`
    - Release the staging repository to Maven Central.
-7. Create a new milestone for the next version at https://github.com/akka/akka-http/milestones, move all unclosed issues there and close the version you're releasing
-8. Create a news item on https://github.com/akka/akka.github.com, using the milestones and `scripts/authors.scala previousVersion thisVersion`
-9. Add the released version to `project/MiMa.scala` to the `mimaPreviousArtifacts` key.
-10. Send a release notification to akka-user and tweet using the akka account (or ask someone to) about the new release
-11. Log into repo.akka.io and update the `current` links on repo.akka.io to point to the latest version with `ln -nsf <latestversion> www/docs/akka-http/current; ln -nsf <latestversion> www/api/akka-http/current; ln -nsf <latestversion> www/japi/akka-http/current`.
+8. Create a new milestone for the next version at https://github.com/akka/akka-http/milestones, move all unclosed issues there and close the version you're releasing
+9. Create a news item on https://github.com/akka/akka.github.com, using the milestones and `scripts/authors.scala previousVersion thisVersion`
+10. Add the released version to `project/MiMa.scala` to the `mimaPreviousArtifacts` key.
+11. Send a release notification to akka-user and tweet using the akka account (or ask someone to) about the new release
+12. Log into repo.akka.io and update the `current` links on repo.akka.io to point to the latest version with `ln -nsf <latestversion> www/docs/akka-http/current; ln -nsf <latestversion> www/api/akka-http/current; ln -nsf <latestversion> www/japi/akka-http/current`.
 
 ### Follow up steps
 


### PR DESCRIPTION
I thought it might be a good idea to communicate the intention to release a new version on the Gitter Akka Dev Channel, so nobody is merging unexpected Pull Requests.