### PR TITLE
Clarify discarding for strict entities #1430

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
@@ -155,6 +155,10 @@ public interface HttpEntity {
      * of its streaming nature. If the dataBytes source is materialized a second time, it will fail with an
      * "stream can cannot be materialized more than once" exception.
      *
+     * When called on `Strict` entities or sources whose values can be buffered in memory,
+     * the above warnings can be ignored. Repeated materialization is not necessary in this case, avoiding
+     * the mentioned exceptions due to the data being held in memory.
+     *
      * In future versions, more automatic ways to warn or resolve these situations may be introduced, see issue #18716.
      */
     HttpMessage.DiscardedEntity discardBytes(Materializer materializer);

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -77,6 +77,10 @@ public interface HttpMessage {
      * of its streaming nature. If the dataBytes source is materialized a second time, it will fail with an
      * "stream can cannot be materialized more than once" exception.
      *
+     * When called on `Strict` entities or sources whose values can be buffered in memory,
+     * the above warnings can be ignored. Repeated materialization is not necessary in this case, avoiding
+     * the mentioned exceptions due to the data being held in memory.
+     *
      * In future versions, more automatic ways to warn or resolve these situations may be introduced, see issue #18716.
      */
     DiscardedEntity discardEntityBytes(Materializer materializer);

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -91,6 +91,10 @@ sealed trait HttpEntity extends jm.HttpEntity {
    * of its streaming nature. If the dataBytes source is materialized a second time, it will fail with an
    * "stream can cannot be materialized more than once" exception.
    *
+   * When called on `Strict` entities or sources whose values can be buffered in memory,
+   * the above warnings can be ignored. Repeated materialization is not necessary in this case, avoiding
+   * the mentioned exceptions due to the data being held in memory.
+   *
    * In future versions, more automatic ways to warn or resolve these situations may be introduced, see issue #18716.
    */
   override def discardBytes(mat: Materializer): HttpMessage.DiscardedEntity =

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -56,6 +56,10 @@ sealed trait HttpMessage extends jm.HttpMessage {
    * of its streaming nature. If the dataBytes source is materialized a second time, it will fail with an
    * "stream can cannot be materialized more than once" exception.
    *
+   * When called on `Strict` entities or sources whose values can be buffered in memory,
+   * the above warnings can be ignored. Repeated materialization is not necessary in this case, avoiding
+   * the mentioned exceptions due to the data being held in memory.
+   *
    * In future versions, more automatic ways to warn or resolve these situations may be introduced, see issue #18716.
    */
   def discardEntityBytes(mat: Materializer): HttpMessage.DiscardedEntity = entity.discardBytes()(mat)
@@ -203,6 +207,10 @@ object HttpMessage {
      * Allowing it to be consumable twice would require buffering the incoming data, thus defeating the purpose
      * of its streaming nature. If the dataBytes source is materialized a second time, it will fail with an
      * "stream can cannot be materialized more than once" exception.
+     *
+     * When called on `Strict` entities or sources whose values can be buffered in memory,
+     * the above warnings can be ignored. Repeated materialization is not necessary in this case, avoiding
+     * the mentioned exceptions due to the data being held in memory.
      *
      * In future versions, more automatic ways to warn or resolve these situations may be introduced, see issue #18716.
      */


### PR DESCRIPTION
Fixes #1430 

Adds a small paragraph to `HttpEntity.discardBytes` and `HttpMessage.discardEntityBytes` that clarifies the different behaviour for `Strict` entities.

Tried to follow the tone and wording in other Scaladocs in the same files for consistency.