### PR TITLE
=htc disable LegacyPoolImplementation in HostConnectionPoolSpec

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -78,9 +78,9 @@ class HostConnectionPoolSpec extends AkkaSpec(
   testSet(poolImplementation = NewPoolImplementation, clientServerImplementation = AkkaHttpEngineTCP)
   //testSet(poolImplementation = NewPoolImplementation, clientServerImplementation = AkkaHttpEngineTLS)
 
-  testSet(poolImplementation = LegacyPoolImplementation, clientServerImplementation = PassThrough)
-  testSet(poolImplementation = LegacyPoolImplementation, clientServerImplementation = AkkaHttpEngineNoNetwork)
-  testSet(poolImplementation = LegacyPoolImplementation, clientServerImplementation = AkkaHttpEngineTCP)
+  //testSet(poolImplementation = LegacyPoolImplementation, clientServerImplementation = PassThrough)
+  //testSet(poolImplementation = LegacyPoolImplementation, clientServerImplementation = AkkaHttpEngineNoNetwork)
+  //testSet(poolImplementation = LegacyPoolImplementation, clientServerImplementation = AkkaHttpEngineTCP)
   //testSet(poolImplementation = OldPoolImplementation, clientServerImplementation = AkkaHttpEngineTLS)
 
   def testSet(poolImplementation: PoolImplementation, clientServerImplementation: ClientServerImplementation) =


### PR DESCRIPTION
These are basically new tests for the old implementation. Let's disable
those and focus on improving reliability of the new one.