### PR TITLE
=htc #1558 try to make authority rendering closer to round-triping to Java

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
@@ -140,7 +140,7 @@ private[http] final class UriParser(val input: ParserInput,
   def authority = rule { optional(userinfo) ~ hostAndPort }
 
   def userinfo = rule {
-    clearSB() ~ zeroOrMore(`userinfo-char` ~ appendSB()| `pct-encoded`) ~ '@' ~ run(_userinfo = sb.toString)
+    clearSB() ~ zeroOrMore(`userinfo-char` ~ appendSB() | `pct-encoded`) ~ '@' ~ run(_userinfo = sb.toString)
   }
 
   def hostAndPort = rule { host ~ optional(':' ~ port)  }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
@@ -230,8 +230,14 @@ private[http] final class UriParser(val input: ParserInput,
     | run(_fragment = Some("")))
 
   def `pct-encoded` = rule {
-    '%' ~ HEXDIG ~ HEXDIG ~ run {
+    ('%' ~ HEXDIG ~ HEXDIG) ~ run {
       if (firstPercentIx == -1) firstPercentIx = sb.length()
+//      val p1 = charAt(-2)
+//      val p2 = lastChar
+//      sb.append('%').append(p1).append(p2)
+//      sb.append(CharUtils.stringFromHexString(charAt(-2), lastChar))
+
+      // put raw things there, later we decode() in getDecodedString()
       sb.append('%').append(charAt(-2)).append(lastChar)
     }
   }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -481,8 +481,12 @@ class UriSpec extends WordSpec with Matchers {
 
       //#dont-double-decode
       // don't double decode
-      Uri("%2520").path.head shouldEqual "%20"
-      Uri("/%2F%5C").path shouldEqual Path / """/\"""
+      // Uri("%2520").path.head shouldEqual "%20" // fails, head is just a String, which is " "
+      Uri("%2520").path.head shouldEqual "%20" // ok, applies rendering which applies the escaping
+      Uri("%2520").path.toString shouldEqual "%2520" // ok, applies rendering which applies the escaping
+      Uri("/%2F%5C").path.toString shouldEqual """/%2F%5C"""
+      Uri("/%2F%5C").path.head shouldEqual '/'
+      Uri("/%2F%5C").path.tail.head shouldEqual """/\"""
       //#dont-double-decode
 
       // render
@@ -728,9 +732,8 @@ class UriSpec extends WordSpec with Matchers {
       Uri.Authority.parse("user@host").toString shouldEqual "user@host"
 
       val a = Uri.Authority.parse("user:p%40ssword@host")
-      a.userinfo.length shouldEqual "user:p%40ssword".length
-      a.userinfo shouldEqual "user:p%40ssword"
       a.toString shouldEqual "user:p%40ssword@host"
+      a.userinfo shouldEqual "user:p@ssword"
     }
 
     "properly render authority" in {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -11,6 +11,7 @@ import org.scalatest.matchers.{ MatchResult, Matcher }
 import org.scalatest.{ Matchers, WordSpec }
 import akka.parboiled2.UTF8
 import Uri._
+import java.net.{ URI ⇒ JavaURI }
 
 class UriSpec extends WordSpec with Matchers {
 
@@ -721,11 +722,23 @@ class UriSpec extends WordSpec with Matchers {
       Uri("https://host:3030/").withPort(4450).effectivePort shouldEqual 4450
     }
 
+    "parse authority" in {
+      Uri.Authority.parse("localhost").toString shouldEqual "localhost"
+      Uri.Authority.parse("example.com:80").toString shouldEqual "example.com:80"
+      Uri.Authority.parse("user@host").toString shouldEqual "user@host"
+
+      val a = Uri.Authority.parse("user:p%40ssword@host")
+      a.userinfo.length shouldEqual "user:p%40ssword".length
+      a.userinfo shouldEqual "user:p%40ssword"
+      a.toString shouldEqual "user:p%40ssword@host"
+    }
+
     "properly render authority" in {
       Uri("http://localhost/test").authority.toString shouldEqual "localhost"
       Uri("http://example.com:80/test").authority.toString shouldEqual "example.com:80"
       Uri("ftp://host/").authority.toString shouldEqual "host"
       Uri("http://user@host").authority.toString shouldEqual "user@host"
+      Uri("http://user:p%40ssword@host").authority.toString shouldEqual "user:p%40ssword@host"
     }
 
     "keep the specified authority port" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -4,17 +4,22 @@
 
 package akka.http.scaladsl.server
 
+import java.nio.file.Paths
+
 import akka.NotUsed
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
-import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.directives.Credentials
 import com.typesafe.config.{ Config, ConfigFactory }
 import akka.actor.ActorSystem
+import akka.http.javadsl.model.BodyPartEntity
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.common.EntityStreamingSupport
+import akka.http.scaladsl.model.Multipart.FormData.BodyPart
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.io.StdIn
 

--- a/akka-parsing/src/main/scala/akka/parboiled2/CharUtils.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/CharUtils.scala
@@ -97,6 +97,13 @@ object CharUtils {
       putChar((63 - java.lang.Long.numberOfLeadingZeros(long)) & 0xFC)
     } else sb.append('0')
 
+  /** Efficient way to convert single URL encoded value (e.g. %40 => @) into its String representation. */
+  def stringFromHexString(ch1: Char, ch2: Char): String = {
+    val v = Integer.parseInt(new String(Array(ch1, ch2)), 16)
+    if (v < 0) throw new IllegalArgumentException("URLDecoder: Illegal hex characters in escape (%) pattern - negative value")
+    new String(Array(v.asInstanceOf[Byte]))
+  }
+
   /**
    * Returns a String representing the given long in signed decimal representation.
    */


### PR DESCRIPTION
Resolves https://github.com/akka/akka-http/issues/1558 though perhaps this should be solved in a different way...

These escaping things are always a bit tricky when not clearly defined when one is to escape and when not. The users expected to be able to pass in the Java URI, but that renders as escaped, so that would not work. I think we should in addition provide a method that takes Uri as a parameter?