### PR TITLE
Add markdown heading.

### DIFF
--- a/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/scala/http/routing-dsl/testkit.md
@@ -54,6 +54,8 @@ status shouldEqual 200
 
 The following inspectors are defined:
 
+### Table of Inspectors
+
 |Inspector                                    | Description                                                                                                                                                         |
 |---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |`charset: HttpCharset`                       | Identical to `contentType.charset`                                                                                                                                  |


### PR DESCRIPTION
The original requirement is from https://github.com/akka/akka-http-quickstart-scala.g8/issues/13.
I think it could be useful for external sites to link this table of inspectors directly. Thanks! :)