### PR TITLE
=doc Fix path matcher doc page

### DIFF
--- a/docs/src/main/paradox/routing-dsl/path-matchers.md
+++ b/docs/src/main/paradox/routing-dsl/path-matchers.md
@@ -1,10 +1,3 @@
-@@@ div { .group-java }
-
-This DSL is only relevant when using the Scala API.
-
-@@@
-
-@@@ div { .group-scala }
 # The PathMatcher DSL
 
 For being able to work with the @ref[PathDirectives](directives/path-directives/index.md) effectively you should have some understanding of the
@@ -59,6 +52,7 @@ The path matching DSL describes what paths to accept **after** URL decoding. Thi
 slashes have special status and cannot simply be specified as part of a string! The string "foo/bar" would match
 the raw URI path "foo%2Fbar", which is most likely not what you want!
 @@@
+
 
 
 ## Basic PathMatchers


### PR DESCRIPTION
Page has dangling `@@@`. Remove top text stating that this only makes sense for Scala DSL.