### PR TITLE
=htc try to keep pool running when a single slot fails

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.0.11.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.11.backwards.excludes
@@ -1,0 +1,2 @@
+# Don't monitor changes to internal API
+ProblemFilters.exclude[Problem]("akka.http.impl.*")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -20,9 +20,12 @@ import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import akka.stream._
+import akka.util.OptionVal
 
+import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.util.control.NonFatal
 import scala.util.{ Failure, Success }
 
 /**
@@ -180,43 +183,76 @@ private[client] object NewHostConnectionPool {
           def onConnectionCompleted(): Unit = updateState(_.onConnectionCompleted(this))
           def onConnectionFailed(cause: Throwable): Unit = updateState(_.onConnectionFailed(this, cause))
 
-          protected def updateState(f: SlotState ⇒ SlotState): Unit = {
-            if (currentTimeout ne null) {
-              currentTimeout.cancel()
-              currentTimeout = null
-              currentTimeoutId = -1
-            }
+          type StateTransition = SlotState ⇒ SlotState
+          protected def updateState(f: StateTransition): Unit = {
+            def runOneTransition(f: StateTransition): OptionVal[StateTransition] =
+              try {
+                cancelCurrentTimeout()
 
-            val previousState = state
-            state = f(state)
-            debug(s"State change [${previousState.name}] -> [${state.name}]")
+                val previousState = state
+                state = f(state)
+                debug(s"State change [${previousState.name}] -> [${state.name}]")
 
-            state.stateTimeout match {
-              case Duration.Inf ⇒
-              case d: FiniteDuration ⇒
-                val myTimeoutId = createNewTimeoutId()
-                currentTimeoutId = myTimeoutId
-                currentTimeout =
-                  materializer.scheduleOnce(d, safeRunnable {
-                    if (myTimeoutId == currentTimeoutId) { // timeout may race with state changes, ignore if timeout isn't current any more
-                      debug(s"Slot timeout after $d")
-                      updateState(_.onTimeout(this))
-                    }
-                  })
-            }
+                state.stateTimeout match {
+                  case Duration.Inf ⇒
+                  case d: FiniteDuration ⇒
+                    val myTimeoutId = createNewTimeoutId()
+                    currentTimeoutId = myTimeoutId
+                    currentTimeout =
+                      materializer.scheduleOnce(d, safeRunnable {
+                        if (myTimeoutId == currentTimeoutId) { // timeout may race with state changes, ignore if timeout isn't current any more
+                          debug(s"Slot timeout after $d")
+                          updateState(_.onTimeout(this))
+                        }
+                      })
+                }
 
-            if (!previousState.isIdle && state.isIdle) {
-              debug("Slot became idle... Trying to pull")
-              pullIfNeeded()
-            }
+                if (!previousState.isIdle && state.isIdle) {
+                  debug("Slot became idle... Trying to pull")
+                  pullIfNeeded()
+                }
 
-            if (state == Unconnected && numConnectedSlots < settings.minConnections) {
-              debug(s"Preconnecting because number of connected slots fell down to $numConnectedSlots")
-              updateState(_.onPreConnect(this))
-            }
+                if (state == Unconnected && numConnectedSlots < settings.minConnections) {
+                  debug(s"Preconnecting because number of connected slots fell down to $numConnectedSlots")
+                  OptionVal.Some(_.onPreConnect(this))
+                } else
+                  OptionVal.None
 
-            // put additional bookkeeping here (like keeping track of idle connections)
+                // put additional bookkeeping here (like keeping track of idle connections)
+              } catch {
+                case NonFatal(ex) ⇒
+                  error(
+                    ex,
+                    "Slot execution failed. That's probably a bug. Please file a bug at https://github.com/akka/akka-http/issues. Slot is restarted.")
+
+                  try {
+                    cancelCurrentTimeout()
+                    closeConnection()
+                    state.onShutdown(this)
+                    OptionVal.None
+                  } catch {
+                    case NonFatal(ex) ⇒
+                      error(ex, "Shutting down slot after error failed.")
+                  }
+                  state = Unconnected
+                  OptionVal.Some(_.onPreConnect(this))
+              }
+
+            /** Run a loop of state transitions */
+            @tailrec def loop(f: StateTransition, remainingIterations: Int): Unit =
+              if (remainingIterations > 0)
+                runOneTransition(f) match {
+                  case OptionVal.None       ⇒ // no more changes
+                  case OptionVal.Some(next) ⇒ loop(next, remainingIterations - 1)
+                }
+              else
+                throw new IllegalStateException(
+                  "State transition loop exceeded maximum number of loops. The pool will shutdown itself. " +
+                    "That's probably a bug. Please file a bug at https://github.com/akka/akka-http/issues. ")
+
+            loop(f, 10)
           }
+
           protected def setState(newState: SlotState): Unit =
             updateState(_ ⇒ newState)
 
@@ -231,6 +267,9 @@ private[client] object NewHostConnectionPool {
 
           def warning(msg: String, arg1: AnyRef): Unit =
             log.warning(s"[{} ({})] $msg", slotId, state.productPrefix, arg1)
+
+          def error(cause: Throwable, msg: String): Unit =
+            log.error(cause, s"[{} ({})] $msg", slotId, state.productPrefix)
 
           def settings: ConnectionPoolSettings = _settings
 
@@ -260,6 +299,13 @@ private[client] object NewHostConnectionPool {
           def dispatchResponse(req: RequestContext, res: HttpResponse): Unit = logic.dispatchResponse(req, res)
           def dispatchFailure(req: RequestContext, cause: Throwable): Unit = logic.dispatchFailure(req, cause)
           def willCloseAfter(res: HttpResponse): Boolean = logic.willClose(res)
+
+          private[this] def cancelCurrentTimeout(): Unit =
+            if (currentTimeout ne null) {
+              currentTimeout.cancel()
+              currentTimeout = null
+              currentTimeoutId = -1
+            }
         }
         final class SlotConnection(
           _slot:                  Slot,

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -98,6 +98,13 @@ private[pool] object SlotState {
   sealed trait BusyState extends SlotState {
     final override def isIdle = false // no HTTP pipelining right now
     def ongoingRequest: RequestContext
+
+    override def onShutdown(ctx: SlotContext): Unit = {
+      ctx.dispatchFailure(
+        ongoingRequest,
+        new IllegalStateException(s"Slot shut down with ongoing request [${ongoingRequest.request.debugString}]"))
+      super.onShutdown(ctx)
+    }
   }
 
   case object Unconnected extends SlotState with IdleState {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -426,7 +426,7 @@ class HostConnectionPoolSpec extends AkkaSpec(
               .joinMat(clientServerImplementation.get(killSwitch))(Keep.right)
               .recover {
                 case ex ⇒
-                  println(s"Pool failed with error ${ex.getMessage}")
+                  println(s"Server connection failed with error ${ex.getMessage}")
                   ex.printStackTrace()
                   throw ex
               }


### PR DESCRIPTION
This is a best effort try not having to kill a pool if a single slot gets
into a weird state. In the best case, that will allow the pool to keep going
in the presence of bugs that are only triggered rarely. On the other hand,
the risk is that we keep a pool alive that might be in a weird state leading
to more problem further down the road.