### PR TITLE
Replaces triple equals assertions with shouldEqual (#1136)

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -762,8 +762,8 @@ class UriSpec extends WordSpec with Matchers {
     }
 
     "properly render as HTTP request target origin forms" in {
-      Uri("http://example.com/foo/bar?query=1#frag").toHttpRequestTargetOriginForm.toString === "/foo/bar?query=1"
-      Uri("http://example.com//foo/bar?query=1#frag").toHttpRequestTargetOriginForm.toString === "//foo/bar?query=1"
+      Uri("http://example.com/foo/bar?query=1#frag").toHttpRequestTargetOriginForm.toString shouldEqual "/foo/bar?query=1"
+      Uri("http://example.com//foo/bar?query=1#frag").toHttpRequestTargetOriginForm.toString shouldEqual "//foo/bar?query=1"
     }
 
     "survive parsing a URI with thousands of path segments" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -5,7 +5,6 @@
 package akka.http.scaladsl.server.directives
 
 import java.io.File
-import java.nio.file.Files
 
 import akka.NotUsed
 import akka.http.scaladsl.model._
@@ -45,9 +44,9 @@ class FileUploadDirectivesSpec extends RoutingSpec {
               complete(info.toString)
           }
         } ~> check {
-          file.isDefined === true
-          responseAs[String] === FileInfo("fieldName", "age.xml", ContentTypes.`text/xml(UTF-8)`).toString
-          read(file.get) === xml
+          file.isDefined shouldEqual true
+          responseAs[String] shouldEqual FileInfo("fieldName", "age.xml", ContentTypes.`text/xml(UTF-8)`).toString
+          read(file.get) shouldEqual xml
         }
       } finally {
         file.foreach(_.delete())
@@ -73,9 +72,9 @@ class FileUploadDirectivesSpec extends RoutingSpec {
             storeUploadedFile("fieldName", tempDest) { (info, tmpFile) ⇒
               complete(info.toString)
             } ~> check {
-              file.isDefined === true
-              responseAs[String] === FileInfo("fieldName", "age.xml", ContentTypes.`text/xml(UTF-8)`).toString
-              read(file.get) === data
+              file.isDefined shouldEqual true
+              responseAs[String] shouldEqual FileInfo("fieldName", "age.xml", ContentTypes.`text/xml(UTF-8)`).toString
+              read(file.get) shouldEqual data
             }
         } finally {
           file.foreach(_.delete())
@@ -122,8 +121,8 @@ class FileUploadDirectivesSpec extends RoutingSpec {
             }
           } ~> check {
             val response = responseAs[String]
-            response === files.map(read).mkString
-            response === txt + xml
+            response shouldEqual files.map(read).mkString
+            response shouldEqual txt + xml
           }
         } finally {
           files.foreach(_.delete())
@@ -134,11 +133,11 @@ class FileUploadDirectivesSpec extends RoutingSpec {
       "strict",
       Multipart.FormData(
         Multipart.FormData.BodyPart.Strict(
-          "field1",
+          "fieldName",
           HttpEntity(ContentTypes.`text/plain(UTF-8)`, txt),
           Map("filename" → "age.txt")),
         Multipart.FormData.BodyPart.Strict(
-          "field1",
+          "fieldName",
           HttpEntity(ContentTypes.`text/xml(UTF-8)`, xml),
           Map("filename" → "age.xml"))))
 
@@ -146,11 +145,11 @@ class FileUploadDirectivesSpec extends RoutingSpec {
       "streamed",
       Multipart.FormData(
         Multipart.FormData.BodyPart(
-          "field1",
+          "fieldName",
           HttpEntity.IndefiniteLength(ContentTypes.`text/plain(UTF-8)`, inChunks(txt)),
           Map("filename" → "age.txt")),
         Multipart.FormData.BodyPart(
-          "field1",
+          "fieldName",
           HttpEntity.IndefiniteLength(ContentTypes.`text/xml(UTF-8)`, inChunks(xml)),
           Map("filename" → "age.xml"))))
   }
@@ -234,7 +233,7 @@ class FileUploadDirectivesSpec extends RoutingSpec {
           Map("filename" → "data1.txt")))
 
       Post("/", multipartForm) ~> route ~> check {
-        rejection === MissingFormFieldRejection("missing")
+        rejection shouldEqual MissingFormFieldRejection("missing")
       }
 
     }
@@ -336,7 +335,7 @@ class FileUploadDirectivesSpec extends RoutingSpec {
           Map("filename" → "data1.txt")))
 
       Post("/", multipartForm) ~> route ~> check {
-        rejection === MissingFormFieldRejection("missing")
+        rejection shouldEqual MissingFormFieldRejection("missing")
       }
 
     }
@@ -344,13 +343,11 @@ class FileUploadDirectivesSpec extends RoutingSpec {
   }
 
   private def read(file: File): String = {
-    val in = Files.newInputStream(file.toPath)
+    val source = scala.io.Source.fromFile(file, "UTF-8")
     try {
-      val buffer = new Array[Byte](1024)
-      in.read(buffer)
-      new String(buffer, "UTF-8")
+      source.mkString
     } finally {
-      in.close()
+      source.close()
     }
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -144,22 +144,22 @@ class FormFieldDirectivesSpec extends RoutingSpec {
     "extract an empty Iterable when the parameter is absent" in {
       Post("/", FormData("age" → "42")) ~> {
         formField('hobby.*) { echoComplete }
-      } ~> check { responseAs[String] === "List()" }
+      } ~> check { responseAs[String] shouldEqual "Vector()" }
     }
     "extract all occurrences into an Iterable when parameter is present" in {
       Post("/", FormData("age" → "42", "hobby" → "cooking", "hobby" → "reading")) ~> {
         formField('hobby.*) { echoComplete }
-      } ~> check { responseAs[String] === "List(cooking, reading)" }
+      } ~> check { responseAs[String] shouldEqual "Vector(cooking, reading)" }
     }
     "extract as Iterable[Int]" in {
       Post("/", FormData("age" → "42", "number" → "3", "number" → "5")) ~> {
         formField('number.as[Int].*) { echoComplete }
-      } ~> check { responseAs[String] === "List(3, 5)" }
+      } ~> check { responseAs[String] shouldEqual "Vector(3, 5)" }
     }
     "extract as Iterable[Int] with an explicit deserializer" in {
       Post("/", FormData("age" → "42", "number" → "3", "number" → "A")) ~> {
         formField('number.as(HexInt).*) { echoComplete }
-      } ~> check { responseAs[String] === "List(3, 10)" }
+      } ~> check { responseAs[String] shouldEqual "Vector(3, 10)" }
     }
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -233,22 +233,22 @@ class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Insi
     "extract an empty Iterable when the parameter is absent" in {
       Get("/person?age=19") ~> {
         parameter('hobby.*) { echoComplete }
-      } ~> check { responseAs[String] === "List()" }
+      } ~> check { responseAs[String] shouldEqual "List()" }
     }
     "extract all occurrences into an Iterable when parameter is present" in {
       Get("/person?age=19&hobby=cooking&hobby=reading") ~> {
         parameter('hobby.*) { echoComplete }
-      } ~> check { responseAs[String] === "List(cooking, reading)" }
+      } ~> check { responseAs[String] shouldEqual "List(reading, cooking)" }
     }
     "extract as Iterable[Int]" in {
       Get("/person?age=19&number=3&number=5") ~> {
         parameter('number.as[Int].*) { echoComplete }
-      } ~> check { responseAs[String] === "List(3, 5)" }
+      } ~> check { responseAs[String] shouldEqual "List(5, 3)" }
     }
     "extract as Iterable[Int] with an explicit deserializer" in {
       Get("/person?age=19&number=3&number=A") ~> {
         parameter('number.as(HexInt).*) { echoComplete }
-      } ~> check { responseAs[String] === "List(3, 10)" }
+      } ~> check { responseAs[String] shouldEqual "List(10, 3)" }
     }
   }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -117,9 +117,9 @@ class RejectionHandlerExamplesSpec extends RoutingSpec {
 
     // tests:
     Get("/nope") ~> route ~> check {
-      status should === (StatusCodes.NotFound)
-      contentType should === (ContentTypes.`application/json`)
-      responseAs[String] should ===("""{"rejection": "The requested resource could not be found."}""")
+      status shouldEqual StatusCodes.NotFound
+      contentType shouldEqual ContentTypes.`application/json`
+      responseAs[String] shouldEqual """{"rejection": "The requested resource could not be found."}"""
     }
     //#example-json
   }
@@ -153,20 +153,26 @@ class RejectionHandlerExamplesSpec extends RoutingSpec {
 
     // tests:
     Get("/hello") ~> anotherRoute ~> check {
-      status should === (StatusCodes.BadRequest)
-      contentType should === (ContentTypes.`application/json`)
-      responseAs[String] should ===("""{"rejection": "Whoops, bad request!"}""")
+      status shouldEqual StatusCodes.BadRequest
+      contentType shouldEqual ContentTypes.`application/json`
+      responseAs[String] shouldEqual """{"rejection": "Whoops, bad request!"}"""
     }
     //#example-json
   }
 
   "test custom handler example" in {
     import akka.http.scaladsl.server._
+    import akka.http.scaladsl.model.StatusCodes.BadRequest
+
+    implicit def myRejectionHandler = RejectionHandler.newBuilder().handle {
+      case MissingCookieRejection(_) => complete(HttpResponse(BadRequest, entity = "No cookies, no service!!!"))
+    }.result()
+
     val route = Route.seal(reject(MissingCookieRejection("abc")))
 
     // tests:
     Get() ~> route ~> check {
-      responseAs[String] === "No cookies, no service!!!"
+      responseAs[String] shouldEqual "No cookies, no service!!!"
     }
   }
 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomDirectivesExamplesSpec.scala
@@ -37,7 +37,7 @@ class CustomDirectivesExamplesSpec extends RoutingSpec {
 
     // tests:
     Get("/?text=abcdefg") ~> lengthDirective(x => complete(x.toString)) ~> check {
-      responseAs[String] === "7"
+      responseAs[String] shouldEqual "7"
     }
     //#map-0
   }
@@ -54,7 +54,7 @@ class CustomDirectivesExamplesSpec extends RoutingSpec {
 
     // tests:
     Get("/?a=2&b=5") ~> myDirective(x => complete(x)) ~> check {
-      responseAs[String] === "7"
+      responseAs[String] shouldEqual "7"
     }
     //#tmap-1
   }
@@ -71,10 +71,10 @@ class CustomDirectivesExamplesSpec extends RoutingSpec {
 
     // tests:
     Get("/?a=21") ~> myDirective(i => complete(i.toString)) ~> check {
-      responseAs[String] === "42"
+      responseAs[String] shouldEqual "42"
     }
     Get("/?a=-18") ~> myDirective(i => complete(i.toString)) ~> check {
-      handled === false
+      handled shouldEqual false
     }
     //#flatMap-0
   }
@@ -92,8 +92,8 @@ class CustomDirectivesExamplesSpec extends RoutingSpec {
     }
 
     Get() ~> Host("akka.io", 8080) ~> route ~> check {
-      status === OK
-      responseAs[String] === "The hostname is akka.io and the port is 8080"
+      status shouldEqual OK
+      responseAs[String] shouldEqual "The hostname is akka.io and the port is 8080"
     }
     //#scratch-1
   }
@@ -113,8 +113,8 @@ class CustomDirectivesExamplesSpec extends RoutingSpec {
     }
 
     Get() ~> Host("akka.io", 8080) ~> route ~> check {
-      status === OK
-      responseAs[String] === "The hostname is akka.io and the port is 8080"
+      status shouldEqual OK
+      responseAs[String] shouldEqual "The hostname is akka.io and the port is 8080"
     }
     //#scratch-2
   }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
@@ -128,15 +128,15 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with PredefinedFromStr
 
     // tests:
     Get("/?color=blue") ~> route ~> check {
-      responseAs[String] === "The color is 'blue' and there are no cities."
+      responseAs[String] shouldEqual "The color is 'blue' and there are no cities."
     }
 
     Get("/?color=blue&city=Chicago") ~> Route.seal(route) ~> check {
-      responseAs[String] === "The color is 'blue' and the city is Chicago."
+      responseAs[String] shouldEqual "The color is 'blue' and the city is Chicago."
     }
 
     Get("/?color=blue&city=Chicago&city=Boston") ~> Route.seal(route) ~> check {
-      responseAs[String] === "The color is 'blue' and the cities are Chicago, Boston."
+      responseAs[String] shouldEqual "The color is 'blue' and the cities are Boston, Chicago."
     }
     //#repeated
   }
@@ -153,15 +153,15 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with PredefinedFromStr
 
     // tests:
     Get("/?color=blue") ~> route ~> check {
-      responseAs[String] === "The color is 'blue' and there are no distances."
+      responseAs[String] shouldEqual "The color is 'blue' and there are no distances."
     }
 
     Get("/?color=blue&distance=5") ~> Route.seal(route) ~> check {
-      responseAs[String] === "The color is 'blue' and the distance is 5."
+      responseAs[String] shouldEqual "The color is 'blue' and the distance is 5."
     }
 
     Get("/?color=blue&distance=5&distance=14") ~> Route.seal(route) ~> check {
-      responseAs[String] === "The color is 'blue' and the distances are 5, 14."
+      responseAs[String] shouldEqual "The color is 'blue' and the distances are 14, 5."
     }
     //#mapped-repeated
   }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/RangeDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/RangeDirectivesExamplesSpec.scala
@@ -42,13 +42,13 @@ class RangeDirectivesExamplesSpec extends RoutingSpec {
       response should have length 2
 
       val part1 = response(0)
-      part1.contentRange === ContentRange(0, 2, 8)
+      part1.contentRange shouldEqual ContentRange(0, 2, 8)
       part1.entity should matchPattern {
         case HttpEntity.Strict(_, bytes) if bytes.utf8String == "ABC" =>
       }
 
       val part2 = response(1)
-      part2.contentRange === ContentRange(6, 7, 8)
+      part2.contentRange shouldEqual ContentRange(6, 7, 8)
       part2.entity should matchPattern {
         case HttpEntity.Strict(_, bytes) if bytes.utf8String == "GH" =>
       }


### PR DESCRIPTION
I've replaced almost all of the triple equals assertions with shouldEqual from the code base. Some of the test cases stopped passing after that change so I've fixed them. 

The last triple equals assertion is located in `akka.http.impl.engine.ws.Utf8CodingSpecs` test class. But fixing that probably will take more time because the failure cause was not clear to me. 

Should I create a new issue for Utf8CodingSpecs as a bug or continue it in #1136?

Refs: #1136 