### PR TITLE
Http header retry-after #1554

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RetryAfter.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RetryAfter.java
@@ -17,19 +17,19 @@ import scala.util.Right;
  */
 public abstract class RetryAfter extends akka.http.scaladsl.model.HttpHeader {
 
-	  protected abstract scala.Option<Long> delaySeconds();
+    protected abstract scala.Option<Long> delaySeconds();
 	  
-	  protected abstract scala.Option<akka.http.scaladsl.model.DateTime> dateTime();
+    protected abstract scala.Option<akka.http.scaladsl.model.DateTime> dateTime();
 
     /** number of seconds for the retry attempt, if available */
-	  public Optional<Long> getDelaySeconds() {
-	  	return Util.convertOption(delaySeconds());
-	  } 
+    public Optional<Long> getDelaySeconds() {
+    	return Util.convertOption(delaySeconds());
+    }
 
     /** the date for the retry attempt, if available */
-	  public Optional<DateTime> getDateTime() {
-	  	return Util.convertOption(dateTime());
-	  }
+    public Optional<DateTime> getDateTime() {
+    	return Util.convertOption(dateTime());
+    }
 
     public static RetryAfter create(Long delaySeconds) {
         return new akka.http.scaladsl.model.headers.Retry$minusAfter(new Left(delaySeconds));

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RetryAfter.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RetryAfter.java
@@ -7,9 +7,6 @@ package akka.http.javadsl.model.headers;
 import java.util.Optional;
 import akka.http.impl.util.Util;
 import akka.http.javadsl.model.DateTime;
-import scala.util.Either;
-import scala.util.Left;
-import scala.util.Right;
 
 /**
  *  Model for the `Retry-After` header.
@@ -32,10 +29,10 @@ public abstract class RetryAfter extends akka.http.scaladsl.model.HttpHeader {
     }
 
     public static RetryAfter create(Long delaySeconds) {
-        return new akka.http.scaladsl.model.headers.Retry$minusAfter(new Left(delaySeconds));
+        return new akka.http.scaladsl.model.headers.RetryAfterDuration(delaySeconds);
     }
 
     public static RetryAfter create(DateTime dateTime) {
-        return new akka.http.scaladsl.model.headers.Retry$minusAfter(new Right((akka.http.scaladsl.model.DateTime) dateTime));
+        return new akka.http.scaladsl.model.headers.RetryAfterDateTime((akka.http.scaladsl.model.DateTime) dateTime);
     }
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RetryAfter.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RetryAfter.java
@@ -7,7 +7,9 @@ package akka.http.javadsl.model.headers;
 import java.util.Optional;
 import akka.http.impl.util.Util;
 import akka.http.javadsl.model.DateTime;
-
+import akka.http.scaladsl.model.headers.Retry$minusAfter;
+import akka.http.scaladsl.model.headers.RetryAfterDuration;
+import akka.http.scaladsl.model.headers.RetryAfterDateTime;
 /**
  *  Model for the `Retry-After` header.
  *  Specification: //https://tools.ietf.org/html/rfc7231#section-7.1.3
@@ -29,10 +31,10 @@ public abstract class RetryAfter extends akka.http.scaladsl.model.HttpHeader {
     }
 
     public static RetryAfter create(Long delaySeconds) {
-        return new akka.http.scaladsl.model.headers.RetryAfterDuration(delaySeconds);
+        return new Retry$minusAfter(new RetryAfterDuration(delaySeconds));
     }
 
     public static RetryAfter create(DateTime dateTime) {
-        return new akka.http.scaladsl.model.headers.RetryAfterDateTime((akka.http.scaladsl.model.DateTime) dateTime);
+        return new Retry$minusAfter(new RetryAfterDateTime((akka.http.scaladsl.model.DateTime) dateTime));
     }
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RetryAfter.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RetryAfter.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.javadsl.model.headers;
+
+import java.util.Optional;
+import akka.http.impl.util.Util;
+import akka.http.javadsl.model.DateTime;
+import scala.util.Either;
+import scala.util.Left;
+import scala.util.Right;
+
+/**
+ *  Model for the `Retry-After` header.
+ *  Specification: //https://tools.ietf.org/html/rfc7231#section-7.1.3
+ */
+public abstract class RetryAfter extends akka.http.scaladsl.model.HttpHeader {
+
+	  protected abstract scala.Option<Long> delaySeconds();
+	  
+	  protected abstract scala.Option<akka.http.scaladsl.model.DateTime> dateTime();
+
+    /** number of seconds for the retry attempt, if available */
+	  public Optional<Long> getDelaySeconds() {
+	  	return Util.convertOption(delaySeconds());
+	  } 
+
+    /** the date for the retry attempt, if available */
+	  public Optional<DateTime> getDateTime() {
+	  	return Util.convertOption(dateTime());
+	  }
+
+    public static RetryAfter create(Long delaySeconds) {
+        return new akka.http.scaladsl.model.headers.Retry$minusAfter(new Left(delaySeconds));
+    }
+
+    public static RetryAfter create(DateTime dateTime) {
+        return new akka.http.scaladsl.model.headers.Retry$minusAfter(new Right((akka.http.scaladsl.model.DateTime) dateTime));
+    }
+}

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -167,6 +167,7 @@ private[http] object HeaderParser {
     "proxy-authorization",
     "range",
     "referer",
+    "retry-after",
     "server",
     "sec-websocket-accept",
     "sec-websocket-extensions",

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -6,7 +6,7 @@ package akka.http.impl.model.parser
 
 import akka.annotation.InternalApi
 import akka.parboiled2.Parser
-import akka.http.scaladsl.model.{ RemoteAddress, Uri, DateTime }
+import akka.http.scaladsl.model.{ RemoteAddress, Uri }
 import akka.http.scaladsl.model.headers._
 import CharacterClasses.`scheme-char`
 

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -189,7 +189,7 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
 
   //https://tools.ietf.org/html/rfc7231#section-7.1.3
   def `retry-after` = rule {
-    (`HTTP-date` ~> (RetryAfterDateTime(_)) | `delta-seconds` ~> (RetryAfterDuration(_))) ~ EOI
+    (`HTTP-date` ~> (RetryAfterDateTime(_)) | `delta-seconds` ~> (RetryAfterDuration(_))) ~ EOI ~> (`Retry-After`(_))
   }
 
   // http://tools.ietf.org/html/rfc7231#section-7.4.2

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -6,7 +6,7 @@ package akka.http.impl.model.parser
 
 import akka.annotation.InternalApi
 import akka.parboiled2.Parser
-import akka.http.scaladsl.model.{ RemoteAddress, Uri }
+import akka.http.scaladsl.model.{ RemoteAddress, Uri, DateTime }
 import akka.http.scaladsl.model.headers._
 import CharacterClasses.`scheme-char`
 
@@ -185,6 +185,11 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
     // we are bit more relaxed than the spec here by also parsing a potential fragment
     // but catch it in the `Referer` instance validation (with a `require` in the constructor)
     uriReference ~ EOI ~> (Referer(_))
+  }
+
+  //https://tools.ietf.org/html/rfc7231#section-7.1.3
+  def `retry-after` = rule {
+    (`HTTP-date` ~> (Right(_)) | `delta-seconds` ~> (Left(_))) ~ EOI ~> (`Retry-After`(_))
   }
 
   // http://tools.ietf.org/html/rfc7231#section-7.4.2

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -189,7 +189,7 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
 
   //https://tools.ietf.org/html/rfc7231#section-7.1.3
   def `retry-after` = rule {
-    (`HTTP-date` ~> (Right(_)) | `delta-seconds` ~> (Left(_))) ~ EOI ~> (`Retry-After`(_))
+    (`HTTP-date` ~> (RetryAfterDateTime(_)) | `delta-seconds` ~> (RetryAfterDuration(_))) ~ EOI
   }
 
   // http://tools.ietf.org/html/rfc7231#section-7.4.2

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/RetryAfterParameter.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/RetryAfterParameter.scala
@@ -6,11 +6,13 @@ package akka.http.scaladsl.model.headers
 
 import akka.http.scaladsl.model._
 
-//https://tools.ietf.org/html/rfc7231#section-7.1.3
-/** Defines different values admitted to define a [[`Retry-After`]] header */
+/**
+ * Defines different values admitted to define a [[`Retry-After`]] header.
+ *
+ * Spec: https://tools.ietf.org/html/rfc7231#section-7.1.3
+ */
 sealed abstract class RetryAfterParameter
 final case class RetryAfterDuration(delayInSeconds: Long) extends RetryAfterParameter {
   require(delayInSeconds >= 0, "Retry-after header must not contain a negative delay in seconds")
 }
 final case class RetryAfterDateTime(dateTime: DateTime) extends RetryAfterParameter
-

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/RetryAfterParameter.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/RetryAfterParameter.scala
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.model.headers
+
+import akka.http.scaladsl.model._
+
+//https://tools.ietf.org/html/rfc7231#section-7.1.3
+/** Defines different values admitted to define a [[`Retry-After`]] header */
+sealed abstract class RetryAfterParameter
+final case class RetryAfterDuration(delayInSeconds: Long) extends RetryAfterParameter {
+  require(delayInSeconds >= 0, "Retry-after header must not contain a negative delay in seconds")
+}
+final case class RetryAfterDateTime(dateTime: DateTime) extends RetryAfterParameter
+

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -705,7 +705,9 @@ final case class Referer(uri: Uri) extends jm.headers.Referer with RequestHeader
 
 //https://tools.ietf.org/html/rfc7231#section-7.1.3
 sealed abstract class RetryAfterParameter
-final case class RetryAfterDuration(delayInSeconds: Long) extends RetryAfterParameter
+final case class RetryAfterDuration(delayInSeconds: Long) extends RetryAfterParameter {
+  require(delayInSeconds >= 0, "Retry-after header must not contain a negative delay in seconds")
+}
 final case class RetryAfterDateTime(dateTime: DateTime) extends RetryAfterParameter
 
 object `Retry-After` extends ModeledCompanion[`Retry-After`] {
@@ -714,11 +716,6 @@ object `Retry-After` extends ModeledCompanion[`Retry-After`] {
 }
 
 final case class `Retry-After`(delaySecondsOrDateTime: RetryAfterParameter) extends jm.headers.RetryAfter with ResponseHeader {
-  delaySecondsOrDateTime match {
-    case RetryAfterDuration(delay) ⇒ require(delay >= 0, "Retry-after header must not contain a negative delay in seconds")
-    case _                         ⇒
-  }
-
   def renderValue[R <: Rendering](r: R): r.type = delaySecondsOrDateTime match {
     case RetryAfterDuration(delay)    ⇒ r ~~ delay
     case RetryAfterDateTime(dateTime) ⇒ dateTime.renderRfc1123DateTimeString(r)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -711,8 +711,8 @@ object `Retry-After` extends ModeledCompanion[`Retry-After`] {
 final case class `Retry-After`(delaySecondsOrDateTime: Either[Long, DateTime]) extends jm.headers.RetryAfter with ResponseHeader {
   require(delaySecondsOrDateTime.left.toOption.forall(_ >= 0), "Retry-after header must not contain a negative delay in seconds")
   def renderValue[R <: Rendering](r: R): r.type = delaySecondsOrDateTime match {
-    case Left(delay)     => r ~~ delay
-    case Right(dateTime) => dateTime.renderRfc1123DateTimeString(r)
+    case Left(delay)     ⇒ r ~~ delay
+    case Right(dateTime) ⇒ dateTime.renderRfc1123DateTimeString(r)
   }
   protected def companion = `Retry-After`
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -709,7 +709,7 @@ object `Retry-After` extends ModeledCompanion[`Retry-After`] {
   def apply(timestamp: DateTime): `Retry-After` = apply(Right(timestamp))
 }
 final case class `Retry-After`(delaySecondsOrDateTime: Either[Long, DateTime]) extends jm.headers.RetryAfter with ResponseHeader {
-  require(delaySecondsOrDateTime.left.toOption.forall(_ > 0), "Retry-after header must not contain a negative delay in seconds")
+  require(delaySecondsOrDateTime.left.toOption.forall(_ >= 0), "Retry-after header must not contain a negative delay in seconds")
   def renderValue[R <: Rendering](r: R): r.type = delaySecondsOrDateTime match {
     case Left(delay)     => r ~~ delay
     case Right(dateTime) => dateTime.renderRfc1123DateTimeString(r)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -703,6 +703,25 @@ final case class Referer(uri: Uri) extends jm.headers.Referer with RequestHeader
   def getUri: akka.http.javadsl.model.Uri = uri.asJava
 }
 
+//https://tools.ietf.org/html/rfc7231#section-7.1.3
+object `Retry-After` extends ModeledCompanion[`Retry-After`] {
+  def apply(delaySeconds: Long): `Retry-After` = apply(Left(delaySeconds))
+  def apply(timestamp: DateTime): `Retry-After` = apply(Right(timestamp))
+}
+final case class `Retry-After`(delaySecondsOrDateTime: Either[Long, DateTime]) extends jm.headers.RetryAfter with ResponseHeader {
+  require(delaySecondsOrDateTime.left.toOption.forall(_ > 0), "Retry-after header must not contain a negative delay in seconds")
+  def renderValue[R <: Rendering](r: R): r.type = delaySecondsOrDateTime match {
+    case Left(delay)     => r ~~ delay
+    case Right(dateTime) => dateTime.renderRfc1123DateTimeString(r)
+  }
+  protected def companion = `Content-Type`
+
+  /** Java API suppport */
+  override protected def delaySeconds(): Option[java.lang.Long] = delaySecondsOrDateTime.left.toOption.map(Long.box)
+
+  override protected def dateTime(): Option[DateTime] = delaySecondsOrDateTime.right.toOption
+}
+
 /**
  * INTERNAL API
  */

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -714,7 +714,7 @@ final case class `Retry-After`(delaySecondsOrDateTime: Either[Long, DateTime]) e
     case Left(delay)     => r ~~ delay
     case Right(dateTime) => dateTime.renderRfc1123DateTimeString(r)
   }
-  protected def companion = `Content-Type`
+  protected def companion = `Retry-After`
 
   /** Java API suppport */
   override protected def delaySeconds(): Option[java.lang.Long] = delaySecondsOrDateTime.left.toOption.map(Long.box)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -703,13 +703,6 @@ final case class Referer(uri: Uri) extends jm.headers.Referer with RequestHeader
   def getUri: akka.http.javadsl.model.Uri = uri.asJava
 }
 
-//https://tools.ietf.org/html/rfc7231#section-7.1.3
-sealed abstract class RetryAfterParameter
-final case class RetryAfterDuration(delayInSeconds: Long) extends RetryAfterParameter {
-  require(delayInSeconds >= 0, "Retry-after header must not contain a negative delay in seconds")
-}
-final case class RetryAfterDateTime(dateTime: DateTime) extends RetryAfterParameter
-
 object `Retry-After` extends ModeledCompanion[`Retry-After`] {
   def apply(delaySeconds: Long): `Retry-After` = apply(RetryAfterDuration(delaySeconds))
   def apply(timestamp: DateTime): `Retry-After` = apply(RetryAfterDateTime(timestamp))

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -412,6 +412,11 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
         "Referer header URI must not contain a fragment")
     }
 
+    "Retry-After" in {
+      "Retry-After: 120" =!= `Retry-After`(120)
+      "Retry-After: Wed, 21 Oct 2015 07:28:00 GMT" =!= `Retry-After`(DateTime(2015, 10, 21, 7, 28))
+    }
+
     "Server" in {
       "Server: as fghf.fdf/xx" =!= `Server`(Vector(ProductVersion("as"), ProductVersion("fghf.fdf", "xx")))
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -62,6 +62,24 @@ class HeaderSpec extends FreeSpec with Matchers {
     }
   }
 
+  "Retry-After should" - {
+    "provide parseFromValueString method" - {
+      "successful parse run" in {
+        headers.`Retry-After`.parseFromValueString("120") shouldEqual Right(headers.`Retry-After`(120))
+        headers.`Retry-After`.parseFromValueString("Wed, 21 Oct 2015 07:28:00 GMT") shouldEqual
+          Right(headers.`Retry-After`(DateTime(2015, 10, 21, 7, 28)))
+      }
+      "failing parse run" in {
+        val Left(List(ErrorInfo(summary, detail))) = `Retry-After`.parseFromValueString("011")
+        summary shouldEqual "Illegal HTTP header 'Retry-After': Invalid input '1', expected OWS or 'EOI' (line 1, column 2)"
+        val Left(List(ErrorInfo(summary2, detail2))) = `Retry-After`.parseFromValueString("-10")
+        summary2 shouldEqual "Illegal HTTP header 'Retry-After': Invalid input '-', expected HTTP-date or delta-seconds (line 1, column 1)"
+        val Left(List(ErrorInfo(summary3, detail3))) = `Retry-After`.parseFromValueString("2015-10-21H07:28:00Z")
+        summary3 shouldEqual "Illegal HTTP header 'Retry-After': Invalid input '-', expected DIGIT, OWS or 'EOI' (line 1, column 5)"
+      }
+    }
+  }
+
   "Strict-Transport-Security should" - {
     "provide parseFromValueString method" - {
       "successful parse run" in {
@@ -165,7 +183,8 @@ class HeaderSpec extends FreeSpec with Matchers {
         `Set-Cookie`(HttpCookie("sessionId", "b0eb8b8b3ad246")),
         `Transfer-Encoding`(TransferEncodings.chunked),
         Upgrade(Vector(UpgradeProtocol("HTTP", Some("2.0")))),
-        `WWW-Authenticate`(HttpChallenge("Basic", Some("example.com"))))
+        `WWW-Authenticate`(HttpChallenge("Basic", Some("example.com"))),
+        `Retry-After`(120))
 
       responseHeaders.foreach { header ⇒
         header shouldBe 'renderInResponses


### PR DESCRIPTION
 * Add the class and companion to the headers
 * Create the corresponding java class
 * Add case in the HeaderParser and SimpleHeaders
 * Create test cases

Note: the current commit won't pass the HttpHeaderSpec, for reasons still
under investigation.