### PR TITLE
=doc #1290 Link client-side docs at the directory level

### DIFF
--- a/docs/src/main/paradox/java/http/client-side
+++ b/docs/src/main/paradox/java/http/client-side
@@ -1,0 +1,1 @@
+../../scala/http/client-side

--- a/docs/src/main/paradox/java/http/client-side/client-https-support.md
+++ b/docs/src/main/paradox/java/http/client-side/client-https-support.md
@@ -1,1 +1,0 @@
-../../../scala/http/client-side/client-https-support.md

--- a/docs/src/main/paradox/java/http/client-side/client-transport.md
+++ b/docs/src/main/paradox/java/http/client-side/client-transport.md
@@ -1,1 +1,0 @@
-../../../scala/http/client-side/client-transport.md

--- a/docs/src/main/paradox/java/http/client-side/connection-level.md
+++ b/docs/src/main/paradox/java/http/client-side/connection-level.md
@@ -1,1 +1,0 @@
-../../../scala/http/client-side/connection-level.md

--- a/docs/src/main/paradox/java/http/client-side/host-level.md
+++ b/docs/src/main/paradox/java/http/client-side/host-level.md
@@ -1,1 +1,0 @@
-../../../scala/http/client-side/host-level.md

--- a/docs/src/main/paradox/java/http/client-side/index.md
+++ b/docs/src/main/paradox/java/http/client-side/index.md
@@ -1,1 +1,0 @@
-../../../scala/http/client-side/index.md

--- a/docs/src/main/paradox/java/http/client-side/pool-overflow.md
+++ b/docs/src/main/paradox/java/http/client-side/pool-overflow.md
@@ -1,1 +1,0 @@
-../../../scala/http/client-side/pool-overflow.md

--- a/docs/src/main/paradox/java/http/client-side/request-level.md
+++ b/docs/src/main/paradox/java/http/client-side/request-level.md
@@ -1,1 +1,0 @@
-../../../scala/http/client-side/request-level.md

--- a/docs/src/main/paradox/java/http/client-side/websocket-support.md
+++ b/docs/src/main/paradox/java/http/client-side/websocket-support.md
@@ -1,1 +1,0 @@
-../../../scala/http/client-side/websocket-support.md


### PR DESCRIPTION
After @jlprat 's hard work to unify the client-side docs let's reduce the link clutter.
References #1290