### PR TITLE
Fix connection closing issue #1724

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
@@ -23,6 +23,8 @@ private[client] object PoolFlow {
 
   case class RequestContext(request: HttpRequest, responsePromise: Promise[HttpResponse], retriesLeft: Int) {
     require(retriesLeft >= 0)
+
+    def canBeRetried: Boolean = retriesLeft > 0
   }
   case class ResponseContext(rc: RequestContext, response: Try[HttpResponse])
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -189,6 +189,11 @@ private[client] object NewHostConnectionPool {
                   case _ ⇒ // no timeout set, nothing to do
                 }
 
+                if (state == Unconnected && connection != null) {
+                  debug(s"State change from [${previousState.name}] to [Unconnected]. Closing the existing connection.")
+                  closeConnection()
+                }
+
                 if (!previousState.isIdle && state.isIdle) {
                   debug("Slot became idle... Trying to pull")
                   pullIfNeeded()

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -99,7 +99,7 @@ private[client] object NewHostConnectionPool {
           slots.exists(_.isIdle)
 
         def dispatchResponseResult(req: RequestContext, result: Try[HttpResponse]): Unit =
-          if (result.isFailure && req.retriesLeft > 0) {
+          if (result.isFailure && req.canBeRetried) {
             log.debug("Request has {} retries left, retrying...", req.retriesLeft)
             retryBuffer.addLast(req.copy(retriesLeft = req.retriesLeft - 1))
           } else

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -130,7 +130,11 @@ private[pool] object SlotState {
 
     private def failOngoingRequest(ctx: SlotContext, signal: String, cause: Throwable): SlotState = {
       ctx.debug("Ongoing request [{}] is failed because of [{}]: [{}]", ongoingRequest.request.debugString, signal, cause.getMessage)
-      WaitingForResponseDispatch(ongoingRequest, Failure(cause))
+      if (ongoingRequest.canBeRetried) { // push directly because it will be buffered internally
+        ctx.dispatchResponseResult(ongoingRequest, Failure(cause))
+        Unconnected
+      } else
+        WaitingForResponseDispatch(ongoingRequest, Failure(cause))
     }
   }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -24,12 +24,9 @@ import scala.util.{ Failure, Success, Try }
 @InternalApi
 private[pool] abstract class SlotContext {
   def openConnection(): Future[Http.OutgoingConnection]
-  def pushRequestToConnectionAndThen(request: HttpRequest, nextState: SlotState): SlotState
-
-  /** Will try to close the current connection. Will do nothing if there is no current connection. */
-  def closeConnection(): Unit
   def isConnectionClosed: Boolean
 
+  def pushRequestToConnectionAndThen(request: HttpRequest, nextState: SlotState): SlotState
   def dispatchResponseResult(req: RequestContext, result: Try[HttpResponse]): Unit
 
   def willCloseAfter(res: HttpResponse): Boolean
@@ -100,12 +97,6 @@ private[pool] sealed abstract class SlotState extends Product {
 private[pool] object SlotState {
   sealed abstract class ConnectedState extends SlotState {
     def isConnected: Boolean = true
-
-    protected def ignoreAndCloseConnection(ctx: SlotContext, when: String): SlotState = {
-      ctx.debug("Closing connection (and staying in state) when [{}]", when)
-      ctx.closeConnection()
-      this
-    }
   }
   sealed trait IdleState extends SlotState {
     final override def isIdle = true
@@ -135,11 +126,10 @@ private[pool] object SlotState {
       // because of the notorious cancel/failure propagation which can convert failures into completion.
       failOngoingRequest(ctx, "connection completed", new IllegalStateException("Connection was shutdown.") with NoStackTrace)
 
-    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = this failOngoingRequest (ctx, "connection failure", cause)
+    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = failOngoingRequest(ctx, "connection failure", cause)
 
     private def failOngoingRequest(ctx: SlotContext, signal: String, cause: Throwable): SlotState = {
       ctx.debug("Ongoing request [{}] is failed because of [{}]: [{}]", ongoingRequest.request.debugString, signal, cause.getMessage)
-      ctx.closeConnection()
       WaitingForResponseDispatch(ongoingRequest, Failure(cause))
     }
   }
@@ -163,7 +153,6 @@ private[pool] object SlotState {
 
     override def onConnectionCompleted(ctx: SlotContext): SlotState = Unconnected
     override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = Unconnected
-
   }
   sealed trait WithRequestDispatching { _: ConnectedState ⇒
     def dispatchRequestToConnection(ctx: SlotContext, ongoingRequest: RequestContext): SlotState = {
@@ -198,7 +187,6 @@ private[pool] object SlotState {
 
     private def closeAndGoToUnconnected(ctx: SlotContext, signal: String, cause: Throwable): SlotState = {
       ctx.debug("Connection was closed by [{}] while preconnecting because of [{}]", signal, cause.getMessage)
-      ctx.closeConnection()
       Unconnected
     }
   }
@@ -222,25 +210,22 @@ private[pool] object SlotState {
       ctx.dispatchResponseResult(ongoingRequest, result)
 
       result match {
-        case Success(res) ⇒ WaitingForResponseEntitySubscription(ongoingRequest, res, ctx.settings.responseEntitySubscriptionTimeout)
-        case Failure(cause) ⇒
-          ctx.closeConnection()
-          Unconnected
+        case Success(res)   ⇒ WaitingForResponseEntitySubscription(ongoingRequest, res, ctx.settings.responseEntitySubscriptionTimeout)
+        case Failure(cause) ⇒ Unconnected
       }
     }
 
     // we already got a result so ignore any subsequent errors
-    override def onConnectionCompleted(ctx: SlotContext): SlotState = ignoreAndCloseConnection(ctx, "connection completed")
-    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = ignoreAndCloseConnection(ctx, "connection failed")
-    override def onConnectionAttemptFailed(ctx: SlotContext, cause: Throwable): SlotState = ignoreAndCloseConnection(ctx, "connection attempt failed")
-    override def onRequestEntityFailed(ctx: SlotContext, cause: Throwable): SlotState = ignoreAndCloseConnection(ctx, "request entity failed")
+    override def onConnectionCompleted(ctx: SlotContext): SlotState = this
+    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = this
+    override def onConnectionAttemptFailed(ctx: SlotContext, cause: Throwable): SlotState = this
+    override def onRequestEntityFailed(ctx: SlotContext, cause: Throwable): SlotState = this
   }
 
   private[pool] /* to avoid warnings */ trait BusyWithResultAlreadyDispatched extends ConnectedState with BusyState {
     override def onResponseEntityFailed(ctx: SlotContext, cause: Throwable): SlotState = {
       ctx.debug(s"Response entity for request [{}] failed with [{}]", ongoingRequest.request.debugString, cause.getMessage)
       // response must have already been dispatched, so don't try to dispatch a response
-      ctx.closeConnection()
       Unconnected
     }
 
@@ -260,7 +245,6 @@ private[pool] object SlotState {
       ctx.warning(
         s"Response entity was not subscribed after $stateTimeout. Make sure to read the response entity body or call `discardBytes()` on it. " +
           s"${ongoingRequest.request.debugString} -> ${ongoingResponse.debugString}")
-      ctx.closeConnection()
       Unconnected
     }
 
@@ -270,10 +254,9 @@ private[pool] object SlotState {
     ongoingResponse: HttpResponse) extends ConnectedState with BusyWithResultAlreadyDispatched {
 
     override def onResponseEntityCompleted(ctx: SlotContext): SlotState =
-      if (ctx.willCloseAfter(ongoingResponse) || ctx.isConnectionClosed) {
-        ctx.closeConnection()
+      if (ctx.willCloseAfter(ongoingResponse) || ctx.isConnectionClosed)
         Unconnected
-      } else
+      else
         Idle
   }
 }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -245,6 +245,7 @@ class HostConnectionPoolSpec extends AkkaSpec(
         // client already received response, no need to report error another time
       }
       "create a new connection when previous one was closed regularly between requests" in new SetupWithServerProbes {
+        pendingIn(targetImpl = LegacyPoolImplementation) // flaky test, no reason to debug old client pool issues for now
         pushRequest(HttpRequest(uri = "/simple"))
 
         val conn1 = expectNextConnection()
@@ -260,6 +261,7 @@ class HostConnectionPoolSpec extends AkkaSpec(
         expectResponseEntityAsString() shouldEqual "response"
       }
       "create a new connection when previous one was closed regularly between requests without sending a `Connection: close` header first" in new SetupWithServerProbes {
+        pendingIn(targetImpl = LegacyPoolImplementation) // flaky test, no reason to debug old client pool issues for now
         pushRequest(HttpRequest(uri = "/simple"))
 
         val conn1 = expectNextConnection()
@@ -281,6 +283,7 @@ class HostConnectionPoolSpec extends AkkaSpec(
         expectResponseEntityAsString() shouldEqual "response"
       }
       "create a new connection when previous one failed between requests" in new SetupWithServerProbes {
+        pendingIn(targetImpl = LegacyPoolImplementation) // flaky test, no reason to debug old client pool issues for now
         pushRequest(HttpRequest(uri = "/simple"))
 
         val conn1 = expectNextConnection()


### PR DESCRIPTION
Likely the bug happened in the Idle state. That's the one state that
didn't explicitly close the connection when the signal came. On the
other hand, the assumption may have been that on reception of a
`onConnectionCompleted` / `onConnectionFailed` signal, a connection was
already thought to be 'closed'.

This will also make the code simpler because SlotContext.closeConnection()
doesn't need to be exposed to the state handlers.

In some way it also shows the redundancy of the whole state handling code
structure as the code doesn't do much more than showing what expected signals
are in which states. The only side-effects left for the states are pushing
requests and results. But even those are never delayed so there's little logic
left in SlotStates.

Refs #1724, #1653, #1721.