### PR TITLE
=htc #1245 fix pool idle-timeout race condition

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
@@ -53,7 +53,9 @@ private[http] final class PoolGateway(gatewayRef: ActorRef, val hcps: HostConnec
 
   /**
    * Shutdown the corresponding pool and signal its termination. If the pool is not running or is
-   * being shutting down, this does nothing,
+   * being shutting down, this does nothing.
+   *
+   * The shutdown will wait for all ongoing requests to be completed.
    *
    * @return a Future completed when the pool has been shutdown.
    */

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
@@ -73,6 +73,12 @@ private class PoolInterfaceActor(gateway: PoolGateway)(implicit fm: Materializer
   private[this] val inputBuffer = Buffer[PoolRequest](hcps.setup.settings.maxOpenRequests, fm)
   private[this] var activeIdleTimeout: Option[Cancellable] = None
 
+  /*
+   * If true, the pool is shutting down and waiting for ongoing requests to be completed. Requests coming in in this state
+   * will be redispatched through the gateway. Once all requests were handled this pool shuts down itself.
+   */
+  private[this] var shuttingDown: Boolean = false
+
   private[this] val PoolOverflowException = new BufferOverflowException( // stack trace cannot be prevented here because `BufferOverflowException` is final
     s"Exceeded configured max-open-requests value of [${inputBuffer.capacity}]. This means that the request queue of this pool (${gateway.hcps}) " +
       s"has completely filled up because the pool currently does not process requests fast enough to handle the incoming request load. " +
@@ -116,6 +122,11 @@ private class PoolInterfaceActor(gateway: PoolGateway)(implicit fm: Materializer
       rc.responsePromise.complete(responseTry)
       activateIdleTimeoutIfNecessary()
 
+      if (shuttingDown && remainingRequested == 0) {
+        debug("Shutting down host connection pool now after all responses have been dispatched")
+        onCompleteThenStop()
+      }
+
     case OnComplete ⇒ // the pool shut down
       debug("Host connection pool has completed orderly shutdown")
       self ! PoisonPill // give potentially queued requests another chance to be forwarded back to the gateway
@@ -126,7 +137,7 @@ private class PoolInterfaceActor(gateway: PoolGateway)(implicit fm: Materializer
 
     /////////////// FROM CLIENT //////////////
 
-    case x: PoolRequest if isActive ⇒
+    case x: PoolRequest if !shuttingDown ⇒
       activeIdleTimeout foreach { timeout ⇒
         timeout.cancel()
         activeIdleTimeout = None
@@ -141,20 +152,28 @@ private class PoolInterfaceActor(gateway: PoolGateway)(implicit fm: Materializer
           debug(s"InputBuffer (max-open-requests = ${hcps.setup.settings.maxOpenRequests}) now filled with ${inputBuffer.used} request after enqueuing ${x.request.debugString}")
         }
       } else dispatchRequest(x) // if we can dispatch right now, do it
-      request(1) // for every incoming request we demand one response from the pool
 
     case PoolRequest(request, responsePromise) ⇒
       // we have already started shutting down, i.e. this pool is not usable anymore
       // so we forward the request back to the gateway
+      //
+      // TODO: How would that happen? Wouldn't it be a bug if the PoolMasterActor/gateway would dispatch
+      //       more requests to this instance after having sent `Shutdown`?
       responsePromise.completeWith(gateway(request))
 
     case Shutdown ⇒ // signal coming in from gateway
-      debug("Shutting down host connection pool")
-      onCompleteThenStop()
       while (!inputBuffer.isEmpty) {
         val PoolRequest(request, responsePromise) = inputBuffer.dequeue()
         responsePromise.completeWith(gateway(request))
       }
+
+      shuttingDown = true
+
+      if (remainingRequested == 0) {
+        debug("Shutting down host connection pool immediately")
+        onCompleteThenStop()
+      } else
+        debug(s"Deferring shutting down host connection pool until all [$remainingRequested] responses have been dispatched")
   }
 
   @tailrec private def dispatchRequests(): Unit =
@@ -172,6 +191,7 @@ private class PoolInterfaceActor(gateway: PoolGateway)(implicit fm: Materializer
         .withDefaultHeaders(hostHeader)
     val retries = if (pr.request.method.isIdempotent) hcps.setup.settings.maxRetries else 0
     onNext(RequestContext(effectiveRequest, pr.responsePromise, retries))
+    request(1) // for every outgoing request we demand one response from the pool
   }
 
   def activateIdleTimeoutIfNecessary(): Unit =
@@ -182,5 +202,5 @@ private class PoolInterfaceActor(gateway: PoolGateway)(implicit fm: Materializer
     }
 
   private def shouldStopOnIdle(): Boolean =
-    remainingRequested == 0 && hcps.setup.settings.idleTimeout.isFinite && hcps.setup.settings.minConnections == 0
+    !shuttingDown && remainingRequested == 0 && hcps.setup.settings.idleTimeout.isFinite && hcps.setup.settings.minConnections == 0
 }


### PR DESCRIPTION
Previously, a shutdown request didn't check if there are outstanding
requests so that outstanding responses were just lost.

This is still missing tests, but I haven't been able to reproduce it reliably. The reason is that there's only a short time frame where you can hit the race, i.e. while the scheduled `gateway.shutdown` is dispatched through `PoolMasterActor` to `PoolInterfaceActor` a new request must come in.