### PR TITLE
=htc #1614 fix genjavadoc generation

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -59,11 +59,10 @@ object ConnectionContext {
 
 abstract class ConnectionContext {
   def isSecure: Boolean
-  /** Java API */
+  def sslConfig: Option[AkkaSSLConfig]
 
   @deprecated("'default-http-port' and 'default-https-port' configuration properties are used instead", since = "10.0.11")
   def getDefaultPort: Int
-  def sslConfig: Option[AkkaSSLConfig]
 }
 
 abstract class HttpConnectionContext extends akka.http.javadsl.ConnectionContext {


### PR DESCRIPTION
It seems something prevented merging the "Java API" docs with the deprecation
docs leading to compilation errors during javadoc generation.