### PR TITLE
Setup travis for snapshot publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,18 +23,15 @@ cache:
     - $HOME/.sbt/boot
 
 script:
-  # need to override as the default is to test
-  - sbt -J-XX:ReservedCodeCacheSize=256m +update
   # make 'git branch' work again
   - git branch -f "$TRAVIS_BRANCH" && git checkout "$TRAVIS_BRANCH"
-  # check policies, if on master also upload
-  - if [[ "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" ]]; then sbt 'set credentials += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY"))' whitesourceCheckPolicies whitesourceUpdate; else sbt 'set credentials += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY"))' whitesourceCheckPolicies; fi ; fi
+  - sbt whitesourceCi
+  - sbt -Dakka.publish.repo=snapshots +publishCi
 
 deploy:
   provider: script
   script:
     - sbt -J-XX:ReservedCodeCacheSize=256m +publish
-#    - sbt -J-XX:ReservedCodeCacheSize=256m +publish akka-http/bintraySyncMavenCentral # enable if we want to sync to central automatically
   on:
     tags: true
     repo: akka/akka-http

--- a/project/CliOptions.scala
+++ b/project/CliOptions.scala
@@ -23,5 +23,10 @@ object CliOption {
       def parse(path: String, default: Boolean) =
         CliOption(System.getProperty(path, default.toString).toBoolean)
     }
+
+    implicit object StringCliOptionParser extends CliOptionParser[String] {
+      def parse(path: String, default: String) =
+        CliOption(System.getProperty(path, default))
+    }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   lazy val scalaCheckVersion = settingKey[String]("The version of ScalaCheck to use.")
 
   val Versions = Seq(
-    crossScalaVersions := Seq("2.11.11", "2.12.4"),
+    crossScalaVersions := Seq("2.11.12", "2.12.4"),
     scalaVersion := crossScalaVersions.value.head,
     akkaVersion := System.getProperty("akka.build.version", akka25Version),
     scalaCheckVersion := System.getProperty("akka.build.scalaCheckVersion", "1.13.5"),

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -21,12 +21,17 @@ object Publish extends AutoPlugin {
   import bintray.BintrayPlugin
   import bintray.BintrayPlugin.autoImport._
 
+  object CliOptions {
+    val publishRepo = CliOption("akka.publish.repo", "maven")
+  }
+
   override def trigger = allRequirements
   override def requires = BintrayPlugin
 
   override def projectSettings = Seq(
     bintrayOrganization := Some("akka"),
-    bintrayPackage := "com.typesafe.akka:akka-http_2.11"
+    bintrayPackage := "com.typesafe.akka:akka-http_2.11",
+    bintrayRepository := CliOptions.publishRepo.get
   )
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0") // for advanced PR validation features
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.3.2")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.5")

--- a/travis.sbt
+++ b/travis.sbt
@@ -1,0 +1,32 @@
+commands ++= Seq(
+  // check policies, if on master also upload
+  Command.command("whitesourceCi") { state =>
+    val extracted = Project.extract(state)
+    import extracted._
+
+    if (sys.env.getOrElse("TRAVIS_SECURE_ENV_VARS", "") == "true") {
+      val stateWithCredentials =
+        append(credentials += Credentials("whitesource", "whitesourcesoftware.com", "", System.getenv("WHITESOURCE_KEY")), state)
+
+      runTask(whitesourceCheckPolicies, stateWithCredentials)
+
+      if (sys.env.getOrElse("TRAVIS_BRANCH", "") == "master" && sys.env.getOrElse("TRAVIS_EVENT_TYPE", "") == "push") {
+        runTask(whitesourceUpdate, stateWithCredentials)
+      }
+    }
+
+    state
+  },
+
+  // publish snapshot to bintray snapshots repo
+  Command.command("publishCi") { state =>
+    val extracted = Project.extract(state)
+    import extracted._
+
+    if (sys.env.getOrElse("TRAVIS_EVENT_TYPE", "") == "cron") {
+      runAggregated(ThisBuild / publish, state)
+    }
+
+    state
+  }
+)


### PR DESCRIPTION
We will need to set up a [cron job](https://docs.travis-ci.com/user/cron-jobs/) on the master branch to start publishing snapshots. The artifacts will end up [here](https://bintray.com/akka/snapshots/com.typesafe.akka%3Aakka-http_2.11) or under a different view [here](https://dl.bintray.com/akka/snapshots/com/typesafe/akka/).

They will be possible to be consumed by users by adding
```
resolvers += Resolver.bintrayRepo("akka", "snapshots")
```
to the build.

I also cleaned up `.travis.yml` a bit and moved the nested bash conditional logic to a separete sbt command for whitesource.

If this looks good for an approach, I will ammend documentation.

Fixes #1254