### PR TITLE
=htc #1492 remove duplicate settings from akka.http.host-connection-pool.client

### DIFF
--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -308,46 +308,10 @@ akka.http {
     # will automatically terminate itself. Set to `infinite` to completely disable idle timeouts.
     idle-timeout = 30 s
 
-    # Modify to tweak client settings for host connection pools only.
-    #
-    # IMPORTANT:
-    # Please note that this section mirrors `akka.http.client` however is used only for pool-based APIs,
-    # such as `Http().superPool` or `Http().singleRequest`.
+    # Modify this section to tweak client settings only for host connection pools APIs like `Http().superPool` or
+    # `Http().singleRequest`.
     client = {
-      # The default value of the `User-Agent` header to produce if no
-      # explicit `User-Agent`-header was included in a request.
-      # If this value is the empty string and no header was included in
-      # the request, no `User-Agent` header will be rendered at all.
-      user-agent-header = akka-http/${akka.http.version}
-
-      # The time period within which the TCP connecting process must be completed.
-      connecting-timeout = 10s
-
-      # The time after which an idle connection will be automatically closed.
-      # Set to `infinite` to completely disable idle timeouts.
-      idle-timeout = 60 s
-
-      # The initial size of the buffer to render the request headers in.
-      # Can be used for fine-tuning request rendering performance but probably
-      # doesn't have to be fiddled with in most applications.
-      request-header-size-hint = 512
-
-      # Socket options to set for the listening socket. If a setting is left
-      # undefined, it will use whatever the default on the system is.
-      socket-options {
-        so-receive-buffer-size = undefined
-        so-send-buffer-size = undefined
-        so-reuse-address = undefined
-        so-traffic-class = undefined
-        tcp-keep-alive = undefined
-        tcp-oob-inline = undefined
-        tcp-no-delay = undefined
-      }
-
-      # IMPORTANT: Please note that this section is replicated in `client` and `server`.
-      parsing {
-        # no overrides by default, see `akka.http.parsing` for default values
-      }
+      # no overrides by default, see `akka.http.client` for default values
     }
   }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.settings
+
+import akka.testkit.AkkaSpec
+import akka.http.scaladsl.model.headers.`User-Agent`
+
+class ConnectionPoolSettingsSpec extends AkkaSpec {
+  "ConnectionPoolSettings" should {
+    "use akka.http.client settings by default" in {
+      val settings = config(
+        """
+          akka.http.client.user-agent-header = "serva/0.0"
+        """)
+
+      settings.connectionSettings.userAgentHeader shouldEqual Some(`User-Agent`.parseFromValueString("serva/0.0").right.get)
+    }
+    "allow overriding client settings with akka.http.host-connection-pool.client" in {
+      val settings = config(
+        """
+          akka.http.client.request-header-size-hint = 1024
+          akka.http.client.user-agent-header = "serva/0.0"
+          akka.http.host-connection-pool.client.user-agent-header = "serva/5.7"
+        """)
+
+      settings.connectionSettings.userAgentHeader shouldEqual Some(`User-Agent`.parseFromValueString("serva/5.7").right.get)
+      settings.connectionSettings.requestHeaderSizeHint shouldEqual 1024 // still fall back
+    }
+  }
+
+  def config(configString: String): ConnectionPoolSettings =
+    ConnectionPoolSettings(configString)
+}


### PR DESCRIPTION
This way the defaults from akka.http.client automatically apply.

Fixes #1492.