### PR TITLE
Make 'sbt unidoc' compile again

### DIFF
--- a/akka-http-caching/src/main/scala/akka/http/caching/javadsl/CachingSettings.scala
+++ b/akka-http-caching/src/main/scala/akka/http/caching/javadsl/CachingSettings.scala
@@ -9,8 +9,6 @@ import akka.http.caching.scaladsl.{ CachingSettingsImpl, LfuCacheSettingsImpl }
 import akka.http.javadsl.settings.SettingsCompanion
 import scala.concurrent.duration.Duration
 import com.typesafe.config.Config
-import akka.http.impl.util.JavaMapping.Implicits._
-import akka.http.caching.CacheJavaMapping.Implicits._
 
 /**
  * Public API but not intended for subclassing
@@ -19,8 +17,11 @@ import akka.http.caching.CacheJavaMapping.Implicits._
 abstract class CachingSettings private[http] () { self: CachingSettingsImpl ⇒
   def lfuCacheSettings: LfuCacheSettings
 
-  def withLfuCacheSettings(newSettings: LfuCacheSettings): CachingSettings =
+  def withLfuCacheSettings(newSettings: LfuCacheSettings): CachingSettings = {
+    import akka.http.impl.util.JavaMapping.Implicits._
+    import akka.http.caching.CacheJavaMapping.Implicits._
     self.copy(lfuCacheSettings = newSettings.asScala)
+  }
 }
 
 /**


### PR DESCRIPTION
I cannot quite explain why 'sbt unidoc' would fail to compile without this
change, but this makes things a little nicer anyway and appears to fix the
problem