### PR TITLE
Supporting trailing response headers in HTTP/2

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -16,6 +16,7 @@ sealed trait FrameEvent { self: Product ⇒
 }
 sealed trait StreamFrameEvent extends FrameEvent { self: Product ⇒
   def streamId: Int
+  def endStream: Boolean
 }
 
 final case class GoAwayFrame(lastStreamId: Int, errorCode: ErrorCode, debug: ByteString = ByteString.empty) extends FrameEvent {
@@ -45,15 +46,21 @@ final case class HeadersFrame(
 final case class ContinuationFrame(
   streamId:   Int,
   endHeaders: Boolean,
-  payload:    ByteString) extends StreamFrameEvent
+  payload:    ByteString) extends StreamFrameEvent {
+  def endStream = false
+}
 
 case class PushPromiseFrame(
   streamId:            Int,
   endHeaders:          Boolean,
   promisedStreamId:    Int,
-  headerBlockFragment: ByteString) extends StreamFrameEvent
+  headerBlockFragment: ByteString) extends StreamFrameEvent {
+  def endStream = false
+}
 
-final case class RstStreamFrame(streamId: Int, errorCode: ErrorCode) extends StreamFrameEvent
+final case class RstStreamFrame(streamId: Int, errorCode: ErrorCode) extends StreamFrameEvent {
+  def endStream = false
+}
 final case class SettingsFrame(settings: immutable.Seq[Setting]) extends FrameEvent
 final case class SettingsAckFrame(acked: immutable.Seq[Setting]) extends FrameEvent
 
@@ -62,13 +69,17 @@ case class PingFrame(ack: Boolean, data: ByteString) extends FrameEvent {
 }
 final case class WindowUpdateFrame(
   streamId:            Int,
-  windowSizeIncrement: Int) extends StreamFrameEvent
+  windowSizeIncrement: Int) extends StreamFrameEvent {
+  def endStream = false
+}
 
 final case class PriorityFrame(
   streamId:         Int,
   exclusiveFlag:    Boolean,
   streamDependency: Int,
-  weight:           Int) extends StreamFrameEvent
+  weight:           Int) extends StreamFrameEvent {
+  def endStream = false
+}
 
 final case class Setting(
   identifier: SettingIdentifier,
@@ -84,7 +95,9 @@ final case class UnknownFrameEvent(
   tpe:      FrameType,
   flags:    ByteFlag,
   streamId: Int,
-  payload:  ByteString) extends StreamFrameEvent
+  payload:  ByteString) extends StreamFrameEvent {
+  def endStream = false
+}
 
 final case class ParsedHeadersFrame(
   streamId:      Int,

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -16,7 +16,6 @@ sealed trait FrameEvent { self: Product ⇒
 }
 sealed trait StreamFrameEvent extends FrameEvent { self: Product ⇒
   def streamId: Int
-  def endStream: Boolean
 }
 
 final case class GoAwayFrame(lastStreamId: Int, errorCode: ErrorCode, debug: ByteString = ByteString.empty) extends FrameEvent {
@@ -46,21 +45,14 @@ final case class HeadersFrame(
 final case class ContinuationFrame(
   streamId:   Int,
   endHeaders: Boolean,
-  payload:    ByteString) extends StreamFrameEvent {
-  def endStream = false
-}
-
+  payload:    ByteString) extends StreamFrameEvent
 case class PushPromiseFrame(
   streamId:            Int,
   endHeaders:          Boolean,
   promisedStreamId:    Int,
-  headerBlockFragment: ByteString) extends StreamFrameEvent {
-  def endStream = false
-}
+  headerBlockFragment: ByteString) extends StreamFrameEvent
 
-final case class RstStreamFrame(streamId: Int, errorCode: ErrorCode) extends StreamFrameEvent {
-  def endStream = false
-}
+final case class RstStreamFrame(streamId: Int, errorCode: ErrorCode) extends StreamFrameEvent
 final case class SettingsFrame(settings: immutable.Seq[Setting]) extends FrameEvent
 final case class SettingsAckFrame(acked: immutable.Seq[Setting]) extends FrameEvent
 
@@ -69,17 +61,13 @@ case class PingFrame(ack: Boolean, data: ByteString) extends FrameEvent {
 }
 final case class WindowUpdateFrame(
   streamId:            Int,
-  windowSizeIncrement: Int) extends StreamFrameEvent {
-  def endStream = false
-}
+  windowSizeIncrement: Int) extends StreamFrameEvent
 
 final case class PriorityFrame(
   streamId:         Int,
   exclusiveFlag:    Boolean,
   streamDependency: Int,
-  weight:           Int) extends StreamFrameEvent {
-  def endStream = false
-}
+  weight:           Int) extends StreamFrameEvent
 
 final case class Setting(
   identifier: SettingIdentifier,
@@ -95,9 +83,7 @@ final case class UnknownFrameEvent(
   tpe:      FrameType,
   flags:    ByteFlag,
   streamId: Int,
-  payload:  ByteString) extends StreamFrameEvent {
-  def endStream = false
-}
+  payload:  ByteString) extends StreamFrameEvent
 
 final case class ParsedHeadersFrame(
   streamId:      Int,

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -21,9 +21,25 @@ import scala.concurrent.{ ExecutionContext, Future }
 /**
  * Represents one direction of an Http2 substream.
  */
-private[http2] final case class Http2SubStream(
+private[http2] sealed trait Http2SubStream {
+  type T
+  val initialHeaders: ParsedHeadersFrame
+  val data: Source[T, Any]
+  def streamId: Int
+}
+
+private[http2] final case class ByteHttp2SubStream(
   initialHeaders: ParsedHeadersFrame,
-  data:           Source[ByteString, Any]) {
+  data:           Source[ByteString, Any]
+) extends Http2SubStream {
+  type T = ByteString
+  def streamId: Int = initialHeaders.streamId
+}
+private[http2] final case class ChunkedHttp2SubStream(
+  initialHeaders: ParsedHeadersFrame,
+  data:           Source[HttpEntity.ChunkStreamPart, Any]
+) extends Http2SubStream {
+  type T = HttpEntity.ChunkStreamPart
   def streamId: Int = initialHeaders.streamId
 }
 

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -233,8 +233,8 @@ private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with Stage
       private def getOrCreateStreamFor(stream: Http2SubStream): OutStream[_] = outStreams.get(stream.streamId) match {
         case None ⇒
           val newOne = stream match {
-            case _: ByteHttp2SubStream => new ByteOutStream(stream.streamId, None, currentInitialWindow)
-            case _: ChunkedHttp2SubStream => new ChunkedOutStream(stream.streamId, None, currentInitialWindow)
+            case _: ByteHttp2SubStream    ⇒ new ByteOutStream(stream.streamId, None, currentInitialWindow)
+            case _: ChunkedHttp2SubStream ⇒ new ChunkedOutStream(stream.streamId, None, currentInitialWindow)
           }
           outStreams += stream.streamId → newOne
           newOne

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -74,7 +74,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
 
         // FIXME: after multiplexer PR is merged
         // prioInfo.foreach(multiplexer.updatePriority)
-        dispatchSubstream(Http2SubStream(frame, data))
+        dispatchSubstream(ByteHttp2SubStream(frame, data))
         nextState
 
       case x ⇒ receivedUnexpectedFrame(x)

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -71,7 +71,7 @@ private[http2] object RequestParsing {
 
           val entity = subStream match {
             case s if s.data == Source.empty || contentLength == 0 ⇒ HttpEntity.Empty
-            case ByteHttp2SubStream(_, data) if contentLength > 0                       ⇒ HttpEntity.Default(contentType, contentLength, data)
+            case ByteHttp2SubStream(_, data) if contentLength > 0  ⇒ HttpEntity.Default(contentType, contentLength, data)
             case ByteHttp2SubStream(_, data)                       ⇒ HttpEntity.Chunked.fromData(contentType, data)
             case ChunkedHttp2SubStream(_, data)                    ⇒ HttpEntity.Chunked(contentType, data)
           }

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -69,10 +69,12 @@ private[http2] object RequestParsing {
 
           if (tlsSessionInfoHeader.isDefined) headers += tlsSessionInfoHeader.get
 
-          val entity =
-            if (subStream.data == Source.empty || contentLength == 0) HttpEntity.Empty
-            else if (contentLength > 0) HttpEntity.Default(contentType, contentLength, subStream.data)
-            else HttpEntity.Chunked.fromData(contentType, subStream.data)
+          val entity = subStream match {
+            case s if s.data == Source.empty || contentLength == 0 ⇒ HttpEntity.Empty
+            case ByteHttp2SubStream(_, data) if contentLength > 0                       ⇒ HttpEntity.Default(contentType, contentLength, data)
+            case ByteHttp2SubStream(_, data)                       ⇒ HttpEntity.Chunked.fromData(contentType, data)
+            case ChunkedHttp2SubStream(_, data)                    ⇒ HttpEntity.Chunked(contentType, data)
+          }
 
           val (path, rawQueryString) = pathAndRawQuery
           val authorityOrDefault: Uri.Authority = if (authority == null) Uri.Authority.Empty else authority

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
@@ -56,10 +56,19 @@ private[http2] object ResponseRendering {
 
       val headers = ParsedHeadersFrame(streamId, endStream = response.entity.isKnownEmpty, headerPairs.result(), None)
 
-      Http2SubStream(
-        headers,
-        response.entity.dataBytes
-      )
+      response.entity match {
+        case HttpEntity.Chunked(_, chunks) ⇒
+          ChunkedHttp2SubStream(
+            headers,
+            chunks
+          )
+        case _ ⇒
+          ByteHttp2SubStream(
+            headers,
+            response.entity.dataBytes
+          )
+      }
+
     }
   }
 

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
@@ -73,6 +73,15 @@ private[http2] object ResponseRendering {
   }
 
   private[http2] def renderHeaders(
+    headers: immutable.Seq[HttpHeader],
+    log:     LoggingAdapter
+  ): Seq[(String, String)] = {
+    val headerPairs = new VectorBuilder[(String, String)]()
+    renderHeaders(headers, headerPairs, None, log)
+    headerPairs.result()
+  }
+
+  private[http2] def renderHeaders(
     headersSeq:   immutable.Seq[HttpHeader],
     headerPairs:  VectorBuilder[(String, String)],
     serverHeader: Option[(String, String)],

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -20,10 +20,10 @@ import akka.http.scaladsl.model.headers.{ CacheDirectives, RawHeader }
 import akka.http.scaladsl.model.http2.Http2StreamIdHeader
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.impl.io.ByteStringParser.ByteReader
-import akka.stream.scaladsl.{ BidiFlow, Flow, Sink, Source, TLSPlacebo }
+import akka.stream.scaladsl.{ BidiFlow, Flow, Sink, Source, SourceQueueWithComplete, TLSPlacebo }
 import akka.stream.testkit.TestPublisher.ManualProbe
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.{ ActorMaterializer, Materializer, OverflowStrategies }
 import akka.testkit._
 import akka.util.{ ByteString, ByteStringBuilder }
 import com.twitter.hpack.{ Decoder, Encoder, HeaderListener }
@@ -33,7 +33,7 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
-import scala.concurrent.Future
+import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
@@ -468,10 +468,60 @@ class Http2ServerSpec extends AkkaSpec("""
         expectDATAFrame(TheStreamId) should be(false, ByteString("foobar"))
         expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = true).headers should be(immutable.Seq(RawHeader("status", "grpc-status 10")))
       }
+      "include the trailing headers even when the buffer is emptied before sending the last chunk" in new WaitingForResponseSetup {
+        val queuePromise = Promise[SourceQueueWithComplete[HttpEntity.ChunkStreamPart]]()
+
+        val response = HttpResponse(entity = HttpEntity.Chunked(
+          ContentTypes.`application/octet-stream`,
+          Source.queue[HttpEntity.ChunkStreamPart](100, OverflowStrategies.Fail)
+            .mapMaterializedValue(queuePromise.success(_))
+        ))
+        emitResponse(TheStreamId, response)
+        val chunkQueue = Await.result(queuePromise.future, 10.seconds)
+
+        chunkQueue.offer(HttpEntity.Chunk("foo"))
+        chunkQueue.offer(HttpEntity.Chunk("bar"))
+
+        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = false)
+        expectDATA(TheStreamId, endStream = false, ByteString("foobar"))
+
+        chunkQueue.offer(HttpEntity.LastChunk(trailer = immutable.Seq[HttpHeader](RawHeader("Status", "grpc-status 10"))))
+        chunkQueue.complete()
+        expectDecodedResponseHEADERS(streamId = TheStreamId).headers should be(immutable.Seq(RawHeader("status", "grpc-status 10")))
+      }
+      "send the trailing headers immediately, even when the window is depleted" in new WaitingForResponseSetup {
+        val queuePromise = Promise[SourceQueueWithComplete[HttpEntity.ChunkStreamPart]]()
+
+        val response = HttpResponse(entity = HttpEntity.Chunked(
+          ContentTypes.`application/octet-stream`,
+          Source.queue[HttpEntity.ChunkStreamPart](100, OverflowStrategies.Fail)
+            .mapMaterializedValue(queuePromise.success(_))
+        ))
+        emitResponse(TheStreamId, response)
+
+        val chunkQueue = Await.result(queuePromise.future, 10.seconds)
+
+        def depleteWindow(): Unit = {
+          val toSend: Int = remainingFromServerWindowFor(TheStreamId) min 1000
+          if (toSend != 0) {
+            val data = "x" * toSend
+            chunkQueue.offer(HttpEntity.Chunk(data))
+            expectDATA(TheStreamId, endStream = false, ByteString(data))
+            depleteWindow()
+          }
+        }
+
+        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = false)
+        depleteWindow()
+
+        chunkQueue.offer(HttpEntity.LastChunk(trailer = immutable.Seq[HttpHeader](RawHeader("Status", "grpc-status 10"))))
+        chunkQueue.complete()
+        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = true).headers should be(immutable.Seq(RawHeader("status", "grpc-status 10")))
+      }
     }
 
     "support multiple concurrent substreams" should {
-      "receive two requests concurrently" in new TestSetup with RequestResponseProbes with AutomaticHpackWireSupport {
+      "receive two requsts concurrently" in new TestSetup with RequestResponseProbes with AutomaticHpackWireSupport {
         val request1 =
           HttpRequest(
             protocol = HttpProtocols.`HTTP/2.0`,

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -27,7 +27,7 @@ class RequestParsingSpec extends AkkaSpec() with Inside with Inspectors {
       uriParsingMode: Uri.ParsingMode         = Uri.ParsingMode.Relaxed
     ): HttpRequest = {
       // Stream containing the request
-      val subStream = Http2SubStream(
+      val subStream = ByteHttp2SubStream(
         initialHeaders = ParsedHeadersFrame(
           streamId = 1,
           endStream = true,


### PR DESCRIPTION
Variation on #1857, this time subclassing OutStream