### PR TITLE
added Marshaller.oneOf(m1, m2) to JavaDSL (#1551)

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -99,14 +99,14 @@ object Marshaller {
   }
 
   /**
-    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
-    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
-    *
-    * Please note that all marshallers will actualy be invoked in order to get the Marshalling object
-    * out of them, and later decide which of the marshallings should be returned. This is by-design,
-    * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
-    * changed in later versions of Akka HTTP.
-    */
+   * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
+   * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
+   *
+   * Please note that all marshallers will actualy be invoked in order to get the Marshalling object
+   * out of them, and later decide which of the marshallings should be returned. This is by-design,
+   * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
+   * changed in later versions of Akka HTTP.
+   */
   def oneOf[A, B](m1: Marshaller[A, B], m2: Marshaller[A, B]): Marshaller[A, B] = {
     fromScala(marshalling.Marshaller.oneOf(m1.asScala, m2.asScala))
   }

--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -99,6 +99,19 @@ object Marshaller {
   }
 
   /**
+    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
+    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
+    *
+    * Please note that all marshallers will actualy be invoked in order to get the Marshalling object
+    * out of them, and later decide which of the marshallings should be returned. This is by-design,
+    * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
+    * changed in later versions of Akka HTTP.
+    */
+  def oneOf[A, B](m1: Marshaller[A, B], m2: Marshaller[A, B]): Marshaller[A, B] = {
+    fromScala(marshalling.Marshaller.oneOf(m1.asScala, m2.asScala))
+  }
+
+  /**
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    *


### PR DESCRIPTION
...to improve the Java DSL for two Marshallers (see #1551)