### PR TITLE
In top-level API don't require materializer where it's just ignored afterwards

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
@@ -20,9 +20,15 @@ private[akka] object HttpAttributes {
 
   private[akka] final case class RemoteAddress(address: InetSocketAddress) extends Attribute
 
-  private[akka] def remoteAddress(address: InetSocketAddress) =
+  private[akka] def remoteAddress(address: Option[InetSocketAddress]): Attributes =
+    address match {
+      case Some(addr) ⇒ remoteAddress(addr)
+      case None       ⇒ empty
+    }
+
+  private[akka] def remoteAddress(address: InetSocketAddress): Attributes =
     Attributes(RemoteAddress(address))
 
-  private[akka] val empty =
+  private[akka] val empty: Attributes =
     Attributes()
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -513,16 +513,26 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     adaptTupleFlow(delegate.superPool[T](defaultClientHttpsContext.asScala, settings.asScala, log)(materializer))
 
   /**
-   * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's
-   * effective URI to produce a response future.
-   *
-   * The [[defaultClientHttpsContext]] is used to configure TLS for the connection.
-   *
-   * Note that the request must have either an absolute URI or a valid `Host` header, otherwise
-   * the future will be completed with an error.
+   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
    */
   def singleRequest(request: HttpRequest, materializer: Materializer): CompletionStage[HttpResponse] =
-    delegate.singleRequest(request.asScala)(materializer).toJava
+    delegate.singleRequestImpl(request.asScala).toJava
+
+  /**
+   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
+   */
+  def singleRequest(request: HttpRequest, connectionContext: HttpsConnectionContext, materializer: Materializer): CompletionStage[HttpResponse] =
+    delegate.singleRequestImpl(request.asScala, connectionContext.asScala).toJava
+
+  /**
+   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
+   */
+  def singleRequest(
+    request:           HttpRequest,
+    connectionContext: HttpsConnectionContext,
+    settings:          ConnectionPoolSettings,
+    log:               LoggingAdapter, materializer: Materializer): CompletionStage[HttpResponse] =
+    delegate.singleRequestImpl(request.asScala, connectionContext.asScala, settings.asScala, log).toJava
 
   /**
    * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's
@@ -533,8 +543,20 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * Note that the request must have either an absolute URI or a valid `Host` header, otherwise
    * the future will be completed with an error.
    */
-  def singleRequest(request: HttpRequest, connectionContext: HttpsConnectionContext, materializer: Materializer): CompletionStage[HttpResponse] =
-    delegate.singleRequest(request.asScala, connectionContext.asScala)(materializer).toJava
+  def singleRequest(request: HttpRequest): CompletionStage[HttpResponse] =
+    delegate.singleRequestImpl(request.asScala).toJava
+
+  /**
+   * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's
+   * effective URI to produce a response future.
+   *
+   * The [[defaultClientHttpsContext]] is used to configure TLS for the connection.
+   *
+   * Note that the request must have either an absolute URI or a valid `Host` header, otherwise
+   * the future will be completed with an error.
+   */
+  def singleRequest(request: HttpRequest, connectionContext: HttpsConnectionContext): CompletionStage[HttpResponse] =
+    delegate.singleRequestImpl(request.asScala, connectionContext.asScala).toJava
 
   /**
    * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's
@@ -549,8 +571,8 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     request:           HttpRequest,
     connectionContext: HttpsConnectionContext,
     settings:          ConnectionPoolSettings,
-    log:               LoggingAdapter, materializer: Materializer): CompletionStage[HttpResponse] =
-    delegate.singleRequest(request.asScala, connectionContext.asScala, settings.asScala, log)(materializer).toJava
+    log:               LoggingAdapter): CompletionStage[HttpResponse] =
+    delegate.singleRequestImpl(request.asScala, connectionContext.asScala, settings.asScala, log).toJava
 
   /**
    * Constructs a WebSocket [[akka.stream.javadsl.BidiFlow]].

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -48,17 +48,15 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * Constructs a server layer stage using the configured default [[akka.http.javadsl.settings.ServerSettings]]. The returned [[akka.stream.javadsl.BidiFlow]] isn't
    * reusable and can only be materialized once.
    */
-  def serverLayer(materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
-    adaptServerLayer(delegate.serverLayer()(materializer))
+  def serverLayer(): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+    adaptServerLayer(delegate.serverLayerImpl())
 
   /**
    * Constructs a server layer stage using the given [[akka.http.javadsl.settings.ServerSettings]]. The returned [[akka.stream.javadsl.BidiFlow]] isn't reusable and
    * can only be materialized once.
    */
-  def serverLayer(
-    settings:     ServerSettings,
-    materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
-    adaptServerLayer(delegate.serverLayer(settings.asScala)(materializer))
+  def serverLayer(settings: ServerSettings): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+    adaptServerLayer(delegate.serverLayerImpl(settings.asScala))
 
   /**
    * Constructs a server layer stage using the given [[akka.http.javadsl.settings.ServerSettings]]. The returned [[akka.stream.javadsl.BidiFlow]] isn't reusable and
@@ -67,9 +65,8 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    */
   def serverLayer(
     settings:      ServerSettings,
-    remoteAddress: Optional[InetSocketAddress],
-    materializer:  Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
-    adaptServerLayer(delegate.serverLayer(settings.asScala, remoteAddress.asScala)(materializer))
+    remoteAddress: Optional[InetSocketAddress]): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+    adaptServerLayer(delegate.serverLayerImpl(settings.asScala, remoteAddress.asScala))
 
   /**
    * Constructs a server layer stage using the given [[ServerSettings]]. The returned [[akka.stream.javadsl.BidiFlow]] isn't reusable and
@@ -79,9 +76,45 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
   def serverLayer(
     settings:      ServerSettings,
     remoteAddress: Optional[InetSocketAddress],
+    log:           LoggingAdapter): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+    adaptServerLayer(delegate.serverLayerImpl(settings.asScala, remoteAddress.asScala, log))
+
+  /**
+   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
+   */
+  @Deprecated
+  def serverLayer(materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+    adaptServerLayer(delegate.serverLayerImpl())
+
+  /**
+   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
+   */
+  @Deprecated
+  def serverLayer(
+    settings:     ServerSettings,
+    materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+    adaptServerLayer(delegate.serverLayerImpl(settings.asScala))
+
+  /**
+   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
+   */
+  @Deprecated
+  def serverLayer(
+    settings:      ServerSettings,
+    remoteAddress: Optional[InetSocketAddress],
+    materializer:  Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+    adaptServerLayer(delegate.serverLayerImpl(settings.asScala, remoteAddress.asScala))
+
+  /**
+   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
+   */
+  @Deprecated
+  def serverLayer(
+    settings:      ServerSettings,
+    remoteAddress: Optional[InetSocketAddress],
     log:           LoggingAdapter,
     materializer:  Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
-    adaptServerLayer(delegate.serverLayer(settings.asScala, remoteAddress.asScala, log)(materializer))
+    adaptServerLayer(delegate.serverLayerImpl(settings.asScala, remoteAddress.asScala, log))
 
   /**
    * Creates a [[akka.stream.javadsl.Source]] of [[IncomingConnection]] instances which represents a prospective HTTP server binding

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
@@ -50,7 +50,7 @@ class ClientCancellationSpec extends AkkaSpec("""
       testCase(
         Flow[HttpRequest]
           .map((_, ()))
-          .via(Http().cachedHostConnectionPool(address.getHostName, address.getPort)(noncheckedMaterializer))
+          .via(Http().cachedHostConnectionPool(address.getHostName, address.getPort))
           .map(_._1.get))
     }
 
@@ -65,7 +65,7 @@ class ClientCancellationSpec extends AkkaSpec("""
       testCase(
         Flow[HttpRequest]
           .map((_, ()))
-          .via(Http().cachedHostConnectionPoolHttps(addressTls.getHostName, addressTls.getPort)(noncheckedMaterializer))
+          .via(Http().cachedHostConnectionPoolHttps(addressTls.getHostName, addressTls.getPort))
           .map(_._1.get))
     }
 

--- a/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
@@ -15,7 +15,6 @@ import akka.japi.Pair
 import akka.actor.ActorSystem
 import akka.event.NoLogging
 import akka.http.javadsl.model._
-import akka.http.javadsl.ServerBinding
 import akka.japi.Function
 import akka.stream.ActorMaterializer
 import akka.stream.javadsl.{ Flow, Keep, Sink, Source }


### PR DESCRIPTION
It seems we had lots of these left over I guess from the early days where creating substreams required materializers to be passed. It seems no one cleaned that up so far. The changes were somewhat big to keep binary compatibility at least for a while. In Scala, it's binary and source compatible (if the materializer was passed implicitly). Java users need to remove the materializer argument.

Going forward, if we deprecate the old methods now and release another 10.0.x in October, we might think about cleaning those methods up for 10.1.0.