### PR TITLE
=htc #1786 fix customMediaTypes behavior

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.settings.ParserSettings
 import akka.http.scaladsl.settings.ParserSettings.CookieParsingMode
 import akka.http.scaladsl.settings.ParserSettings.IllegalResponseHeaderValueProcessingMode
 import akka.http.scaladsl.model.headers.HttpCookiePair
-import akka.stream.impl.ConstantFun
+import akka.util.ConstantFun
 
 import scala.util.control.NonFatal
 import akka.http.impl.util.SingletonException
@@ -42,6 +42,7 @@ private[http] class HeaderParser(
   import CharacterClasses._
 
   override def customMediaTypes = settings.customMediaTypes
+  override def areNoCustomMediaTypesDefined: Boolean = settings.areNoCustomMediaTypesDefined
 
   // http://www.rfc-editor.org/errata_search.php?rfc=7230 errata id 4189
   def `header-field-value`: Rule1[String] = rule {
@@ -189,6 +190,7 @@ private[http] object HeaderParser {
     def uriParsingMode: Uri.ParsingMode
     def cookieParsingMode: ParserSettings.CookieParsingMode
     def customMediaTypes: MediaTypes.FindCustom
+    def areNoCustomMediaTypesDefined: Boolean
     def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode
   }
   def Settings(
@@ -206,6 +208,8 @@ private[http] object HeaderParser {
       def uriParsingMode: Uri.ParsingMode = _uriParsingMode
       def cookieParsingMode: CookieParsingMode = _cookieParsingMode
       def customMediaTypes: MediaTypes.FindCustom = _customMediaTypes
+      def areNoCustomMediaTypesDefined: Boolean = _customMediaTypes eq ConstantFun.scalaAnyToNone
+
       def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode =
         _illegalResponseHeaderValueProcessingMode
     }

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -6,7 +6,7 @@ package akka.http.impl.settings
 
 import akka.annotation.InternalApi
 import akka.http.scaladsl.settings.ParserSettings.{ CookieParsingMode, ErrorLoggingVerbosity, IllegalResponseHeaderValueProcessingMode }
-import akka.stream.impl.ConstantFun
+import akka.util.ConstantFun
 import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
@@ -54,13 +54,16 @@ private[akka] final case class ParserSettingsImpl(
     headerValueCacheLimits.getOrElse(headerName, defaultHeaderValueCacheLimit)
 
   override def productPrefix = "ParserSettings"
+
+  // optimization: if we see the default value as defined below, we know it hasn't been changed
+  override def areNoCustomMediaTypesDefined: Boolean = customMediaTypes eq ParserSettingsImpl.noCustomMediaTypes
 }
 
 object ParserSettingsImpl extends SettingsCompanion[ParserSettingsImpl]("akka.http.parsing") {
 
   private[this] val noCustomMethods: String ⇒ Option[HttpMethod] = ConstantFun.scalaAnyToNone
   private[this] val noCustomStatusCodes: Int ⇒ Option[StatusCode] = ConstantFun.scalaAnyToNone
-  private[this] val noCustomMediaTypes: (String, String) ⇒ Option[MediaType] = ConstantFun.scalaAnyTwoToNone
+  private[ParserSettingsImpl] val noCustomMediaTypes: (String, String) ⇒ Option[MediaType] = ConstantFun.scalaAnyTwoToNone
 
   def fromSubConfig(root: Config, inner: Config) = {
     val c = inner.withFallback(root.getConfig(prefix))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -22,6 +22,7 @@ import akka.http.impl.util._
 import akka.http.scaladsl.model.HttpEntity._
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.HttpProtocols._
+import akka.http.scaladsl.model.MediaType.WithFixedCharset
 import akka.http.scaladsl.model.MediaTypes._
 import akka.http.scaladsl.model.RequestEntityAcceptance.Expected
 import akka.http.scaladsl.model.StatusCodes._
@@ -315,6 +316,50 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
             `Raw-Request-URI`("/f%6f%6fbar?q=b%61z"),
             Host("ping")),
           HttpEntity.empty(`application/pdf`)))
+    }
+
+    "support custom media type parsing" in new Test {
+      val `application/custom`: WithFixedCharset =
+        MediaType.customWithFixedCharset("application", "custom", HttpCharsets.`UTF-8`)
+
+      override protected def parserSettings: ParserSettings =
+        super.parserSettings.withCustomMediaTypes(`application/custom`)
+
+      """POST / HTTP/1.1
+        |Host: ping
+        |Content-Type: application/custom
+        |Content-Length: 0
+        |
+        |""" should parseTo(
+        HttpRequest(
+          POST,
+          "/",
+          List(Host("ping")),
+          HttpEntity.empty(`application/custom`)))
+
+      """POST / HTTP/1.1
+        |Host: ping
+        |Content-Type: application/json
+        |Content-Length: 3
+        |
+        |123""" should parseTo(
+        HttpRequest(
+          POST,
+          "/",
+          List(Host("ping")),
+          HttpEntity(ContentTypes.`application/json`, "123")))
+
+      """POST / HTTP/1.1
+        |Host: ping
+        |Content-Type: text/plain; charset=UTF-8
+        |Content-Length: 8
+        |
+        |abcdefgh""" should parseTo(
+        HttpRequest(
+          POST,
+          "/",
+          List(Host("ping")),
+          HttpEntity(ContentTypes.`text/plain(UTF-8)`, "abcdefgh")))
     }
 
     "reject a message chunk with" - {


### PR DESCRIPTION
Previously, defining customMediaType in ParserSettings broke parsing of
predefined media types or custom ad-hoc media-types with charsets. This had
two reasons:

 * when custom media types were defined, we never parsed into our own
   predefined ones any more
 * areCustomMediaTypesDefined was defined the wrong way round: just checking
   that the value was changed from the magic one doesn't mean there might
   still be none defined

Fixes #1786.