### PR TITLE
Mark a lot more internal classes as such

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Randoms.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Randoms.scala
@@ -7,7 +7,11 @@ package akka.http.impl.engine.ws
 import java.security.SecureRandom
 import java.util.Random
 
-object Randoms {
+import akka.annotation.InternalApi
+
+/** INTERNAL API */
+@InternalApi
+private[http] object Randoms {
   /** A factory that creates SecureRandom instances */
   private[http] case object SecureRandomInstances extends (() ⇒ Random) {
     override def apply(): Random = new SecureRandom()

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
@@ -5,6 +5,7 @@
 package akka.http.impl.engine.ws
 
 import akka.NotUsed
+import akka.annotation.InternalApi
 import akka.http.scaladsl.model.ws._
 
 import scala.concurrent.{ Future, Promise }
@@ -26,7 +27,9 @@ import akka.http.impl.engine.ws.Handshake.Client.NegotiatedWebSocketSettings
 import akka.http.impl.util.StreamUtils
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 
-object WebSocketClientBlueprint {
+/** INTERNAL API */
+@InternalApi
+private[http] object WebSocketClientBlueprint {
   /**
    * Returns a WebSocketClientLayer that can be materialized once.
    */

--- a/akka-http-core/src/main/scala/akka/http/impl/model/JavaQuery.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/JavaQuery.scala
@@ -22,7 +22,7 @@ import akka.http.impl.util.JavaMapping.Implicits._
 
 /** INTERNAL API */
 @InternalApi
-final case class JavaQuery(query: sm.Uri.Query) extends jm.Query {
+final private[http] case class JavaQuery(query: sm.Uri.Query) extends jm.Query {
   override def get(key: String): Optional[String] = query.get(key).asJava
   override def toMap: ju.Map[String, String] = query.toMap.asJava
   override def toList: ju.List[Pair[String, String]] = query.map(_.asJava).asJava

--- a/akka-http-core/src/main/scala/akka/http/impl/model/JavaUri.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/JavaUri.scala
@@ -16,7 +16,7 @@ import akka.http.impl.util.JavaMapping.Implicits._
 
 /** INTERNAL API */
 @InternalApi
-case class JavaUri(uri: sm.Uri) extends jm.Uri {
+private[http] case class JavaUri(uri: sm.Uri) extends jm.Uri {
   def isRelative: Boolean = uri.isRelative
   def isAbsolute: Boolean = uri.isAbsolute
   def isEmpty: Boolean = uri.isEmpty

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/Base64Parsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/Base64Parsing.scala
@@ -16,12 +16,16 @@
 
 package akka.http.impl.model.parser
 
+import akka.annotation.InternalApi
 import akka.parboiled2.util.Base64
 import akka.parboiled2._
 
 /**
+ * INTERNAL API
+ *
  * Rules for parsing Base-64 encoded strings.
  */
+@InternalApi
 private[parser] trait Base64Parsing { this: Parser ⇒
   import Base64Parsing._
 
@@ -63,7 +67,9 @@ private[parser] trait Base64Parsing { this: Parser ⇒
   }
 }
 
-object Base64Parsing {
+/** INTERNAL API */
+@InternalApi
+private[http] object Base64Parsing {
   type Decoder = Array[Char] ⇒ Array[Byte]
 
   val rfc2045Alphabet = CharPredicate(Base64.rfc2045().getAlphabet).asMaskBased

--- a/akka-http-core/src/main/scala/akka/http/impl/util/ByteStringParserInput.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/ByteStringParserInput.scala
@@ -6,6 +6,7 @@ package akka.http.impl.util
 
 import java.nio.charset.StandardCharsets
 
+import akka.annotation.InternalApi
 import akka.parboiled2.ParserInput.DefaultParserInput
 import akka.util.ByteString
 
@@ -21,7 +22,8 @@ import akka.util.ByteString
  * 7-bit ASCII characters (0x00-0x7F) then UTF-8 is fine, since the first 127 UTF-8 characters are
  * encoded with only one byte that is identical to 7-bit ASCII and ISO-8859-1.
  */
-final class ByteStringParserInput(bytes: ByteString) extends DefaultParserInput {
+@InternalApi
+final private[http] class ByteStringParserInput(bytes: ByteString) extends DefaultParserInput {
   override def charAt(ix: Int): Char = (bytes(ix) & 0xFF).toChar
   override def length: Int = bytes.size
   override def sliceString(start: Int, end: Int): String = bytes.slice(start, end).decodeString(StandardCharsets.ISO_8859_1)

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaAccessors.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaAccessors.scala
@@ -18,7 +18,7 @@ import akka.http.scaladsl.model
  *  Accessors for constructors with default arguments to be used from the Java implementation
  */
 @InternalApi
-object JavaAccessors {
+private[http] object JavaAccessors {
   /** INTERNAL API */
   def HttpRequest(): HttpRequest = model.HttpRequest()
 

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StageLoggingWithOverride.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StageLoggingWithOverride.scala
@@ -47,10 +47,13 @@ private[akka] trait StageLoggingWithOverride { self: GraphStageLogic ⇒
 }
 
 /**
+ * INTERNAL API
+ *
  * A copy of NoLogging that can be used as a place-holder for "logging not explicitly specified".
  * It can be matched on to be overridden with default behavior.
  */
-object DefaultNoLogging extends LoggingAdapter {
+@InternalApi
+private[akka] object DefaultNoLogging extends LoggingAdapter {
   /**
    * Java API to return the reference to NoLogging
    * @return The NoLogging instance

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/AlpnSwitch.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/AlpnSwitch.scala
@@ -7,6 +7,7 @@ package akka.http.impl.engine.http2
 import javax.net.ssl.SSLException
 
 import akka.NotUsed
+import akka.annotation.InternalApi
 import akka.http.impl.engine.server.HttpAttributes
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.stream.TLSProtocol.{ SessionBytes, SessionTruncated, SslTlsInbound, SslTlsOutbound }
@@ -14,7 +15,9 @@ import akka.stream.scaladsl.{ BidiFlow, Flow }
 import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import akka.stream._
 
-object AlpnSwitch {
+/** INTERNAL API */
+@InternalApi
+private[http] object AlpnSwitch {
   type HttpServerBidiFlow = BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed]
 
   def apply(

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -4,6 +4,7 @@
 
 package akka.http.impl.engine.http2
 
+import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2.Http2Protocol.FrameType
 import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
@@ -11,83 +12,91 @@ import akka.util.ByteString
 
 import scala.collection.immutable
 
-sealed trait FrameEvent { self: Product ⇒
+/** INTERNAL API */
+@InternalApi
+private[http2] sealed trait FrameEvent { self: Product ⇒
   def frameTypeName: String = productPrefix
 }
-sealed trait StreamFrameEvent extends FrameEvent { self: Product ⇒
-  def streamId: Int
+/** INTERNAL API */
+@InternalApi
+private[http2] object FrameEvent {
+
+  sealed trait StreamFrameEvent extends FrameEvent { self: Product ⇒
+    def streamId: Int
+  }
+
+  final case class GoAwayFrame(lastStreamId: Int, errorCode: ErrorCode, debug: ByteString = ByteString.empty) extends FrameEvent {
+    override def toString: String = s"GoAwayFrame($lastStreamId,$errorCode,debug:<hidden>)"
+  }
+  final case class DataFrame(
+    streamId:  Int,
+    endStream: Boolean,
+    payload:   ByteString) extends StreamFrameEvent {
+    /**
+     * The amount of bytes this frame consumes of a window. According to RFC 7540, 6.9.1:
+     *
+     *        For flow-control calculations, the 9-octet frame header is not
+     *        counted.
+     *
+     * That means this size amounts to data size + padding size field + padding.
+     */
+    def sizeInWindow: Int = payload.size // FIXME: take padding size into account, #1313
+  }
+
+  final case class HeadersFrame(
+    streamId:            Int,
+    endStream:           Boolean,
+    endHeaders:          Boolean,
+    headerBlockFragment: ByteString,
+    priorityInfo:        Option[PriorityFrame]) extends StreamFrameEvent
+  final case class ContinuationFrame(
+    streamId:   Int,
+    endHeaders: Boolean,
+    payload:    ByteString) extends StreamFrameEvent
+  case class PushPromiseFrame(
+    streamId:            Int,
+    endHeaders:          Boolean,
+    promisedStreamId:    Int,
+    headerBlockFragment: ByteString) extends StreamFrameEvent
+
+  final case class RstStreamFrame(streamId: Int, errorCode: ErrorCode) extends StreamFrameEvent
+  final case class SettingsFrame(settings: immutable.Seq[Setting]) extends FrameEvent
+  final case class SettingsAckFrame(acked: immutable.Seq[Setting]) extends FrameEvent
+
+  case class PingFrame(ack: Boolean, data: ByteString) extends FrameEvent {
+    require(data.size == 8, s"PingFrame payload must be of size 8 but was ${data.size}")
+  }
+  final case class WindowUpdateFrame(
+    streamId:            Int,
+    windowSizeIncrement: Int) extends StreamFrameEvent
+
+  final case class PriorityFrame(
+    streamId:         Int,
+    exclusiveFlag:    Boolean,
+    streamDependency: Int,
+    weight:           Int) extends StreamFrameEvent
+
+  final case class Setting(
+    identifier: SettingIdentifier,
+    value:      Int)
+
+  object Setting {
+    implicit def autoConvertFromTuple(tuple: (SettingIdentifier, Int)): Setting =
+      Setting(tuple._1, tuple._2)
+  }
+
+  /** Dummy event for all unknown frames */
+  final case class UnknownFrameEvent(
+    tpe:      FrameType,
+    flags:    ByteFlag,
+    streamId: Int,
+    payload:  ByteString) extends StreamFrameEvent
+
+  final case class ParsedHeadersFrame(
+    streamId:      Int,
+    endStream:     Boolean,
+    keyValuePairs: Seq[(String, String)],
+    priorityInfo:  Option[PriorityFrame]
+  ) extends StreamFrameEvent
+
 }
-
-final case class GoAwayFrame(lastStreamId: Int, errorCode: ErrorCode, debug: ByteString = ByteString.empty) extends FrameEvent {
-  override def toString: String = s"GoAwayFrame($lastStreamId,$errorCode,debug:<hidden>)"
-}
-final case class DataFrame(
-  streamId:  Int,
-  endStream: Boolean,
-  payload:   ByteString) extends StreamFrameEvent {
-  /**
-   * The amount of bytes this frame consumes of a window. According to RFC 7540, 6.9.1:
-   *
-   *        For flow-control calculations, the 9-octet frame header is not
-   *        counted.
-   *
-   * That means this size amounts to data size + padding size field + padding.
-   */
-  def sizeInWindow: Int = payload.size // FIXME: take padding size into account, #1313
-}
-
-final case class HeadersFrame(
-  streamId:            Int,
-  endStream:           Boolean,
-  endHeaders:          Boolean,
-  headerBlockFragment: ByteString,
-  priorityInfo:        Option[PriorityFrame]) extends StreamFrameEvent
-final case class ContinuationFrame(
-  streamId:   Int,
-  endHeaders: Boolean,
-  payload:    ByteString) extends StreamFrameEvent
-case class PushPromiseFrame(
-  streamId:            Int,
-  endHeaders:          Boolean,
-  promisedStreamId:    Int,
-  headerBlockFragment: ByteString) extends StreamFrameEvent
-
-final case class RstStreamFrame(streamId: Int, errorCode: ErrorCode) extends StreamFrameEvent
-final case class SettingsFrame(settings: immutable.Seq[Setting]) extends FrameEvent
-final case class SettingsAckFrame(acked: immutable.Seq[Setting]) extends FrameEvent
-
-case class PingFrame(ack: Boolean, data: ByteString) extends FrameEvent {
-  require(data.size == 8, s"PingFrame payload must be of size 8 but was ${data.size}")
-}
-final case class WindowUpdateFrame(
-  streamId:            Int,
-  windowSizeIncrement: Int) extends StreamFrameEvent
-
-final case class PriorityFrame(
-  streamId:         Int,
-  exclusiveFlag:    Boolean,
-  streamDependency: Int,
-  weight:           Int) extends StreamFrameEvent
-
-final case class Setting(
-  identifier: SettingIdentifier,
-  value:      Int)
-
-object Setting {
-  implicit def autoConvertFromTuple(tuple: (SettingIdentifier, Int)): Setting =
-    Setting(tuple._1, tuple._2)
-}
-
-/** Dummy event for all unknown frames */
-final case class UnknownFrameEvent(
-  tpe:      FrameType,
-  flags:    ByteFlag,
-  streamId: Int,
-  payload:  ByteString) extends StreamFrameEvent
-
-final case class ParsedHeadersFrame(
-  streamId:      Int,
-  endStream:     Boolean,
-  keyValuePairs: Seq[(String, String)],
-  priorityInfo:  Option[PriorityFrame]
-) extends StreamFrameEvent

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
@@ -11,6 +11,8 @@ import akka.util.ByteString
 
 import scala.collection.immutable.Seq
 
+import FrameEvent._
+
 /**
  * INTERNAL API
  */

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -5,6 +5,7 @@
 package akka.http.impl.engine.http2
 
 import akka.NotUsed
+import akka.annotation.InternalApi
 import akka.event.LoggingAdapter
 import akka.http.impl.engine.http2.framing.{ Http2FrameParsing, Http2FrameRendering }
 import akka.http.impl.engine.http2.hpack.{ HeaderCompression, HeaderDecompression }
@@ -37,7 +38,9 @@ private[http2] final case class ChunkedHttp2SubStream(
   data:           Source[HttpEntity.ChunkStreamPart, Any]
 ) extends Http2SubStream
 
-object Http2Blueprint {
+/** INTERNAL API */
+@InternalApi
+private[http] object Http2Blueprint {
   
   // format: OFF
   def serverStack(settings: ServerSettings, log: LoggingAdapter): BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, NotUsed] =

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -19,6 +19,8 @@ import akka.util.ByteString
 
 import scala.concurrent.{ ExecutionContext, Future }
 
+import FrameEvent._
+
 /**
  * Represents one direction of an Http2 substream.
  */

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Compliance.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Compliance.scala
@@ -9,7 +9,7 @@ import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 
 /** INTERNAL API */
 @InternalApi
-private[akka] object Http2Compliance {
+private[http2] object Http2Compliance {
 
   final class IllegalHttp2StreamIdException(id: Int, expected: String)
     extends IllegalArgumentException(s"Illegal HTTP/2 stream id: [$id]. $expected!")

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -13,6 +13,8 @@ import scala.collection.immutable
 import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler, StageLogging }
 import akka.util.ByteString
 
+import FrameEvent._
+
 /**
  * INTERNAL API
  *

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -4,6 +4,7 @@
 
 package akka.http.impl.engine.http2
 
+import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode.FLOW_CONTROL_ERROR
 import akka.http.scaladsl.settings.Http2ServerSettings
@@ -18,6 +19,8 @@ import akka.util.ByteString
 import scala.util.control.NonFatal
 
 /**
+ * INTERNAL API
+ *
  * This stage contains all control logic for handling frames and (de)muxing data to/from substreams.
  *
  * (This is not a final documentation, more like a brain-dump of how it could work.)
@@ -64,7 +67,8 @@ import scala.util.control.NonFatal
  * not work because the sending decision relies on dynamic window size and settings information that will be
  * only available in this stage.
  */
-class Http2ServerDemux(http2Settings: Http2ServerSettings) extends GraphStage[BidiShape[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream]] {
+@InternalApi
+private[http2] class Http2ServerDemux(http2Settings: Http2ServerSettings) extends GraphStage[BidiShape[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream]] {
   val frameIn = Inlet[FrameEvent]("Demux.frameIn")
   val frameOut = Outlet[FrameEvent]("Demux.frameOut")
 

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -18,6 +18,8 @@ import akka.util.ByteString
 
 import scala.util.control.NonFatal
 
+import FrameEvent._
+
 /**
  * INTERNAL API
  *

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -15,6 +15,8 @@ import akka.util.ByteString
 
 import scala.collection.immutable
 
+import FrameEvent._
+
 /** INTERNAL API */
 @InternalApi
 private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLogging ⇒

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/IncomingFlowController.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/IncomingFlowController.scala
@@ -15,14 +15,15 @@ private[http2] trait IncomingFlowController {
   def onStreamDataDispatched(outstandingConnectionLevelWindow: Int, totalBufferedData: Int,
                              outstandingStreamLevelWindow: Int, streamBufferedData: Int): IncomingFlowController.WindowIncrements
 }
+
+/** INTERNAL API */
+@InternalApi
 private[http2] object IncomingFlowController {
-  /** INTERNAL API */
-  @InternalApi
-  private[http2] case class WindowIncrements(connectionLevel: Int, streamLevel: Int) {
+  case class WindowIncrements(connectionLevel: Int, streamLevel: Int) {
     require(connectionLevel >= 0, s"Connection-level window increment must be >= 0 but was $connectionLevel")
     require(streamLevel >= 0, s"Stream-level window increment must be >= 0 but was $streamLevel")
   }
-  private[http2] object WindowIncrements {
+  object WindowIncrements {
     val NoIncrements = WindowIncrements(0, 0)
   }
 

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
@@ -4,12 +4,14 @@
 
 package akka.http.impl.engine.http2
 
+import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.util.AsciiTreeLayout
 
 import scala.collection.immutable
 import scala.collection.immutable.{ TreeMap, TreeSet }
 
 /** INTERNAL API */
+@InternalApi
 private[http2] trait PriorityNode {
   def streamId: Int
   def weight: Int
@@ -18,6 +20,7 @@ private[http2] trait PriorityNode {
 }
 
 /** INTERNAL API */
+@InternalApi
 private[http2] trait PriorityTree {
   /**
    * Returns a new priority tree containing the new or existing and updated stream.
@@ -36,6 +39,7 @@ private[http2] trait PriorityTree {
 }
 
 /** INTERNAL API */
+@InternalApi
 private[http2] object PriorityTree {
   def apply(): PriorityTree = create(TreeMap(0 → RootNode))
 

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
@@ -14,6 +14,8 @@ import akka.http.scaladsl.settings.ServerSettings
 import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
 
+import FrameEvent.ParsedHeadersFrame
+
 private[http2] object ResponseRendering {
 
   @volatile

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/StreamPrioritizer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/StreamPrioritizer.scala
@@ -8,6 +8,8 @@ import akka.annotation.InternalApi
 
 import scala.collection.immutable
 
+import FrameEvent.PriorityFrame
+
 /**
  * INTERNAL API
  *

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/StreamPrioritizer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/StreamPrioritizer.scala
@@ -4,9 +4,16 @@
 
 package akka.http.impl.engine.http2
 
+import akka.annotation.InternalApi
+
 import scala.collection.immutable
 
-/** The interface for pluggable stream prioritizers */
+/**
+ * INTERNAL API
+ *
+ * The interface for pluggable stream prioritizers
+ */
+@InternalApi
 private[http2] trait StreamPrioritizer {
   /** Update priority information for a substream */
   def updatePriority(priorityFrame: PriorityFrame): Unit
@@ -15,6 +22,8 @@ private[http2] trait StreamPrioritizer {
   def chooseSubstream(streams: immutable.Set[Int]): Int
 }
 
+/** INTERNAL API */
+@InternalApi
 private[http2] object StreamPrioritizer {
   /** A prioritizer that ignores priority information and just sends to the first stream */
   def first(): StreamPrioritizer =

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
@@ -14,6 +14,8 @@ import akka.annotation.InternalApi
 
 import scala.annotation.tailrec
 
+import FrameEvent._
+
 /** INTERNAL API */
 @InternalApi
 private[http2] object FrameRenderer {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
@@ -13,6 +13,8 @@ import Http2Protocol.FrameType._
 import Http2Protocol.{ ErrorCode, Flags, FrameType, SettingIdentifier }
 import akka.annotation.InternalApi
 
+import FrameEvent._
+
 /** INTERNAL API */
 @InternalApi
 private[http2] class Http2FrameParsing(shouldReadPreface: Boolean) extends ByteStringParser[FrameEvent] {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameRendering.scala
@@ -14,6 +14,8 @@ import akka.util.ByteString
 
 import scala.collection.immutable
 
+import FrameEvent._
+
 /** INTERNAL API */
 @InternalApi
 private[http] class Http2FrameRendering extends GraphStage[FlowShape[FrameEvent, ByteString]] {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/ByteStringInputStream.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/ByteStringInputStream.scala
@@ -4,12 +4,15 @@
 
 package akka.http.impl.engine.http2.hpack
 
-import java.io.{ ByteArrayInputStream, InputStream }
+import java.io.{ByteArrayInputStream, InputStream}
 
+import akka.annotation.InternalApi
 import akka.util.ByteString
 import akka.util.ByteString.ByteString1C
 
-object ByteStringInputStream {
+/** INTERNAL API */
+@InternalApi
+private[http2] object ByteStringInputStream {
 
   def apply(bs: ByteString): InputStream =
     bs match {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/ByteStringInputStream.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/ByteStringInputStream.scala
@@ -4,7 +4,7 @@
 
 package akka.http.impl.engine.http2.hpack
 
-import java.io.{ByteArrayInputStream, InputStream}
+import java.io.{ ByteArrayInputStream, InputStream }
 
 import akka.annotation.InternalApi
 import akka.util.ByteString

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -15,6 +15,8 @@ import akka.util.ByteString
 
 import scala.collection.immutable
 
+import FrameEvent._
+
 /**
  * INTERNAL API
  */

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -17,6 +17,8 @@ import com.twitter.hpack.HeaderListener
 
 import scala.collection.immutable.VectorBuilder
 
+import FrameEvent._
+
 /**
  * INTERNAL API
  *

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -37,6 +37,8 @@ import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
+import FrameEvent._
+
 class Http2ServerSpec extends AkkaSpec("""
     akka.loglevel = debug
     akka.loggers = ["akka.http.impl.util.SilenceAllTestEventListener"]

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -15,6 +15,8 @@ import akka.testkit.AkkaSpec
 import akka.util.ByteString
 import org.scalatest.{ Inside, Inspectors }
 
+import FrameEvent._
+
 class RequestParsingSpec extends AkkaSpec() with Inside with Inspectors {
 
   "RequestParsing" should {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
@@ -17,6 +17,8 @@ import org.scalatest.{ FreeSpec, Matchers }
 import scala.collection.immutable
 import scala.concurrent.duration._
 
+import FrameEvent._
+
 class Http2FramingSpec extends FreeSpec with Matchers with WithMaterializerSpec {
   import BitBuilder._
   import akka.http.impl.engine.http2._

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val root = Project(
   .disablePlugins(BintrayPlugin, MimaPlugin)
   .settings(
     // Unidoc doesn't like macros
-    unidocProjectExcludes := Seq(parsing),
+    unidocProjectExcludes := Seq(parsing, httpJmhBench),
     unmanagedSources in (Compile, headerCreate) := (baseDirectory.value / "project").**("*.scala").get,
     deployRsyncArtifact := {
       val unidocArtifacts = (unidoc in Compile).value


### PR DESCRIPTION
I went through the current [API docs](https://doc.akka.io/api/akka-http/10.1.0-RC2/akka/http/javadsl/index.html) which should exclude private stuff and so found a few more classes that should be marked as internal.