### PR TITLE
=htc #1592 fix NPE during text execution leading to spurious test failures

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -438,7 +438,7 @@ class HostConnectionPoolSpec extends AkkaSpec(
               .run()(singleElementBufferMaterializer)
         }
 
-        private val serverConnections = TestProbe()
+        private lazy val serverConnections = TestProbe()
 
         def expectNextConnection(): ServerConnection =
           serverConnections.expectMsgType[ServerConnection]
@@ -446,7 +446,7 @@ class HostConnectionPoolSpec extends AkkaSpec(
         def expectNoNewConnection(): Unit =
           serverConnections.expectNoMsg()
 
-        protected lazy val server =
+        protected override lazy val server =
           Flow.fromSinkAndSourceMat(
             // buffer is needed because the async subscriber/publisher boundary will otherwise request > 1
             Flow[HttpRequest].buffer(1, OverflowStrategy.backpressure)


### PR DESCRIPTION
Couldn't reproduce the exact issue but NPE in this line

    serverConnections.ref ! connection

is most likely to be caused by an initialization issue.

Fixes #1592.