### PR TITLE
wrong advice of throughput setting for blocking dispatcher

### DIFF
--- a/docs/src/main/paradox/handling-blocking-operations-in-akka-http-routes.md
+++ b/docs/src/main/paradox/handling-blocking-operations-in-akka-http-routes.md
@@ -89,7 +89,7 @@ my-blocking-dispatcher {
   thread-pool-executor {
     fixed-pool-size = 16
   }
-  throughput = 100
+  throughput = 1
 }
 ```
 


### PR DESCRIPTION
* if you have blocking tasks it's likely that they are also
  rather long running tasks (several millis) and therefore it
  makes most sense to have a low throughput setting for better
  fairness