### PR TITLE
Support OAuth2 access token in URI query component as defined in RFC6750

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -150,21 +150,21 @@ trait SecurityDirectives {
           case Some(t) ⇒ AuthenticationResult.success(t)
           case None    ⇒ AuthenticationResult.failWithChallenge(HttpChallenges.oAuth2(realm))
         }
-      }
-    }.recoverPF {
-      case rejections: Seq[Rejection] ⇒
-        val accessToken = {
-          import akka.http.scaladsl.server.Directives._
-          parameter('access_token.?)
-        }
-
-        accessToken.flatMap {
-          case cred @ Some(_) ⇒ onSuccess(authenticator(Credentials(cred.map(OAuth2BearerToken)))).flatMap {
-            case Some(t) ⇒ provide(t)
-            case None    ⇒ reject(AuthenticationFailedRejection(CredentialsRejected, HttpChallenges.oAuth2(realm))): Directive1[T]
+      }.recoverPF {
+        case rejections: Seq[Rejection] ⇒
+          val accessToken = {
+            import akka.http.scaladsl.server.Directives._
+            parameter('access_token.?)
           }
-          case None ⇒ reject(rejections: _*): Directive1[T]
-        }
+
+          accessToken.flatMap {
+            case cred @ Some(_) ⇒ onSuccess(authenticator(Credentials(cred.map(OAuth2BearerToken)))).flatMap {
+              case Some(t) ⇒ provide(t)
+              case None    ⇒ reject(AuthenticationFailedRejection(CredentialsRejected, HttpChallenges.oAuth2(realm))): Directive1[T]
+            }
+            case None ⇒ reject(rejections: _*): Directive1[T]
+          }
+      }
     }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -145,27 +145,22 @@ trait SecurityDirectives {
    */
   def authenticateOAuth2Async[T](realm: String, authenticator: AsyncAuthenticator[T]): AuthenticationDirective[T] =
     extractExecutionContext.flatMap { implicit ec ⇒
-      def liftedAuthenticator(cred: Option[HttpCredentials]) = authenticator(Credentials(cred)).fast.map {
-        case Some(t) ⇒ AuthenticationResult.success(t)
-        case None    ⇒ AuthenticationResult.failWithChallenge(HttpChallenges.oAuth2(realm))
+      def extractAccessTokenParameterAsBearerToken = {
+        import akka.http.scaladsl.server.Directives._
+        parameter('access_token.?).map(_.map(OAuth2BearerToken))
       }
+      val extractCreds: Directive1[Option[OAuth2BearerToken]] =
+        extractCredentials.flatMap {
+          case Some(c: OAuth2BearerToken) ⇒ provide(Some(c))
+          case _                          ⇒ extractAccessTokenParameterAsBearerToken
+        }
 
-      authenticateOrRejectWithChallenge[OAuth2BearerToken, T](liftedAuthenticator).recoverPF {
-        case Seq(AuthenticationFailedRejection(CredentialsMissing, _)) ⇒
-          val accessToken = {
-            import akka.http.scaladsl.server.Directives._
-            parameter('access_token.?).map(_.map(OAuth2BearerToken))
-          }
-
-          accessToken.flatMap { cred ⇒
-            onSuccess(liftedAuthenticator(cred)).flatMap {
-              case Right(user) ⇒ provide(user)
-              case Left(challenge) ⇒
-                val cause = if (cred.isEmpty) CredentialsMissing else CredentialsRejected
-                reject(AuthenticationFailedRejection(cause, challenge)): Directive1[T]
-            }
-          }
-      }
+      extractCredentialsAndAuthenticateOrRejectWithChallenge[OAuth2BearerToken, T](extractCreds, { cred ⇒
+        authenticator(Credentials(cred)).fast.map {
+          case Some(t) ⇒ AuthenticationResult.success(t)
+          case None    ⇒ AuthenticationResult.failWithChallenge(HttpChallenges.oAuth2(realm))
+        }
+      })
     }
 
   /**
@@ -198,19 +193,32 @@ trait SecurityDirectives {
    * to the inner route. If the function returns `Left(challenge)` the request is rejected with an
    * [[AuthenticationFailedRejection]] that contains this challenge to be added to the response.
    *
+   * You can supply a directive to extract the credentials (to support alternative ways of providing credentials).
+   *
+   * @group security
+   */
+  private def extractCredentialsAndAuthenticateOrRejectWithChallenge[C <: HttpCredentials, T](
+    extractCredentials: Directive1[Option[C]],
+    authenticator:      Option[C] ⇒ Future[AuthenticationResult[T]]): AuthenticationDirective[T] =
+    extractCredentials.flatMap { cred ⇒
+      onSuccess(authenticator(cred)).flatMap {
+        case Right(user) ⇒ provide(user)
+        case Left(challenge) ⇒
+          val cause = if (cred.isEmpty) CredentialsMissing else CredentialsRejected
+          reject(AuthenticationFailedRejection(cause, challenge)): Directive1[T]
+      }
+    }
+
+  /**
+   * Lifts an authenticator function into a directive. The authenticator function gets passed in credentials from the
+   * [[Authorization]] header of the request. If the function returns `Right(user)` the user object is provided
+   * to the inner route. If the function returns `Left(challenge)` the request is rejected with an
+   * [[AuthenticationFailedRejection]] that contains this challenge to be added to the response.
+   *
    * @group security
    */
   def authenticateOrRejectWithChallenge[T](authenticator: Option[HttpCredentials] ⇒ Future[AuthenticationResult[T]]): AuthenticationDirective[T] =
-    extractExecutionContext.flatMap { implicit ec ⇒
-      extractCredentials.flatMap { cred ⇒
-        onSuccess(authenticator(cred)).flatMap {
-          case Right(user) ⇒ provide(user)
-          case Left(challenge) ⇒
-            val cause = if (cred.isEmpty) CredentialsMissing else CredentialsRejected
-            reject(AuthenticationFailedRejection(cause, challenge)): Directive1[T]
-        }
-      }
-    }
+    extractCredentialsAndAuthenticateOrRejectWithChallenge(extractCredentials, authenticator)
 
   /**
    * Lifts an authenticator function into a directive. Same as `authenticateOrRejectWithChallenge`
@@ -220,7 +228,7 @@ trait SecurityDirectives {
    */
   def authenticateOrRejectWithChallenge[C <: HttpCredentials: ClassTag, T](
     authenticator: Option[C] ⇒ Future[AuthenticationResult[T]]): AuthenticationDirective[T] =
-    authenticateOrRejectWithChallenge[T](cred ⇒ authenticator(cred collect { case c: C ⇒ c }))
+    extractCredentialsAndAuthenticateOrRejectWithChallenge(extractCredentials.map(_ collect { case c: C ⇒ c }), authenticator)
 
   /**
    * Applies the given authorization check to the request.

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -152,6 +152,7 @@ trait SecurityDirectives {
 
       accessToken.flatMap { uriCred ⇒
         authenticateOrRejectWithChallenge[OAuth2BearerToken, T] { headerCred ⇒
+          // If `Authorization` header is missing take URI's `access_token` query parameter
           val cred = headerCred.orElse(uriCred.map(OAuth2BearerToken))
           authenticator(Credentials(cred)).fast.map {
             case Some(t) ⇒ AuthenticationResult.success(t)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -152,7 +152,7 @@ trait SecurityDirectives {
 
       accessToken.flatMap { uriCred ⇒
         authenticateOrRejectWithChallenge[OAuth2BearerToken, T] { headerCred ⇒
-          // If `Authorization` header is missing take URI's `access_token` query parameter
+          // If `Authorization` header is missing try `access_token` URI query parameter
           val cred = headerCred.orElse(uriCred.map(OAuth2BearerToken))
           authenticator(Credentials(cred)).fast.map {
             case Some(t) ⇒ AuthenticationResult.success(t)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -169,15 +169,6 @@ trait SecurityDirectives {
           authenticateOrRejectWithChallenge[OAuth2BearerToken, T](liftedAuthenticator)
       }
     }
-
-    /*extractExecutionContext.flatMap { implicit ec ⇒
-      authenticateOrRejectWithChallenge[OAuth2BearerToken, T] { cred ⇒
-        authenticator(Credentials(cred)).fast.map {
-          case Some(t) ⇒ AuthenticationResult.success(t)
-          case None ⇒ AuthenticationResult.failWithChallenge(HttpChallenges.oAuth2(realm))
-        }
-      }
-    }*/
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -143,7 +143,7 @@ trait SecurityDirectives {
    *
    * @group security
    */
-  def authenticateOAuth2Async[T](realm: String, authenticator: AsyncAuthenticator[T]): AuthenticationDirective[T] = {
+  def authenticateOAuth2Async[T](realm: String, authenticator: AsyncAuthenticator[T]): AuthenticationDirective[T] =
     extractExecutionContext.flatMap { implicit ec ⇒
       authenticateOrRejectWithChallenge[OAuth2BearerToken, T] { cred ⇒
         authenticator(Credentials(cred)).fast.map {
@@ -166,7 +166,6 @@ trait SecurityDirectives {
           case None ⇒ reject(rejections: _*): Directive1[T]
         }
     }
-  }
 
   /**
    * A directive that wraps the inner route with OAuth2 Bearer Token authentication support.

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -74,10 +74,10 @@ trait SecurityDirectives {
    * @group security
    */
   def extractCredentials: Directive1[Option[HttpCredentials]] = {
-    optionalHeaderValueByType[Authorization](()).map(_.map(_.credentials)).flatMap { cred ⇒
+    optionalHeaderValueByType[Authorization](()).map(_.map(_.credentials)).flatMap { headerCred ⇒
       import akka.http.scaladsl.server.Directives._
-      parameter('access_token.?).map { a ⇒
-        cred.orElse(a.map(OAuth2BearerToken))
+      parameter('access_token.?).map { uriCred ⇒
+        headerCred.orElse(uriCred.map(OAuth2BearerToken))
       }
     }
   }


### PR DESCRIPTION
Implements https://github.com/akka/akka-http/issues/1769

If `Authorization` header is missing check `access_token` URI query parameter instead.