### PR TITLE
=doc Fix #1541: Bump number of unique requests to 500

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
@@ -165,7 +165,7 @@ public class CachingDirectivesExamplesTest extends JUnitRouteTest {
       .run(HttpRequest.GET("/1"))
       .assertEntity("Request for http://example.com/1 @ count 1");
 
-    for (int i = 1; i < 100; i++) {
+    for (int i = 1; i < 500; i++) {
       testRoute(route)
         .run(HttpRequest.GET("/" + i))
         .assertEntity("Request for http://example.com/" + i + " @ count " + i);
@@ -173,6 +173,6 @@ public class CachingDirectivesExamplesTest extends JUnitRouteTest {
 
     testRoute(route)
       .run(HttpRequest.GET("/1"))
-      .assertEntity("Request for http://example.com/1 @ count 100");
+      .assertEntity("Request for http://example.com/1 @ count 500");
   }
 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala
@@ -131,14 +131,14 @@ class CachingDirectivesExamplesSpec extends RoutingSpec with CachingDirectives {
       responseAs[String] shouldEqual "Request for http://example.com/1 @ count 1"
     }
 
-    for (i <- 1 until 100) {
+    for (i <- 1 until 500) {
       Get(s"/$i") ~> route ~> check {
         responseAs[String] shouldEqual s"Request for http://example.com/$i @ count $i"
       }
     }
 
     Get("/1") ~> route ~> check {
-      responseAs[String] shouldEqual "Request for http://example.com/1 @ count 100"
+      responseAs[String] shouldEqual "Request for http://example.com/1 @ count 500"
     }
   }
 }


### PR DESCRIPTION
The create cache tests demonstrate that if we set a small max capacity
(say 50 entries) and make more than that amount of unique requests and
finally redo the initial request then a new cache entry should be
generated. That is the entry of the initial request has been evicted and
regenerated.

The problem is that the LFU-cache implementation does not guarantee when
eviction happens. It might happen at next write time or as we clearly
see in #1541 at some later convenience. As a workaround bump the number
of requests to be much higher.