### PR TITLE
=htc simplify decompressor/deflate infrastructure

### DIFF
--- a/akka-http/src/main/mima-filters/10.0.10.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.0.10.backwards.excludes
@@ -1,6 +1,12 @@
 # Mima filters needed to check newer versions against 10.0.10
 
-# Issue #1033 Add multiple file upload directive
+# Issue #1033 Add multiple file upload directive, trait not to be extended by third-party implementors
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.FileUploadDirectives.fileUploadAll")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.FileUploadDirectives.storeUploadedFile")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.FileUploadDirectives.storeUploadedFiles")
+
+# Changes to (now) internal API. These implementation classes were only accidentally public and unlikely to be used by third-party code.
+ProblemFilters.exclude[MissingClassProblem]("akka.http.scaladsl.coding.DeflateDecompressorBase$DecompressorParsingLogic")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.coding.DeflateDecompressor.createLogic")
+ProblemFilters.exclude[MissingClassProblem]("akka.http.scaladsl.coding.DeflateDecompressorBase$DecompressorParsingLogic$Inflate")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.coding.GzipDecompressor.createLogic")

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
@@ -88,72 +88,62 @@ private[http] object DeflateCompressor {
 
 class DeflateDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
 
-  override def createLogic(attr: Attributes) = new DecompressorParsingLogic {
-    var _inflater: Inflater = _
-    override def inflater: Inflater = if (_inflater != null) {
-      _inflater
-    } else {
-      throw new IllegalStateException("Inflater used before the header was analysed for wrapping")
-    }
-
-    override val inflateState = new Inflate(true) {
+  override def createLogic(attr: Attributes) = new ParsingLogic {
+    /** Step that probes if the deflate stream contains a zlib wrapper */
+    case object ProbeWrapping extends ParseStep[ByteString] {
       override def onTruncation(): Unit = completeStage()
 
       override def parse(reader: ByteStringParser.ByteReader): ParseResult[ByteString] = {
-        val data = reader.remainingData
-        if (_inflater == null) {
-          _inflater = examineAndBuildInflater(data)
-        }
-        super.parse(new ByteStringParser.ByteReader(reader.takeAll()))
+        val inflater = examineAndBuildInflater(reader.remainingData)
+        ParseResult(None, new Inflate(inflater, noPostProcessing = true, ProbeWrapping))
       }
     }
 
     /**
-     * We examine the head byte of the incoming data stream, looking for the standard 0x8 in the first 4 bits of the  header
+     * We examine the head byte of the incoming data stream, looking for the standard 0x8 in the first 4 bits of the header
      * that marks a byte stream as using a wrapped deflate stream. If we don't find that header, we fall back to the no-wrap
-     * inflater
+     * inflater.
+     *
+     * Wrapped deflate streams usually start with the first byte being 0x78 == b01111000. The lower three bits == 000 would mean an
+     * uncompressed stream for an unwrapped deflate stream. However, in that case the remaining bits are undefined and
+     * would likely be set to zero as well. Therefore, checking the lower 4 bits to be b1000 seems to be sufficient to
+     * decide that a stream is wrapped.
+     *
      * More details on the structure of wrap and no-wrap headers of Deflate can be found at:
      * https://www.ietf.org/rfc/rfc1950.txt (wrap) and
      * https://www.ietf.org/rfc/rfc1951.txt (no-wrap)
      */
-    private def examineAndBuildInflater(bytes: ByteString): Inflater =
-      bytes.headOption.filter(b ⇒ (b & 0x0F) != 8)
-        .fold(new Inflater())(_ ⇒ new Inflater(true))
+    private def examineAndBuildInflater(bytes: ByteString): Inflater = {
+      val wrapped = (bytes.head & 0x0F) == 0x08
+      new Inflater(!wrapped)
+    }
 
-    override def afterInflate = inflateState
-    override def afterBytesRead(buffer: Array[Byte], offset: Int, length: Int): Unit = {}
-
-    startWith(inflateState)
+    startWith(ProbeWrapping)
   }
 }
 
 abstract class DeflateDecompressorBase(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault)
   extends ByteStringParser[ByteString] {
 
-  abstract class DecompressorParsingLogic extends ParsingLogic {
-    def inflater: Inflater
-    def afterInflate: ParseStep[ByteString]
-    def afterBytesRead(buffer: Array[Byte], offset: Int, length: Int): Unit
-    val inflateState: Inflate
+  class Inflate(inflater: Inflater, noPostProcessing: Boolean, afterInflate: ParseStep[ByteString]) extends ParseStep[ByteString] {
+    protected def afterBytesRead(buffer: Array[Byte], offset: Int, length: Int): Unit = {}
 
-    abstract class Inflate(noPostProcessing: Boolean) extends ParseStep[ByteString] {
-      override def canWorkWithPartialData = true
-      override def parse(reader: ByteStringParser.ByteReader): ParseResult[ByteString] = {
-        inflater.setInput(reader.remainingData.toArray)
+    override def canWorkWithPartialData = true
+    override def parse(reader: ByteStringParser.ByteReader): ParseResult[ByteString] = {
+      inflater.setInput(reader.remainingData.toArray)
 
-        val buffer = new Array[Byte](maxBytesPerChunk)
-        val read = inflater.inflate(buffer)
+      val buffer = new Array[Byte](maxBytesPerChunk)
+      val read = inflater.inflate(buffer)
 
-        reader.skip(reader.remainingSize - inflater.getRemaining)
+      reader.skip(reader.remainingSize - inflater.getRemaining)
 
-        if (read > 0) {
-          afterBytesRead(buffer, 0, read)
-          val next = if (inflater.finished()) afterInflate else this
-          ParseResult(Some(ByteString.fromArray(buffer, 0, read)), next, noPostProcessing)
-        } else {
-          if (inflater.finished()) ParseResult(None, afterInflate, noPostProcessing)
-          else throw ByteStringParser.NeedMoreData
-        }
+      if (read > 0) {
+        afterBytesRead(buffer, 0, read)
+        val next = if (inflater.finished()) afterInflate else this
+        ParseResult(Some(ByteString.fromArray(buffer, 0, read)), next, noPostProcessing)
+      } else {
+        if (inflater.finished()) ParseResult(None, afterInflate, noPostProcessing)
+        else throw ByteStringParser.NeedMoreData
       }
     }
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
@@ -4,11 +4,13 @@
 
 package akka.http.scaladsl.coding
 
-import java.util.zip.{ Inflater, Deflater }
+import java.util.zip.{ Deflater, Inflater }
+
 import akka.stream.Attributes
 import akka.stream.impl.io.ByteStringParser
 import ByteStringParser.{ ParseResult, ParseStep }
-import akka.util.{ ByteStringBuilder, ByteString }
+import akka.annotation.InternalApi
+import akka.util.{ ByteString, ByteStringBuilder }
 
 import scala.annotation.tailrec
 import akka.http.scaladsl.model._
@@ -70,7 +72,9 @@ class DeflateCompressor extends Compressor {
   }
 }
 
-private[http] object DeflateCompressor {
+/** Internal API */
+@InternalApi
+private[coding] object DeflateCompressor {
   val MinBufferSize = 1024
 
   @tailrec
@@ -86,7 +90,9 @@ private[http] object DeflateCompressor {
   }
 }
 
-class DeflateDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
+/** Internal API */
+@InternalApi
+private[coding] class DeflateDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
 
   override def createLogic(attr: Attributes) = new ParsingLogic {
     /** Step that probes if the deflate stream contains a zlib wrapper */
@@ -122,7 +128,9 @@ class DeflateDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefaul
   }
 }
 
-abstract class DeflateDecompressorBase(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault)
+/** Internal API */
+@InternalApi
+private[coding] abstract class DeflateDecompressorBase(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault)
   extends ByteStringParser[ByteString] {
 
   class Inflate(inflater: Inflater, noPostProcessing: Boolean, afterInflate: ParseStep[ByteString]) extends ParseStep[ByteString] {

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Gzip.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Gzip.scala
@@ -27,7 +27,9 @@ object Gzip extends Gzip(Encoder.DefaultFilter) {
   def apply(messageFilter: HttpMessage ⇒ Boolean) = new Gzip(messageFilter)
 }
 
-class GzipCompressor extends DeflateCompressor {
+/** Internal API */
+@InternalApi
+private[coding] class GzipCompressor extends DeflateCompressor {
   override protected lazy val deflater = new Deflater(Deflater.BEST_COMPRESSION, true)
   private val checkSum = new CRC32 // CRC32 of uncompressed data
   private var headerSent = false
@@ -60,7 +62,9 @@ class GzipCompressor extends DeflateCompressor {
   }
 }
 
-class GzipDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
+/** Internal API */
+@InternalApi
+private[coding] class GzipDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
   override def createLogic(attr: Attributes) = new ParsingLogic {
     private[this] val inflater = new Inflater(true)
     private[this] var crc32: CRC32 = new CRC32

--- a/docs/src/main/paradox/scala/http/release-notes.md
+++ b/docs/src/main/paradox/scala/http/release-notes.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 10.0.11
+
+### Incompatible changes to akka.http.{java,scala}dsl.coding classes
+
+To clean up internal code, we made a few incompatible changes to classes that were previously kept public accidentally.
+We now made those classes private and marked them as `@InternalApi`. Affected classes are `akka.http.scaladsl.coding.DeflateDecompressorBase`,
+`akka.http.scaladsl.coding.DeflateCompressor`, and `akka.http.scaladsl.coding.GzipCompressor`.
+This is in violation with a strict reading of our binary compatibility guidelines. We did that change for
+pragmatic reasons because we believe that it is unlikely that these classes have been used or extended by third parties.
+If this assumption turns out to be too optimistic and integration with third-party code breaks because of this,
+please let us know.
+
 ## 10.0.10
 
 ### Support for HTTP(S) proxies with Authorization


### PR DESCRIPTION
The idea is to replace the handlers in `DecompressorParsingLogic` with simple parameters of the `Inflate` step.