### PR TITLE
Move ClientTransport to ClientConnectionSettings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ target
 .*.swp
 *.vim
 .ensime*
+**/.classpath
+**/.project
+**/.settings
+

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
@@ -98,7 +98,7 @@ private class PoolInterfaceActor(gateway: PoolGateway)(implicit fm: Materializer
     import setup.{ connectionContext, settings }
 
     val connectionFlow =
-      Http().outgoingConnectionUsingTransport(host, port, settings.transport, connectionContext, settings.connectionSettings, setup.log)
+      Http().outgoingConnectionUsingContext(host, port, connectionContext, settings.connectionSettings, setup.log)
 
     val poolFlow =
       settings.poolImplementation match {

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
@@ -10,6 +10,7 @@ import java.util.Random
 import akka.annotation.InternalApi
 import akka.http.impl.engine.ws.Randoms
 import akka.http.impl.util._
+import akka.http.scaladsl.ClientTransport
 import akka.http.scaladsl.model.headers.`User-Agent`
 import akka.http.scaladsl.settings.ClientConnectionSettings.LogUnencryptedNetworkBytes
 import akka.http.scaladsl.settings.ParserSettings
@@ -30,7 +31,8 @@ private[akka] final case class ClientConnectionSettingsImpl(
   websocketRandomFactory:     () ⇒ Random,
   socketOptions:              immutable.Seq[SocketOption],
   parserSettings:             ParserSettings,
-  localAddress:               Option[InetSocketAddress])
+  localAddress:               Option[InetSocketAddress],
+  transport:                  ClientTransport)
   extends akka.http.scaladsl.settings.ClientConnectionSettings {
 
   require(connectingTimeout >= Duration.Zero, "connectingTimeout must be >= 0")
@@ -51,6 +53,7 @@ object ClientConnectionSettingsImpl extends SettingsCompanion[ClientConnectionSe
       websocketRandomFactory = Randoms.SecureRandomInstances, // can currently only be overridden from code
       socketOptions = SocketOptionSettings.fromSubConfig(root, c.getConfig("socket-options")),
       parserSettings = ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing")),
-      localAddress = None)
+      localAddress = None,
+      transport = ClientTransport.TCP)
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
@@ -10,6 +10,7 @@ import java.util.{ Optional, Random }
 import akka.actor.ActorSystem
 import akka.annotation.DoNotInherit
 import akka.http.impl.settings.ClientConnectionSettingsImpl
+import akka.http.javadsl.ClientTransport
 import akka.http.javadsl.model.headers.UserAgent
 import akka.io.Inet.SocketOption
 import com.typesafe.config.Config
@@ -39,6 +40,9 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   }
   final def getLocalAddress: Optional[InetSocketAddress] = OptionConverters.toJava(localAddress)
 
+  /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
+  def getTransport: ClientTransport = transport.asJava
+
   // ---
 
   def withUserAgentHeader(newValue: Optional[UserAgent]): ClientConnectionSettings = self.copy(userAgentHeader = newValue.asScala.map(_.asScala))
@@ -50,6 +54,7 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ClientConnectionSettings = self.copy(socketOptions = newValue.asScala.toList)
   def withParserSettings(newValue: ParserSettings): ClientConnectionSettings = self.copy(parserSettings = newValue.asScala)
   def withLocalAddress(newValue: Optional[InetSocketAddress]): ClientConnectionSettings = self.copy(localAddress = OptionConverters.toScala(newValue))
+  def withTransport(newValue: ClientTransport): ClientConnectionSettings = self.copy(transport = newValue.asScala)
 }
 
 object ClientConnectionSettings extends SettingsCompanion[ClientConnectionSettings] {

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -40,6 +40,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def getResponseEntitySubscriptionTimeout: Duration = responseEntitySubscriptionTimeout
 
   /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
+  @deprecated("Deprecated as transport is now retrieved from ClientConnectionSettings)", "10.0.12")
   def getTransport: ClientTransport = transport.asJava
 
   // ---
@@ -58,6 +59,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   @ApiMayChange
   def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(responseEntitySubscriptionTimeout = newValue)
 
+  @deprecated("Deprecated as transport is now retrieved from ClientConnectionSettings)", "10.0.12")
   def withTransport(newValue: ClientTransport): ConnectionPoolSettings = self.copy(transport = newValue.asScala)
 }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
@@ -9,6 +9,7 @@ import java.util.Random
 import akka.annotation.DoNotInherit
 import akka.http.impl.util._
 import akka.http.impl.settings.ClientConnectionSettingsImpl
+import akka.http.scaladsl.ClientTransport
 import akka.http.scaladsl.model.headers.`User-Agent`
 import akka.io.Inet.SocketOption
 import com.typesafe.config.Config
@@ -31,6 +32,9 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   def logUnencryptedNetworkBytes: Option[Int]
   def localAddress: Option[InetSocketAddress]
 
+  /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
+  def transport: ClientTransport
+
   // ---
 
   // overrides for more specific return type
@@ -45,6 +49,7 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   def withSocketOptions(newValue: immutable.Seq[SocketOption]): ClientConnectionSettings = self.copy(socketOptions = newValue)
   def withParserSettings(newValue: ParserSettings): ClientConnectionSettings = self.copy(parserSettings = newValue)
   def withLocalAddress(newValue: Option[InetSocketAddress]): ClientConnectionSettings = self.copy(localAddress = newValue)
+  def withTransport(newTransport: ClientTransport): ClientConnectionSettings = self.copy(transport = newTransport)
 
   /**
    * Returns a new instance with the given local address set if the given override is `Some(address)`, otherwise

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -40,6 +40,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   def responseEntitySubscriptionTimeout: Duration
 
   /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
+  @deprecated("Deprecated as transport is now retrieved from ClientConnectionSettings)", "10.0.12")
   def transport: ClientTransport
 
   // ---
@@ -60,6 +61,8 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
 
   @ApiMayChange
   override def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(responseEntitySubscriptionTimeout = newValue)
+
+  @deprecated("Deprecated as transport is now retrieved from ClientConnectionSettings)", "10.0.12")
   def withTransport(newTransport: ClientTransport): ConnectionPoolSettings = self.copy(transport = newTransport)
 }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -359,9 +359,9 @@ abstract class ConnectionPoolSpec(poolImplementation: PoolImplementation) extend
     "use the configured ClientTransport" in new ClientTransportTestSetup {
       def issueRequest(request: HttpRequest, settings: ConnectionPoolSettings): Future[HttpResponse] =
         Source.single(request.withUri(request.uri.toRelative))
-          .via(Http().outgoingConnectionUsingTransport(
+          .via(Http().outgoingConnectionUsingContext(
             host = request.uri.authority.host.address, port = request.uri.effectivePort,
-            transport = settings.transport, settings = settings.connectionSettings, connectionContext = ConnectionContext.noEncryption()))
+            settings = settings.connectionSettings, connectionContext = ConnectionContext.noEncryption()))
           .runWith(Sink.head)
     }
   }
@@ -649,8 +649,7 @@ abstract class ConnectionPoolSpec(poolImplementation: PoolImplementation) extend
     val transport = new CustomTransport
     val poolSettings =
       ConnectionPoolSettings(system)
-        .withTransport(transport)
-        .withConnectionSettings(ClientConnectionSettings(system).withIdleTimeout(CustomIdleTimeout))
+        .withConnectionSettings(ClientConnectionSettings(system).withIdleTimeout(CustomIdleTimeout).withTransport(transport))
         .withPoolImplementation(poolImplementation)
 
     val responseFuture = issueRequest(HttpRequest(uri = "http://example.org/test"), settings = poolSettings)

--- a/docs/src/main/paradox/scala/http/client-side/client-transport.md
+++ b/docs/src/main/paradox/scala/http/client-side/client-transport.md
@@ -28,16 +28,20 @@ of strategy by implementing @unidoc[ClientTransport] yourself).
 
 ### Connection Pool Usage
 
-The @unidoc[ConnectionPoolSettings] class allows setting a custom transport for any of the pool methods. Use
-`ConnectionPoolSettings.withTransport` to configure a transport and pass those settings to one of the
-pool methods like
+The @unidoc[ClientConnectionSettings] class allows setting a custom transport for any of the pool methods. First use
+`ClientConnectionSettings.withTransport` to configure a transport, then use `ConnectionPoolSettings.withConnectionSettings` and
+pass those settings to one of the pool methods like
 @scala[`Http().singleRequest`, `Http().superPool`, or `Http().cachedHostConnectionPool`]
 @java[`Http.get(...).singleRequest`, `Http.get(...).superPool`, or `Http.get(...).cachedHostConnectionPool`].
 
+Same feature is available for Web Sockets, directly with `ClientConnectionSettings` and methods like
+@scala[`Http().singleWebSocketRequest`, `Http().webSocketClientFlow` or `Http().webSocketClientLayer`]
+@java[`Http.get(...).singleWebSocketRequest`, `Http.get(...).webSocketClientFlow` or `Http.get(...).webSocketClientLayer`].
+
 ### Single Connection Usage
 
-You can configure a custom transport for a single HTTP connection by passing it to the `Http().outgoingConnectionUsingTransport`
-method.
+You can configure a custom transport for a single HTTP connection by setting it to a `ClientConnectionSettings` that you pass to the
+`Http().outgoingConnectionUsingContext` method.
 
 ## Predefined Transports
 
@@ -60,7 +64,7 @@ Instantiate the HTTP(S) proxy transport using `ClientTransport.httpsProxy(proxyA
 ### Use HTTP(S) proxy with @scala[`Http().singleRequest`]@java[`Http.get(...).singleRequest`]
 
 To make use of an HTTP proxy when using the `singleRequest` API you simply need to configure the proxy and pass
-the apropriate settings object when calling the single request method.
+the appropriate settings object when calling the single request method.
 
 Scala
 :  @@snip [HttpClientExampleSpec.scala]($test$/scala/docs/http/scaladsl/HttpClientExampleSpec.scala) { #https-proxy-example-single-request }
@@ -79,6 +83,28 @@ Scala
 
 Java
 :  @@snip [HttpClientExampleDocTest.java]($test$/java/docs/http/javadsl/HttpClientExampleDocTest.java) { #auth-https-proxy-example-single-request }
+
+### Use HTTP(S) proxy with @scala[Http().singleWebSocketRequest]@java[Http.get(...).singleWebSocketRequest]
+
+Making use of an HTTP proxy when using the `singleWebSocketRequest` is done like using `singleRequest`, except you set `ClientConnectionSettings`
+instead of `ConnectionPoolSettings`:
+
+Scala
+:  @@snip [WebSocketClientExampleSpec.scala]($test$/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala) { #https-proxy-singleWebSocket-request-example }
+
+Java
+:  @@snip [WebSocketClientExampleTest.java]($test$/java/docs/http/javadsl/WebSocketClientExampleTest.java) { #https-proxy-singleWebSocket-request-example }
+
+### Use HTTP(S) proxy that requires authentication for Web Sockets
+
+Here is an example for Web Socket:
+
+Scala
+:  @@snip [WebSocketClientExampleSpec.scala]($test$/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala) { #auth-https-proxy-singleWebSocket-request-example }
+
+Java
+:  @@snip [WebSocketClientExampleTest.java]($test$/java/docs/http/javadsl/WebSocketClientExampleTest.java) { #auth-https-proxy-singleWebSocket-request-example }
+
 
 ## Implementing Custom Transports
 

--- a/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
@@ -13,6 +13,7 @@ import akka.util.ByteString;
 import scala.concurrent.ExecutionContextExecutor;
 import akka.stream.javadsl.*;
 import akka.http.javadsl.ClientTransport;
+import akka.http.javadsl.settings.ClientConnectionSettings;
 import akka.http.javadsl.settings.ConnectionPoolSettings;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.OutgoingConnection;
@@ -173,7 +174,8 @@ public class HttpClientExampleDocTest {
     final Materializer materializer = ActorMaterializer.create(system);
 
     ClientTransport proxy = ClientTransport.httpsProxy(InetSocketAddress.createUnresolved("192.168.2.5", 8080));
-    ConnectionPoolSettings poolSettingsWithHttpsProxy = ConnectionPoolSettings.create(system).withTransport(proxy);
+    ConnectionPoolSettings poolSettingsWithHttpsProxy = ConnectionPoolSettings.create(system)
+        .withConnectionSetting(ClientConnectionSettings.create(system).withTransport(proxy));
 
     final CompletionStage<HttpResponse> responseFuture =
         Http.get(system)
@@ -200,7 +202,8 @@ public class HttpClientExampleDocTest {
       HttpCredentials.createBasicHttpCredentials("proxy-user", "secret-proxy-pass-dont-tell-anyone");
     
     ClientTransport proxy = ClientTransport.httpsProxy(proxyAddress, credentials); // include credentials
-    ConnectionPoolSettings poolSettingsWithHttpsProxy = ConnectionPoolSettings.create(system).withTransport(proxy);
+    ConnectionPoolSettings poolSettingsWithHttpsProxy = ConnectionPoolSettings.create(system)
+        .withConnectionSetting(ClientConnectionSettings.create(system).withTransport(proxy));
 
     final CompletionStage<HttpResponse> responseFuture =
         Http.get(system)

--- a/docs/src/test/java/docs/http/javadsl/WebSocketClientExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/WebSocketClientExampleTest.java
@@ -6,13 +6,16 @@ package docs.http.javadsl;
 import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
+import akka.http.javadsl.ClientTransport;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.model.headers.Authorization;
+import akka.http.javadsl.model.headers.HttpCredentials;
 import akka.http.javadsl.model.ws.Message;
 import akka.http.javadsl.model.ws.TextMessage;
 import akka.http.javadsl.model.ws.WebSocketRequest;
 import akka.http.javadsl.model.ws.WebSocketUpgradeResponse;
+import akka.http.javadsl.settings.ClientConnectionSettings;
 import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
@@ -21,6 +24,7 @@ import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -236,6 +240,68 @@ public class WebSocketClientExampleTest {
     //#WebSocket-client-flow
   }
 
+  // compile only test
+  public void testSingleWebSocketRequestWithHttpsProxyExample() {
+    //#https-proxy-singleWebSocket-request-example
+
+    final ActorSystem system = ActorSystem.create();
+    final Materializer materializer = ActorMaterializer.create(system);
+
+    final Flow<Message, Message, NotUsed> flow =
+      Flow.fromSinkAndSource(
+        Sink.foreach(System.out::println),
+        Source.single(TextMessage.create("hello world")));
+
+    ClientTransport proxy = ClientTransport.httpsProxy(InetSocketAddress.createUnresolved("192.168.2.5", 8080));
+    ClientConnectionSettings clientSettingsWithHttpsProxy = ClientConnectionSettings.create(system)
+    		.withTransport(proxy);
+
+    Http.get(system)
+      .singleWebSocketRequest(
+        WebSocketRequest.create("wss://example.com:8080/some/path"),
+        flow,
+        Http.get(system).defaultClientHttpsContext(),
+        null,
+        clientSettingsWithHttpsProxy, // <- pass in the custom settings here
+        system.log(),
+        materializer);
+
+    //#https-proxy-singleWebSocket-request-example
+  }
+  
+  // compile only test
+  public void testSingleWebSocketRequestWithHttpsProxyExampleWithAuth() {
+
+    final ActorSystem system = ActorSystem.create();
+    final Materializer materializer = ActorMaterializer.create(system);
+
+    final Flow<Message, Message, NotUsed> flow =
+      Flow.fromSinkAndSource(
+        Sink.foreach(System.out::println),
+        Source.single(TextMessage.create("hello world")));
+
+    //#auth-https-proxy-singleWebSocket-request-example
+    InetSocketAddress proxyAddress = 
+      InetSocketAddress.createUnresolved("192.168.2.5", 8080);
+    HttpCredentials credentials = 
+      HttpCredentials.createBasicHttpCredentials("proxy-user", "secret-proxy-pass-dont-tell-anyone");
+    
+    ClientTransport proxy = ClientTransport.httpsProxy(proxyAddress, credentials); // include credentials
+    ClientConnectionSettings clientSettingsWithHttpsProxy = ClientConnectionSettings.create(system)
+    		.withTransport(proxy);
+
+    Http.get(system)
+      .singleWebSocketRequest(
+        WebSocketRequest.create("wss://example.com:8080/some/path"),
+        flow,
+        Http.get(system).defaultClientHttpsContext(),
+        null,
+        clientSettingsWithHttpsProxy, // <- pass in the custom settings here
+        system.log(),
+        materializer);
+
+    //#auth-https-proxy-singleWebSocket-request-example
+}
 
 
   }

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -5,6 +5,7 @@
 package docs.http.scaladsl
 
 import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import docs.CompileOnlySpec
 import org.scalatest.{ Matchers, WordSpec }
@@ -353,7 +354,9 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
 
     val httpsProxyTransport = ClientTransport.httpsProxy(InetSocketAddress.createUnresolved(proxyHost, proxyPort))
 
-    val settings = ConnectionPoolSettings(system).withTransport(httpsProxyTransport)
+    val settings = ConnectionPoolSettings(system)
+      .withConnectionSettings(ClientConnectionSettings(system)
+        .withTransport(httpsProxyTransport))
     Http().singleRequest(HttpRequest(uri = "https://google.com"), settings = settings)
     //#https-proxy-example-single-request
   }
@@ -379,7 +382,9 @@ class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec 
 
     val httpsProxyTransport = ClientTransport.httpsProxy(proxyAddress, auth)
 
-    val settings = ConnectionPoolSettings(system).withTransport(httpsProxyTransport)
+    val settings = ConnectionPoolSettings(system)
+      .withConnectionSettings(ClientConnectionSettings(system)
+        .withTransport(httpsProxyTransport))
     Http().singleRequest(HttpRequest(uri = "http://akka.io"), settings = settings)
     //#auth-https-proxy-example-single-request
   }

--- a/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
@@ -244,4 +244,69 @@ class WebSocketClientExampleSpec extends WordSpec with Matchers with CompileOnly
     //#WebSocket-client-flow
   }
 
+  "https-proxy-singleWebSocket-request-example" in compileOnlySpec {
+    //#https-proxy-singleWebSocket-request-example
+    import java.net.InetSocketAddress
+
+    import akka.actor.ActorSystem
+    import akka.NotUsed
+    import akka.stream.ActorMaterializer
+    import akka.http.scaladsl.{ ClientTransport, Http }
+    import akka.http.scaladsl.settings.ClientConnectionSettings
+    import akka.http.scaladsl.model.ws._
+    import akka.stream.scaladsl._
+
+    implicit val system = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+
+    val flow: Flow[Message, Message, NotUsed] =
+      Flow.fromSinkAndSource(
+        Sink.foreach(println),
+        Source.single(TextMessage("hello world!")))
+
+    val proxyHost = "localhost"
+    val proxyPort = 8888
+
+    val httpsProxyTransport = ClientTransport.httpsProxy(InetSocketAddress.createUnresolved(proxyHost, proxyPort))
+
+    val settings = ClientConnectionSettings(system).withTransport(httpsProxyTransport)
+    Http().singleWebSocketRequest(WebSocketRequest(uri = "wss://example.com:8080/some/path"), clientFlow = flow, settings = settings)
+    //#https-proxy-singleWebSocket-request-example
+  }
+
+  "https-proxy-singleWebSocket-request-example with auth" in compileOnlySpec {
+    import java.net.InetSocketAddress
+
+    import akka.actor.ActorSystem
+    import akka.NotUsed
+    import akka.stream.ActorMaterializer
+    import akka.http.scaladsl.{ ClientTransport, Http }
+    import akka.http.scaladsl.settings.ClientConnectionSettings
+    import akka.http.scaladsl.model.ws._
+    import akka.stream.scaladsl._
+
+    implicit val system = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+
+    val flow: Flow[Message, Message, NotUsed] =
+      Flow.fromSinkAndSource(
+        Sink.foreach(println),
+        Source.single(TextMessage("hello world!")))
+
+    val proxyHost = "localhost"
+    val proxyPort = 8888
+
+    //#auth-https-proxy-singleWebSocket-request-example
+    import akka.http.scaladsl.model.headers
+
+    val proxyAddress = InetSocketAddress.createUnresolved(proxyHost, proxyPort)
+    val auth = headers.BasicHttpCredentials("proxy-user", "secret-proxy-pass-dont-tell-anyone")
+
+    val httpsProxyTransport = ClientTransport.httpsProxy(proxyAddress, auth)
+
+    val settings = ClientConnectionSettings(system).withTransport(httpsProxyTransport)
+    Http().singleWebSocketRequest(WebSocketRequest(uri = "wss://example.com:8080/some/path"), clientFlow = flow, settings = settings)
+    //#auth-https-proxy-singleWebSocket-request-example
+  }
+
 }


### PR DESCRIPTION
Hello,

As I saw that a new version (10.0.11) was released after my previous PR (#1548) I decided to try to solve issue #1562 with this new one.

Notice that the unit test error, regarding some `HttpAppSpec` on the server side, occurs in master branch too...

I still have a "Binary compatibility failure" as the new `transport` method I added to `ClientConnectionSettings` is "_present only in the current version_"... I guess it's normal, isn't it ?

```
[info] akka-http-core: found 1 potential binary incompatibilities while checking against com.typesafe.akka:akka-http-core_2.11:10.0.2  (filtered 90)
[error]  * abstract method transport()akka.http.scaladsl.ClientTransport in class akka.http.scaladsl.settings.ClientConnectionSettings is present only in current version
[error]    filter with: ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ClientConnectionSettings.transport")
```

BTW, I removed my "web-socket-behind-proxy" branch related to useless PR #1548.