### PR TITLE
Adding percent encoding length check for Path.Uri #1553

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -726,7 +726,7 @@ object Uri {
           def intValueOfHexChar(j: Int) = {
             val c = string.charAt(j)
             if (HEXDIG(c)) CharUtils.hexValue(c)
-            else throw new IllegalArgumentException("Illegal percent-encoding at pos " + j)
+            else fail("Illegal percent-encoding at pos " + j)
           }
           intValueOfHexChar(i) * 16 + intValueOfHexChar(i + 1)
         }
@@ -734,6 +734,12 @@ object Uri {
         var lastPercentSignIndexPlus3 = ix + 3
         while (lastPercentSignIndexPlus3 < string.length && string.charAt(lastPercentSignIndexPlus3) == '%')
           lastPercentSignIndexPlus3 += 3
+
+        // check % and 2 HEX string at last %.
+        if (string.length < lastPercentSignIndexPlus3) {
+          fail("Illegal percent-encoding at pos " + (lastPercentSignIndexPlus3 - 3))
+        }
+
         val bytesCount = (lastPercentSignIndexPlus3 - ix) / 3
         val bytes = new Array[Byte](bytesCount)
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -270,6 +270,12 @@ class UriSpec extends WordSpec with Matchers {
       Path("/abc/def/").dropChars(8) shouldEqual Path("/")
       Path("/abc/def/").dropChars(9) shouldEqual Empty
     }
+
+    "not accept illegal parcent-encoding" in {
+      the[IllegalUriException] thrownBy Path("/example/%12%")
+      the[IllegalUriException] thrownBy Path("/example/%12%1")
+      the[IllegalUriException] thrownBy Path("/example/%12%1V")
+    }
   }
 
   "Uri.Query instances" should {
@@ -595,6 +601,14 @@ class UriSpec extends WordSpec with Matchers {
           "Illegal URI reference: Invalid input 'G', expected HEXDIG (line 1, column 13)",
           "http://use%2G@host\n" +
             "            ^")
+      }
+
+      // illgal percent-encoding ends with %
+      the[IllegalUriException] thrownBy Uri("http://www.example.com/%CE%B8%") shouldBe {
+        IllegalUriException(
+          "Illegal URI reference: Unexpected end of input, expected HEXDIG (line 1, column 31)",
+          "http://www.example.com/%CE%B8%\n" +
+            "                              ^")
       }
 
       // illegal path

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -603,7 +603,7 @@ class UriSpec extends WordSpec with Matchers {
             "            ^")
       }
 
-      // illgal percent-encoding ends with %
+      // illegal percent-encoding ends with %
       the[IllegalUriException] thrownBy Uri("http://www.example.com/%CE%B8%") shouldBe {
         IllegalUriException(
           "Illegal URI reference: Unexpected end of input, expected HEXDIG (line 1, column 31)",


### PR DESCRIPTION
* Add percent encoding length check at Uri.decode. Bcause
StringIndexOutOfBoundsException raises when Uri.Path call by illegal
format(ex. %AA%, %AA%1).
* Add test case