### PR TITLE
add monad syntax and tests

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
@@ -5,7 +5,7 @@
 package akka.http.scaladsl.server.directives
 
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.{Directive, Directive1, Route, RoutingSpec, ValidationRejection}
+import akka.http.scaladsl.server.{ Directive, Directive1, Route, RoutingSpec, ValidationRejection }
 import akka.http.scaladsl.server.directives.DirectiveMonad._
 
 class DirectiveMonadSpec extends RoutingSpec {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
@@ -1,15 +1,15 @@
 package akka.http.scaladsl.server.directives
 
 import akka.http.scaladsl.server.directives.DirectiveMonad._
-import akka.http.scaladsl.server.{Route, RoutingSpec}
+import akka.http.scaladsl.server.{ Route, RoutingSpec }
 
 class DirectiveMonadSpec extends RoutingSpec {
 
   "extract method and 1 path segment and return string" in {
     val route: Route = for {
-      _ <- get
-      segment <- path("some" / Segment)
-      method <- extractMethod
+      _ ← get
+      segment ← path("some" / Segment)
+      method ← extractMethod
     } yield s"method: ${method.value}, segment: $segment"
     Get("/some/1") ~> route ~> check {
       responseAs[String] shouldEqual "method: GET, segment: 1"
@@ -18,9 +18,9 @@ class DirectiveMonadSpec extends RoutingSpec {
 
   "extract 2 path segments and return string" in {
     val route: Route = for {
-      _ <- get
-      _ <- pathPrefix("test")
-      (segment1, segment2) <- path("some" / Segment / Segment)
+      _ ← get
+      _ ← pathPrefix("test")
+      (segment1, segment2) ← path("some" / Segment / Segment)
     } yield {
       s"segment1: $segment1, segment2: $segment2"
     }
@@ -31,9 +31,9 @@ class DirectiveMonadSpec extends RoutingSpec {
 
   "extract 3 path segments and return string" in {
     val route: Route = for {
-      _ <- get
-      (segment1, segment2, segment3) <- path("test" / "some" / Segment / Segment / Segment)
-      method <- extractMethod
+      _ ← get
+      (segment1, segment2, segment3) ← path("test" / "some" / Segment / Segment / Segment)
+      method ← extractMethod
     } yield s"method: ${method.value}, segment1: $segment1, segment2: $segment2, segment3: $segment3"
     Get("/test/some/1/2/3") ~> route ~> check {
       responseAs[String] shouldEqual "method: GET, segment1: 1, segment2: 2, segment3: 3"

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
@@ -1,0 +1,43 @@
+package akka.http.scaladsl.server.directives
+
+import akka.http.scaladsl.server.directives.DirectiveMonad._
+import akka.http.scaladsl.server.{Route, RoutingSpec}
+
+class DirectiveMonadSpec extends RoutingSpec {
+
+  "extract method and 1 path segment and return string" in {
+    val route: Route = for {
+      _ <- get
+      segment <- path("some" / Segment)
+      method <- extractMethod
+    } yield s"method: ${method.value}, segment: $segment"
+    Get("/some/1") ~> route ~> check {
+      responseAs[String] shouldEqual "method: GET, segment: 1"
+    }
+  }
+
+  "extract 2 path segments and return string" in {
+    val route: Route = for {
+      _ <- get
+      _ <- pathPrefix("test")
+      (segment1, segment2) <- path("some" / Segment / Segment)
+    } yield {
+      s"segment1: $segment1, segment2: $segment2"
+    }
+    Get("/test/some/1/2") ~> route ~> check {
+      responseAs[String] shouldEqual "segment1: 1, segment2: 2"
+    }
+  }
+
+  "extract 3 path segments and return string" in {
+    val route: Route = for {
+      _ <- get
+      (segment1, segment2, segment3) <- path("test" / "some" / Segment / Segment / Segment)
+      method <- extractMethod
+    } yield s"method: ${method.value}, segment1: $segment1, segment2: $segment2, segment3: $segment3"
+    Get("/test/some/1/2/3") ~> route ~> check {
+      responseAs[String] shouldEqual "method: GET, segment1: 1, segment2: 2, segment3: 3"
+    }
+  }
+
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.scaladsl.server.directives
 
 import akka.http.scaladsl.server.directives.DirectiveMonad._

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DirectiveMonadSpec.scala
@@ -75,7 +75,7 @@ class DirectiveMonadSpec extends RoutingSpec {
     }
   }
 
-  "use recover() on wrapped directives" in {
+  "use recover() and other methods on wrapped directives" in {
     def commonDirective(x: Int) = for {
       _ ← get
       _ ← pathPrefix("test")
@@ -84,8 +84,8 @@ class DirectiveMonadSpec extends RoutingSpec {
 
     def route(x: Int): Route = for {
       _ ← commonDirective(x) & path("t1")
-      h ← headerValueByName("nonexistent").recover(_ ⇒ provide("header"): Directive[Tuple1[Any]])
-    } yield s"OK: $h"
+      header ← headerValueByName("nonexistent").recover(_ ⇒ provide("header"))
+    } yield s"OK: $header"
 
     Get("/test/t1") ~> route(1) ~> check {
       responseAs[String] shouldEqual "OK: header"

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
@@ -1,7 +1,7 @@
 package akka.http.scaladsl.server.directives
 
 import akka.http.scaladsl.marshalling.ToResponseMarshaller
-import akka.http.scaladsl.server.{Directive, Directive1, Directives, Route}
+import akka.http.scaladsl.server.{ Directive, Directive1, Directives, Route }
 
 import scala.language.implicitConversions
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.scaladsl.server.directives
 
 import akka.http.scaladsl.marshalling.ToResponseMarshaller

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
@@ -5,25 +5,27 @@
 package akka.http.scaladsl.server.directives
 
 import akka.http.scaladsl.marshalling.ToResponseMarshaller
-import akka.http.scaladsl.server.{ Directive, Directive1, Directives, Route }
+import akka.http.scaladsl.server.util.Tuple
+import akka.http.scaladsl.server.{Directive, Directive1, Directives, Route}
 
 import scala.language.implicitConversions
 
-// This wrapper exposes `map` and `flatMap` APIs and removes the need for the `Tuple` type class.
+// This wrapper exposes `map` and `flatMap` APIs and removes the need for the `Tuple` type class constraint.
 // Note that `Directive.tapply[T]()` has type `(T ⇒ Route) ⇒ Route)` (the continuation monad).
-// We wrap this function in this case class and provide the monadic methods for the for/yield syntax.
-case class WrapDirective[T](directive: (T ⇒ Route) ⇒ Route) extends AnyVal {
+// We wrap `Directive.tapply` in this case class and provide the syntax for the `for/yield` block.
+// In this way, we avoid having to deal with `Directive1` and `Directive` separately.
+case class WrapDirective[+T](tapply: (T ⇒ Route) ⇒ Route) extends AnyVal {
   // Note: this code copies the library code for `Directive.tmap`.
-  def map[U](f: T ⇒ U): WrapDirective[U] = WrapDirective { inner ⇒ directive { values ⇒ inner(f(values)) } }
+  def map[U](f: T ⇒ U): WrapDirective[U] = WrapDirective { inner ⇒ tapply { values ⇒ inner(f(values)) } }
 
   // Note: this code copies the library code for `Directive.tflatMap`.
-  def flatMap[U](f: T ⇒ WrapDirective[U]): WrapDirective[U] = WrapDirective { inner ⇒ directive { values ⇒ f(values) directive inner } }
+  def flatMap[U](f: T ⇒ WrapDirective[U]): WrapDirective[U] = WrapDirective { inner ⇒ tapply { values ⇒ f(values) tapply inner } }
 
   // `withFilter` is required when using a pattern-match syntax such as `(s1, s2) ← path(Segment / Segment)`.
   // Scala issue still open: https://issues.scala-lang.org/browse/SI-1336
   // Note: this code copies the library code for `Directive.tfilter`.
   def withFilter(predicate: T ⇒ Boolean): WrapDirective[T] = WrapDirective { inner ⇒
-    directive { values ⇒ ctx ⇒
+    tapply { values ⇒ ctx ⇒
       if (predicate(values)) {
         inner(values)(ctx)
       } else {
@@ -36,6 +38,9 @@ case class WrapDirective[T](directive: (T ⇒ Route) ⇒ Route) extends AnyVal {
 private[server] sealed trait AkkaHttpMonadLowPriority {
   // Convert `Directive` to `WrapDirective` to activate new syntax.
   implicit def toWrapped[L](directive: Directive[L]): WrapDirective[L] = WrapDirective(directive.tapply)
+  
+  // Convert `WrapDirective` back to `Directive`, so that we could use the library functions.
+  implicit def fromWrapped[L: Tuple](wrapped: WrapDirective[L]): Directive[L] = Directive(wrapped.tapply)
 }
 
 object DirectiveMonad extends AkkaHttpMonadLowPriority {
@@ -44,7 +49,14 @@ object DirectiveMonad extends AkkaHttpMonadLowPriority {
   // Unwrap `Tuple1` data when converting Directive1 to WrapDirective..
   implicit def toWrapped1[L](directive1: Directive1[L]): WrapDirective[L] = WrapDirective(lr ⇒ directive1.tapply(t1 ⇒ lr(t1._1)))
 
-  // Provide syntax for `yield` that avoids the need for `complete`.
+  // Convert `WrapDirective` back to `Directive1` when needed.
+  implicit def fromWrapped1[L](wrapped: WrapDirective[L]): Directive1[L] = Directive(inner ⇒ wrapped.tapply(t ⇒ inner(Tuple1(t))))
+  
+  // Adds a `complete` to enable the syntax: `for { _ <- get } yield "OK"`
   implicit def toRoute[L: ToResponseMarshaller](wrapped: WrapDirective[L]): Route =
-    wrapped.directive(response ⇒ Directives.complete(response))
+    wrapped.tapply(response ⇒ Directives.complete(response))
+
+  // Enable the syntax: `for { _ <- get } yield complete("OK")`
+  implicit def toRoute(wrapped: WrapDirective[Route]): Route = wrapped.tapply(identity[Route])
+
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
@@ -6,7 +6,7 @@ package akka.http.scaladsl.server.directives
 
 import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.server.util.Tuple
-import akka.http.scaladsl.server.{Directive, Directive1, Directives, Route}
+import akka.http.scaladsl.server.{ Directive, Directive1, Directives, Route }
 
 import scala.language.implicitConversions
 
@@ -38,7 +38,7 @@ case class WrapDirective[+T](tapply: (T ⇒ Route) ⇒ Route) extends AnyVal {
 private[server] sealed trait AkkaHttpMonadLowPriority {
   // Convert `Directive` to `WrapDirective` to activate new syntax.
   implicit def toWrapped[L](directive: Directive[L]): WrapDirective[L] = WrapDirective(directive.tapply)
-  
+
   // Convert `WrapDirective` back to `Directive`, so that we could use the library functions.
   implicit def fromWrapped[L: Tuple](wrapped: WrapDirective[L]): Directive[L] = Directive(wrapped.tapply)
 }
@@ -51,7 +51,7 @@ object DirectiveMonad extends AkkaHttpMonadLowPriority {
 
   // Convert `WrapDirective` back to `Directive1` when needed.
   implicit def fromWrapped1[L](wrapped: WrapDirective[L]): Directive1[L] = Directive(inner ⇒ wrapped.tapply(t ⇒ inner(Tuple1(t))))
-  
+
   // Adds a `complete` to enable the syntax: `for { _ <- get } yield "OK"`
   implicit def toRoute[L: ToResponseMarshaller](wrapped: WrapDirective[L]): Route =
     wrapped.tapply(response ⇒ Directives.complete(response))

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DirectiveMonad.scala
@@ -1,0 +1,46 @@
+package akka.http.scaladsl.server.directives
+
+import akka.http.scaladsl.marshalling.ToResponseMarshaller
+import akka.http.scaladsl.server.{Directive, Directive1, Directives, Route}
+
+import scala.language.implicitConversions
+
+// This wrapper exposes `map` and `flatMap` APIs and removes the need for the `Tuple` type class.
+// Note that `Directive.tapply[T]()` has type `(T ⇒ Route) ⇒ Route)` (the continuation monad).
+// We wrap this function in this case class and provide the monadic methods for the for/yield syntax.
+case class WrapDirective[T](directive: (T ⇒ Route) ⇒ Route) extends AnyVal {
+  // Note: this code copies the library code for `Directive.tmap`.
+  def map[U](f: T ⇒ U): WrapDirective[U] = WrapDirective { inner ⇒ directive { values ⇒ inner(f(values)) } }
+
+  // Note: this code copies the library code for `Directive.tflatMap`.
+  def flatMap[U](f: T ⇒ WrapDirective[U]): WrapDirective[U] = WrapDirective { inner ⇒ directive { values ⇒ f(values) directive inner } }
+
+  // `withFilter` is required when using a pattern-match syntax such as `(s1, s2) ← path(Segment / Segment)`.
+  // Scala issue still open: https://issues.scala-lang.org/browse/SI-1336
+  // Note: this code copies the library code for `Directive.tfilter`.
+  def withFilter(predicate: T ⇒ Boolean): WrapDirective[T] = WrapDirective { inner ⇒
+    directive { values ⇒ ctx ⇒
+      if (predicate(values)) {
+        inner(values)(ctx)
+      } else {
+        ctx.reject()
+      }
+    }
+  }
+}
+
+private[server] sealed trait AkkaHttpMonadLowPriority {
+  // Convert `Directive` to `WrapDirective` to activate new syntax.
+  implicit def toWrapped[L](directive: Directive[L]): WrapDirective[L] = WrapDirective(directive.tapply)
+}
+
+object DirectiveMonad extends AkkaHttpMonadLowPriority {
+  def pure[T](t: T): WrapDirective[T] = WrapDirective { inner ⇒ inner(t) }
+
+  // Unwrap `Tuple1` data when converting Directive1 to WrapDirective..
+  implicit def toWrapped1[L](directive1: Directive1[L]): WrapDirective[L] = WrapDirective(lr ⇒ directive1.tapply(t1 ⇒ lr(t1._1)))
+
+  // Provide syntax for `yield` that avoids the need for `complete`.
+  implicit def toRoute[L: ToResponseMarshaller](wrapped: WrapDirective[L]): Route =
+    wrapped.directive(response ⇒ Directives.complete(response))
+}

--- a/akka-parsing/src/main/scala/akka/parboiled2/support/OpTreeContext.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/support/OpTreeContext.scala
@@ -595,7 +595,7 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
         case Left(_)  ⇒ super.render(wrapped)
         case Right(x) ⇒ q"$x ne null"
       }
-    def renderInner(wrapped: Boolean) = call.asInstanceOf[Left[OpTree, Tree]].value.render(wrapped)
+    def renderInner(wrapped: Boolean) = call.asInstanceOf[Left[OpTree, Tree]].a.render(wrapped)
   }
 
   def CharRange(lowerTree: Tree, upperTree: Tree): CharacterRange = {

--- a/akka-parsing/src/main/scala/akka/parboiled2/support/OpTreeContext.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/support/OpTreeContext.scala
@@ -595,7 +595,7 @@ trait OpTreeContext[OpTreeCtx <: ParserMacros.ParserContext] {
         case Left(_)  ⇒ super.render(wrapped)
         case Right(x) ⇒ q"$x ne null"
       }
-    def renderInner(wrapped: Boolean) = call.asInstanceOf[Left[OpTree, Tree]].a.render(wrapped)
+    def renderInner(wrapped: Boolean) = call.asInstanceOf[Left[OpTree, Tree]].value.render(wrapped)
   }
 
   def CharRange(lowerTree: Tree, upperTree: Tree): CharacterRange = {


### PR DESCRIPTION
Support the Scala `for`/`yield` syntax in route directives, simplify route code.

## Writing routes in `for`/`yield` syntax

The default Akka-HTTP style is to use nested functions for defining routes, for example:

```scala
val myRoute: Route = get {
  path("test" / Segment) { userId =>
    val user = userById(userId)
    extractLog { log =>
      extractUri { uri =>
        parameter('x, 'y, 'z) { (x, y, z) =>
          log.info(s"Got URI $uri with parameters $x, $y, $z") // log this before parsing JSON
          entity(as[MyCaseClass]) { input =>
            // `computeAsFuture` is our business logic function returning a `Future`
            onSuccess(computeAsFuture(input, user, x, y, z)) { result =>
              complete(MyResultCaseClass(result))
            }
          }
        }
      }
    }
  }
}
```

Each of the functions `get`, `path`, `extractLog`, `entity` etc. are defined by the Akka-HTTP library as values of type `Directive[L]`.
A `Directive[L]` has a `tapply()` method that takes as an argument a function of type `L => Route` and returns a `Route`.
Therefore, each directive in a route requires you to write one more nested function of type `L => Route`.

It also follows that a `Directive[L]` is equivalent to a value of type `(L => Route) => Route`, which is known in functional programming as the "continuation monad".
Being a monad, this type can be used in `for`/`yield` syntax, which is idiomatic in Scala, and avoids having to write several nested functions.
The only missing part is the methods `map`, `flatMap`, and `withFilter` as required by the `for`/`yield` syntax.

The class `Directive[L]` already has methods `tmap`, `tflatMap`, and `tfilter` but their type signatures are not suitable because of the type class constraint on `L` and because of using magnets.

This PR adds syntax helpers that enable the `for`/`yield` syntax for routes, so that the route above can be rewritten like this:
 
```scala
import DirectiveMonad._

val myRoute: Route = for {
  _         <- get
  userId    <- path("test" / Segment)
  user      =  userById(userId)
  log       <- extractLog
  uri       <- extractUri
  (x, y, z) <- parameter('x, 'y, 'z)
  _         =  log.info(s"Got URI $uri with parameters $x, $y, $z") // log this before parsing JSON
  input     <- entity(as[MyCaseClass])
  result    <- onSuccess(computeAsFuture(input, user, x, y, z))
} yield MyResultCaseClass(result) // no need for `complete()`
```

[All Akka-HTTP directives](https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/alphabetically.html) can be used without any changes in this syntax.
Directive operations such as `&` can be used as well, in the right-hand side of `<-`.

The new syntax is added using a zero-allocation wrapper, `WrapDirective[L]`, which can be created out of a `Directive[L]` or a `Directive1[L]` automatically via an implicit conversion.
There are also implicit conversions from `WrapDirective[L]` back to `Directive[L]` and `Directive1[L]` for convenience.

Some comments:

- Directives that appear to have no arguments (such as `get`) need to be used with the syntax `_ <- get` (these directives are of type `Directive0` and have an argument of type `Unit`).
- Ordinary (non-directive) computations within the `for` block are written as `a = b` instead of `val a = b`.
- Computations returning `Unit`, such as `log.info(...)`, are written as `_ = log.info(...)`.
- Filtering conditions such as `if x.length > 0` are permitted within the `for` block as usual; the route will be rejected if the condition fails.
- To return a `complete(xyz)`, just write `yield xyz`, where `xyz` must be a marshallable value (a string, a case class, or an http response.)
- For convenience, `yield` can be also used on a `Route`, so that `yield complete(xyz)`, `yield reject(...)`, etc. are also supported.
- Directive methods, such as `recover()`, `&` etc., can be used on a `WrapDirective` (i.e. on the result of `for/yield`) as well.

The advantages of this syntax:

- the `for`/`yield` syntax is a standard, idiomatic Scala syntax for sequential computations
- code is easier to read and refactor because it is not deeply nested
- directives become composable in the usual way, as monadic values
- further enrichment can be done using monad transformers

Example of refactoring several routes with a common prefix:

```scala
val commonDirectives = for {
  _ <- get
  _ <- pathPrefix("my_app")
} yield ()

val route1: Route = ???
val route2: Route = ???

val route: Route = for {
  _ <- commonDirectives
} yield route1 ~ route2
```
