### PR TITLE
Run DontLeakActorsOnFailingConnectionSpecs against new client pool + fix unexpected connection signal reception

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -154,6 +154,13 @@ private[pool] object SlotState {
       ctx.dispatchFailure(ongoingRequest, cause)
       Unconnected
     }
+
+    override def onConnectionCompleted(ctx: SlotContext): SlotState = {
+      ctx.debug("Connection completed.")
+      ctx.closeConnection()
+      ctx.dispatchFailure(ongoingRequest, new IllegalStateException("Connection was completed when waiting for connection establishment"))
+      Unconnected
+    }
   }
 
   case object PreConnecting extends ConnectedState with IdleState with WithRequestDispatching {
@@ -164,6 +171,18 @@ private[pool] object SlotState {
     override def onConnectionAttemptFailed(ctx: SlotContext, cause: Throwable): SlotState = {
       ctx.debug("Connection attempt failed.")
       // FIXME: register failed connection attempt, schedule request for rerun, backoff new connection attempts
+      ctx.closeConnection()
+      Unconnected
+    }
+
+    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = {
+      ctx.debug("Connection failed.")
+      ctx.closeConnection()
+      Unconnected
+    }
+
+    override def onConnectionCompleted(ctx: SlotContext): SlotState = {
+      ctx.debug("Connection completed.")
       ctx.closeConnection()
       Unconnected
     }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -142,6 +142,15 @@ private[pool] object SlotState {
     override def onConnectionAttemptFailed(ctx: SlotContext, cause: Throwable): SlotState = {
       ctx.debug("Connection attempt failed.")
       // FIXME: register failed connection attempt, schedule request for rerun, backoff new connection attempts
+      ctx.closeConnection()
+      ctx.dispatchFailure(ongoingRequest, cause)
+      Unconnected
+    }
+
+    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = {
+      ctx.debug("Connection failed.")
+      // FIXME: register failed connection attempt, schedule request for rerun, backoff new connection attempts
+      ctx.closeConnection()
       ctx.dispatchFailure(ongoingRequest, cause)
       Unconnected
     }
@@ -155,6 +164,7 @@ private[pool] object SlotState {
     override def onConnectionAttemptFailed(ctx: SlotContext, cause: Throwable): SlotState = {
       ctx.debug("Connection attempt failed.")
       // FIXME: register failed connection attempt, schedule request for rerun, backoff new connection attempts
+      ctx.closeConnection()
       Unconnected
     }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -45,7 +45,8 @@ abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String
       assertAllStagesStopped {
         val reqsCount = 100
         val clientFlow = Http().superPool[Int]()
-        val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+        val host = "127.0.0.46" // unlikely to be used host / port
+        val port = 34763
         val source = Source(1 to reqsCount)
           .map(i ⇒ HttpRequest(uri = Uri(s"http://$host:$port/test/$i")) → i)
 


### PR DESCRIPTION
Still does not succeed reliably, but a starting point for further work