### PR TITLE
=doc Link Java server-side docs at the directory level

### DIFF
--- a/docs/src/main/paradox/java/http/server-side
+++ b/docs/src/main/paradox/java/http/server-side
@@ -1,0 +1,1 @@
+../../scala/http/server-side

--- a/docs/src/main/paradox/java/http/server-side/http2.md
+++ b/docs/src/main/paradox/java/http/server-side/http2.md
@@ -1,1 +1,0 @@
-../../../scala/http/server-side/http2.md

--- a/docs/src/main/paradox/java/http/server-side/low-level-api.md
+++ b/docs/src/main/paradox/java/http/server-side/low-level-api.md
@@ -1,1 +1,0 @@
-../../../scala/http/server-side/low-level-api.md

--- a/docs/src/main/paradox/java/http/server-side/server-https-support.md
+++ b/docs/src/main/paradox/java/http/server-side/server-https-support.md
@@ -1,1 +1,0 @@
-../../../scala/http/server-side/server-https-support.md

--- a/docs/src/main/paradox/java/http/server-side/websocket-support.md
+++ b/docs/src/main/paradox/java/http/server-side/websocket-support.md
@@ -1,1 +1,0 @@
-../../../scala/http/server-side/websocket-support.md


### PR DESCRIPTION
Since all server-side documents are now shared between Java and Scala we can link the Java version at the directory level.