### PR TITLE
Moved exception handler code in example

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -79,7 +79,7 @@ class ExceptionHandlerExamplesSpec extends RoutingSpec {
 
   "test explicit example" in {
     // tests:
-    Get() ~> handleExceptions(MyExplicitExceptionHandler.myExceptionHandler) {
+    Get() ~> handleExceptions(MyExplicitExceptionHandler.MyApp.myExceptionHandler) {
       _.complete((1 / 0).toString)
     } ~> check {
       responseAs[String] === "Bad numbers, bad result!!!"
@@ -88,7 +88,7 @@ class ExceptionHandlerExamplesSpec extends RoutingSpec {
 
   "test implicit example" in {
     import akka.http.scaladsl.server._
-    import MyImplicitExceptionHandler.myExceptionHandler
+    import MyImplicitExceptionHandler.MyApp.myExceptionHandler
     // tests:
     Get() ~> Route.seal(ctx => ctx.complete((1 / 0).toString)) ~> check {
       responseAs[String] === "Bad numbers, bad result!!!"

--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -17,15 +17,16 @@ object MyExplicitExceptionHandler {
   import StatusCodes._
   import Directives._
 
-  val myExceptionHandler = ExceptionHandler {
-    case _: ArithmeticException =>
-      extractUri { uri =>
-        println(s"Request to $uri could not be handled normally")
-        complete(HttpResponse(InternalServerError, entity = "Bad numbers, bad result!!!"))
-      }
-  }
-
   object MyApp extends App {
+
+    val myExceptionHandler = ExceptionHandler {
+      case _: ArithmeticException =>
+        extractUri { uri =>
+          println(s"Request to $uri could not be handled normally")
+          complete(HttpResponse(InternalServerError, entity = "Bad numbers, bad result!!!"))
+        }
+    }
+
     implicit val system = ActorSystem()
     implicit val materializer = ActorMaterializer()
 
@@ -51,16 +52,17 @@ object MyImplicitExceptionHandler {
   import StatusCodes._
   import Directives._
 
-  implicit def myExceptionHandler: ExceptionHandler =
-    ExceptionHandler {
-      case _: ArithmeticException =>
-        extractUri { uri =>
-          println(s"Request to $uri could not be handled normally")
-          complete(HttpResponse(InternalServerError, entity = "Bad numbers, bad result!!!"))
-        }
-    }
-
   object MyApp extends App {
+
+    implicit def myExceptionHandler: ExceptionHandler =
+      ExceptionHandler {
+        case _: ArithmeticException =>
+          extractUri { uri =>
+            println(s"Request to $uri could not be handled normally")
+            complete(HttpResponse(InternalServerError, entity = "Bad numbers, bad result!!!"))
+          }
+      }
+
     implicit val system = ActorSystem()
     implicit val materializer = ActorMaterializer()
 


### PR DESCRIPTION
- Moved the code inside the MyApp object, it compiles fine with Paradox due to encapsulating object, but looks broken in the docs.