### PR TITLE
Fix nesting WrapDirective's in docs

### DIFF
--- a/docs/src/main/paradox/routing-dsl/case-class-extraction.md
+++ b/docs/src/main/paradox/routing-dsl/case-class-extraction.md
@@ -42,12 +42,10 @@ the directive into one extracting only a single `Color` instance.
 Generally, when you have routes that work with, say, more than 3 extractions it's a good idea to introduce a case class
 for these and resort to case class extraction. Especially since it supports another nice feature: validation.
 
-@@@ warning { title="Caution" }
 There is one quirk to look out for when using case class extraction: If you create an explicit companion
 object for your case class, no matter whether you actually add any members to it or not, the syntax presented above
 will not (quite) work anymore. Instead of `as(Color)` you will then have to say `as(Color.apply)`. This behavior
 appears as if it's not really intended, so this might be improved in future Scala versions.
-@@@
 
 ## Case Class Validation
 

--- a/docs/src/main/paradox/routing-dsl/case-class-extraction.md
+++ b/docs/src/main/paradox/routing-dsl/case-class-extraction.md
@@ -42,10 +42,12 @@ the directive into one extracting only a single `Color` instance.
 Generally, when you have routes that work with, say, more than 3 extractions it's a good idea to introduce a case class
 for these and resort to case class extraction. Especially since it supports another nice feature: validation.
 
+@@@@warning { title="Caution" }
 There is one quirk to look out for when using case class extraction: If you create an explicit companion
 object for your case class, no matter whether you actually add any members to it or not, the syntax presented above
 will not (quite) work anymore. Instead of `as(Color)` you will then have to say `as(Color.apply)`. This behavior
 appears as if it's not really intended, so this might be improved in future Scala versions.
+@@@@
 
 ## Case Class Validation
 


### PR DESCRIPTION
This [does not work](https://github.com/lightbend/paradox/issues/185)

In this case this made Scala-specific content pop up at https://doc.akka.io/docs/akka-http/current/routing-dsl/case-class-extraction.html?language=java