### PR TITLE
Update build to use sbt 1.0

### DIFF
--- a/akka-http2-support/build.sbt
+++ b/akka-http2-support/build.sbt
@@ -10,7 +10,7 @@ OSGi.http2Support
 fork in run in Test := true
 fork in Test := true
 
-connectInput in run in Test := true
+sbt.Keys.connectInput in run in Test := true
 
 lazy val h2specPath = Def.task {
   (target in Test).value / h2specName / h2specExe
@@ -18,10 +18,11 @@ lazy val h2specPath = Def.task {
 
 javaOptions in Test += "-Dh2spec.path=" + h2specPath.value
 resourceGenerators in Test += Def.task {
+  val log = streams.value.log
   val h2spec = h2specPath.value
 
   if (!h2spec.exists) {
-    streams.value.log.info("Extracting h2spec to " + h2spec)
+    log.info("Extracting h2spec to " + h2spec)
 
     for (zip <- (update in Test).value.select(artifact = artifactFilter(name = h2specName, extension = "zip")))
       IO.unzip(zip, (target in Test).value)

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val root = Project(
     // Unidoc doesn't like macros
     unidocProjectExcludes := Seq(parsing),
     deployRsyncArtifact :=
-      (sbtunidoc.Plugin.UnidocKeys.unidoc in Compile).value zip Seq(s"www/api/akka-http/${version.value}", s"www/japi/akka-http/${version.value}")
+      (unidoc in Compile).value zip Seq(s"www/api/akka-http/${version.value}", s"www/japi/akka-http/${version.value}")
   )
   .aggregate(
     parsing,
@@ -75,23 +75,26 @@ lazy val parsing = project("akka-parsing")
   .addAkkaModuleDependency("akka-actor")
 
 lazy val httpCore = project("akka-http-core")
+  .enablePlugins(Unidoc)
   .settings(Dependencies.httpCore)
-  .settings(Version.versionSettings)
+  .settings(VersionGenerator.versionSettings)
   .dependsOn(parsing)
   .addAkkaModuleDependency("akka-stream")
   .addAkkaModuleDependency("akka-stream-testkit", "test")
 
 lazy val http = project("akka-http")
+  .enablePlugins(Unidoc)
   .dependsOn(httpCore)
 
 lazy val http2Support = project("akka-http2-support")
-  .enablePlugins(JavaAgent)
+  .enablePlugins(JavaAgent, Unidoc)
   .disablePlugins(MimaPlugin) // experimental module still
   .settings(javaAgents += Dependencies.Compile.Test.alpnAgent)
   .dependsOn(httpCore, httpTestkit % "test", httpCore % "test->test")
   .addAkkaModuleDependency("akka-stream-testkit", "test")
 
 lazy val httpTestkit = project("akka-http-testkit")
+  .enablePlugins(Unidoc)
   .settings(Dependencies.httpTestkit)
   .dependsOn(http)
   .addAkkaModuleDependency("akka-stream-testkit")
@@ -132,16 +135,18 @@ def project(name: String) =
 def httpMarshallersScalaSubproject(name: String) =
   Project(
     id = s"akka-http-$name",
-    base = file(s"akka-http-marshallers-scala/akka-http-$name"),
-    dependencies = Seq(http)
+    base = file(s"akka-http-marshallers-scala/akka-http-$name")
   )
+  .dependsOn(http)
+  .enablePlugins(Unidoc)
 
 def httpMarshallersJavaSubproject(name: String) =
   Project(
     id = s"akka-http-$name",
     base = file(s"akka-http-marshallers-java/akka-http-$name"),
-    dependencies = Seq(http)
   )
+  .dependsOn(http)
+  .enablePlugins(Unidoc)
 
 lazy val docs = project("docs")
   .enablePlugins(AkkaParadoxPlugin, NoPublish, DeployRsync)

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ lazy val parsing = project("akka-parsing")
   .addAkkaModuleDependency("akka-actor")
 
 lazy val httpCore = project("akka-http-core")
-  .enablePlugins(Unidoc)
+  .enablePlugins(BootstrapGenjavadoc)
   .settings(Dependencies.httpCore)
   .settings(VersionGenerator.versionSettings)
   .dependsOn(parsing)
@@ -83,18 +83,18 @@ lazy val httpCore = project("akka-http-core")
   .addAkkaModuleDependency("akka-stream-testkit", "test")
 
 lazy val http = project("akka-http")
-  .enablePlugins(Unidoc)
+  .enablePlugins(BootstrapGenjavadoc)
   .dependsOn(httpCore)
 
 lazy val http2Support = project("akka-http2-support")
-  .enablePlugins(JavaAgent, Unidoc)
+  .enablePlugins(JavaAgent, BootstrapGenjavadoc)
   .disablePlugins(MimaPlugin) // experimental module still
   .settings(javaAgents += Dependencies.Compile.Test.alpnAgent)
   .dependsOn(httpCore, httpTestkit % "test", httpCore % "test->test")
   .addAkkaModuleDependency("akka-stream-testkit", "test")
 
 lazy val httpTestkit = project("akka-http-testkit")
-  .enablePlugins(Unidoc)
+  .enablePlugins(BootstrapGenjavadoc)
   .settings(Dependencies.httpTestkit)
   .dependsOn(http)
   .addAkkaModuleDependency("akka-stream-testkit")
@@ -138,7 +138,7 @@ def httpMarshallersScalaSubproject(name: String) =
     base = file(s"akka-http-marshallers-scala/akka-http-$name")
   )
   .dependsOn(http)
-  .enablePlugins(Unidoc)
+  .enablePlugins(BootstrapGenjavadoc)
 
 def httpMarshallersJavaSubproject(name: String) =
   Project(
@@ -146,7 +146,7 @@ def httpMarshallersJavaSubproject(name: String) =
     base = file(s"akka-http-marshallers-java/akka-http-$name"),
   )
   .dependsOn(http)
-  .enablePlugins(Unidoc)
+  .enablePlugins(BootstrapGenjavadoc)
 
 lazy val docs = project("docs")
   .enablePlugins(AkkaParadoxPlugin, NoPublish, DeployRsync)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
   import Versions._
 
 
+  // format: OFF
   object Compile {
     val scalaXml      = "org.scala-lang.modules"      %% "scala-xml"                   % "1.0.6" // Scala License
     val scalaReflect  = ScalaVersionDependentModuleID.versioned("org.scala-lang" % "scala-reflect" % _) // Scala License
@@ -71,6 +72,7 @@ object Dependencies {
       val h2spec       = "io.github.summerwind"        % h2specName                     % h2specVersion      % "test" from(h2specUrl) // MIT
     }
   }
+  // format: ON
 
   import Compile._
 
@@ -80,7 +82,7 @@ object Dependencies {
     DependencyHelpers.versionDependentDeps(
       Dependencies.Compile.scalaReflect % "provided"
     ),
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.fullMapped(nominalScalaVersion))
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   )
 
   lazy val httpCore = l ++= Seq(
@@ -95,8 +97,8 @@ object Dependencies {
 
   lazy val httpTestkit = l ++= Seq(
     Test.junit, Test.junitIntf, Compile.junit % "provided",
-    Test.scalatest.value.copy(configurations = Some("provided; test")),
-    Test.specs2.value.copy(configurations = Some("provided; test"))
+    Test.scalatest.value.withConfigurations(Some("provided; test")),
+    Test.specs2.value.withConfigurations(Some("provided; test"))
   )
 
   lazy val httpTests = l ++= Seq(Test.junit, Test.scalatest.value, Test.junitIntf)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,6 @@ object Dependencies {
   import Versions._
 
 
-  // format: OFF
   object Compile {
     val scalaXml      = "org.scala-lang.modules"      %% "scala-xml"                   % "1.0.6" // Scala License
     val scalaReflect  = ScalaVersionDependentModuleID.versioned("org.scala-lang" % "scala-reflect" % _) // Scala License
@@ -72,7 +71,6 @@ object Dependencies {
       val h2spec       = "io.github.summerwind"        % h2specName                     % h2specVersion      % "test" from(h2specUrl) // MIT
     }
   }
-  // format: ON
 
   import Compile._
 

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -4,11 +4,13 @@
 package akka
 
 import sbt._
-import sbtunidoc.Plugin.UnidocKeys._
-import sbtunidoc.Plugin.{ ScalaUnidoc, JavaUnidoc, Genjavadoc, scalaJavaUnidocSettings, genjavadocExtraSettings, scalaUnidocSettings }
 import sbt.Keys._
-import sbt.File
 import scala.annotation.tailrec
+import sbtunidoc.{ GenJavadocPlugin, JavaUnidocPlugin, ScalaUnidocPlugin }
+import sbtunidoc.BaseUnidocPlugin.autoImport.{ unidoc, unidocProjectFilter }
+import sbtunidoc.JavaUnidocPlugin.autoImport.JavaUnidoc
+import sbtunidoc.ScalaUnidocPlugin.autoImport.ScalaUnidoc
+import sbtunidoc.GenJavadocPlugin.autoImport.{ Genjavadoc, unidocGenjavadocVersion }
 
 object Doc {
   val BinVer = """(\d+\.\d+)\.\d+""".r
@@ -53,7 +55,7 @@ object Scaladoc extends AutoPlugin {
     CliOptions.scaladocDiagramsEnabled.ifTrue("-diagrams").toList ::: opts
   }
 
-  def scaladocVerifier(file: File): File= {
+  def scaladocVerifier(file: File): File = {
     @tailrec
     def findHTMLFileWithDiagram(dirs: Seq[File]): Boolean = {
       if (dirs.isEmpty) false
@@ -114,13 +116,14 @@ object UnidocRoot extends AutoPlugin {
   }
 
   override def trigger = noTrigger
+  override def requires = ScalaUnidocPlugin && CliOptions.genjavadocEnabled.ifTrue(JavaUnidocPlugin).getOrElse(plugins.JvmPlugin)
 
   val akkaSettings = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(Seq(
     javacOptions in (JavaUnidoc, unidoc) ++= Seq("-Xdoclint:none"),
     // genjavadoc needs to generate synthetic methods since the java code uses them
     scalacOptions += "-P:genjavadoc:suppressSynthetic=false",
     // FIXME: see https://github.com/akka/akka-http/issues/230
-    sources in(JavaUnidoc, unidoc) ~= (_.filterNot(_.getPath.contains("Access$minusControl$minusAllow$minusOrigin")))
+    sources in (JavaUnidoc, unidoc) ~= (_.filterNot(_.getPath.contains("Access$minusControl$minusAllow$minusOrigin")))
   )).getOrElse(Nil)
 
   val settings = inTask(unidoc)(Seq(
@@ -129,7 +132,6 @@ object UnidocRoot extends AutoPlugin {
   ))
 
   override lazy val projectSettings =
-    CliOptions.genjavadocEnabled.ifTrue(scalaJavaUnidocSettings).getOrElse(scalaUnidocSettings) ++
     settings ++
     akkaSettings
 }
@@ -140,17 +142,15 @@ object UnidocRoot extends AutoPlugin {
 object Unidoc extends AutoPlugin {
 
   override def trigger = allRequirements
-  override def requires = plugins.JvmPlugin
+  override def requires = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(GenJavadocPlugin).getOrElse(plugins.JvmPlugin)
 
   override lazy val projectSettings = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(
-    genjavadocExtraSettings ++ Seq(
+    Seq(
       javacOptions in compile += "-Xdoclint:none",
       javacOptions in test += "-Xdoclint:none",
       javacOptions in doc += "-Xdoclint:none",
       scalacOptions in Compile += "-P:genjavadoc:fabricateParams=true",
-      unidocGenjavadocVersion in Global := "0.10",
-      // FIXME: see https://github.com/akka/akka-http/issues/230
-      sources in(Genjavadoc, doc) ~= (_.filterNot(_.getPath.contains("Access$minusControl$minusAllow$minusOrigin")))
+      unidocGenjavadocVersion in Global := "0.10"
     )
   ).getOrElse(Seq.empty)
 }

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -139,7 +139,7 @@ object UnidocRoot extends AutoPlugin {
 /**
  * Unidoc settings for every multi-project. Adds genjavadoc specific settings.
  */
-object Unidoc extends AutoPlugin {
+object BootstrapGenjavadoc extends AutoPlugin {
 
   override def trigger = allRequirements
   override def requires = UnidocRoot.CliOptions.genjavadocEnabled.ifTrue(GenJavadocPlugin).getOrElse(plugins.JvmPlugin)

--- a/project/MultiNode.scala
+++ b/project/MultiNode.scala
@@ -73,6 +73,14 @@ object MultiNode extends AutoPlugin {
         testResults.events ++ multiNodeResults.events,
         testResults.summaries ++ multiNodeResults.summaries)
     })
+
+  implicit class TestResultOps(val self: TestResult) extends AnyVal {
+    def id: Int = self match {
+      case TestResult.Passed ⇒ 0
+      case TestResult.Failed ⇒ 1
+      case TestResult.Error  ⇒ 2
+    }
+  }
 }
 
 /**

--- a/project/ParadoxSignatureDirective.scala
+++ b/project/ParadoxSignatureDirective.scala
@@ -15,9 +15,14 @@ import scala.io.{Codec, Source}
 
 object ParadoxSupport {
   val paradoxWithSignatureDirective = Seq(
-    paradoxDirectives += { context: Writer.Context =>
-      new SignatureDirective(context.location.tree.label, context.properties, msg => streams.value.log.warn(msg))
-    }
+    paradoxDirectives += Def.taskDyn {
+      val log = streams.value.log
+      Def.task {
+        { context: Writer.Context ⇒
+          new SignatureDirective(context.location.tree.label, context.properties, msg ⇒ log.warn(msg))
+        }
+      }
+    }.value
   )
 
   class SignatureDirective(page: Page, variables: Map[String, String], logWarn: String => Unit) extends LeafBlockDirective("signature") {

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -5,8 +5,8 @@ package akka
 
 import com.typesafe.tools.mima.plugin.MimaKeys.mimaReportBinaryIssues
 import com.typesafe.tools.mima.plugin.MimaPlugin
-//import net.virtualvoid.sbt.graph.backend.SbtUpdateReport
-//import net.virtualvoid.sbt.graph.ModuleGraph
+import net.virtualvoid.sbt.graph.backend.SbtUpdateReport
+import net.virtualvoid.sbt.graph.ModuleGraph
 import org.kohsuke.github.{ GHIssueComment, GitHubBuilder }
 import sbtunidoc.BaseUnidocPlugin.autoImport.unidoc
 import sbt.Keys._
@@ -84,7 +84,6 @@ object ValidatePullRequest extends AutoPlugin {
   val validatePullRequest = taskKey[Unit]("Validate pull request")
   val additionalTasks = taskKey[Seq[TaskKey[_]]]("Additional tasks for pull request validation")
 
-  /* See https://github.com/akka/akka-http/issues/1438
   def changedDirectoryIsDependency(changedDirs: Set[String], name: String, graphsToTest: Seq[(Configuration, ModuleGraph)])(log: Logger): Boolean = {
     val dirsOrExperimental = changedDirs.flatMap(dir => Set(dir, s"$dir-experimental"))
     graphsToTest exists { case (ivyScope, deps) =>
@@ -102,7 +101,6 @@ object ValidatePullRequest extends AutoPlugin {
       }
     }
   }
-  */
 
   def localTargetBranch: Option[String] = System.getenv.asScala.get("PR_TARGET_BRANCH")
   def jenkinsTargetBranch: Option[String] = System.getenv.asScala.get("ghprbTargetBranch")
@@ -200,14 +198,10 @@ object ValidatePullRequest extends AutoPlugin {
 
       val thisProjectId = CrossVersion(scalaVersion.value, scalaBinaryVersion.value)(projectID.value)
 
-      /* See https://github.com/akka/akka-http/issues/1438
       def graphFor(updateReport: UpdateReport, config: Configuration): (Configuration, ModuleGraph) =
         config -> SbtUpdateReport.fromConfigurationReport(updateReport.configuration(config).get, thisProjectId)
-      */
 
       def isDependency: Boolean = {
-        false
-        /* See https://github.com/akka/akka-http/issues/1438
         changedDirectoryIsDependency(
           changedDirs,
           name.value,
@@ -217,7 +211,6 @@ object ValidatePullRequest extends AutoPlugin {
             graphFor((update in Runtime).value, Runtime),
             graphFor((update in Provided).value, Provided),
             graphFor((update in Optional).value, Optional)))(log)
-        */
       }
 
       if (githubCommandEnforcedBuildAll.isDefined)

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -9,7 +9,7 @@ import sbt.Keys._
 /**
  * Generate version.conf and akka/Version.scala files based on the version setting.
  */
-object Version {
+object VersionGenerator {
 
   def versionSettings: Seq[Setting[_]] = inConfig(Compile)(Seq(
     resourceGenerators += generateVersion(resourceManaged, _ / "akka-http-version.conf",

--- a/project/Whitesource.scala
+++ b/project/Whitesource.scala
@@ -9,7 +9,7 @@ object Whitesource extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  def majorMinor(version: String): Option[String] ="""\d+\.\d+""".r.findFirstIn(version)
+  def majorMinor(version: String): Option[String] = """\d+\.\d+""".r.findFirstIn(version)
 
   override lazy val projectSettings = Seq(
     // do not change the value of whitesourceProduct

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,8 +15,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.2")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
-// See https://github.com/akka/akka-http/issues/1438
-//addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.3-SNAPSHOT") // for advanced PR validation features
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0") // for advanced PR validation features
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,21 +6,21 @@ resolvers += Resolver.sonatypeRepo("releases") // to more quickly obtain paradox
 // which is used by plugin "org.kohsuke" % "github-api" % "1.68"
 resolvers += Resolver.jcenterRepo
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.3.8")
+addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.15")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.1")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "1.1.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.1")
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "1.0.0")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.2")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
-addSbtPlugin("pl.project13.sbt" % "sbt-jol" % "0.1.1")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2") // for advanced PR validation features
-addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.0")
+// See https://github.com/akka/akka-http/issues/1438
+//addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.3-SNAPSHOT") // for advanced PR validation features
+addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
-addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.2")
+addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.4")
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.2")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.6")
 
 libraryDependencies += "org.kohsuke" % "github-api" % "1.68"


### PR DESCRIPTION
Fixes #1434.

Includes the unidoc update changes from #925 which was reverted in #940 since it broke the  integrated build with akka/akka.

`sbt-jol` is removed based on https://github.com/akka/akka-http/issues/1434#issuecomment-331334611