### PR TITLE
Remove incorrect usage of the term "Phantom Type"

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/Tuple.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/Tuple.scala
@@ -5,7 +5,7 @@
 package akka.http.scaladsl.server.util
 
 /**
- * Phantom type providing implicit evidence that a given type is a Tuple or Unit.
+ * type class providing implicit evidence that a given type is a Tuple or Unit.
  */
 sealed trait Tuple[T]
 


### PR DESCRIPTION
The `Tuple[T]` type class is not a "Phantom Type".