### PR TITLE
remove '/' from getFromResourceDirectory example

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FileAndResourceDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FileAndResourceDirectivesExamplesSpec.scala
@@ -107,7 +107,7 @@ class FileAndResourceDirectivesExamplesSpec extends RoutingSpec {
     //#getFromResourceDirectory-examples
     val route =
       pathPrefix("examples") {
-        getFromResourceDirectory("/examples")
+        getFromResourceDirectory("examples")
       }
 
     // tests:


### PR DESCRIPTION
with '/', it is not working at lastest version (2.11 / 10.0.9)