### PR TITLE
Explicitly check if a resource is a dir

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -283,7 +283,8 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
         val jar = new java.util.zip.ZipFile(filePath)
         try {
           val entry = jar.getEntry(resourcePath)
-          Option(jar.getInputStream(entry)) map { is ⇒
+          if (entry.isDirectory) None
+          else Option(jar.getInputStream(entry)) map { is ⇒
             is.close()
             ResourceFile(url, entry.getSize, entry.getTime)
           }


### PR DESCRIPTION
Refs #1560

It appears in a previous JRE version(?) `jar.getInputStream` would
fail for directories, while now an explicit check is needed.

We could even argue opening the input stream is no longer needed
at all, why did we not simply check `isDirectory` before?