### PR TITLE
=doc #1563 remove eviction tests from caching example specs

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
@@ -160,19 +160,7 @@ public class CachingDirectivesExamplesTest extends JUnitRouteTest {
     final Route route = cache(lfuCache, keyerFunction, () -> innerRoute);
     //#create-cache
 
-    // tests:
-    testRoute(route)
-      .run(HttpRequest.GET("/1"))
-      .assertEntity("Request for http://example.com/1 @ count 1");
-
-    for (int i = 1; i < 500; i++) {
-      testRoute(route)
-        .run(HttpRequest.GET("/" + i))
-        .assertEntity("Request for http://example.com/" + i + " @ count " + i);
-    }
-
-    testRoute(route)
-      .run(HttpRequest.GET("/1"))
-      .assertEntity("Request for http://example.com/1 @ count 500");
+    // We don't test the eviction settings here. Deterministic testing of eviction is hard because
+    // caffeine's LFU is probabilistic.
   }
 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala
@@ -126,19 +126,7 @@ class CachingDirectivesExamplesSpec extends RoutingSpec with CachingDirectives {
     val route = cache(lfuCache, keyerFunction)(innerRoute)
     //#create-cache
 
-    // tests:
-    Get("/1") ~> route ~> check {
-      responseAs[String] shouldEqual "Request for http://example.com/1 @ count 1"
-    }
-
-    for (i <- 1 until 500) {
-      Get(s"/$i") ~> route ~> check {
-        responseAs[String] shouldEqual s"Request for http://example.com/$i @ count $i"
-      }
-    }
-
-    Get("/1") ~> route ~> check {
-      responseAs[String] shouldEqual "Request for http://example.com/1 @ count 500"
-    }
+    // We don't test the eviction settings here. Deterministic testing of eviction is hard because
+    // caffeine's LFU is probabilistic.
   }
 }


### PR DESCRIPTION
Eviction is probabilistic in caffeine's LFU cache, so simple deterministic
tests are likely to fail now and then.

Fixes #1563.