### PR TITLE
=pro build with Scala 2.12 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 sudo: false
 
 scala:
-  - "2.11.8"
+  - "2.12.4"
 
 jdk:
   - oraclejdk8

--- a/akka-http-core/src/main/mima-filters/10.0.11.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.0.11.backwards.excludes
@@ -64,6 +64,8 @@ ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.scaladsl.model.Mu
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.model.Multipart#General#Strict.toEntity$default$3")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.model.Multipart#General#Strict.toEntity")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.scaladsl.model.Multipart#General#Strict.toEntity")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.scaladsl.model.Multipart#Strict.toEntity")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.scaladsl.model.Multipart.toEntity")
 
 # Add headers and getHeaders on HttpMessage https://github.com/akka/akka-http/issues/1731
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage.getHeaders")

--- a/akka-http/src/main/mima-filters/10.0.11.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.0.11.backwards.excludes
@@ -19,3 +19,4 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.coding.No
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.scaladsl.coding.NoCoding.decode")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.coding.Encoder.encode")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.coding.Decoder.decode")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.scaladsl.coding.Decoder.decode")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
   lazy val scalaCheckVersion = settingKey[String]("The version of ScalaCheck to use.")
 
   val Versions = Seq(
-    crossScalaVersions := Seq("2.11.12", "2.12.4"),
+    crossScalaVersions := Seq("2.12.4", "2.11.12"),
     scalaVersion := crossScalaVersions.value.head,
     akkaVersion := System.getProperty("akka.build.version", akka25Version),
     scalaCheckVersion := System.getProperty("akka.build.scalaCheckVersion", "1.13.5"),


### PR DESCRIPTION
I think it's time to switch the default. I started changing the nightlies to use explicit versions when building.