### PR TITLE
Fix several warnings across the project

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/RouteTest.scala
@@ -42,7 +42,7 @@ abstract class RouteTest extends AllDirectives with WSTestRequestBuilding {
     runRoute(route, request, defaultHostInfo)
 
   def runRoute(route: Route, request: HttpRequest, defaultHostInfo: DefaultHostInfo): TestRouteResult =
-    runScalaRoute(route.seal(system, materializer).delegate, request, defaultHostInfo)
+    runScalaRoute(route.seal().delegate, request, defaultHostInfo)
 
   def runRouteUnSealed(route: Route, request: HttpRequest): TestRouteResult =
     runRouteUnSealed(route, request, defaultHostInfo)

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/MarshallingTestUtils.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/MarshallingTestUtils.scala
@@ -18,10 +18,10 @@ trait MarshallingTestUtils {
   def marshal[T: ToEntityMarshaller](value: T)(implicit ec: ExecutionContext, mat: Materializer): HttpEntity.Strict =
     Await.result(Marshal(value).to[HttpEntity].flatMap(_.toStrict(1.second)), 2.second)
 
-  def marshalToResponseForRequestAccepting[T: ToResponseMarshaller](value: T, mediaRanges: MediaRange*)(implicit ec: ExecutionContext, mat: Materializer): HttpResponse =
+  def marshalToResponseForRequestAccepting[T: ToResponseMarshaller](value: T, mediaRanges: MediaRange*)(implicit ec: ExecutionContext): HttpResponse =
     marshalToResponse(value, HttpRequest(headers = Accept(mediaRanges: _*) :: Nil))
 
-  def marshalToResponse[T: ToResponseMarshaller](value: T, request: HttpRequest = HttpRequest())(implicit ec: ExecutionContext, mat: Materializer): HttpResponse =
+  def marshalToResponse[T: ToResponseMarshaller](value: T, request: HttpRequest = HttpRequest())(implicit ec: ExecutionContext): HttpResponse =
     Await.result(Marshal(value).toResponseFor(request), 1.second)
 
   def unmarshalValue[T: FromEntityUnmarshaller](entity: HttpEntity)(implicit ec: ExecutionContext, mat: Materializer): T =

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -146,7 +146,6 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
                                  executionContext: ExecutionContext,
                                  materializer:     Materializer,
                                  routingLog:       RoutingLog,
-                                 rejectionHandler: RejectionHandler = RejectionHandler.default,
                                  exceptionHandler: ExceptionHandler = null) =
       new TildeArrow[RequestContext, Future[RouteResult]] {
         type Out = RouteTestResult

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/MarshallerTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/MarshallerTest.java
@@ -135,7 +135,7 @@ public class MarshallerTest extends JUnitRouteTest {
           path("nummer", () ->
             parameter(StringUnmarshallers.INTEGER, "n", nummerHandler)
           )
-        ).seal(system(), materializer()) // needed to get the content negotiation, maybe
+        ).seal() // needed to get the content negotiation, maybe
       );
 
     route.run(HttpRequest.GET("/nummer?n=1"))

--- a/akka-http/src/main/mima-filters/10.0.11.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.0.11.backwards.excludes
@@ -23,3 +23,6 @@ ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.scaladsl.coding.D
 
 # Additions to @DoNotInherit directives trait
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.TimeoutDirectives.extractRequestTimeout")
+
+# Adding new overloads with less parameters
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.server.Route.seal")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -50,8 +50,42 @@ trait Route {
    *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.
+   * @deprecated Use the variant without [[Materializer]]
    */
+  @Deprecated
   def seal(system: ActorSystem, materializer: Materializer): Route
+
+  /**
+   * Seals a route by wrapping it with default exception handling and rejection conversion.
+   *
+   * A sealed route has these properties:
+   *  - The result of the route will always be a complete response, i.e. the result of the future is a
+   *    ``Success(RouteResult.Complete(response))``, never a failed future and never a rejected route. These
+   *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
+   *    the default handlers if none are given or can be found implicitly).
+   *  - Consequently, no route alternatives will be tried that were combined with this route.
+   */
+  def seal(system: ActorSystem): Route
+
+  /**
+   * Seals a route by wrapping it with explicit exception handling and rejection conversion.
+   *
+   * A sealed route has these properties:
+   *  - The result of the route will always be a complete response, i.e. the result of the future is a
+   *    ``Success(RouteResult.Complete(response))``, never a failed future and never a rejected route. These
+   *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
+   *    the default handlers if none are given or can be found implicitly).
+   *  - Consequently, no route alternatives will be tried that were combined with this route.
+   * @deprecated Use the variant without [[ActorSystem]] and [[Materializer]]
+   */
+  @Deprecated
+  def seal(
+    routingSettings:  RoutingSettings,
+    parserSettings:   ParserSettings,
+    rejectionHandler: RejectionHandler,
+    exceptionHandler: ExceptionHandler,
+    system:           ActorSystem,
+    materializer:     Materializer): Route
 
   /**
    * Seals a route by wrapping it with explicit exception handling and rejection conversion.
@@ -67,9 +101,7 @@ trait Route {
     routingSettings:  RoutingSettings,
     parserSettings:   ParserSettings,
     rejectionHandler: RejectionHandler,
-    exceptionHandler: ExceptionHandler,
-    system:           ActorSystem,
-    materializer:     Materializer): Route
+    exceptionHandler: ExceptionHandler): Route
 
   def orElse(alternative: Route): Route
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -50,7 +50,7 @@ trait Route {
    *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.
-   * @deprecated Use the variant without [[Materializer]]
+   * @deprecated Use the variant without [[ActorSystem]] and [[Materializer]]
    */
   @Deprecated
   def seal(system: ActorSystem, materializer: Materializer): Route
@@ -65,7 +65,7 @@ trait Route {
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.
    */
-  def seal(system: ActorSystem): Route
+  def seal(): Route
 
   /**
    * Seals a route by wrapping it with explicit exception handling and rejection conversion.

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -26,8 +26,8 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
     scalaFlow(system, materializer).asJava
 
   private def scalaFlow(system: ActorSystem, materializer: Materializer): Flow[HttpRequest, HttpResponse, NotUsed] = {
-    implicit val s = system
-    implicit val m = materializer
+    implicit val s: ActorSystem = system
+    implicit val m: Materializer = materializer
     Flow[HttpRequest].map(_.asScala).via(delegate).map(_.asJava)
   }
 
@@ -38,16 +38,19 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
     }
 
   override def seal(system: ActorSystem, materializer: Materializer): Route = {
-    implicit val s = system
-    implicit val m = materializer
+    seal(system)
+  }
 
+  override def seal(system: ActorSystem): Route = {
+    implicit val s: ActorSystem = system
     RouteAdapter(scaladsl.server.Route.seal(delegate))
   }
 
   override def seal(routingSettings: RoutingSettings, parserSettings: ParserSettings, rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler, system: ActorSystem, materializer: Materializer): Route = {
-    implicit val s = system
-    implicit val m = materializer
+    seal(routingSettings, parserSettings, rejectionHandler, exceptionHandler)
+  }
 
+  override def seal(routingSettings: RoutingSettings, parserSettings: ParserSettings, rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler): Route = {
     RouteAdapter(scaladsl.server.Route.seal(delegate)(
       routingSettings.asScala,
       parserSettings.asScala,

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -38,12 +38,16 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
     }
 
   override def seal(system: ActorSystem, materializer: Materializer): Route = {
-    seal(system)
+    seal()
   }
 
-  override def seal(system: ActorSystem): Route = {
-    implicit val s: ActorSystem = system
-    RouteAdapter(scaladsl.server.Route.seal(delegate))
+  override def seal(): Route = {
+    // TODO: scaladsl.server.Route.seal shouldn't require an implicit RoutingSettings when it can retrieve it itself. See https://github.com/akka/akka-http/issues/1898
+    RouteAdapter {
+      akka.http.scaladsl.server.directives.BasicDirectives.extractSettings { implicit settings ⇒
+        scaladsl.server.Route.seal(delegate)
+      }
+    }
   }
 
   override def seal(routingSettings: RoutingSettings, parserSettings: ParserSettings, rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler, system: ActorSystem, materializer: Materializer): Route = {

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
@@ -169,7 +169,7 @@ object PredefinedToResponseMarshallers extends PredefinedToResponseMarshallers {
     HttpResponse(status = statusCode, headers = headers, entity = entity)
   }
 
-  private def statusCodeAndEntityResponse(statusCode: StatusCode, headers: immutable.Seq[HttpHeader] = Nil, entity: ResponseEntity = HttpEntity.Empty): HttpResponse = {
+  private def statusCodeAndEntityResponse(statusCode: StatusCode, headers: immutable.Seq[HttpHeader], entity: ResponseEntity): HttpResponse = {
     if (statusCode.allowsEntity) HttpResponse(statusCode, headers, entity)
     else HttpResponse(statusCode, headers, HttpEntity.Empty)
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -235,7 +235,7 @@ object FileAndResourceDirectives extends FileAndResourceDirectives {
       case path ⇒ checkIsSafeDescendant(basePath, path, log)
     }
 
-  private def safeJoinPaths(base: String, path: Uri.Path, log: LoggingAdapter, separator: Char = File.separatorChar): String = {
+  private def safeJoinPaths(base: String, path: Uri.Path, log: LoggingAdapter, separator: Char): String = {
     import java.lang.StringBuilder
     @tailrec def rec(p: Uri.Path, result: StringBuilder = new StringBuilder(base)): String =
       p match {

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala
@@ -120,7 +120,6 @@ trait FileUploadDirectives {
     entity(as[Multipart.FormData]).flatMap { formData ⇒
       extractRequestContext.flatMap { ctx ⇒
         implicit val mat = ctx.materializer
-        implicit val ec = ctx.executionContext
 
         val onePartSource: Source[(FileInfo, Source[ByteString, Any]), Any] = formData.parts
           .filter(part ⇒ part.filename.isDefined && part.name == fieldName)
@@ -148,7 +147,6 @@ trait FileUploadDirectives {
   @ApiMayChange
   def fileUploadAll(fieldName: String): Directive1[immutable.Seq[(FileInfo, Source[ByteString, Any])]] =
     extractRequestContext.flatMap { ctx ⇒
-      implicit val mat = ctx.materializer
       implicit val ec = ctx.executionContext
 
       def tempDest(fileInfo: FileInfo): File = {

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -6,7 +6,7 @@ package akka.http.scaladsl.server
 package directives
 
 import scala.collection.immutable
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }
 import akka.http.scaladsl.common._
 import akka.http.impl.util._
@@ -110,7 +110,7 @@ object ParameterDirectives extends ParameterDirectives {
     type FSOU[T] = Unmarshaller[Option[String], T]
 
     private def extractParameter[A, B](f: A ⇒ Directive1[B]): ParamDefAux[A, Directive1[B]] = paramDef(f)
-    private def handleParamResult[T](paramName: String, result: Future[T])(implicit ec: ExecutionContext): Directive1[T] =
+    private def handleParamResult[T](paramName: String, result: Future[T]): Directive1[T] =
       onComplete(result).flatMap {
         case Success(x)                               ⇒ provide(x)
         case Failure(Unmarshaller.NoContentException) ⇒ reject(MissingQueryParamRejection(paramName))

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParser.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParser.scala
@@ -41,7 +41,7 @@ private final class LineParser(maxLineSize: Int) extends GraphStage[FlowShape[By
         def parseLines(
           bs:            ByteString,
           from:          Int            = 0,
-          at:            Int            = 0,
+          at:            Int,
           parsedLines:   Vector[String] = Vector.empty,
           lastCharWasCr: Boolean        = false): (ByteString, Vector[String], Boolean) =
           if (at >= bs.length)

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
@@ -118,8 +118,6 @@ private[http2] object PriorityTree {
     // lens-like "mutators"
     private def updateNodes(updater: TreeMap[Int, PriorityInfo] ⇒ TreeMap[Int, PriorityInfo]): PriorityTreeImpl =
       create(updater(nodes))
-    private def updateAll(updaters: (TreeMap[Int, PriorityInfo] ⇒ TreeMap[Int, PriorityInfo])*): PriorityTreeImpl =
-      updateNodes(nodes ⇒ updaters.foldLeft(nodes)((updater, state) ⇒ state(updater)))
 
     private def updateNode(streamId: Int)(updater: PriorityInfo ⇒ PriorityInfo): PriorityTreeImpl =
       updateNodes { nodes ⇒

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -26,7 +26,7 @@ private[http2] object HeaderCompression extends GraphStage[FlowShape[FrameEvent,
   val shape = FlowShape(eventsIn, eventsOut)
 
   def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new HandleOrPassOnStage[FrameEvent, FrameEvent](shape) with StageLogging {
-    var currentMaxFrameSize = Http2Protocol.InitialMaxFrameSize
+    val currentMaxFrameSize = Http2Protocol.InitialMaxFrameSize
 
     val encoder = new com.twitter.hpack.Encoder(Http2Protocol.InitialMaxHeaderTableSize)
     val os = new ByteArrayOutputStream()

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -41,7 +41,7 @@ private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEven
     // Receiving headers: waiting for CONTINUATION frame
 
     def parseAndEmit(streamId: Int, endStream: Boolean, payload: ByteString, prioInfo: Option[PriorityFrame]): Unit = {
-      var headers = new VectorBuilder[(String, String)]
+      val headers = new VectorBuilder[(String, String)]
       object Receiver extends HeaderListener {
         def addHeader(name: Array[Byte], value: Array[Byte], sensitive: Boolean): Unit =
           // TODO: optimization: use preallocated strings for well-known names, similar to what happens in HeaderParser

--- a/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
+++ b/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
@@ -36,7 +36,7 @@ public class RouteSealExample extends AllDirectives {
       () -> pathSingleSlash( () ->
         complete("Captain on the bridge!")
       )
-    ).seal(system, materializer);
+    ).seal();
 
     Route route = respondWithHeader(
       RawHeader.create("special-header", "you always have this even in 404"),

--- a/docs/src/test/java/docs/http/javadsl/server/directives/SecurityDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/SecurityDirectivesExamplesTest.java
@@ -40,7 +40,7 @@ public class SecurityDirectivesExamplesTest extends JUnitRouteTest {
       authenticateBasic("secure site", myUserPassAuthenticator, userName ->
         complete("The user is '" + userName + "'")
       )
-    ).seal(system(), materializer());
+    ).seal();
 
     // tests:
     testRoute(route).run(HttpRequest.GET("/secured"))
@@ -86,7 +86,7 @@ public class SecurityDirectivesExamplesTest extends JUnitRouteTest {
       authenticateBasicPF("secure site", myUserPassAuthenticator, userName ->
         complete("The user is '" + userName + "'")
       )
-    ).seal(system(), materializer());
+    ).seal();
 
     // tests:
     testRoute(route).run(HttpRequest.GET("/secured"))
@@ -142,7 +142,7 @@ public class SecurityDirectivesExamplesTest extends JUnitRouteTest {
     final Route route = path("secured", () ->
       authenticateBasicPFAsync("secure site", myUserPassAuthenticator, user ->
         complete("The user is '" + user.getId() + "'"))
-    ).seal(system(), materializer());
+    ).seal();
 
     // tests:
     testRoute(route).run(HttpRequest.GET("/secured"))
@@ -179,7 +179,7 @@ public class SecurityDirectivesExamplesTest extends JUnitRouteTest {
       authenticateBasicAsync("secure site", myUserPassAuthenticator, userName ->
         complete("The user is '" + userName + "'")
       )
-    ).seal(system(), materializer());
+    ).seal();
 
     // tests:
     testRoute(route).run(HttpRequest.GET("/secured"))
@@ -222,7 +222,7 @@ public class SecurityDirectivesExamplesTest extends JUnitRouteTest {
       authenticateOrRejectWithChallenge(myUserPassAuthenticator, userName ->
         complete("Authenticated!")
       )
-    ).seal(system(), materializer());
+    ).seal();
 
     // tests:
     testRoute(route).run(HttpRequest.GET("/secured"))
@@ -272,7 +272,7 @@ public class SecurityDirectivesExamplesTest extends JUnitRouteTest {
           complete("'" + user.getName() +"' visited Peter's lair")
         )
       )
-    ).seal(system(), materializer());
+    ).seal();
 
     // tests:
     final HttpCredentials johnsCred =
@@ -326,7 +326,7 @@ public class SecurityDirectivesExamplesTest extends JUnitRouteTest {
           complete("'" + user.getName() +"' visited Peter's lair")
         )
       )
-    ).seal(system(), materializer());
+    ).seal();
 
     // tests:
     final HttpCredentials johnsCred =


### PR DESCRIPTION
Removes unused private methods
Converts unnecessary `var` to `val`
Adds new overloads without unnecessary implicts
Removes unnecessary default values for parameters
Removes unnecessary `implicit val`s
Migrates deprecated methods to new ones