### PR TITLE
[DO NOT MERGE] Additional fixes for allowing compilation with 2.13.0-M3

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -307,11 +307,11 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
     case None    ⇒ ContentTypes.`application/octet-stream`
   }
 
-  protected final def emptyEntity(cth: Option[`Content-Type`]) =
+  protected final def emptyEntity(cth: Option[`Content-Type`]): StrictEntityCreator[Output, UniversalEntity] =
     StrictEntityCreator(if (cth.isDefined) HttpEntity.empty(cth.get.contentType) else HttpEntity.Empty)
 
   protected final def strictEntity(cth: Option[`Content-Type`], input: ByteString, bodyStart: Int,
-                                   contentLength: Int) =
+                                   contentLength: Int): StrictEntityCreator[Output, UniversalEntity] =
     StrictEntityCreator(HttpEntity.Strict(contentType(cth), input.slice(bodyStart, bodyStart + contentLength)))
 
   protected final def defaultEntity[A <: ParserOutput](cth: Option[`Content-Type`], contentLength: Long) =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/ParserOutput.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/ParserOutput.scala
@@ -71,7 +71,7 @@ private[http] object ParserOutput {
   /**
    * An entity creator that uses the given entity directly and ignores the passed-in source.
    */
-  final case class StrictEntityCreator[-A <: ParserOutput, +B <: HttpEntity](entity: B) extends EntityCreator[A, B] {
+  final case class StrictEntityCreator[-A <: ParserOutput, +B <: UniversalEntity](entity: B) extends EntityCreator[A, B] {
     def apply(parts: Source[A, NotUsed]) = {
       // We might need to drain stray empty tail streams which will be read by no one.
       StreamUtils.cancelSource(parts)(StreamUtils.OnlyRunInGraphInterpreterContext) // only called within Http graphs stages

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
@@ -98,13 +98,21 @@ private[http] final class UriParser(
     case _                      ⇒ `relaxed-fragment-char`
   }
 
-  var _scheme = ""
-  var _userinfo = ""
-  var _host: Host = Host.Empty
-  var _port: Int = 0
-  var _path: Path = Path.Empty
-  var _rawQueryString: Option[String] = None
-  var _fragment: Option[String] = None
+  private[this] var _scheme = ""
+  private[this] var _userinfo = ""
+  private[this] var _host: Host = Host.Empty
+  private[this] var _port: Int = 0
+  private[this] var _path: Path = Path.Empty
+  private[this] var _rawQueryString: Option[String] = None
+  private[this] var _fragment: Option[String] = None
+
+  private[this] def setScheme(scheme: String): Unit = _scheme = scheme
+  private[this] def setUserInfo(userinfo: String): Unit = _userinfo = userinfo
+  private[this] def setHost(host: Host): Unit = _host = host
+  private[this] def setPort(port: Int): Unit = _port = port
+  private[this] def setPath(path: Path): Unit = _path = path
+  private[this] def setRawQueryString(rawQueryString: String): Unit = _rawQueryString = Some(rawQueryString)
+  private[this] def setFragment(fragment: String): Unit = _fragment = Some(fragment)
 
   // http://tools.ietf.org/html/rfc3986#appendix-A
 
@@ -133,15 +141,15 @@ private[http] final class UriParser(
       | `path-empty`)
 
   def scheme = rule(
-    'h' ~ 't' ~ 't' ~ 'p' ~ (&(':') ~ run(_scheme = "http") | 's' ~ &(':') ~ run(_scheme = "https"))
-      | clearSB() ~ ALPHA ~ appendLowered() ~ zeroOrMore(`scheme-char` ~ appendLowered()) ~ &(':') ~ run(_scheme = sb.toString))
+    'h' ~ 't' ~ 't' ~ 'p' ~ (&(':') ~ run(setScheme("http")) | 's' ~ &(':') ~ run(setScheme("https")))
+      | clearSB() ~ ALPHA ~ appendLowered() ~ zeroOrMore(`scheme-char` ~ appendLowered()) ~ &(':') ~ run(setScheme(sb.toString)))
 
-  def `scheme-pushed` = rule { oneOrMore(`scheme-char` ~ appendLowered()) ~ run(_scheme = sb.toString) ~ push(_scheme) }
+  def `scheme-pushed` = rule { oneOrMore(`scheme-char` ~ appendLowered()) ~ run(setScheme(sb.toString)) ~ push(_scheme) }
 
   def authority = rule { optional(userinfo) ~ hostAndPort }
 
   def userinfo = rule {
-    clearSBForDecoding() ~ zeroOrMore(`userinfo-char` ~ appendSB() | `pct-encoded`) ~ '@' ~ run(_userinfo = getDecodedString())
+    clearSBForDecoding() ~ zeroOrMore(`userinfo-char` ~ appendSB() | `pct-encoded`) ~ '@' ~ run(setUserInfo(getDecodedString()))
   }
 
   def hostAndPort = rule { host ~ optional(':' ~ port) }
@@ -154,22 +162,22 @@ private[http] final class UriParser(
   def relaxedHost = rule { `IP-literal` | ipv6Host | ipv4Host | `reg-name` }
 
   def port = rule {
-    DIGIT ~ run(_port = lastChar - '0') ~ optional(
-      DIGIT ~ run(_port = 10 * _port + lastChar - '0') ~ optional(
-        DIGIT ~ run(_port = 10 * _port + lastChar - '0') ~ optional(
-          DIGIT ~ run(_port = 10 * _port + lastChar - '0') ~ optional(
-            DIGIT ~ run(_port = 10 * _port + lastChar - '0')))))
+    DIGIT ~ run(setPort(lastChar - '0')) ~ optional(
+      DIGIT ~ run(setPort(10 * _port + lastChar - '0')) ~ optional(
+        DIGIT ~ run(setPort(10 * _port + lastChar - '0')) ~ optional(
+          DIGIT ~ run(setPort(10 * _port + lastChar - '0')) ~ optional(
+            DIGIT ~ run(setPort(10 * _port + lastChar - '0'))))))
   }
 
   def `IP-literal` = rule { '[' ~ ipv6Host ~ ']' } // IPvFuture not currently recognized
 
   def ipv4Host = rule { capture(`ip-v4-address`) ~ &(colonSlashEOI) ~> ((b, a) ⇒ _host = IPv4Host(b, a)) }
-  def ipv6Host = rule { capture(`ip-v6-address`) ~> ((b, a) ⇒ _host = IPv6Host(b, a)) }
+  def ipv6Host = rule { capture(`ip-v6-address`) ~> ((b, a) ⇒ setHost(IPv6Host(b, a))) }
 
   def `reg-name` = rule(
     clearSBForDecoding() ~ oneOrMore(`lower-reg-name-char` ~ appendSB() | UPPER_ALPHA ~ appendLowered() | `pct-encoded`) ~
-      run(_host = NamedHost(getDecodedStringAndLowerIfEncoded(UTF8)))
-      | run(_host = Host.Empty))
+      run(setHost(NamedHost(getDecodedStringAndLowerIfEncoded(UTF8))))
+      | run(setHost(Host.Empty)))
 
   def `path-abempty` = rule { clearSB() ~ slashSegments ~ savePath() }
   def `path-absolute` = rule { clearSB() ~ '/' ~ appendSB('/') ~ optional(`segment-nz` ~ slashSegments) ~ savePath() }
@@ -186,7 +194,7 @@ private[http] final class UriParser(
   def pchar = rule { `path-segment-char` ~ appendSB() | `pct-encoded` }
 
   def rawQueryString = rule {
-    clearSB() ~ oneOrMore(`raw-query-char` ~ appendSB()) ~ run(_rawQueryString = Some(sb.toString)) | run(_rawQueryString = Some(""))
+    clearSB() ~ oneOrMore(`raw-query-char` ~ appendSB()) ~ run(setRawQueryString(sb.toString)) | run(setRawQueryString(""))
   }
 
   // http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
@@ -227,8 +235,8 @@ private[http] final class UriParser(
   }
 
   def fragment = rule(
-    clearSBForDecoding() ~ oneOrMore(`fragment-char` ~ appendSB() | `pct-encoded`) ~ run(_fragment = Some(getDecodedString()))
-      | run(_fragment = Some("")))
+    clearSBForDecoding() ~ oneOrMore(`fragment-char` ~ appendSB() | `pct-encoded`) ~ run(setFragment(getDecodedString()))
+      | run(setFragment("")))
 
   def `pct-encoded` = rule {
     '%' ~ HEXDIG ~ HEXDIG ~ run {
@@ -287,7 +295,7 @@ private[http] final class UriParser(
 
   private def appendLowered(): Rule0 = rule { run(sb.append(CharUtils.toLowerCase(lastChar))) }
 
-  private def savePath() = rule { run(_path = Path(sb.toString, uriParsingCharset)) }
+  private def savePath() = rule { run(setPath(Path(sb.toString, uriParsingCharset))) }
 
   private[this] var firstPercentIx = -1
 

--- a/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
@@ -121,14 +121,16 @@ private[http] object Renderer {
   def genericSeqRenderer[S, T](separator: S, empty: S)(implicit sRenderer: Renderer[S], tRenderer: Renderer[T]): Renderer[immutable.Seq[T]] =
     new Renderer[immutable.Seq[T]] {
       def render[R <: Rendering](r: R, value: immutable.Seq[T]): r.type = {
-        @tailrec def recI(values: IndexedSeq[T], ix: Int = 0): r.type =
+        /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+        def recI(values: IndexedSeq[T], ix: Int = 0): r.type =
           if (ix < values.size) {
             if (ix > 0) sRenderer.render(r, separator)
             tRenderer.render(r, values(ix))
             recI(values, ix + 1)
           } else r
 
-        @tailrec def recL(remaining: LinearSeq[T]): r.type =
+        /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+        def recL(remaining: LinearSeq[T]): r.type =
           if (remaining.nonEmpty) {
             if (remaining ne value) sRenderer.render(r, separator)
             tRenderer.render(r, remaining.head)
@@ -172,7 +174,8 @@ private[http] trait Rendering {
    */
   def ~~%(lng: Long): this.type =
     if (lng != 0) {
-      @tailrec def putChar(shift: Int): this.type = {
+      /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+      def putChar(shift: Int): this.type = {
         this ~~ CharUtils.lowerHexDigit(lng >>> shift)
         if (shift > 0) putChar(shift - 4) else this
       }
@@ -180,13 +183,15 @@ private[http] trait Rendering {
     } else this ~~ '0'
 
   def ~~(string: String): this.type = {
-    @tailrec def rec(ix: Int = 0): this.type =
+    /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+    def rec(ix: Int = 0): this.type =
       if (ix < string.length) { this ~~ string.charAt(ix); rec(ix + 1) } else this
     rec()
   }
 
   def ~~(chars: Array[Char]): this.type = {
-    @tailrec def rec(ix: Int = 0): this.type =
+    /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+    def rec(ix: Int = 0): this.type =
       if (ix < chars.length) { this ~~ chars(ix); rec(ix + 1) } else this
     rec()
   }
@@ -206,7 +211,8 @@ private[http] trait Rendering {
   def ~~#!(s: String): this.type = ~~('"').putEscaped(s) ~~ '"'
 
   def putEscaped(s: String, escape: CharPredicate = Rendering.`\"`, escChar: Char = '\\'): this.type = {
-    @tailrec def rec(ix: Int = 0): this.type =
+    /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+    def rec(ix: Int = 0): this.type =
       if (ix < s.length) {
         val c = s.charAt(ix)
         if (escape(c)) this ~~ escChar
@@ -239,7 +245,8 @@ private[http] class StringRendering extends Rendering {
   private[this] val sb = new java.lang.StringBuilder
   def ~~(ch: Char): this.type = { sb.append(ch); this }
   def ~~(bytes: Array[Byte]): this.type = {
-    @tailrec def rec(ix: Int = 0): this.type =
+    /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+    def rec(ix: Int = 0): this.type =
       if (ix < bytes.length) { this ~~ bytes(ix).asInstanceOf[Char]; rec(ix + 1) } else this
     rec()
   }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -907,7 +907,8 @@ object UriRendering {
   def renderQuery[R <: Rendering](r: R, query: Query, charset: Charset,
                                   keep: CharPredicate = `strict-query-char-np`): r.type = {
     def enc(s: String): Unit = encode(r, s, charset, keep, replaceSpaces = true)
-    @tailrec def append(q: Query): r.type =
+    /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+    def append(q: Query): r.type =
       q match {
         case Query.Empty ⇒ r
         case Query.Cons(key, value, tail) ⇒
@@ -923,7 +924,8 @@ object UriRendering {
   private[http] def encode(r: Rendering, string: String, charset: Charset, keep: CharPredicate,
                            replaceSpaces: Boolean = false): r.type = {
     val asciiCompatible = isAsciiCompatible(charset)
-    @tailrec def rec(ix: Int): r.type = {
+    /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+    def rec(ix: Int): r.type = {
       def appendEncoded(byte: Byte): Unit = r ~~ '%' ~~ CharUtils.upperHexDigit(byte >>> 4) ~~ CharUtils.upperHexDigit(byte)
       if (ix < string.length) {
         val charSize = string.charAt(ix) match {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
@@ -35,7 +35,8 @@ object CacheDirective {
     final def render[R <: Rendering](r: R): r.type =
       if (fieldNames.nonEmpty) {
         r ~~ productPrefix ~~ '=' ~~ '"'
-        @tailrec def rec(i: Int = 0): r.type =
+        /* FIXME: broken in 2.13.0-M3, see https://github.com/scala/scala-dev/issues/467 @tailrec */
+        def rec(i: Int = 0): r.type =
           if (i < fieldNames.length) {
             if (i > 0) r ~~ ','
             r.putEscaped(fieldNames(i))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -190,7 +190,7 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends WordS
     "continue parsing raw headers even if the overall cache value capacity is reached" in new TestSetup() {
       val randomHeaders = Stream.continually {
         val name = nextRandomString(nextRandomAlphaNumChar _, nextRandomInt(4, 16))
-        val value = nextRandomString(nextRandomPrintableChar, nextRandomInt(4, 16))
+        val value = nextRandomString(nextRandomPrintableChar _, nextRandomInt(4, 16))
         RawHeader(name, value)
       }
       randomHeaders.take(300).foldLeft(0) {
@@ -222,7 +222,7 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends WordS
 
     "continue parsing raw headers even if the header-specific cache capacity is reached" in new TestSetup() {
       val randomHeaders = Stream.continually {
-        val value = nextRandomString(nextRandomPrintableChar, nextRandomInt(4, 16))
+        val value = nextRandomString(nextRandomPrintableChar _, nextRandomInt(4, 16))
         RawHeader("Fancy", value)
       }
       randomHeaders.take(20).foldLeft(0) {

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
@@ -38,7 +38,7 @@ trait Encoder {
     def encodeChunk(bytes: ByteString): ByteString = compressor.compressAndFlush(bytes)
     def finish(): ByteString = compressor.finish()
 
-    StreamUtils.byteStringTransformer(encodeChunk, finish)
+    StreamUtils.byteStringTransformer(encodeChunk, finish _)
   }
 }
 

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -73,9 +73,9 @@ class Http2Ext(private val config: Config)(implicit val system: ActorSystem)
         Http2AlpnSupport.applySessionParameters(engine, httpsContext.firstSession)
         Http2AlpnSupport.enableForServer(engine, setChosenProtocol)
       }
-      val tls = TLS(createEngine, _ ⇒ Success(()), IgnoreComplete)
+      val tls = TLS(createEngine _, _ ⇒ Success(()), IgnoreComplete)
 
-      AlpnSwitch(getChosenProtocol, http.serverLayer(settings, None, log), http2Layer()) atop
+      AlpnSwitch(getChosenProtocol _, http.serverLayer(settings, None, log), http2Layer()) atop
         tls
     }
 


### PR DESCRIPTION
These additional changes on top of #1918 shouldn't be merged, but can be used to release a version for 2.13.0-M3.

 * Eta Expansion fixes could be fine but are a bit ugly
 * Removing `@tailrec` to make the code compile but then tail optimization actually doesn't apply which might lead to stack overflows.