### PR TITLE
Adapt Actor Examples to Akka 2.5 #992

### DIFF
--- a/docs/src/main/paradox/client-side/request-level.md
+++ b/docs/src/main/paradox/client-side/request-level.md
@@ -48,37 +48,7 @@ Scala
 :   @@snip [HttpClientExampleSpec.scala]($test$/scala/docs/http/scaladsl/HttpClientExampleSpec.scala) { #single-request-in-actor-example }
 
 Java
-:   
-
-        import akka.actor.AbstractActor;
-        import akka.http.javadsl.Http;
-        import akka.http.javadsl.model.HttpRequest;
-        import akka.http.javadsl.model.HttpResponse;
-        import akka.japi.pf.ReceiveBuilder;
-        import akka.stream.ActorMaterializer;
-        import akka.stream.Materializer;
-        import scala.concurrent.ExecutionContextExecutor;
-        
-        import java.util.concurrent.CompletionStage;
-        
-        import static akka.pattern.PatternsCS.pipe;
-        
-        public class SingleRequestInActorExample extends AbstractActor {
-            final Http http = Http.get(context().system());
-            final ExecutionContextExecutor dispatcher = context().dispatcher();
-            final Materializer materializer = ActorMaterializer.create(context());
-        
-            public SingleRequestInActorExample() { // syntax changes slightly in Akka 2.5, see the migration guide
-                receive(ReceiveBuilder
-                        .match(String.class, url -> pipe(fetch(url), dispatcher).to(self()))
-                        .build());
-            }
-        
-            CompletionStage<HttpResponse> fetch(String url) {
-                return http.singleRequest(HttpRequest.create(url), materializer);
-            }
-        }
-       
+:   @@snip [HttpClientExampleDocTest.java]($test$/java/docs/http/javadsl/HttpClientExampleDocTest.java) { #single-request-in-actor-example }
 
 @@@ warning
 

--- a/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
@@ -189,22 +189,22 @@ public class HttpClientExampleDocTest {
   // compile only test
   public void singleRequestInActorExample1() {
     //#single-request-in-actor-example
-      class SingleRequestInActorExample extends AbstractActor {
+    class SingleRequestInActorExample extends AbstractActor {
       final Http http = Http.get(context().system());
       final ExecutionContextExecutor dispatcher = context().dispatcher();
       final Materializer materializer = ActorMaterializer.create(context());
 
-       @Override
-       public Receive createReceive() {
-         return receiveBuilder()
-                 .match(String.class, url -> pipe(fetch(url), dispatcher).to(self()))
-                 .build();
-       }
+      @Override
+      public Receive createReceive() {
+        return receiveBuilder()
+          .match(String.class, url -> pipe(fetch(url), dispatcher).to(self()))
+          .build();
+      }
 
       CompletionStage<HttpResponse> fetch(String url) {
         return http.singleRequest(HttpRequest.create(url));
       }
-     }
+    }
     //#single-request-in-actor-example
   }
 

--- a/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
@@ -39,6 +39,22 @@ import java.util.stream.StreamSupport;
 import akka.http.javadsl.model.headers.SetCookie;
 //#collecting-headers-example
 
+
+//#single-request-in-actor-example
+import akka.actor.AbstractActor;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import scala.concurrent.ExecutionContextExecutor;
+
+import java.util.concurrent.CompletionStage;
+
+import static akka.pattern.PatternsCS.pipe;
+
+//#single-request-in-actor-example
+
 @SuppressWarnings("unused")
 public class HttpClientExampleDocTest {
 
@@ -168,6 +184,28 @@ public class HttpClientExampleDocTest {
       Http.get(system)
           .singleRequest(HttpRequest.create("http://akka.io"));
     //#single-request-example
+  }
+
+  // compile only test
+  public void singleRequestInActorExample1() {
+    //#single-request-in-actor-example
+      class SingleRequestInActorExample extends AbstractActor {
+      final Http http = Http.get(context().system());
+      final ExecutionContextExecutor dispatcher = context().dispatcher();
+      final Materializer materializer = ActorMaterializer.create(context());
+
+       @Override
+       public Receive createReceive() {
+         return receiveBuilder()
+                 .match(String.class, url -> pipe(fetch(url), dispatcher).to(self()))
+                 .build();
+       }
+
+      CompletionStage<HttpResponse> fetch(String url) {
+        return http.singleRequest(HttpRequest.create(url));
+      }
+     }
+    //#single-request-in-actor-example
   }
 
   // compile only test

--- a/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
@@ -118,11 +118,10 @@ public class HttpServerActorInteractionExample extends AllDirectives {
     @Override
     public Receive createReceive() {
       return receiveBuilder()
-        .match(
-          HttpServerActorInteractionExample.Bid.class, bid -> {
-            bids.add(bid);
-            log.info("Bid complete: {}, {}", bid.userId, bid.offer);
-            })
+        .match(HttpServerActorInteractionExample.Bid.class, bid -> {
+          bids.add(bid);
+          log.info("Bid complete: {}, {}", bid.userId, bid.offer);
+        })
         .match(HttpServerActorInteractionExample.GetBids.class, m -> {
           sender().tell(new HttpServerActorInteractionExample.Bids(bids), self());
         })

--- a/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
@@ -22,7 +22,6 @@ import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.Route;
 import akka.http.javadsl.unmarshalling.StringUnmarshallers;
-import akka.japi.pf.ReceiveBuilder;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
 import akka.util.Timeout;
@@ -34,7 +33,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import static akka.pattern.PatternsCS.ask;
-
 
 public class HttpServerActorInteractionExample extends AllDirectives {
 
@@ -107,10 +105,6 @@ public class HttpServerActorInteractionExample extends AllDirectives {
     }
   }
 
-  //#actor-interaction
-  /* TODO: replace with code that works for both 2.4 and 2.5, see #821
-  //#actor-interaction
-  // compiles only against Akka 2.4, see migration guide for how to rewrite for Akka 2.5
   static class Auction extends AbstractActor {
 
     private final LoggingAdapter log = Logging.getLogger(context().system(), this);
@@ -121,26 +115,20 @@ public class HttpServerActorInteractionExample extends AllDirectives {
       return Props.create(Auction.class);
     }
 
-    public Auction() {
-      receive(ReceiveBuilder.
-        match(HttpServerActorInteractionExample.Bid.class, bid -> {
-          bids.add(bid);
-          log.info("Bid complete: {}, {}", bid.userId, bid.offer);
-        }).
-        match(HttpServerActorInteractionExample.GetBids.class, m -> {
+    @Override
+    public Receive createReceive() {
+      return receiveBuilder()
+        .match(
+          HttpServerActorInteractionExample.Bid.class, bid -> {
+            bids.add(bid);
+            log.info("Bid complete: {}, {}", bid.userId, bid.offer);
+            })
+        .match(HttpServerActorInteractionExample.GetBids.class, m -> {
           sender().tell(new HttpServerActorInteractionExample.Bids(bids), self());
-        }).
-        matchAny(o -> log.info("Invalid message")).
-        build()
-      );
+        })
+        .matchAny(o -> log.info("Invalid message"))
+        .build();
     }
   }
-  //#actor-interaction
-  */
-
-  static class Auction {
-    static Props props() { return null; }
-  }
-  //#actor-interaction
 }
 //#actor-interaction


### PR DESCRIPTION
This pr for #992:
- updates the code example for actor interaction in Java
- updates the code example for single request in actor in Java and extracts to snippet 