### PR TITLE
Fix not sending back WebSocket Close Connection bug(#1358)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameOutHandler.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameOutHandler.scala
@@ -42,10 +42,6 @@ private[http] class FrameOutHandler(serverSide: Boolean, _closeTimeout: FiniteDu
         grab(in) match {
           case start: FrameStart   ⇒ push(out, start)
           case DirectAnswer(frame) ⇒ push(out, frame)
-          case PeerClosed(code, reason) if !code.exists(Protocol.CloseCodes.isError) ⇒
-            // let user complete it, FIXME: maybe make configurable? immediately, or timeout
-            setHandler(in, new WaitingForUserHandlerClosed(FrameEvent.closeFrame(code.getOrElse(Protocol.CloseCodes.Regular), reason)))
-            pull(in)
           case PeerClosed(code, reason) ⇒
             val closeFrame = FrameEvent.closeFrame(code.getOrElse(Protocol.CloseCodes.Regular), reason)
             if (serverSide) {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/MessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/MessageSpec.scala
@@ -453,10 +453,6 @@ class MessageSpec extends FreeSpec with Matchers with WithMaterializerSpec with 
         pushInput(closeFrame(Protocol.CloseCodes.Regular, mask = true))
         expectComplete(messageIn)
 
-        netIn.expectNoMsg(100.millis.dilated) // especially the cancellation not yet
-        expectNoNetworkData()
-        messageOut.sendComplete()
-
         expectCloseCodeOnNetwork(Protocol.CloseCodes.Regular)
         netOut.expectComplete()
         netIn.expectCancellation()
@@ -482,34 +478,9 @@ class MessageSpec extends FreeSpec with Matchers with WithMaterializerSpec with 
         pushInput(closeFrame(Protocol.CloseCodes.Regular, mask = true))
         expectComplete(messageIn)
 
-        netIn.expectNoMsg(100.millis.dilated) // especially the cancellation not yet
-        expectNoNetworkData()
-        messageOut.sendComplete()
-
         expectCloseCodeOnNetwork(Protocol.CloseCodes.Regular)
         netOut.expectComplete()
         netIn.expectCancellation()
-      }
-      "after receiving regular close frame when idle (user still sends some data)" in new ServerTestSetup {
-        pushInput(closeFrame(Protocol.CloseCodes.Regular, mask = true))
-        expectComplete(messageIn)
-
-        // sending another message is allowed before closing (inherently racy)
-        val pub = TestPublisher.manualProbe[ByteString]()
-        val msg = BinaryMessage(Source.fromPublisher(pub))
-        pushMessage(msg)
-
-        val data = ByteString("abc", "ASCII")
-        val dataSub = pub.expectSubscription()
-        dataSub.sendNext(data)
-        expectFrameOnNetwork(Opcode.Binary, data, fin = false)
-
-        dataSub.sendComplete()
-        expectFrameOnNetwork(Opcode.Continuation, ByteString.empty, fin = true)
-
-        messageOut.sendComplete()
-        expectCloseCodeOnNetwork(Protocol.CloseCodes.Regular)
-        netOut.expectComplete()
       }
       "after receiving regular close frame when fragmented message is still open" in new ServerTestSetup {
         pushInput(frameHeader(Protocol.Opcode.Binary, 0, fin = false, mask = Some(Random.nextInt())))
@@ -531,23 +502,7 @@ class MessageSpec extends FreeSpec with Matchers with WithMaterializerSpec with 
         // could be seen as something being amiss.
         expectError(messageIn)
         inSubscriber.expectError()
-        // truncation of open message
 
-        // sending another message is allowed before closing (inherently racy)
-
-        val pub = TestPublisher.manualProbe[ByteString]()
-        val msg = BinaryMessage(Source.fromPublisher(pub))
-        pushMessage(msg)
-
-        val data = ByteString("abc", "ASCII")
-        val dataSub = pub.expectSubscription()
-        dataSub.sendNext(data)
-        expectFrameOnNetwork(Opcode.Binary, data, fin = false)
-
-        dataSub.sendComplete()
-        expectFrameOnNetwork(Opcode.Continuation, ByteString.empty, fin = true)
-
-        messageOut.sendComplete()
         expectCloseCodeOnNetwork(Protocol.CloseCodes.Regular)
         netOut.expectComplete()
 


### PR DESCRIPTION
This will fix this issue. https://github.com/akka/akka-http/issues/1358
This behavior will be sending back WebSocket Close Connection immediately either normal or abnormal cases instead of waiting for user handler closed. 