### PR TITLE
Add NoSuchElementException without stack trace being filled in

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/util/FastFuture.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/util/FastFuture.scala
@@ -28,7 +28,7 @@ class FastFuture[A](val future: Future[A]) extends AnyVal {
   def filter(pred: A ⇒ Boolean)(implicit executor: ExecutionContext): Future[A] =
     flatMap { r ⇒
       if (pred(r)) future
-      else throw new NoSuchElementException("Future.filter predicate is not satisfied") // FIXME: avoid stack trace generation
+      else throw new NoSuchElementException("Future.filter predicate is not satisfied")
     }
 
   def foreach(f: A ⇒ Unit)(implicit ec: ExecutionContext): Unit = map(f)


### PR DESCRIPTION
Also this PR fixes one TODO with creating exception with suppressed stack trace:

    if (pred(r)) future
    else throw new NoSuchElementException("Future.filter predicate is not satisfied") // FIXME: avoid stack trace generation


NOTE: I am not sure how to properly name this exception.