### PR TITLE
=doc Change server side links to not be Scala specific

### DIFF
--- a/docs/src/main/paradox/java/http/routing-dsl/index.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/index.md
@@ -1,6 +1,6 @@
 # High-level Server-Side API
 
-In addition to the @ref[Low-Level Server-Side API](../../../scala/http/server-side/low-level-api.md) Akka HTTP provides a very flexible "Routing DSL" for elegantly
+In addition to the @ref[Low-Level Server-Side API](../server-side/low-level-api.md) Akka HTTP provides a very flexible "Routing DSL" for elegantly
 defining RESTful web services. It picks up where the low-level API leaves off and offers much of the higher-level
 functionality of typical web servers or frameworks, like deconstruction of URIs, content negotiation or
 static content serving.
@@ -61,7 +61,7 @@ In this case the "binding future" will fail immediately, and we can react to it 
 
 @@@ note
 For a more low-level overview of the kinds of failures that can happen and also more fine-grained control over them
-refer to the @ref[Handling HTTP Server failures in the Low-Level API](../../../scala/http/server-side/low-level-api.md#handling-http-server-failures-low-level) documentation.
+refer to the @ref[Handling HTTP Server failures in the Low-Level API](../server-side/low-level-api.md#handling-http-server-failures-low-level) documentation.
 @@@
 
 ### Failures and exceptions inside the Routing DSL

--- a/docs/src/main/paradox/java/http/routing-dsl/overview.md
+++ b/docs/src/main/paradox/java/http/routing-dsl/overview.md
@@ -1,8 +1,8 @@
 # Routing DSL Overview
 
-The Akka HTTP @ref[Low-Level Server-Side API](../../../scala/http/server-side/low-level-api.md) provides a `Flow`- or `Function`-level interface that allows
+The Akka HTTP @ref[Low-Level Server-Side API](../server-side/low-level-api.md) provides a `Flow`- or `Function`-level interface that allows
 an application to respond to incoming HTTP requests by simply mapping requests to responses
-(excerpt from @ref[Low-level server side example](../../../scala/http/server-side/low-level-api.md#http-low-level-server-side-example)):
+(excerpt from @ref[Low-level server side example](../server-side/low-level-api.md#http-low-level-server-side-example)):
 
 @@snip [HttpServerExampleDocTest.java]($test$/java/docs/http/javadsl/server/HttpServerExampleDocTest.java) { #request-handler }
 

--- a/docs/src/main/paradox/scala/http/common/index.md
+++ b/docs/src/main/paradox/scala/http/common/index.md
@@ -3,7 +3,7 @@
 HTTP and related specifications define a great number of concepts and functionality that is not specific to either
 HTTP's client- or server-side since they are meaningful on both end of an HTTP connection.
 The documentation for their counterparts in Akka HTTP lives in this section rather than in the ones for the
-@ref[Client-Side API](../client-side/index.md), @ref[Low-Level Server-Side API](../../../scala/http/server-side/low-level-api.md) or @ref[High-level Server-Side API](../routing-dsl/index.md),
+@ref[Client-Side API](../client-side/index.md), @ref[Low-Level Server-Side API](../server-side/low-level-api.md) or @ref[High-level Server-Side API](../routing-dsl/index.md),
 which are specific to one side only.
 
 @@toc { depth=3 }

--- a/docs/src/main/paradox/scala/http/implications-of-streaming-http-entity.md
+++ b/docs/src/main/paradox/scala/http/implications-of-streaming-http-entity.md
@@ -130,7 +130,7 @@ Scala
 Java
 :   @@snip [HttpServerExampleDocTest.java]($test$/java/docs/http/javadsl/server/HttpServerExampleDocTest.java) { #discard-close-connections }
 
-Closing connections is also explained in depth in the @ref[Closing a connection](../../scala/http/server-side/low-level-api.md#http-closing-connection-low-level)
+Closing connections is also explained in depth in the @ref[Closing a connection](server-side/low-level-api.md#http-closing-connection-low-level)
 section of the docs.
 
 ### Pending: Automatic discarding of not used entities

--- a/docs/src/main/paradox/scala/http/introduction.md
+++ b/docs/src/main/paradox/scala/http/introduction.md
@@ -191,7 +191,7 @@ Scala
 Java
 :   @@snip [HttpServerLowLevelExample.java]($test$/java/docs/http/javadsl/HttpServerLowLevelExample.java) { #low-level-server-example }
 
-Read more details about the low level APIs in the section @ref[Low-Level Server-Side API](../../scala/http/server-side/low-level-api.md).
+Read more details about the low level APIs in the section @ref[Low-Level Server-Side API](server-side/low-level-api.md).
 
 ## HTTP client API
 
@@ -220,7 +220,7 @@ with Akka HTTP. Details can be found in the section @ref[High-level Server-Side 
 
 akka-http-core
 : A complete, mostly low-level, server- and client-side implementation of HTTP (incl. WebSockets)
-Details can be found in sections @ref[Low-Level Server-Side API](../../scala/http/server-side/low-level-api.md) and @ref[Consuming HTTP-based Services (Client-Side)](client-side/index.md)
+Details can be found in sections @ref[Low-Level Server-Side API](server-side/low-level-api.md) and @ref[Consuming HTTP-based Services (Client-Side)](client-side/index.md)
 
 akka-http-testkit
 : A test harness and set of utilities for verifying server-side service implementations

--- a/docs/src/main/paradox/scala/http/routing-dsl/routes.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/routes.md
@@ -40,7 +40,7 @@ instances to convert rejections and exceptions into appropriate HTTP responses f
 
 
 Using `Route.handlerFlow` or `Route.asyncHandler` a `Route` can be lifted into a handler `Flow` or async handler
-function to be used with a `bindAndHandleXXX` call from the @ref[Low-Level Server-Side API](../../../scala/http/server-side/low-level-api.md).
+function to be used with a `bindAndHandleXXX` call from the @ref[Low-Level Server-Side API](../server-side/low-level-api.md).
 
 Note: There is also an implicit conversion from `Route` to `Flow[HttpRequest, HttpResponse, Unit]` defined in the
 `RouteResult` companion, which relies on `Route.handlerFlow`.

--- a/docs/src/main/paradox/scala/http/server-side/index.md
+++ b/docs/src/main/paradox/scala/http/server-side/index.md
@@ -13,7 +13,7 @@ It sports the following features:
 
 The server-side components of Akka HTTP are split into two layers:
 
-@ref[Low-Level Server-Side API](../../../scala/http/server-side/low-level-api.md)
+@ref[Low-Level Server-Side API](low-level-api.md)
 :  The basic low-level server implementation in the `akka-http-core` module.
 
 @ref[High-level Server-Side API](../routing-dsl/index.md)
@@ -36,9 +36,9 @@ from a background with non-"streaming first" HTTP Servers.
 
 @@@ index
 
-* [low-level-api](../../../scala/http/server-side/low-level-api.md)
-* [websocket-support](../../../scala/http/server-side/websocket-support.md)
-* [server-https-support](../../../scala/http/server-side/server-https-support.md)
-* [http2](../../../scala/http/server-side/http2.md)
+* [low-level-api](low-level-api.md)
+* [websocket-support](websocket-support.md)
+* [server-https-support](server-https-support.md)
+* [http2](http2.md)
 
 @@@


### PR DESCRIPTION
Revert most of 6f0634068c8cb91968bf0214aaf2a900498df0fa so links
inside consolidated documentation pages are language agnostic.