### PR TITLE
=pro also allow building for 2.13.0-M3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,10 +25,10 @@ object Dependencies {
   lazy val scalaCheckVersion = settingKey[String]("The version of ScalaCheck to use.")
 
   val Versions = Seq(
-    crossScalaVersions := Seq("2.12.4", "2.11.12"),
+    crossScalaVersions := Seq("2.12.4", "2.11.12", "2.13.0-M3"),
     scalaVersion := crossScalaVersions.value.head,
     scalaCheckVersion := System.getProperty("akka.build.scalaCheckVersion", "1.13.5"),
-    scalaTestVersion := "3.0.5",
+    scalaTestVersion := "3.0.5-M1",
     specs2Version := "4.0.3"
   )
   import Versions._


### PR DESCRIPTION
This will allow running the nightlies for 2.13. Let's see if that helps for anything or if it just produces spurious failures.