### PR TITLE
MessageSpec fixes

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/MessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/MessageSpec.scala
@@ -243,8 +243,8 @@ class MessageSpec extends FreeSpec with Matchers with WithMaterializerSpec with 
 
         // push single-byte ByteStrings without reading anything until it fails
         // this should be after the internal input buffers have filled up
-        eventually(PatienceConfiguration.Timeout(500.millis.dilated), PatienceConfiguration.Interval(1.milli.dilated)) {
-          the[AssertionError] thrownBy pushInput(ByteString("a"))
+        eventually(timeout(1.second.dilated), interval(10.millis)) {
+          an[AssertionError] should be thrownBy pushInput(ByteString("a"))
         }
       }
     }


### PR DESCRIPTION
Refs #1142 but doesn't really fix it:

* The ScalaTest match style didn't really make sense
* dilating the interval didn't really make sense
* A bit more generous timeout