### PR TITLE
Hide non-informative lines from snippets

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -436,7 +436,7 @@ class HttpServerExampleSpec extends WordSpec with Matchers
               .as(OrderItem) { orderItem =>
                 // ... route using case class instance created from
                 // required and optional query parameters
-                complete("") // hide
+                complete("") // #hide
               }
           }
         }

--- a/docs/src/test/scala/docs/http/scaladsl/server/CaseClassExtractionExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/CaseClassExtractionExamplesSpec.scala
@@ -25,10 +25,10 @@ class CaseClassExtractionExamplesSpec extends RoutingSpec with Inside {
         parameters('red.as[Int], 'green.as[Int], 'blue.as[Int]) { (red, green, blue) =>
           val color = Color(red, green, blue)
           // ... route working with the `color` instance
-          null // hide
+          null // #hide
         }
       }
-    Get("/color?red=1&green=2&blue=3") ~> route ~> check { responseAs[String] shouldEqual "Color(1,2,3)" } // hide
+    Get("/color?red=1&green=2&blue=3") ~> route ~> check { responseAs[String] shouldEqual "Color(1,2,3)" } // #hide
     //#example-1
   }
 
@@ -40,10 +40,10 @@ class CaseClassExtractionExamplesSpec extends RoutingSpec with Inside {
       path("color") {
         parameters('red.as[Int], 'green.as[Int], 'blue.as[Int]).as(Color) { color =>
           // ... route working with the `color` instance
-          null // hide
+          null // #hide
         }
       }
-    Get("/color?red=1&green=2&blue=3") ~> route ~> check { responseAs[String] shouldEqual "Color(1,2,3)" } // hide
+    Get("/color?red=1&green=2&blue=3") ~> route ~> check { responseAs[String] shouldEqual "Color(1,2,3)" } // #hide
     //#example-2
   }
 
@@ -55,9 +55,9 @@ class CaseClassExtractionExamplesSpec extends RoutingSpec with Inside {
       (path("color" / Segment) & parameters('r.as[Int], 'g.as[Int], 'b.as[Int]))
         .as(Color) { color =>
           // ... route working with the `color` instance
-          null // hide
+          null // #hide
         }
-    Get("/color/abc?r=1&g=2&b=3") ~> route ~> check { responseAs[String] shouldEqual "Color(abc,1,2,3)" } // hide
+    Get("/color/abc?r=1&g=2&b=3") ~> route ~> check { responseAs[String] shouldEqual "Color(abc,1,2,3)" } // #hide
     //#example-3
   }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/DirectiveExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/DirectiveExamplesSpec.scala
@@ -25,7 +25,7 @@ class DirectiveExamplesSpec extends RoutingSpec {
           }
         }
       }
-    verify(route) // hide
+    verify(route) // #hide
     //#example-1
   }
 
@@ -44,7 +44,7 @@ class DirectiveExamplesSpec extends RoutingSpec {
       }
 
     val route: Route = path("order" / IntNumber) { id => innerRoute(id) }
-    verify(route) // hide
+    verify(route) // #hide
     //#example-2
   }
 
@@ -56,7 +56,7 @@ class DirectiveExamplesSpec extends RoutingSpec {
           ctx.complete(s"Received ${ctx.request.method.name} request for order $id")
         }
       }
-    verify(route) // hide
+    verify(route) // #hide
     //#example-3
   }
 
@@ -70,7 +70,7 @@ class DirectiveExamplesSpec extends RoutingSpec {
           }
         }
       }
-    verify(route) // hide
+    verify(route) // #hide
     //#example-4
   }
 
@@ -85,7 +85,7 @@ class DirectiveExamplesSpec extends RoutingSpec {
           }
         }
       }
-    verify(route) // hide
+    verify(route) // #hide
     //#example-5
   }
 
@@ -96,7 +96,7 @@ class DirectiveExamplesSpec extends RoutingSpec {
       (path("order" / IntNumber) & getOrPut & extractMethod) { (id, m) =>
         complete(s"Received ${m.name} request for order $id")
       }
-    verify(route) // hide
+    verify(route) // #hide
     //#example-6
   }
 
@@ -108,7 +108,7 @@ class DirectiveExamplesSpec extends RoutingSpec {
       orderGetOrPutWithMethod { (id, m) =>
         complete(s"Received ${m.name} request for order $id")
       }
-    verify(route) // hide
+    verify(route) // #hide
     //#example-7
   }
 
@@ -127,7 +127,7 @@ class DirectiveExamplesSpec extends RoutingSpec {
       })
 
     val route: Route = path("order" / IntNumber) { id => innerRoute(id) }
-    verify(route) // hide
+    verify(route) // #hide
     //#example-8
   }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -32,7 +32,7 @@ object MyExplicitExceptionHandler {
     val route: Route =
       handleExceptions(myExceptionHandler) {
         // ... some route structure
-        null // hide
+        null // #hide
       }
 
     Http().bindAndHandle(route, "localhost", 8080)
@@ -66,7 +66,7 @@ object MyImplicitExceptionHandler {
 
     val route: Route =
     // ... some route structure
-      null // hide
+      null // #hide
 
     Http().bindAndHandle(route, "localhost", 8080)
   }

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -45,9 +45,7 @@ object MyRejectionHandler {
 
     val route: Route =
       // ... some route structure
-      //#custom-handler-example
-      null // hide
-      //#custom-handler-example
+      null // #hide
 
     Http().bindAndHandle(route, "localhost", 8080)
   }


### PR DESCRIPTION
With paradox code lines from snippets are being hidden by adding anything that starts with `#` to the line (see [here](https://github.com/lightbend/paradox/issues/157)). This fixes the issue where these non-informative lines where being included in code snippets like [here](https://doc.akka.io/docs/akka-http/10.0.10/scala/http/routing-dsl/case-class-extraction.html).