### PR TITLE
Http2 inbound flow control

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.9.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.9.backwards.excludes
@@ -1,3 +1,5 @@
+# Mima filters needed to check newer versions against 10.0.9
+
 # Changes allow for adding proxy auth headers to the client transport.
 # Changes allow for backwards compatibility when auth is not needed. Most changes are to internal classes only.
 ProblemFilters.exclude[MissingTypesProblem]("akka.http.scaladsl.ClientTransport$HttpsProxyTransport$")
@@ -5,3 +7,9 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.ClientTra
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.ClientTransport#HttpsProxyTransport.copy")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.client.HttpsProxyGraphStage.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.client.HttpsProxyGraphStage.apply")
+
+# added new Http2Settings
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ServerSettings.http2Settings")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.apply")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -165,6 +165,37 @@ akka.http {
     # `off` : no log messages are produced
     # Int   : determines how many bytes should be logged per data chunk
     log-unencrypted-network-bytes = off
+
+    http2 {
+      # The maximum number of bytes to receive from a request entity in a single chunk.
+      #
+      # The reasoning to limit that amount (instead of delivering all buffered data for a stream) is that
+      # the amount of data in the internal buffers will drive backpressure and flow control on the HTTP/2 level. Bigger
+      # chunks would mean that the user-level entity reader will have to buffer all that data if it cannot read it in one
+      # go. The implementation would not be able to backpressure further data in that case because it does not know about
+      # this user-level buffer.
+      request-entity-chunk-size = 65536 b
+
+      # The number of request data bytes the HTTP/2 implementation is allowed to buffer internally per connection. Free
+      # space in this buffer is communicated to the peer using HTTP/2 flow-control messages to backpressure data if it
+      # isn't read fast enough.
+      #
+      # When there is no backpressure, this amount will limit the amount of in-flight data. It might need to be increased
+      # for high bandwidth-delay-product connections.
+      #
+      # There is a relation between the `incoming-connection-level-buffer-size` and the `incoming-stream-level-buffer-size`:
+      # If incoming-connection-level-buffer-size < incoming-stream-level-buffer-size * number_of_streams, then
+      # head-of-line blocking is possible between different streams on the same connection.
+      incoming-connection-level-buffer-size = 10 MB
+
+      # The number of request data bytes the HTTP/2 implementation is allowed to buffer internally per stream. Free space
+      # in this buffer is communicated to the peer using HTTP/2 flow-control messages to backpressure data if it isn't
+      # read fast enough.
+      #
+      # When there is no backpressure, this amount will limit the amount of in-flight data per stream. It might need to
+      # be increased for high bandwidth-delay-product connections.
+      incoming-stream-level-buffer-size = 512kB
+    }
   }
 
   client {

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
@@ -7,7 +7,7 @@ package akka.http.impl.settings
 import java.util.Random
 
 import akka.http.impl.engine.ws.Randoms
-import akka.http.scaladsl.settings.{ ParserSettings, PreviewServerSettings, ServerSettings }
+import akka.http.scaladsl.settings.{ Http2ServerSettings, ParserSettings, PreviewServerSettings, ServerSettings }
 import com.typesafe.config.Config
 
 import scala.language.implicitConversions
@@ -40,7 +40,8 @@ private[akka] final case class ServerSettingsImpl(
   socketOptions:              immutable.Seq[SocketOption],
   defaultHostHeader:          Host,
   websocketRandomFactory:     () ⇒ Random,
-  parserSettings:             ParserSettings) extends ServerSettings {
+  parserSettings:             ParserSettings,
+  http2Settings:              Http2ServerSettings) extends ServerSettings {
 
   require(0 < maxConnections, "max-connections must be > 0")
   require(0 < pipeliningLimit && pipeliningLimit <= 1024, "pipelining-limit must be > 0 and <= 1024")
@@ -92,5 +93,6 @@ private[http] object ServerSettingsImpl extends SettingsCompanion[ServerSettings
           throw new ConfigurationException(info.formatPretty)
       },
     Randoms.SecureRandomInstances, // can currently only be overridden from code
-    ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing")))
+    ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing")),
+    Http2ServerSettings.Http2ServerSettingsImpl.fromSubConfig(root, c.getConfig("http2")))
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
@@ -194,6 +194,7 @@ private[http] object JavaMapping {
   implicit object ServerSettings extends Inherited[js.ServerSettings, akka.http.scaladsl.settings.ServerSettings]
   implicit object PreviewServerSettings extends Inherited[js.PreviewServerSettings, akka.http.scaladsl.settings.PreviewServerSettings]
   implicit object ServerSettingsT extends Inherited[js.ServerSettings.Timeouts, akka.http.scaladsl.settings.ServerSettings.Timeouts]
+  implicit object Http2ServerSettingT extends Inherited[js.Http2ServerSettings, akka.http.scaladsl.settings.Http2ServerSettings]
 
   implicit object OutgoingConnection extends JavaMapping[jdsl.OutgoingConnection, sdsl.Http.OutgoingConnection] {
     def toScala(javaObject: jdsl.OutgoingConnection): sdsl.Http.OutgoingConnection = javaObject.delegate

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.javadsl.settings
+
+import akka.http.scaladsl
+import com.typesafe.config.Config
+
+trait Http2ServerSettings { self: scaladsl.settings.Http2ServerSettings ⇒
+  def getRequestEntityChunkSize: Int = requestEntityChunkSize
+  def withRequestEntityChunkSize(newRequestEntityChunkSize: Int): Http2ServerSettings
+
+  def getIncomingConnectionLevelBufferSize: Int = incomingConnectionLevelBufferSize
+  def withIncomingConnectionLevelBufferSize(newIncomingConnectionLevelBufferSize: Int): Http2ServerSettings
+
+  def getIncomingStreamLevelBufferSize: Int = incomingStreamLevelBufferSize
+  def withIncomingStreamLevelBufferSize(newIncomingStreamLevelBufferSize: Int): Http2ServerSettings
+}
+object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
+  def create(config: Config): Http2ServerSettings = scaladsl.settings.Http2ServerSettings(config)
+  def create(configOverrides: String): Http2ServerSettings = scaladsl.settings.Http2ServerSettings(configOverrides)
+}

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
@@ -39,6 +39,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def getWebsocketRandomFactory: java.util.function.Supplier[Random]
   def getParserSettings: ParserSettings
   def getLogUnencryptedNetworkBytes: Optional[Int]
+  def getHttp2Settings: Http2ServerSettings = self.http2Settings
 
   // ---
 
@@ -58,7 +59,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue.asScala)
   def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketRandomFactory = () ⇒ newValue.get())
   def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ServerSettings = self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
-
+  def withHttp2Settings(newValue: Http2ServerSettings): ServerSettings = self.copy(http2Settings = newValue.asScala)
 }
 
 object ServerSettings extends SettingsCompanion[ServerSettings] {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.settings
+
+import akka.annotation.{ ApiMayChange, InternalApi }
+import akka.http.javadsl
+import akka.http.impl.util._
+import com.typesafe.config.Config
+
+/**
+ * Placeholder for any kind of internal settings that might be interesting for HTTP/2 (like custom strategies)
+ */
+@InternalApi
+private[http] trait Http2InternalServerSettings
+
+@ApiMayChange
+trait Http2ServerSettings extends javadsl.settings.Http2ServerSettings { self: Http2ServerSettings.Http2ServerSettingsImpl ⇒
+  def requestEntityChunkSize: Int
+  def withRequestEntityChunkSize(newValue: Int): Http2ServerSettings =
+    copy(requestEntityChunkSize = newValue)
+
+  def incomingConnectionLevelBufferSize: Int
+  def withIncomingConnectionLevelBufferSize(newValue: Int): Http2ServerSettings =
+    copy(incomingConnectionLevelBufferSize = newValue)
+
+  def incomingStreamLevelBufferSize: Int
+  def withIncomingStreamLevelBufferSize(newValue: Int): Http2ServerSettings =
+    copy(incomingStreamLevelBufferSize = newValue)
+
+  @InternalApi
+  private[http] def internalSettings: Option[Http2InternalServerSettings]
+  @InternalApi
+  private[http] def withInternalSettings(newValue: Http2InternalServerSettings): Http2ServerSettings =
+    copy(internalSettings = Some(newValue))
+}
+
+@ApiMayChange
+object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
+  def apply(config: Config): Http2ServerSettings = Http2ServerSettingsImpl(config)
+  def apply(configOverrides: String): Http2ServerSettings = Http2ServerSettingsImpl(configOverrides)
+
+  private[http] case class Http2ServerSettingsImpl(
+    requestEntityChunkSize:            Int,
+    incomingConnectionLevelBufferSize: Int,
+    incomingStreamLevelBufferSize:     Int,
+    internalSettings:                  Option[Http2InternalServerSettings])
+    extends Http2ServerSettings {
+    require(requestEntityChunkSize > 0, "request-entity-chunk-size must be > 0")
+    require(incomingConnectionLevelBufferSize > 0, "incoming-connection-level-buffer-size must be > 0")
+    require(incomingStreamLevelBufferSize > 0, "incoming-stream-level-buffer-size must be > 0")
+  }
+
+  private[http] object Http2ServerSettingsImpl extends akka.http.impl.util.SettingsCompanion[Http2ServerSettingsImpl]("akka.http.server.http2") {
+    def fromSubConfig(root: Config, c: Config): Http2ServerSettingsImpl = Http2ServerSettingsImpl(
+      requestEntityChunkSize = c getIntBytes "request-entity-chunk-size",
+      incomingConnectionLevelBufferSize = c getIntBytes "incoming-connection-level-buffer-size",
+      incomingStreamLevelBufferSize = c getIntBytes "incoming-stream-level-buffer-size",
+      None // no possibility to configure internal settings with config
+    )
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -43,6 +43,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def websocketRandomFactory: () ⇒ Random
   def parserSettings: ParserSettings
   def logUnencryptedNetworkBytes: Option[Int]
+  def http2Settings: Http2ServerSettings
 
   /* Java APIs */
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
@@ -35,6 +35,8 @@ private[http] trait ByteStringSinkProbe {
   def ensureSubscription(): Unit
   def request(n: Long): Unit
   def cancel(): Unit
+
+  def within[T](max: FiniteDuration)(f: ⇒ T): T
 }
 
 /** INTERNAL API */
@@ -87,5 +89,7 @@ private[http] object ByteStringSinkProbe {
       def ensureSubscription(): Unit = probe.ensureSubscription()
       def request(n: Long): Unit = probe.request(n)
       def cancel(): Unit = probe.cancel()
+
+      def within[T](max: FiniteDuration)(f: ⇒ T): T = probe.within(max)(f)
     }
 }

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -24,7 +24,17 @@ final case class GoAwayFrame(lastStreamId: Int, errorCode: ErrorCode, debug: Byt
 final case class DataFrame(
   streamId:  Int,
   endStream: Boolean,
-  payload:   ByteString) extends StreamFrameEvent
+  payload:   ByteString) extends StreamFrameEvent {
+  /**
+   * The amount of bytes this frame consumes of a window. According to RFC 7540, 6.9.1:
+   *
+   *        For flow-control calculations, the 9-octet frame header is not
+   *        counted.
+   *
+   * That means this size amounts to data size + padding size field + padding.
+   */
+  def sizeInWindow: Int = payload.size // FIXME: take padding size into account, #1313
+}
 
 final case class HeadersFrame(
   streamId:            Int,

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -8,22 +8,29 @@ import akka.NotUsed
 import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.scaladsl.model.http2.PeerClosedStreamException
+import akka.http.scaladsl.settings.Http2ServerSettings
 import akka.stream.scaladsl.Source
-import akka.stream.stage.{ GraphStageLogic, StageLogging }
+import akka.stream.stage.{ GraphStageLogic, OutHandler, StageLogging }
 import akka.util.ByteString
 
 import scala.collection.immutable
 
 /** INTERNAL API */
 @InternalApi
-private[http2] trait Http2StreamHandling { self: GraphStageLogic with GenericOutletSupport with StageLogging ⇒
+private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLogging ⇒
   // required API from demux
   def multiplexer: Http2Multiplexer
+  def settings: Http2ServerSettings
   def pushGOAWAY(errorCode: ErrorCode, debug: String): Unit
   def dispatchSubstream(sub: Http2SubStream): Unit
 
+  def flowController: IncomingFlowController = IncomingFlowController.default(settings)
+
   private var incomingStreams = new immutable.TreeMap[Int, IncomingStreamState]
   private var largestIncomingStreamId = 0
+  private var outstandingConnectionLevelWindow = Http2Protocol.InitialWindowSize
+  private var totalBufferedData = 0
+
   private def streamFor(streamId: Int): IncomingStreamState =
     incomingStreams.get(streamId) match {
       case Some(state) ⇒ state
@@ -62,11 +69,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with GenericOut
           if (endStream) (Source.empty, HalfClosedRemote)
           else {
             val subSource = new SubSourceOutlet[ByteString](s"substream-out-$streamId")
-            (Source.fromGraph(subSource.source), Open(new BufferedOutlet[ByteString](subSource) {
-              override def onDownstreamFinish(): Unit =
-                multiplexer.pushControlFrame(RstStreamFrame(streamId, ErrorCode.CANCEL))
-              incomingStreams -= streamId
-            }))
+            (Source.fromGraph(subSource.source), Open(new IncomingStreamBuffer(streamId, subSource)))
           }
 
         // FIXME: after multiplexer PR is merged
@@ -77,18 +80,28 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with GenericOut
       case x ⇒ receivedUnexpectedFrame(x)
     }
   }
-  sealed abstract class ReceivingData(outlet: BufferedOutlet[ByteString], afterEndStreamReceived: IncomingStreamState) extends IncomingStreamState { _: Product ⇒
+  sealed abstract class ReceivingData(afterEndStreamReceived: IncomingStreamState) extends IncomingStreamState { _: Product ⇒
+    protected def buffer: IncomingStreamBuffer
     def handle(event: StreamFrameEvent): IncomingStreamState = event match {
       case d: DataFrame ⇒
-        outlet.push(d.payload)
+        outstandingConnectionLevelWindow -= d.sizeInWindow
+        totalBufferedData += d.payload.size // padding can be seen as instantly discarded
 
-        // FIXME: this completely removes backpressure, data will accumulate in the BufferedOutlet
-        multiplexer.pushControlFrame(WindowUpdateFrame(0, d.payload.size))
-        multiplexer.pushControlFrame(WindowUpdateFrame(d.streamId, d.payload.size))
+        if (outstandingConnectionLevelWindow < 0) {
+          pushGOAWAY(ErrorCode.FLOW_CONTROL_ERROR, "Received more data than connection-level window would allow")
+          Closed
+        } else {
+          val windowSizeIncrement = flowController.onConnectionDataReceived(outstandingConnectionLevelWindow, totalBufferedData)
+          if (windowSizeIncrement > 0) {
+            multiplexer.pushControlFrame(WindowUpdateFrame(Http2Protocol.NoStreamId, windowSizeIncrement))
+            outstandingConnectionLevelWindow += windowSizeIncrement
+          }
 
-        maybeFinishStream(d.endStream)
+          buffer.onDataFrame(d).getOrElse(
+            maybeFinishStream(d.endStream))
+        }
       case r: RstStreamFrame ⇒
-        outlet.fail(new PeerClosedStreamException(r.streamId, r.errorCode))
+        buffer.onRstStreamFrame(r)
         multiplexer.cancelSubStream(r.streamId)
         Closed
 
@@ -96,18 +109,17 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with GenericOut
         // ignored
         log.debug(s"Ignored intermediate HEADERS frame: $h")
 
+        if (h.endStream) buffer.onDataFrame(DataFrame(h.streamId, endStream = true, ByteString.empty)) // simulate end stream by empty dataframe
         maybeFinishStream(h.endStream)
     }
 
     protected def maybeFinishStream(endStream: Boolean): IncomingStreamState =
-      if (endStream) {
-        outlet.complete()
-        afterEndStreamReceived
-      } else this
+      if (endStream) afterEndStreamReceived else this
   }
   // on the incoming side there's (almost) no difference between Open and HalfClosedLocal
-  case class Open(outlet: BufferedOutlet[ByteString]) extends ReceivingData(outlet, HalfClosedRemote)
-  case class HalfClosedLocal(outlet: BufferedOutlet[ByteString]) extends ReceivingData(outlet, Closed)
+  case class Open(buffer: IncomingStreamBuffer) extends ReceivingData(HalfClosedRemote)
+  // currently unused: we never close a stream before the peer does
+  // case class HalfClosedLocal(buffer: Buffer) extends ReceivingData(Closed)
   case object HalfClosedRemote extends IncomingStreamState {
     def handle(event: StreamFrameEvent): IncomingStreamState = event match {
       case r: RstStreamFrame ⇒
@@ -118,6 +130,75 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with GenericOut
   }
   case object Closed extends IncomingStreamState {
     def handle(event: StreamFrameEvent): IncomingStreamState = receivedUnexpectedFrame(event)
+  }
+
+  class IncomingStreamBuffer(streamId: Int, outlet: SubSourceOutlet[ByteString]) extends OutHandler {
+    private var buffer: ByteString = ByteString.empty
+    private var wasClosed: Boolean = false
+    private var outstandingStreamWindow: Int = Http2Protocol.InitialWindowSize // adapt if we negotiate greater sizes by settings
+    outlet.setHandler(this)
+
+    def onPull(): Unit = dispatchNextChunk()
+    override def onDownstreamFinish(): Unit = {
+      multiplexer.pushControlFrame(RstStreamFrame(streamId, ErrorCode.CANCEL))
+      incomingStreams -= streamId
+    }
+
+    def onDataFrame(data: DataFrame): Option[IncomingStreamState] = {
+      if (data.endStream) wasClosed = true
+
+      outstandingStreamWindow -= data.sizeInWindow
+      if (outstandingStreamWindow < 0) {
+        multiplexer.pushControlFrame(RstStreamFrame(streamId, ErrorCode.FLOW_CONTROL_ERROR))
+        // also close response delivery if that has already started
+        multiplexer.cancelSubStream(streamId)
+        Some(Closed)
+      } else {
+        buffer ++= data.payload
+        log.debug(s"Received DATA ${data.sizeInWindow} for stream [$streamId], remaining window space now $outstandingStreamWindow, buffered: ${buffer.size}")
+        dispatchNextChunk()
+        None // don't change state
+      }
+    }
+    def onRstStreamFrame(rst: RstStreamFrame): Unit = {
+      outlet.fail(new PeerClosedStreamException(rst.streamId, rst.errorCode))
+      buffer = ByteString.empty
+      wasClosed = true
+    }
+
+    private def dispatchNextChunk(): Unit = {
+      if (buffer.nonEmpty && outlet.isAvailable) {
+        val dataSize = buffer.size min settings.requestEntityChunkSize
+        outlet.push(buffer.take(dataSize))
+        buffer = buffer.drop(dataSize)
+
+        totalBufferedData -= dataSize
+
+        log.debug(s"Dispatched chunk of $dataSize for stream [$streamId], remaining window space now $outstandingStreamWindow, buffered: ${buffer.size}")
+        updateWindows()
+      }
+      if (buffer.isEmpty && wasClosed) outlet.complete()
+    }
+
+    private def updateWindows(): Unit = {
+      val IncomingFlowController.WindowIncrements(connectionLevel, streamLevel) = flowController.onStreamDataDispatched(
+        outstandingConnectionLevelWindow, totalBufferedData,
+        outstandingStreamWindow, buffer.size)
+
+      if (connectionLevel > 0) {
+        multiplexer.pushControlFrame(WindowUpdateFrame(Http2Protocol.NoStreamId, connectionLevel))
+        outstandingConnectionLevelWindow += connectionLevel
+      }
+      if (streamLevel > 0 && !wasClosed /* No reason to update window on closed streams */ ) {
+        multiplexer.pushControlFrame(WindowUpdateFrame(streamId, streamLevel))
+        outstandingStreamWindow += streamLevel
+      }
+
+      log.debug(
+        s"adjusting con-level window by $connectionLevel, stream-level window by $streamLevel, " +
+          s"remaining window space now $outstandingStreamWindow, buffered: ${buffer.size}, " +
+          s"remaining connection window space now $outstandingConnectionLevelWindow, total buffered: $totalBufferedData")
+    }
   }
 
   // needed once PUSH_PROMISE support was added

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/IncomingFlowController.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/IncomingFlowController.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+
+import akka.annotation.InternalApi
+import akka.http.scaladsl.settings.Http2ServerSettings
+
+/** INTERNAL API */
+@InternalApi
+private[http2] trait IncomingFlowController {
+  def onConnectionDataReceived(outstandingConnectionLevelWindow: Int, totalBufferedData: Int): Int
+
+  def onStreamDataDispatched(outstandingConnectionLevelWindow: Int, totalBufferedData: Int,
+                             outstandingStreamLevelWindow: Int, streamBufferedData: Int): IncomingFlowController.WindowIncrements
+}
+private[http2] object IncomingFlowController {
+  /** INTERNAL API */
+  @InternalApi
+  private[http2] case class WindowIncrements(connectionLevel: Int, streamLevel: Int) {
+    require(connectionLevel >= 0, s"Connection-level window increment must be >= 0 but was $connectionLevel")
+    require(streamLevel >= 0, s"Stream-level window increment must be >= 0 but was $streamLevel")
+  }
+  private[http2] object WindowIncrements {
+    val NoIncrements = WindowIncrements(0, 0)
+  }
+
+  def default(settings: Http2ServerSettings): IncomingFlowController =
+    default(settings.incomingConnectionLevelBufferSize, settings.incomingStreamLevelBufferSize)
+
+  /** The default scheme sends out WINDOW_UPDATE frames when buffered + outstanding data falls below half of the maximum configured size */
+  def default(maximumConnectionLevelWindow: Int, maximumStreamLevelWindow: Int): IncomingFlowController =
+    new IncomingFlowController {
+      def onConnectionDataReceived(outstandingConnectionLevelWindow: Int, totalBufferedData: Int): Int =
+        ifMoreThanHalfUsed(maximumConnectionLevelWindow, outstandingConnectionLevelWindow, totalBufferedData)
+
+      def onStreamDataDispatched(outstandingConnectionLevelWindow: Int, totalBufferedData: Int, outstandingStreamLevelWindow: Int, streamBufferedData: Int): WindowIncrements =
+        WindowIncrements(
+          onConnectionDataReceived(outstandingConnectionLevelWindow, totalBufferedData),
+          ifMoreThanHalfUsed(maximumStreamLevelWindow, outstandingStreamLevelWindow, streamBufferedData)
+        )
+
+      private def ifMoreThanHalfUsed(max: Int, outstanding: Int, buffered: Int): Int = {
+        val totalReservedSpace = outstanding + buffered
+        if (totalReservedSpace < max / 2) max - totalReservedSpace
+        else 0
+      }
+    }
+}

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -10,6 +10,7 @@ import akka.actor.ActorSystem
 import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream._
 import akka.stream.scaladsl.FileIO
 import com.typesafe.config.Config
@@ -56,8 +57,20 @@ object Http2ServerTest extends App {
     case _: HttpRequest                                ⇒ HttpResponse(404, entity = "Unknown resource!")
   }
 
-  val asyncHandler: HttpRequest ⇒ Future[HttpResponse] =
-    req ⇒ Future.successful(syncHandler(req))
+  val asyncHandler: HttpRequest ⇒ Future[HttpResponse] = {
+    case HttpRequest(POST, Uri.Path("/upload"), _, entity, _) ⇒
+      Unmarshal(entity).to[Multipart.FormData]
+        .flatMap { formData ⇒
+          formData.parts.runFoldAsync("") { (msg, part) ⇒
+            part.entity.dataBytes.runFold(0)(_ + _.size)
+              .map(dataSize ⇒ msg + s"${part.name} ${part.filename} $dataSize ${part.entity.contentType} ${part.additionalDispositionParams}\n")
+          }
+        }
+        .map { msg ⇒
+          HttpResponse(entity = s"Got upload: $msg")
+        }
+    case req ⇒ Future.successful(syncHandler(req))
+  }
 
   try {
     val bindings =
@@ -89,6 +102,12 @@ object Http2ServerTest extends App {
         |      <li><a href="/image-page">/image-page</a></li>
         |      <li><a href="/crash">/crash</a></li>
         |    </ul>
+        |    <div>
+        |      <form method="post" enctype="multipart/form-data" action="upload">
+        |        <label for="file">File</label><input type="file" name="file" multiple="true"/><br/>
+        |        <input type="submit" />
+        |      </form>
+        |    </div>
         |  </body>
         |</html>""".stripMargin))
 


### PR DESCRIPTION
The tests pass but the code is not yet in its final shape. A few constants need to be converted to configuration values. There's currently only a simplistics strategy of sending out WINDOW_UPDATE frames. It is configured with maximum values for connection-level and stream-level windows. When outstanding + buffered data falls below half the maximum configured number it sends out a WINDOW_UPDATE frame to the peer.

I think there are a few hard flow-control problems that cannot be easily solved (but putting it in strategies should help experimenting with other ones):
 * If `max-stream-level-window * num_connections > max-connection-level-window`, there can be head-of-line blocking between streams. Since this is only for uploads, it doesn't seem to be a serious concern for now, the client can still prioritize streams in any way it likes.
 * If the [BDP](https://en.wikipedia.org/wiki/Bandwidth-delay_product) is lower than the configured connection-level window, then there will be head-of-line blocking also for control frames (stuck in TCP buffers at the peer). If the BDP is higher than the configured connection-level window, then the full bandwidth will not be used. Any better solution would at least need some way of estimating the real, current but dynamic BDP. This problem is probably as hard as any kind of TCP congestion control. One potential building block could be trying to read the current BDP as estimated by the OS (`tcp_info` structure in Linux).

Refs #737 
