### PR TITLE
[HTTP2] Do not require non-empty frames

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -67,7 +67,6 @@ private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with Stage
         def nextFrame(maxBytesToSend: Int): DataFrame = {
           val toTake = maxBytesToSend min buffer.size min outboundWindowLeft
           val toSend = buffer.take(toTake)
-          require(toSend.nonEmpty)
 
           outboundWindowLeft -= toTake
           buffer = buffer.drop(toTake)


### PR DESCRIPTION
This was found when sending large amounts of data from the server to the client. After sending some data to the client `outboundWindowLeft` would get depleted and then this assertion would not pass:
<details><pre>
outboundWindowLeft [1025]
[DEBUG] [02/23/2018 16:20:21.929] [default-akka.actor.default-dispatcher-7] [Http2ServerDemux(akka://default)] [3] sending 1025 bytes, endStream = false
[DEBUG] [02/23/2018 16:20:21.931] [default-akka.actor.default-dispatcher-7] [Http2ServerDemux(akka://default)] Changing state from WaitingForConnectionWindow to WaitingForNetworkToSendData
maxBytesToSend [16384]
buffer.size [ByteString(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)... and [26442] more.size]
outboundWindowLeft [0]
[ERROR] [02/23/2018 16:20:21.935] [default-akka.actor.default-dispatcher-7] [akka://default/user/StreamSupervisor-0/flow-2-1-map] Error in stage [akka.http.impl.engine.http2.Http2ServerDemux@7094ccef]: requirement failed
java.lang.IllegalArgumentException: requirement failed
        at scala.Predef$.require(Predef.scala:264)
        at akka.http.impl.engine.http2.Http2MultiplexerSupport$$anon$1$OutStream.nextFrame(Http2Multiplexer.scala:73)
        at akka.http.impl.engine.http2.Http2MultiplexerSupport$$anon$1$WithSendableOutStreams.sendNext(Http2Multiplexer.scala:304)
        at akka.http.impl.engine.http2.Http2MultiplexerSupport$$anon$1$WaitingForNetworkToSendData.onPull(Http2Multiplexer.scala:315)
        at akka.http.impl.engine.http2.Http2MultiplexerSupport$$anon$1.onPull(Http2Multiplexer.scala:225)
</pre></details>

After removing this assertion, an empty frame is being sent and then output stream is backpressured until window_update frame is received for the corresponding stream:

<details><pre>
outboundWindowLeft [1025]
[DEBUG] [02/23/2018 17:32:43.361] [default-akka.actor.default-dispatcher-8] [Http2ServerDemux(akka://default)] Updating outgoing connection window by 35135 to 35135
[DEBUG] [02/23/2018 17:32:43.363] [default-akka.actor.default-dispatcher-8] [Http2ServerDemux(akka://default)] [3] sending 1025 bytes, endStream = false
maxBytesToSend [16384]
[DEBUG] [02/23/2018 17:32:43.363] [default-akka.actor.default-dispatcher-8] [Http2ServerDemux(akka://default)] Changing state from WaitingForConnectionWindow to WaitingForNetworkToSendData
buffer.size [ByteString(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)... and [26442] more.size]
outboundWindowLeft [0]
updating window for [3] by [34110]
[DEBUG] [02/23/2018 17:32:43.366] [default-akka.actor.default-dispatcher-8] [Http2ServerDemux(akka://default)] [3] sending 0 bytes, endStream = false
[DEBUG] [02/23/2018 17:32:43.368] [default-akka.actor.default-dispatcher-8] [Http2ServerDemux(akka://default)] Updating window for 3 by 34110 to 34110 buffered bytes: 26542
maxBytesToSend [16384]
buffer.size [ByteString(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)... and [26442] more.size]
outboundWindowLeft [34110]
[DEBUG] [02/23/2018 17:32:43.369] [default-akka.actor.default-dispatcher-8] [Http2ServerDemux(akka://default)] [3] sending 16384 bytes, endStream = false
...
</pre></details>

An alternative fix (which would prevent sending empty frames) would be to reorganize the code so `nextFrame` is not called but stream is backpressured instead if the `outboundWindowLeft` for the stream has depleted.