### PR TITLE
=htc replace usage of `RuleNotFoundException` by introducing explicit result ADT

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.10.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.10.backwards.excludes
@@ -1,0 +1,2 @@
+# Don't monitor changes to internal API
+ProblemFilters.exclude[Problem]("akka.http.impl.*")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -499,10 +499,12 @@ private[http] object HttpHeaderParser {
       val (headerValue, endIx) = scanHeaderValue(hhp, input, valueStart, valueStart + maxHeaderValueLength + 2, log, settings.illegalResponseHeaderValueProcessingMode)()
       val trimmedHeaderValue = headerValue.trim
       val header = HeaderParser.parseFull(headerName, trimmedHeaderValue, settings) match {
-        case Right(h) ⇒ h
-        case Left(error) ⇒
+        case HeaderParser.Success(h) ⇒ h
+        case HeaderParser.Failure(error) ⇒
           onIllegalHeader(error.withSummaryPrepended(s"Illegal '$headerName' header"))
           RawHeader(headerName, trimmedHeaderValue)
+        case HeaderParser.RuleNotFound ⇒
+          throw new IllegalStateException(s"Unexpected RuleNotFound exception for modeled header [${headerName}]")
       }
       header → endIx
     }

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -696,8 +696,8 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
 
     "parse with custom uri parsing mode" in {
       val targetUri = Uri("http://example.org/?abc=def=ghi", Uri.ParsingMode.Relaxed)
-      HeaderParser.parseFull("location", "http://example.org/?abc=def=ghi", HeaderParser.Settings(uriParsingMode = Uri.ParsingMode.Relaxed)) shouldEqual
-        Right(Location(targetUri))
+      HttpHeader.parse("location", "http://example.org/?abc=def=ghi", HeaderParser.Settings(uriParsingMode = Uri.ParsingMode.Relaxed)) shouldEqual
+        ParsingResult.Ok(Location(targetUri), Nil)
     }
   }
 


### PR DESCRIPTION
Before every attempt to parse an unknown (i.e. not modeled) header would
end up in throwing and catching an exception. This does not really make
sense as parboiled already provides for delivering these signals without
an exception.

Refs playframework/playframework#7822