### PR TITLE
[WIP] fail ws flow on idle timeout

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
@@ -5,40 +5,89 @@
 package akka.http.impl.engine
 
 import java.net.InetSocketAddress
-import java.util.concurrent.TimeoutException
+import java.util.concurrent.{ TimeUnit, TimeoutException }
 
 import akka.NotUsed
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
+import akka.http.impl.engine.server.HttpAttributes
+import akka.stream._
 import akka.stream.scaladsl.{ BidiFlow, Flow }
+import akka.stream.stage._
 import akka.util.ByteString
 
+import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NoStackTrace
 
 /** INTERNAL API */
 @InternalApi
 private[akka] object HttpConnectionIdleTimeoutBidi {
-  def apply(idleTimeout: FiniteDuration, remoteAddress: Option[InetSocketAddress]): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] = {
-    val connectionToString = remoteAddress match {
-      case Some(addr) ⇒ s" on connection to [$addr]"
-      case _          ⇒ ""
+  def apply(idleTimeout: FiniteDuration): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] = {
+    val killSwitchP = Promise[UniqueKillSwitch]()
+    val connectionKiller = Flow.fromGraph(KillSwitches.single[ByteString]).mapMaterializedValue { switch ⇒
+      killSwitchP.success(switch)
+      NotUsed
     }
-    val ex = new HttpIdleTimeoutException(
-      "HTTP idle-timeout encountered" + connectionToString + ", " +
-        "no bytes passed in the last " + idleTimeout + ". " +
-        "This is configurable by akka.http.[server|client].idle-timeout.", idleTimeout)
+    val idleCallback = (remoteAddress: Option[InetSocketAddress]) ⇒ {
+      killSwitchP.future.foreach { killSwitch ⇒
+        val connectionToString = remoteAddress match {
+          case Some(addr) ⇒ s" on connection to [$addr]"
+          case _          ⇒ ""
+        }
+        killSwitch.abort(new HttpIdleTimeoutException(
+          "HTTP idle-timeout encountered" + connectionToString + ", " +
+            "no bytes passed in the last " + idleTimeout + ". " +
+            "This is configurable by akka.http.[server|client].idle-timeout.", idleTimeout))
+      }(ExecutionContexts.sameThreadExecutionContext)
+    }
+    val idleDetector = new HttpIdleStage[ByteString](idleTimeout, idleCallback)
 
-    val mapError = Flow[ByteString].mapError({ case t: TimeoutException ⇒ ex })
+    BidiFlow.fromFlows(
+      connectionKiller.via(idleDetector),
+      idleDetector
+    )
+  }
 
-    val toNetTimeout: BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
-      BidiFlow.fromFlows(
-        mapError,
-        Flow[ByteString]
-      )
-    val fromNetTimeout: BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
-      toNetTimeout.reversed
+  private object IdleTick
 
-    fromNetTimeout atop BidiFlow.bidirectionalIdleTimeout[ByteString, ByteString](idleTimeout) atop toNetTimeout
+  // Custom idle stage for HTTP that instead of failing the stream completes a promise upon timeout
+  // so that we can make sure we fail the stream from the source and avoid a race where cancel reaches
+  // the user logic first, issue #1026
+  private class HttpIdleStage[T](timeout: FiniteDuration, onIdle: (Option[InetSocketAddress]) ⇒ Unit) extends GraphStage[FlowShape[T, T]] {
+    val in = Inlet[T]("HttpIdleStage")
+    val out = Outlet[T]("HttpIdleStage")
+    override val shape = FlowShape[T, T](in, out)
+    private val timeoutNanos = timeout.toNanos
+    private val idleCheckInterval = {
+      import scala.concurrent.duration._
+      FiniteDuration(
+        math.min(math.max(timeoutNanos / 8, 100.millis.toNanos), timeoutNanos / 2),
+        TimeUnit.NANOSECONDS)
+    }
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) with InHandler with OutHandler {
+      private var nextDeadline: Long = System.nanoTime + timeoutNanos
+      private def onActivity(): Unit = nextDeadline = System.nanoTime + timeoutNanos
+      override def preStart(): Unit = schedulePeriodically(IdleTick, idleCheckInterval)
+
+      override def onPush(): Unit = {
+        onActivity()
+        push(out, grab(in))
+      }
+
+      final override def onTimer(key: Any): Unit =
+        if (nextDeadline - System.nanoTime < 0) {
+          onIdle(inheritedAttributes.get[HttpAttributes.RemoteAddress].map(_.address))
+          cancelTimer(IdleTick)
+        }
+
+      override def onPull(): Unit = pull(in)
+
+      setHandlers(in, out, this)
+    }
+
+    override def toString = s"HttpIdleStage($timeout)"
   }
 
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
@@ -35,6 +35,7 @@ private[akka] object HttpConnectionIdleTimeoutBidi {
           case Some(addr) ⇒ s" on connection to [$addr]"
           case _          ⇒ ""
         }
+        println("hitting that killswitch")
         killSwitch.abort(new HttpIdleTimeoutException(
           "HTTP idle-timeout encountered" + connectionToString + ", " +
             "no bytes passed in the last " + idleTimeout + ". " +
@@ -44,8 +45,8 @@ private[akka] object HttpConnectionIdleTimeoutBidi {
     val idleDetector = new HttpIdleStage[ByteString](idleTimeout, idleCallback)
 
     BidiFlow.fromFlows(
-      connectionKiller.via(idleDetector),
-      idleDetector
+      idleDetector,
+      connectionKiller.via(idleDetector)
     )
   }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -33,6 +33,7 @@ import akka.http.javadsl.model
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ws.Message
 import akka.http.impl.util.LogByteStringTools._
+import scala.concurrent.duration._
 
 /**
  * INTERNAL API

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -74,7 +74,7 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
 
     val serverBidiFlow =
       settings.idleTimeout match {
-        case t: FiniteDuration ⇒ httpLayer atop delayCancellationStage(settings) atop tlsStage atop HttpConnectionIdleTimeoutBidi(t, None)
+        case t: FiniteDuration ⇒ httpLayer atop delayCancellationStage(settings) atop tlsStage atop HttpConnectionIdleTimeoutBidi(t)
         case _                 ⇒ httpLayer atop delayCancellationStage(settings) atop tlsStage
       }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -74,7 +74,7 @@ class HttpExt(private val config: Config)(implicit val system: ActorSystem) exte
 
     val serverBidiFlow =
       settings.idleTimeout match {
-        case t: FiniteDuration ⇒ httpLayer atop delayCancellationStage(settings) atop tlsStage atop HttpConnectionIdleTimeoutBidi(t)
+        case t: FiniteDuration ⇒ httpLayer atop delayCancellationStage(settings) atop tlsStage atop HttpConnectionIdleTimeoutBidi(t, server = true)
         case _                 ⇒ httpLayer atop delayCancellationStage(settings) atop tlsStage
       }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/WebSocketIntegrationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/WebSocketIntegrationSpec.scala
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.http.scaladsl.server
+
+import akka.{ Done, NotUsed }
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.impl.engine.HttpIdleTimeoutException
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.ws.{ Message, TextMessage, WebSocketRequest }
+import akka.stream.Attributes.LogLevels
+import akka.stream.{ ActorMaterializer, Attributes }
+import akka.stream.scaladsl.{ Flow, Sink, Source }
+import akka.stream.testkit.{ TestPublisher, TestSubscriber }
+import akka.testkit.{ AkkaSpec, SocketUtil, TestKit }
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+
+import scala.concurrent.Promise
+
+class WebSocketIntegrationSpec extends WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with IntegrationPatience {
+
+  implicit val system = ActorSystem(
+    AkkaSpec.getCallerName(getClass),
+    ConfigFactory.parseString(
+      """
+        akka.loglevel = debug # to see the timeout log entry
+        akka.http.server.idle-timeout = 3 seconds
+      """)
+  )
+  implicit val mat = ActorMaterializer()
+  import system.dispatcher
+
+  "The WebSocket" should {
+
+    "fail the user flow on timeout" in new Server {
+
+      val upstreamCompletion = Promise[Done]()
+      val downstreamCompletion = Promise[Done]()
+
+      def completeWithTermination[T](p: Promise[Done]) =
+        Flow[T].watchTermination() { (_, fDone) ⇒
+          p.completeWith(fDone)
+          fDone.onComplete(c ⇒ system.log.debug("Saw termination: {}", c))
+          NotUsed
+        }
+
+      def route =
+        get {
+          handleWebSocketMessages(
+            completeWithTermination[Message](upstreamCompletion)
+              .log("test-ws-log")
+              .via(completeWithTermination[Message](downstreamCompletion))
+          )
+        }
+
+      val toServer = TestPublisher.probe[Message]()
+      val fromServer = TestSubscriber.probe[Message]()
+
+      Http().singleWebSocketRequest(
+        WebSocketRequest(s"ws://$host:$port"),
+        Flow.fromSinkAndSource(Sink.fromSubscriber(fromServer), Source.fromPublisher(toServer))
+      )._1.futureValue
+
+      fromServer.request(1)
+
+      val msg = TextMessage("bon giorno")
+      toServer.sendNext(msg)
+      fromServer.expectNext().asTextMessage shouldEqual msg
+
+      Thread.sleep(3000)
+
+      upstreamCompletion.future.failed.futureValue shouldBe a[HttpIdleTimeoutException]
+      downstreamCompletion.future.failed.futureValue shouldBe a[HttpIdleTimeoutException]
+
+      binding.unbind()
+    }
+
+  }
+
+  trait Server extends Directives {
+    def route: Route
+
+    val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+    val binding = Http().bindAndHandle(route, host, port).futureValue
+  }
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+}


### PR DESCRIPTION
Refs #1026

This is the first version I got to work, not sure about the consequences, needs both the custom idle stage that fails upstream rather than downstream _and_ the delay as close to the user flow as possible, not 100% sure but think that is because failing the upstream also leads to the connection failing and that in turn starts to cancel stages up the stream.