### PR TITLE
=htc lookup predefined header parsers as early as possible

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -104,20 +104,24 @@ private[http] object HeaderParser {
 
   object EmptyCookieException extends SingletonException("Cookie header contained no parsable cookie values.")
 
-  def parseFull(headerName: String, value: String, settings: Settings = DefaultSettings): HeaderParser#Result = {
-    import akka.parboiled2.EOI
-    val v = value + EOI // this makes sure the parser isn't broken even if there's no trailing garbage in this value
-    val parser = new HeaderParser(v, settings)
-    dispatch(parser, headerName) match {
-      case r @ Success(_) if parser.cursor == v.length ⇒ r
-      case r @ Success(_) ⇒
-        Failure(ErrorInfo(
-          "Header parsing error",
-          s"Rule for $headerName accepted trailing garbage. Is the parser missing a trailing EOI?"))
-      case Failure(e)   ⇒ Failure(e.copy(summary = e.summary.filterNot(_ == EOI), detail = e.detail.filterNot(_ == EOI)))
-      case RuleNotFound ⇒ RuleNotFound
+  def lookupParser(headerName: String, settings: Settings = DefaultSettings): Option[String ⇒ HeaderParser#Result] =
+    dispatch.lookup(headerName).map { runner ⇒ (value: String) ⇒
+      import akka.parboiled2.EOI
+      val v = value + EOI // this makes sure the parser isn't broken even if there's no trailing garbage in this value
+      val parser = new HeaderParser(v, settings)
+      runner(parser) match {
+        case r @ Success(_) if parser.cursor == v.length ⇒ r
+        case r @ Success(_) ⇒
+          Failure(ErrorInfo(
+            "Header parsing error",
+            s"Rule for $headerName accepted trailing garbage. Is the parser missing a trailing EOI?"))
+        case Failure(e)   ⇒ Failure(e.copy(summary = e.summary.filterNot(_ == EOI), detail = e.detail.filterNot(_ == EOI)))
+        case RuleNotFound ⇒ RuleNotFound
+      }
     }
-  }
+
+  def parseFull(headerName: String, value: String, settings: Settings = DefaultSettings): HeaderParser#Result =
+    lookupParser(headerName, settings).map(_(value)).getOrElse(HeaderParser.RuleNotFound)
 
   val (dispatch, ruleNames) = DynamicRuleDispatch[HeaderParser, HttpHeader :: HNil](
     "accept",


### PR DESCRIPTION
Another small improvement as a follow up to #1424.

Previously, every header parsing attempt had to go through the
`DynamicRuleDispatch`, a binary search to find the parsing rule for an
HTTP header name.

However, the `HttpHeaderParser` already has a parsing tree that with a node
for every header name.

This change divides header parsing into two steps: looking up the rule
and invoking the parser. Looking up the rule now only needs to be once
per node in the `HttpHeaderParser` and afterwards it can just run
without going through the dispatch.