### PR TITLE
A few pool improvements

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -180,7 +180,6 @@ private[client] object NewHostConnectionPool {
                 debug(s"State change [${previousState.name}] -> [${state.name}]")
 
                 state.stateTimeout match {
-                  case Duration.Inf ⇒
                   case d: FiniteDuration ⇒
                     val myTimeoutId = createNewTimeoutId()
                     currentTimeoutId = myTimeoutId
@@ -191,6 +190,7 @@ private[client] object NewHostConnectionPool {
                           updateState(_.onTimeout(this))
                         }
                       })
+                  case _ ⇒ // no timeout set, nothing to do
                 }
 
                 if (!previousState.isIdle && state.isIdle) {
@@ -366,6 +366,7 @@ private[client] object NewHostConnectionPool {
                       case Success(_)     ⇒ withSlot(_.onResponseEntityCompleted())
                       case Failure(cause) ⇒ withSlot(_.onResponseEntityFailed(cause))
                     })(ExecutionContexts.sameThreadExecutionContext)
+                  case Failure(_) ⇒ throw new IllegalStateException("Should never fail")
                 })(ExecutionContexts.sameThreadExecutionContext)
 
                 withSlot(_.onResponseReceived(response.withEntity(newEntity)))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -12,7 +12,7 @@ import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
 import akka.http.impl.engine.client.PoolFlow.{ RequestContext, ResponseContext }
-import akka.http.impl.engine.client.pool.SlotState.Unconnected
+import akka.http.impl.engine.client.pool.SlotState.{ Unconnected, WaitingForEndOfResponseEntity, WaitingForResponseDispatch, WaitingForResponseEntitySubscription }
 import akka.http.impl.util.{ StageLoggingWithOverride, StreamUtils }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse, headers }
@@ -26,7 +26,7 @@ import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success }
+import scala.util.{ Failure, Success, Try }
 
 /**
  * Internal API
@@ -36,15 +36,8 @@ import scala.util.{ Failure, Success }
  * Backpressure logic of the external interface:
  *
  *  * pool pulls if there's a free slot
- *  * pool buffers responses until they are pulled. The buffer is unlimited in theory with the reasoning that
- *    reasonable behavior can be expected from downstream consumers, i.e. at least one pull for every request sent in.
- *
- *    It's hard to say if that's reasonable enough. As we can only ever receive a single pull we will always need a
- *    buffer of at least `max-connections` elements to allow for any parallelism. So, an alternative strategy could be
- *    to leave a response in its slot until it is fetched.
- *
- *    (The old implementation may or may not have implemented similar behavior. It probably had a buffer because of
- *     the merge in the involved graph structure.)
+ *  * pool buffers outgoing response in a slot and registers them for becoming dispatchable. When a response is pulled
+ *    a waiting slot is notified and the response is then dispatched.
  *
  * The implementation is split up into this class which does all the stream-based wiring. It contains a vector of
  * slots that contain the mutable slot state for every slot.
@@ -76,7 +69,7 @@ private[client] object NewHostConnectionPool {
         private[this] var lastTimeoutId = 0L
 
         val slots = Vector.tabulate(_settings.maxConnections)(new Slot(_))
-        val outBuffer: util.Deque[ResponseContext] = new util.ArrayDeque[ResponseContext]
+        val slotsWaitingForDispatch: util.Deque[Slot] = new util.ArrayDeque[Slot]
         val retryBuffer: util.Deque[RequestContext] = new util.ArrayDeque[RequestContext]
 
         override def preStart(): Unit = {
@@ -89,8 +82,9 @@ private[client] object NewHostConnectionPool {
           pullIfNeeded()
         }
         def onPull(): Unit =
-          if (!outBuffer.isEmpty)
-            push(responsesOut, outBuffer.pollFirst())
+          if (!slotsWaitingForDispatch.isEmpty)
+            slotsWaitingForDispatch.pollFirst().onResponseDispatchable()
+        // else push when next slot becomes dispatchable
 
         def manageState(): Unit = {
           pullIfNeeded()
@@ -108,22 +102,12 @@ private[client] object NewHostConnectionPool {
           // TODO: optimize by keeping track of idle connections?
           slots.exists(_.isIdle)
 
-        def dispatchResponse(req: RequestContext, res: HttpResponse): Unit =
-          dispatchResponseContext(ResponseContext(req, Success(res)))
-
-        def dispatchFailure(req: RequestContext, cause: Throwable): Unit = {
-          if (req.retriesLeft > 0) {
+        def dispatchResponseResult(req: RequestContext, result: Try[HttpResponse]): Unit =
+          if (result.isFailure && req.retriesLeft > 0) {
             log.debug("Request has {} retries left, retrying...", req.retriesLeft)
             retryBuffer.addLast(req.copy(retriesLeft = req.retriesLeft - 1))
           } else
-            dispatchResponseContext(ResponseContext(req, Failure(cause)))
-        }
-
-        def dispatchResponseContext(resCtx: ResponseContext): Unit =
-          if (outBuffer.isEmpty && isAvailable(responsesOut))
-            push(responsesOut, resCtx)
-          else
-            outBuffer.addLast(resCtx)
+            push(responsesOut, ResponseContext(req, result))
 
         def dispatchRequest(req: RequestContext): Unit = {
           val slot =
@@ -173,6 +157,8 @@ private[client] object NewHostConnectionPool {
 
           def onResponseReceived(response: HttpResponse): Unit =
             updateState(_.onResponseReceived(this, response))
+          def onResponseDispatchable(): Unit =
+            updateState(_.onResponseDispatchable(this))
           def onResponseEntitySubscribed(): Unit =
             updateState(_.onResponseEntitySubscribed(this))
           def onResponseEntityCompleted(): Unit =
@@ -212,11 +198,24 @@ private[client] object NewHostConnectionPool {
                   pullIfNeeded()
                 }
 
-                if (state == Unconnected && numConnectedSlots < settings.minConnections) {
-                  debug(s"Preconnecting because number of connected slots fell down to $numConnectedSlots")
-                  OptionVal.Some(_.onPreConnect(this))
-                } else
-                  OptionVal.None
+                state match {
+                  case _: WaitingForResponseDispatch ⇒
+                    if (isAvailable(responsesOut)) OptionVal.Some(_.onResponseDispatchable(this))
+                    else {
+                      logic.slotsWaitingForDispatch.addLast(this)
+                      OptionVal.None
+                    }
+                  case WaitingForResponseEntitySubscription(_, HttpResponse(_, _, _: HttpEntity.Strict, _), _) ⇒
+                    // the connection cannot drive these for a strict entity so we have to loop ourselves
+                    OptionVal.Some(_.onResponseEntitySubscribed(this))
+                  case WaitingForEndOfResponseEntity(_, HttpResponse(_, _, _: HttpEntity.Strict, _)) ⇒
+                    // the connection cannot drive these for a strict entity so we have to loop ourselves
+                    OptionVal.Some(_.onResponseEntityCompleted(this))
+                  case Unconnected if numConnectedSlots < settings.minConnections ⇒
+                    debug(s"Preconnecting because number of connected slots fell down to $numConnectedSlots")
+                    OptionVal.Some(_.onPreConnect(this))
+                  case _ ⇒ OptionVal.None
+                }
 
                 // put additional bookkeeping here (like keeping track of idle connections)
               } catch {
@@ -296,8 +295,8 @@ private[client] object NewHostConnectionPool {
           def isCurrentConnection(conn: SlotConnection): Boolean = connection eq conn
           def isConnectionClosed: Boolean = (connection eq null) || connection.isClosed
 
-          def dispatchResponse(req: RequestContext, res: HttpResponse): Unit = logic.dispatchResponse(req, res)
-          def dispatchFailure(req: RequestContext, cause: Throwable): Unit = logic.dispatchFailure(req, cause)
+          def dispatchResponseResult(req: RequestContext, result: Try[HttpResponse]): Unit = logic.dispatchResponseResult(req, result)
+
           def willCloseAfter(res: HttpResponse): Boolean = logic.willClose(res)
 
           private[this] def cancelCurrentTimeout(): Unit =
@@ -352,10 +351,7 @@ private[client] object NewHostConnectionPool {
             withSlot(_.debug("Received response")) // FIXME: add abbreviated info
 
             response.entity match {
-              case _: HttpEntity.Strict ⇒
-                withSlot(_.onResponseReceived(response))
-                withSlot(_.onResponseEntitySubscribed())
-                withSlot(_.onResponseEntityCompleted())
+              case _: HttpEntity.Strict ⇒ withSlot(_.onResponseReceived(response))
               case e ⇒
                 ongoingResponseEntity = Some(e)
 
@@ -411,7 +407,6 @@ private[client] object NewHostConnectionPool {
         }
         def openConnection(slot: Slot): SlotConnection = {
           val requestOut = new SubSourceOutlet[HttpRequest](s"PoolSlot[${slot.slotId}].requestOut")
-
           val responseIn = new SubSinkInlet[HttpResponse](s"PoolSlot[${slot.slotId}].responseIn")
           responseIn.pull()
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -100,7 +100,7 @@ private[pool] object SlotState {
   sealed trait IdleState extends SlotState {
     final override def isIdle = true
   }
-  sealed trait BusyState extends SlotState {
+  sealed private[pool] /* to avoid warnings */ trait BusyState extends SlotState {
     final override def isIdle = false // no HTTP pipelining right now
     def ongoingRequest: RequestContext
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -25,6 +25,7 @@ import akka.stream.testkit.{ TestPublisher, TestSubscriber }
 import akka.testkit._
 import akka.util.ByteString
 import org.reactivestreams.{ Publisher, Subscriber }
+import org.scalatest.concurrent.Eventually
 
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
@@ -47,7 +48,7 @@ class HostConnectionPoolSpec extends AkkaSpec(
      }
      akka.http.client.log-unencrypted-network-bytes = 200
   """
-) {
+) with Eventually {
   implicit val materializer = ActorMaterializer()
   val singleElementBufferMaterializer = materializer // ActorMaterializer(ActorMaterializerSettings(system).withInputBuffer(1, 1))
   val defaultSettings =
@@ -119,6 +120,7 @@ class HostConnectionPoolSpec extends AkkaSpec(
 
         pushRequest(HttpRequest(uri = "/3"))
         conn1.pushResponse(HttpResponse())
+        expectResponse()
         conn1.expectRequestToPath("/3")
       }
       "only buffer a reasonable number of extra requests" in pending
@@ -295,6 +297,20 @@ class HostConnectionPoolSpec extends AkkaSpec(
 
         expectNextConnection()
       }
+      "not buffer an unreasonable number of outgoing responses" in new SetupWithServerProbes(_.withMaxConnections(1).withMinConnections(1)) {
+        val conn1 = expectNextConnection()
+
+        def oneCycle(): Unit = {
+          pushRequest()
+          conn1.expectRequest(within = 100.millis.dilated)
+          conn1.pushResponse()
+        }
+
+        eventually {
+          // should fail eventually because backpressure kicks in and one of the expects / pushes above will timeout
+          a[Throwable] should be thrownBy oneCycle()
+        }
+      }
       "not send requests to known-to-be-closed-soon connections" in pending
       "support retries" in pending
       "strictly enforce number of established connections in longer running case" in pending
@@ -326,7 +342,7 @@ class HostConnectionPoolSpec extends AkkaSpec(
             .via(impl)
             .runWith(Sink.fromSubscriber(responseOut))
 
-        def pushRequest(req: HttpRequest, numRetries: Int = 5): Unit =
+        def pushRequest(req: HttpRequest = HttpRequest(), numRetries: Int = 5): Unit =
           requestIn.sendNext(RequestContext(req, Promise(), numRetries))
 
         def pushChunkedRequest(req: HttpRequest = HttpRequest(), numRetries: Int = 5): TestPublisher.Probe[ByteString] = {
@@ -368,6 +384,9 @@ class HostConnectionPoolSpec extends AkkaSpec(
 
           def expectRequest(): HttpRequest =
             serverRequests.requestNext()
+
+          def expectRequest(within: FiniteDuration): HttpRequest =
+            serverRequests.within(within)(serverRequests.requestNext())
 
           def expectRequestToPath(path: String): Unit =
             expectRequest().uri.path.toString shouldEqual path


### PR DESCRIPTION
 * no unbounded response buffers, in a code comment I previously speculated whether buffering would be ok or not. I figured, probably unbounded buffering is not so cool so I removed it. Now the outgoing result is buffered in the slot until it is fetched
 * some additional failure handlers