### PR TITLE
[WIP] Fix Uri.apply didn't normalize port (#1763)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
@@ -301,7 +301,7 @@ private[http] final class UriParser(
 
   private def createUriReference(): Uri = {
     val path = if (_scheme.isEmpty) _path else collapseDotSegments(_path)
-    create(_scheme, _userinfo, _host, _port, path, _rawQueryString, _fragment)
+    create(_scheme, _userinfo, _host, normalizePort(_port, _scheme), path, _rawQueryString, _fragment)
   }
 }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -500,7 +500,7 @@ class UriSpec extends WordSpec with Matchers {
 
       // empty host
       Uri("http://:8000/foo") shouldEqual Uri("http", Authority(Host.Empty, 8000), Path / "foo")
-      Uri("http://:80/foo") shouldEqual Uri("http", Authority(Host.Empty, 80), Path / "foo")
+      Uri("http://:80/foo") shouldEqual Uri("http", Authority(Host.Empty, 0), Path / "foo")
     }
 
     "properly complete a normalization cycle" in {
@@ -702,7 +702,7 @@ class UriSpec extends WordSpec with Matchers {
       val nonDefaultUri = Uri("http://host:6060/path?query#fragment")
 
       uri.withScheme("https") shouldEqual Uri("https://host/path?query#fragment")
-      explicitDefault.withScheme("https") shouldEqual Uri("https://host:80/path?query#fragment")
+      explicitDefault.withScheme("https") shouldEqual Uri("https://host/path?query#fragment")
       nonDefaultUri.withScheme("https") shouldEqual Uri("https://host:6060/path?query#fragment")
 
       uri.withAuthority(Authority(Host("other"), 3030)) shouldEqual Uri("http://other:3030/path?query#fragment")
@@ -749,7 +749,7 @@ class UriSpec extends WordSpec with Matchers {
 
     "properly render authority" in {
       Uri("http://localhost/test").authority.toString shouldEqual "localhost"
-      Uri("http://example.com:80/test").authority.toString shouldEqual "example.com:80"
+      Uri("http://example.com:80/test").authority.toString shouldEqual "example.com"
       Uri("ftp://host/").authority.toString shouldEqual "host"
       Uri("http://user@host").authority.toString shouldEqual "user@host"
       Uri("http://user:p%40ssword@host").authority.toString shouldEqual "user:p%40ssword@host"


### PR DESCRIPTION
Fix #1763.
This commit should fix the example of #1763. I am still investigating other `apply` constructors, so I labeled it as WIP. This issue somehow related to https://github.com/akka/akka/issues/19650. 