### PR TITLE
Fix server-side doc link

### DIFF
--- a/docs/src/main/paradox/java/http/server-side
+++ b/docs/src/main/paradox/java/http/server-side
@@ -1,0 +1,1 @@
+../../scala/http/server-side

--- a/docs/src/main/paradox/java/http/server-side/index.md
+++ b/docs/src/main/paradox/java/http/server-side/index.md
@@ -1,1 +1,0 @@
-../../../scala/http/server-side/index.md


### PR DESCRIPTION
When #1371 was merged it broke the directory level symlink of the
server-side docs. Restore the symlink so the java doc group works
correctly.

CC @ktoso 