### PR TITLE
Allow client setting overrides for host / host-patterns #996

### DIFF
--- a/akka-http-caching/src/main/java/akka/http/caching/javadsl/Cache.java
+++ b/akka-http-caching/src/main/java/akka/http/caching/javadsl/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.caching.javadsl;

--- a/akka-http-caching/src/main/scala/akka/http/caching/CacheJavaMapping.scala
+++ b/akka-http-caching/src/main/scala/akka/http/caching/CacheJavaMapping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.caching

--- a/akka-http-caching/src/main/scala/akka/http/caching/LfuCache.scala
+++ b/akka-http-caching/src/main/scala/akka/http/caching/LfuCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.caching

--- a/akka-http-caching/src/main/scala/akka/http/caching/javadsl/CachingSettings.scala
+++ b/akka-http-caching/src/main/scala/akka/http/caching/javadsl/CachingSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.caching.javadsl

--- a/akka-http-caching/src/main/scala/akka/http/caching/scaladsl/Cache.scala
+++ b/akka-http-caching/src/main/scala/akka/http/caching/scaladsl/Cache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.caching.scaladsl

--- a/akka-http-caching/src/main/scala/akka/http/caching/scaladsl/CachingSettings.scala
+++ b/akka-http-caching/src/main/scala/akka/http/caching/scaladsl/CachingSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.caching.scaladsl

--- a/akka-http-caching/src/main/scala/akka/http/javadsl/server/directives/CachingDirectives.scala
+++ b/akka-http-caching/src/main/scala/akka/http/javadsl/server/directives/CachingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http-caching/src/main/scala/akka/http/scaladsl/server/directives/CachingDirectives.scala
+++ b/akka-http-caching/src/main/scala/akka/http/scaladsl/server/directives/CachingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-caching/src/test/scala/akka/http/caching/ExpiringLfuCacheSpec.scala
+++ b/akka-http-caching/src/test/scala/akka/http/caching/ExpiringLfuCacheSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.caching

--- a/akka-http-caching/src/test/scala/akka/http/scaladsl/server/directives/CachingDirectivesSpec.scala
+++ b/akka-http-caching/src/test/scala/akka/http/scaladsl/server/directives/CachingDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-core/src/main/java/akka/http/impl/util/Util.java
+++ b/akka-http-core/src/main/java/akka/http/impl/util/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util;

--- a/akka-http-core/src/main/java/akka/http/javadsl/TimeoutAccess.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/TimeoutAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Authority.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Authority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/BodyPartEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/BodyPartEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/ContentRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/ContentRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypeRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypeRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/DateTime.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/DateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/FormData.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/FormData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Host.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Host.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharset.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharsetRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharsetRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharsetRanges.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharsetRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharsets.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpCharsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntities.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpHeader.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethod.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethods.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpProtocol.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpProtocols.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpProtocols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpRequest.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpResponse.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/MediaRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/MediaRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/MediaRanges.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/MediaRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Multipart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Multiparts.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Multiparts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Query.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddresses.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddresses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/RequestEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/RequestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/RequestEntityAcceptance.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/RequestEntityAcceptance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/RequestEntityAcceptances.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/RequestEntityAcceptances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/ResponseEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/ResponseEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCode.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/TransferEncoding.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/TransferEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/TransferEncodings.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/TransferEncodings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/UniversalEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/UniversalEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Uri.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Uri.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Accept.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Accept.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AcceptCharset.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AcceptCharset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AcceptEncoding.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AcceptEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AcceptLanguage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AcceptLanguage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AcceptRanges.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AcceptRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlAllowCredentials.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlAllowCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlAllowHeaders.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlAllowHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlAllowMethods.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlAllowMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlAllowOrigin.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlAllowOrigin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlExposeHeaders.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlExposeHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlMaxAge.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlMaxAge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlRequestHeaders.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlRequestHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlRequestMethod.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/AccessControlRequestMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Age.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Age.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Allow.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Allow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Authorization.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Authorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/BasicHttpCredentials.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/BasicHttpCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ByteRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ByteRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheControl.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirective.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirective.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Connection.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentDisposition.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentDisposition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentDispositionType.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentDispositionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentDispositionTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentDispositionTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentEncoding.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentLength.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentType.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ContentType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Cookie.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Cookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CustomHeader.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CustomHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Date.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Date.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ETag.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ETag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTag.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRanges.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/EntityTagRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Expires.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Expires.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Host.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Host.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpChallenge.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpChallenge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCookie.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCookiePair.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCookiePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCredentials.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncoding.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRanges.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodingRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodings.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpEncodings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOrigin.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOrigin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRanges.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpOriginRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/IfMatch.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/IfMatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/IfModifiedSince.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/IfModifiedSince.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/IfNoneMatch.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/IfNoneMatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/IfUnmodifiedSince.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/IfUnmodifiedSince.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Language.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Language.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LanguageRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LanguageRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LanguageRanges.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LanguageRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LastModified.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LastModified.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Link.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Link.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkParam.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkParams.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkValue.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Location.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Location.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ModeledCustomHeader.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ModeledCustomHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ModeledCustomHeaderFactory.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ModeledCustomHeaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/OAuth2BearerToken.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/OAuth2BearerToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Origin.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Origin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ProductVersion.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ProductVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ProxyAuthenticate.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ProxyAuthenticate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ProxyAuthorization.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/ProxyAuthorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Range.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Range.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RangeUnit.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RangeUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RangeUnits.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RangeUnits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RawHeader.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RawHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RawRequestURI.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RawRequestURI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Referer.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Referer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RemoteAddress.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/RemoteAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/SecWebSocketProtocol.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/SecWebSocketProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Server.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/SetCookie.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/SetCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/StrictTransportSecurity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/StrictTransportSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/TimeoutAccess.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/TimeoutAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/TlsSessionInfo.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/TlsSessionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/TransferEncoding.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/TransferEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/UserAgent.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/UserAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/WWWAuthenticate.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/WWWAuthenticate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/XForwardedFor.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/XForwardedFor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/XForwardedHost.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/XForwardedHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/XForwardedProto.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/XForwardedProto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/XRealIp.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/XRealIp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.headers;

--- a/akka-http-core/src/main/mima-filters/10.1.5.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.5.backwards.excludes
@@ -1,0 +1,6 @@
+# ConnectionPoolSettingsImpl is private[akka]
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.this")
+
+

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -384,6 +384,20 @@ akka.http {
     client = {
       # no overrides by default, see `akka.http.client` for default values
     }
+
+    # Add client specific overrides to host-connectioin-pool. Allows exact and prefixed urls
+    # eg:
+    #
+    # "akka.io" = { # can use same things as in global `host-connection-pool` section
+    #   max-connections = 10
+    # }
+
+    # "*.example.com" = { # allow `*` to apply overrides for all subdomains, including `example.com`
+    # }
+    #
+    per-host-override {
+
+    }
   }
 
   # Modify to tweak default parsing settings.

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -385,19 +385,18 @@ akka.http {
       # no overrides by default, see `akka.http.client` for default values
     }
 
-    # Add client specific overrides to host-connectioin-pool. Allows exact and prefixed urls
+    # Add client specific overrides to host-connection-pool. Allows exact and prefixed urls
     # eg:
-    #
-    # "akka.io" = { # can use same things as in global `host-connection-pool` section
-    #   max-connections = 10
-    # }
+    # per-host-override = [
+    #   "akka.io" = { # can use same things as in global `host-connection-pool` section
+    #     max-connections = 10
+    #   },
 
-    # "*.example.com" = { # allow `*` to apply overrides for all subdomains, including `example.com`
-    # }
-    #
-    per-host-override {
+    #   "*.example.com" = { # allow `*` to apply overrides for all subdomains, including `example.com`
+    #   }
+    #]
+    per-host-override = []
 
-    }
   }
 
   # Modify to tweak default parsing settings.

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/Http2Shadow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/Http2Shadow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolConductor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolFlow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolGateway.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterfaceActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolMasterActor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolMasterActor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client.pool

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client.pool

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/BodyPartParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/BodyPartParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/BoyerMoore.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/BoyerMoore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/ParserOutput.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/ParserOutput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/SpecializedHeaderValueParsers.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/SpecializedHeaderValueParsers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.rendering

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.rendering

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.rendering

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.rendering

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpAttributes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.server

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.server

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/ServerTerminator.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/ServerTerminator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.server

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEvent.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEventParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEventParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEventRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameEventRenderer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameHandler.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameOutHandler.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameOutHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Handshake.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Handshake.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Masking.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Masking.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/MessageToFrameRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/MessageToFrameRenderer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Protocol.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Protocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Randoms.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Randoms.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/UpgradeToWebSocketLowLevel.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/UpgradeToWebSocketLowLevel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/UpgradeToWebSocketsResponseHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/UpgradeToWebSocketsResponseHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Utf8Decoder.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Utf8Decoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Utf8Encoder.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Utf8Encoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/main/scala/akka/http/impl/model/JavaQuery.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/JavaQuery.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model

--- a/akka-http-core/src/main/scala/akka/http/impl/model/JavaUri.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/JavaUri.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model

--- a/akka-http-core/src/main/scala/akka/http/impl/model/UriJavaAccessor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/UriJavaAccessor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptCharsetHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptCharsetHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptEncodingHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptEncodingHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptLanguageHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/AcceptLanguageHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CacheControlHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CacheControlHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CharacterClasses.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CharacterClasses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonActions.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonActions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentDispositionHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentDispositionHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/IpAddressParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/IpAddressParsing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/LinkHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/LinkHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/WebSocketHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/WebSocketHeaders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -25,7 +25,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   connectionSettings:                ClientConnectionSettings,
   poolImplementation:                PoolImplementation,
   responseEntitySubscriptionTimeout: Duration,
-  hostMap:                           immutable.Map[Regex, ConnectionPoolSettings])
+  hostMap:                           immutable.Seq[(Regex, ConnectionPoolSettings)])
   extends ConnectionPoolSettings {
 
   require(maxConnections > 0, "max-connections must be > 0")
@@ -94,7 +94,7 @@ object ConnectionPoolSettingsImpl extends SettingsCompanion[ConnectionPoolSettin
         case "new"    ⇒ PoolImplementation.New
       },
       c getPotentiallyInfiniteDuration "response-entity-subscription-timeout",
-      Map.empty
+      List.empty
     )
   }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSetup.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSetup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/HostConnectionPoolSetup.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/HostConnectionPoolSetup.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/HttpsProxySettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/HttpsProxySettingsImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/PreviewServerSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/PreviewServerSettingsImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/RoutingSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/RoutingSettingsImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/WebSocketSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/WebSocketSettingsImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.settings

--- a/akka-http-core/src/main/scala/akka/http/impl/util/ByteStringParserInput.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/ByteStringParserInput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedByteArray.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedByteArray.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedByteStringTraversableOnce.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedByteStringTraversableOnce.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedConfig.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedRegex.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedRegex.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedString.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedString.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaAccessors.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaAccessors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/LogByteStringTools.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/LogByteStringTools.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/ObjectRegistry.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/ObjectRegistry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/One2OneBidiFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/One2OneBidiFlow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/SettingsCompanion.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/SettingsCompanion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/SingletonException.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/SingletonException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/SocketOptionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/SocketOptionSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StageLoggingWithOverride.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StageLoggingWithOverride.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  *
  * Copied and adapted from akka-remote
  * https://github.com/akka/akka/blob/c90121485fcfc44a3cee62a0c638e1982d13d812/akka-remote/src/main/scala/akka/remote/artery/StageLogging.scala

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/Timestamp.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Timestamp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ClientTransport.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ClientTransport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/HostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/HostConnectionPool.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/IncomingConnection.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/IncomingConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/OutgoingConnection.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/OutgoingConnection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ServerBinding.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ServerBinding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/UseHttp2.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/UseHttp2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ContentType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/MediaType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/PeerClosedConnectionException.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/PeerClosedConnectionException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocket.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocketRequest.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocketRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocketUpgradeResponse.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocketUpgradeResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -56,12 +56,6 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue)
   def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue)
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala)
-  /** Java API */
-  def withHostMap(newValue: java.util.Map[String, ConnectionPoolSettings]): ConnectionPoolSettings =
-    self.copy(hostMap = newValue.asScala.map { case (k, v) ⇒ ConnectionPoolSettingsImpl.hostRegex(k) -> v.asScala })
-  /** Java API */
-  def withHostOverride(hostPattern: String, settings: ConnectionPoolSettings): ConnectionPoolSettings =
-    self.copy(hostMap = hostMap.updated(ConnectionPoolSettingsImpl.hostRegex(hostPattern), settings.asScala))
 
   @ApiMayChange
   def withPoolImplementation(newValue: PoolImplementation): ConnectionPoolSettings = self.copy(poolImplementation = newValue.asScala)

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -49,6 +49,15 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
 
   // ---
 
+  @ApiMayChange
+  def withHostOverrides(hostOverrides: java.util.List[(String, ConnectionPoolSettings)]): ConnectionPoolSettings = {
+    import scala.collection.JavaConverters._
+    self.copy(hostOverrides = hostOverrides.asScala.toList.map{case (h, s) => ConnectionPoolSettingsImpl.hostRegex(h) -> s.asScala})
+  }
+
+  @ApiMayChange
+  def appendHostOverride(hostPattern: String, settings: ConnectionPoolSettings): ConnectionPoolSettings = self.copy(hostOverrides = hostOverrides :+ (ConnectionPoolSettingsImpl.hostRegex(hostPattern) -> settings.asScala))
+
   def withMaxConnections(n: Int): ConnectionPoolSettings = self.copy(maxConnections = n, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withMaxConnections(n) })
   def withMinConnections(n: Int): ConnectionPoolSettings = self.copy(minConnections = n, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withMinConnections(n) })
   def withMaxRetries(n: Int): ConnectionPoolSettings = self.copy(maxRetries = n, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withMaxRetries(n) })

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -52,7 +52,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   @ApiMayChange
   def withHostOverrides(hostOverrides: java.util.List[(String, ConnectionPoolSettings)]): ConnectionPoolSettings = {
     import scala.collection.JavaConverters._
-    self.copy(hostOverrides = hostOverrides.asScala.toList.map{case (h, s) => ConnectionPoolSettingsImpl.hostRegex(h) -> s.asScala})
+    self.copy(hostOverrides = hostOverrides.asScala.toList.map { case (h, s) ⇒ ConnectionPoolSettingsImpl.hostRegex(h) -> s.asScala })
   }
 
   @ApiMayChange

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -49,19 +49,19 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
 
   // ---
 
-  def withMaxConnections(n: Int): ConnectionPoolSettings = self.copy(maxConnections = n)
-  def withMinConnections(n: Int): ConnectionPoolSettings = self.copy(minConnections = n)
-  def withMaxRetries(n: Int): ConnectionPoolSettings = self.copy(maxRetries = n)
-  def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copy(maxOpenRequests = newValue)
-  def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue)
-  def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue)
-  def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala)
+  def withMaxConnections(n: Int): ConnectionPoolSettings = self.copy(maxConnections = n, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withMaxConnections(n) })
+  def withMinConnections(n: Int): ConnectionPoolSettings = self.copy(minConnections = n, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withMinConnections(n) })
+  def withMaxRetries(n: Int): ConnectionPoolSettings = self.copy(maxRetries = n, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withMaxRetries(n) })
+  def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copy(maxOpenRequests = newValue, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withMaxOpenRequests(newValue) })
+  def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withPipeliningLimit(newValue) })
+  def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withIdleTimeout(newValue) })
+  def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withConnectionSettings(newValue).asScala })
 
   @ApiMayChange
-  def withPoolImplementation(newValue: PoolImplementation): ConnectionPoolSettings = self.copy(poolImplementation = newValue.asScala)
+  def withPoolImplementation(newValue: PoolImplementation): ConnectionPoolSettings = self.copy(poolImplementation = newValue.asScala, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withPoolImplementation(newValue).asScala })
 
   @ApiMayChange
-  def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(responseEntitySubscriptionTimeout = newValue)
+  def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(responseEntitySubscriptionTimeout = newValue, hostOverrides = hostOverrides.map { case (k, v) ⇒ k -> v.withResponseEntitySubscriptionTimeout(newValue) })
 
   def withTransport(newValue: ClientTransport): ConnectionPoolSettings = withUpdatedConnectionSettings(_.withTransport(newValue.asScala))
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -56,6 +56,12 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue)
   def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue)
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala)
+  /** Java API */
+  def withHostMap(newValue: java.util.Map[String, ConnectionPoolSettings]): ConnectionPoolSettings =
+    self.copy(hostMap = newValue.asScala.map { case (k, v) ⇒ ConnectionPoolSettingsImpl.hostRegex(k) -> v.asScala })
+  /** Java API */
+  def withHostOverride(hostPattern: String, settings: ConnectionPoolSettings): ConnectionPoolSettings =
+    self.copy(hostMap = hostMap.updated(ConnectionPoolSettingsImpl.hostRegex(hostPattern), settings.asScala))
 
   @ApiMayChange
   def withPoolImplementation(newValue: PoolImplementation): ConnectionPoolSettings = self.copy(poolImplementation = newValue.asScala)

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/HttpsProxySettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/HttpsProxySettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/PreviewServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/PreviewServerSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/RoutingSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/RoutingSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/SettingsCompanion.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/SettingsCompanion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/WebSocketSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/WebSocketSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ClientTransport.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ClientTransport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -61,7 +61,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
   override val sslConfig = AkkaSSLConfig(system)
   validateAndWarnAboutLooseSettings()
 
-  private[this] val defaultConnectionPoolSettings = ConnectionPoolSettings.forDefault(system)
+  private[this] val defaultConnectionPoolSettings = ConnectionPoolSettings.withOverrides(system)
 
   // configured default HttpsContext for the client-side
   // SYNCHRONIZED ACCESS ONLY!

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/TimeoutAccess.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/TimeoutAccess.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/UseHttp2.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/UseHttp2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/DateTime.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/DateTime.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/FormData.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/FormData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpCharset.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpCharset.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMethod.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMethod.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpProtocol.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/RemoteAddress.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/RemoteAddress.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/TransferEncoding.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/TransferEncoding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/WithQValue.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/WithQValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/ByteRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/ByteRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/CacheDirective.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/ContentDispositionType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/ContentDispositionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/EntityTag.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/EntityTag.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpChallenge.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpChallenge.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCookie.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCookie.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCredentials.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCredentials.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpEncoding.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpEncoding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpOrigin.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpOrigin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LanguageRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LanguageRange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LinkValue.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LinkValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/ProductVersion.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/ProductVersion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/RangeUnit.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/RangeUnit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/RetryAfterParameter.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/RetryAfterParameter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/UpgradeProtocol.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/UpgradeProtocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/WebSocketExtension.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/WebSocketExtension.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/sse/ServerSentEvent.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/sse/ServerSentEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/PeerClosedConnectionException.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/PeerClosedConnectionException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/WebSocketRequest.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/WebSocketRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/WebSocketUpgradeResponse.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/WebSocketUpgradeResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.ws

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -5,9 +5,9 @@
 package akka.http.scaladsl.settings
 
 import akka.actor.ActorSystem
-import akka.annotation.{ApiMayChange, DoNotInherit, InternalApi}
+import akka.annotation.{ ApiMayChange, DoNotInherit, InternalApi }
 import akka.http.impl.settings.ConnectionPoolSettingsImpl
-import akka.http.javadsl.{settings => js}
+import akka.http.javadsl.{ settings ⇒ js }
 import akka.http.scaladsl.ClientTransport
 import com.typesafe.config.Config
 
@@ -84,7 +84,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   // overrides for more precise return type
 
   @ApiMayChange
-  def withHostOverrides(hostOverrides: immutable.Seq[(String, ConnectionPoolSettings)]): ConnectionPoolSettings = self.copy(hostOverrides = hostOverrides.map{case (h, s) => ConnectionPoolSettingsImpl.hostRegex(h) -> s})
+  def withHostOverrides(hostOverrides: immutable.Seq[(String, ConnectionPoolSettings)]): ConnectionPoolSettings = self.copy(hostOverrides = hostOverrides.map { case (h, s) ⇒ ConnectionPoolSettingsImpl.hostRegex(h) -> s })
 
   @ApiMayChange
   def appendHostOverride(hostPattern: String, settings: ConnectionPoolSettings): ConnectionPoolSettings = self.copy(hostOverrides = hostOverrides :+ (ConnectionPoolSettingsImpl.hostRegex(hostPattern) -> settings))

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/HttpsProxySettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/HttpsProxySettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/PreviewServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/PreviewServerSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/RoutingSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/RoutingSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/SettingsCompanion.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/SettingsCompanion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/WebSocketSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/WebSocketSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/util/FastFuture.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/util/FastFuture.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.util

--- a/akka-http-core/src/test/java/akka/http/JavaTestServer.java
+++ b/akka-http-core/src/test/java/akka/http/JavaTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http;

--- a/akka-http-core/src/test/java/akka/http/javadsl/GracefulTerminationCompileTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/GracefulTerminationCompileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl;

--- a/akka-http-core/src/test/java/akka/http/javadsl/WSEchoTestClientApp.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/WSEchoTestClientApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl;

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/EntityDiscardingTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/EntityDiscardingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/JavaApiTestCases.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/JavaApiTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model;

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/ClientConnectionSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/ClientConnectionSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings;

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/ConnectionPoolSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/ConnectionPoolSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings;

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/ParserSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/ParserSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings;

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/RoutingSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/RoutingSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings;

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/ServerSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/ServerSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.settings;

--- a/akka-http-core/src/test/scala/akka/http/ConfigSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/ConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HttpConfigurationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HttpConfigurationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HttpsProxyGraphStageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HttpsProxyGraphStageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/PrepareResponseSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/PrepareResponseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.client.pool

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/BoyerMooreSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/BoyerMooreSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ContentLengthHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ContentLengthHeaderParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserTestBed.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserTestBed.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.parsing

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.rendering

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.rendering

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.server

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.server

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.server

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/PrepareRequestsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/PrepareRequestsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.server

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/BitBuilder.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/BitBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/EchoTestClientApp.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/EchoTestClientApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/FramingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/FramingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/MessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/MessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/Utf8CodingSpecs.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/Utf8CodingSpecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSClientAutobahnTest.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSClientAutobahnTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSServerAutobahnTest.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSServerAutobahnTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSTestSetupBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSTestUtils.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSTestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketClientSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketServerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WithMaterializerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WithMaterializerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.ws

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.model.parser

--- a/akka-http-core/src/test/scala/akka/http/impl/util/ByteStringParserInputSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/ByteStringParserInputSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/test/scala/akka/http/impl/util/CollectionStage.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/CollectionStage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/test/scala/akka/http/impl/util/ExampleHttpContexts.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/ExampleHttpContexts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/test/scala/akka/http/impl/util/RenderingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/RenderingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/test/scala/akka/http/impl/util/WithLogCapturing.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/WithLogCapturing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.util

--- a/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/test/scala/akka/http/javadsl/ConnectionContextSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/ConnectionContextSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/test/scala/akka/http/javadsl/JavaInitializationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/JavaInitializationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiTestCaseSpecs.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiTestCaseSpecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.model

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/SslConfigWarningsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/SslConfigWarningsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/DateTimeSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/DateTimeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/SerializabilitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/SerializabilitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/TurkishISpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/TurkishISpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.headers

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/sse/ServerSentEventSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/sse/ServerSentEventSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -9,6 +9,7 @@ import scala.util.Success
 import scala.util.Try
 import akka.testkit.AkkaSpec
 import akka.http.scaladsl.model.headers.`User-Agent`
+import com.typesafe.config.ConfigFactory
 
 class ConnectionPoolSettingsSpec extends AkkaSpec {
   "ConnectionPoolSettings" should {
@@ -39,6 +40,151 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
       expectError("akka.http.host-connection-pool.max-open-requests = 100") should include("Perhaps try 64 or 128")
       expectError("akka.http.host-connection-pool.max-open-requests = 1000") should include("Perhaps try 512 or 1024")
     }
+
+    "allow per host overrides" in {
+
+      val settingsString =
+        """
+              |akka.http.host-connection-pool {
+              |  max-connections = 7
+              |
+              |  per-host-override {
+              |    "akka.io" = { # can use same things as in global `host-connection-pool` section
+              |      max-connections = 47
+              |    }
+              |
+              |   "*.example.com" = { # allow `*` to apply overrides for all subdomains
+              |      max-connections = 34
+              |   }
+              |
+              |   "glob:*example2.com" = {
+              |      max-connections = 39
+              |   }
+              |
+              |   "regex:((w{3})?\\.)?scala-lang\\.(com|org)" = {
+              |      max-connections = 36
+              |
+              |   }
+              |  }
+              |}
+            """.stripMargin
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("akka.io").maxConnections shouldEqual 47
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("test.akka.io").maxConnections shouldEqual 7
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("example.com").maxConnections shouldEqual 34
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.example.com").maxConnections shouldEqual 34
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("example2.com").maxConnections shouldEqual 39
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.example2.com").maxConnections shouldEqual 39
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.someexample2.com").maxConnections shouldEqual 39
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("test.example.com").maxConnections shouldEqual 34
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("lightbend.com").maxConnections shouldEqual 7
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.scala-lang.org").maxConnections shouldEqual 36
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("scala-lang.org").maxConnections shouldEqual 36
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("ww.scala-lang.org").maxConnections shouldEqual 7
+
+      ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("scala-lang.com").maxConnections shouldEqual 36
+
+      // Make sure calls to .apply instead of .forDefault don't get overridden by config
+      ConnectionPoolSettings(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("akka.io").maxConnections shouldEqual 7
+
+    }
+
+    "disregard per host overrides when not created via forDefault method" in {
+      val settingsString =
+        """
+          |akka.http.host-connection-pool {
+          |  max-connections = 7
+          |
+          |  per-host-override {
+          |    "akka.io" = { # can use same things as in global `host-connection-pool` section
+          |      max-connections = 47
+          |    }
+          |  }
+          |}
+        """.stripMargin
+
+      ConnectionPoolSettings(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("akka.io").maxConnections shouldEqual 7
+
+    }
+
+    "allow modifying host overrides in code" in {
+      val settingsString =
+        """
+          |akka.http.host-connection-pool {
+          |  max-connections = 7
+          |
+          |  per-host-override {
+          |    "akka.io" = { # can use same things as in global `host-connection-pool` section
+          |      max-connections = 47
+          |    }
+          |  }
+          |}
+        """.stripMargin
+
+      val pool = ConnectionPoolSettings.forDefault(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader)))
+
+      val poolWithHostOverride = pool.withHostOverride(
+
+        "lightbend.com", ConnectionPoolSettings.apply(ConfigFactory.defaultReference(getClass.getClassLoader)).withMaxConnections(33)
+      )
+
+      poolWithHostOverride.forHost("akka.io").maxConnections shouldEqual 47
+      poolWithHostOverride.forHost("lightbend.com").maxConnections shouldEqual 33
+
+      val poolWithHostMap = poolWithHostOverride.withHostMap(
+        Map(
+          "example.com" -> ConnectionPoolSettings.apply(ConfigFactory.defaultReference(getClass.getClassLoader)).withMaxConnections(39)
+        )
+      )
+
+      poolWithHostMap.forHost("akka.io").maxConnections shouldEqual 7
+      poolWithHostMap.forHost("lightbend.com").maxConnections shouldEqual 7
+      poolWithHostMap.forHost("example.com").maxConnections shouldEqual 39
+    }
+
     def expectError(configString: String): String = Try(config(configString)) match {
       case Failure(cause) ⇒ cause.getMessage
       case Success(_)     ⇒ fail("Expected a failure when max-open-requests is not a power of 2")

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -76,55 +76,55 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
           |}
         """.stripMargin
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("akka.io").maxConnections shouldEqual 47
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("test.akka.io").maxConnections shouldEqual 7
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("example.com").maxConnections shouldEqual 34
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.example.com").maxConnections shouldEqual 34
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("example2.com").maxConnections shouldEqual 39
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.example2.com").maxConnections shouldEqual 39
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.someexample2.com").maxConnections shouldEqual 39
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("test.example.com").maxConnections shouldEqual 34
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("lightbend.com").maxConnections shouldEqual 7
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.scala-lang.org").maxConnections shouldEqual 36
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("scala-lang.org").maxConnections shouldEqual 36
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("ww.scala-lang.org").maxConnections shouldEqual 7
 
-      ConnectionPoolSettings.forDefault(
+      ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("scala-lang.com").maxConnections shouldEqual 36
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/PreviewServerSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/PreviewServerSettingsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/SettingsEqualitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/SettingsEqualitySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.settings

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/util/FastFutureSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/util/FastFutureSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.util

--- a/akka-http-core/src/test/scala/akka/stream/testkit/Utils.scala
+++ b/akka-http-core/src/test/scala/akka/stream/testkit/Utils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.stream.testkit

--- a/akka-http-core/src/test/scala/akka/testkit/AkkaSpec.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/AkkaSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.testkit

--- a/akka-http-core/src/test/scala/akka/testkit/Coroner.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/Coroner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.testkit

--- a/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package io.akka.integrationtest.http

--- a/akka-http-marshallers-java/akka-http-jackson/src/main/java/akka/http/javadsl/marshallers/jackson/Jackson.java
+++ b/akka-http-marshallers-java/akka-http-jackson/src/main/java/akka/http/javadsl/marshallers/jackson/Jackson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.marshallers.jackson;

--- a/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonByteStringParserInput.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonByteStringParserInput.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshallers.sprayjson

--- a/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshallers.sprayjson

--- a/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshallers.sprayjson

--- a/akka-http-marshallers-scala/akka-http-xml/src/main/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala
+++ b/akka-http-marshallers-scala/akka-http-xml/src/main/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshallers.xml

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/DefaultHostInfo.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/DefaultHostInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/JUnitRouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/JUnitRouteTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/RouteTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/TestRoute.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/TestRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/TestRouteResult.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/TestRouteResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/WSProbe.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/WSProbe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/WSTestRequestBuilding.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/WSTestRequestBuilding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/MarshallingTestUtils.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/MarshallingTestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestTimeout.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestTimeout.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/ScalatestUtils.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/ScalatestUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/Specs2Utils.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/Specs2Utils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/TestFrameworkInterface.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/TestFrameworkInterface.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSProbe.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSProbe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSTestRequestBuilding.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSTestRequestBuilding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/test/java/akka/http/javadsl/testkit/JUnitRouteTestTest.java
+++ b/akka-http-testkit/src/test/java/akka/http/javadsl/testkit/JUnitRouteTestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.testkit;

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/Specs2RouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/Specs2RouteTestSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.testkit

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/Pet.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/Pet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.examples.petstore;

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreController.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.examples.petstore;

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.examples.petstore;

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.examples.simple;

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerHttpHttpsApp.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerHttpHttpsApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.examples.simple;

--- a/akka-http-tests/src/test/java/AllJavaTests.java
+++ b/akka-http-tests/src/test/java/AllJavaTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 import akka.http.javadsl.server.HandlerBindingTest;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/CompleteTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/CompleteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/HandlerBindingTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/HandlerBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/JavaRouteTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/JavaRouteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/JavaTestServer.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/JavaTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/MarshallerTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/MarshallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/SneakHttpApp.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/SneakHttpApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/UnmarshallerTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/UnmarshallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/CodingDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/CodingDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ComposingDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ComposingDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/CookieDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/CookieDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ExecutionDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ExecutionDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/HeaderDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/HeaderDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/HostDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/HostDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MarshallingDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MarshallingDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/PathDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/PathDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/SchemeDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/SchemeDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/SecurityDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/SecurityDirectivesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/examples/petstore/PetStoreAPITest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/examples/petstore/PetStoreAPITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.examples.petstore;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/examples/simple/SimpleServerTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/examples/simple/SimpleServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.examples.simple;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/values/FormFieldsTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/values/FormFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.values;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/values/HeadersTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/values/HeadersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.values;

--- a/akka-http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
+++ b/akka-http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/akka-http-tests/src/test/java/docs/http/javadsl/server/RouteJavaScalaDslConversionTest.java
+++ b/akka-http-tests/src/test/java/docs/http/javadsl/server/RouteJavaScalaDslConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/akka-http-tests/src/test/scala/akka/http/javadsl/DirectivesConsistencySpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/javadsl/DirectivesConsistencySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl

--- a/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http-tests/src/test/scala/akka/http/javadsl/server/directives/SampleCustomHeader.scala
+++ b/akka-http-tests/src/test/scala/akka/http/javadsl/server/directives/SampleCustomHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/RouteJavaScalaDslConversionSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/RouteJavaScalaDslConversionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/TestSingleRequest.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/TestSingleRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/TypedActorSystemSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/TypedActorSystemSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/DecoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/DecoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/DeflateSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/DeflateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/EncoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/EncoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/GzipSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/GzipSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/NoCodingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/NoCodingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/JsonSupportSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/JsonSupportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshallers

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshallers.sprayjson

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshallers.xml

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/FromStatusCodeAndXYZMarshallerSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/FromStatusCodeAndXYZMarshallerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/sse/EventStreamMarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/sse/EventStreamMarshallingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/BasicRouteSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/BasicRouteSpecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DiscardEntityDefaultExceptionHandlerSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DiscardEntityDefaultExceptionHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DiscardEntityDefaultRejectionHandlerSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DiscardEntityDefaultRejectionHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ModeledCustomHeaderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ModeledCustomHeaderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RoutingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RoutingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/StreamingResponseSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/StreamingResponseSpecs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CodingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CodingDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CookieDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CookieDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ExecutionDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ExecutionDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FutureDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FutureDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HostDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HostDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MethodDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MethodDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RangeDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RangeDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RespondWithDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RespondWithDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/SchemeDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/SchemeDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/SecurityDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/SecurityDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/WebSocketDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/WebSocketDirectivesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/util/TupleOpsSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/util/TupleOpsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.util

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.unmarshalling

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.unmarshalling

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/BaseUnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/BaseUnmarshallingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/EventStreamUnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/EventStreamUnmarshallingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/LineParserSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/LineParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http/src/main/java/akka/http/javadsl/coding/Coder.java
+++ b/akka-http/src/main/java/akka/http/javadsl/coding/Coder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.coding;

--- a/akka-http/src/main/java/akka/http/javadsl/common/RegexConverters.java
+++ b/akka-http/src/main/java/akka/http/javadsl/common/RegexConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.common;

--- a/akka-http/src/main/java/akka/http/javadsl/server/ExceptionHandlerBuilder.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/ExceptionHandlerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http/src/main/java/akka/http/javadsl/server/directives/ContentTypeResolver.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/directives/ContentTypeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http/src/main/java/akka/http/javadsl/server/directives/CorrespondsTo.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/directives/CorrespondsTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives;

--- a/akka-http/src/main/java/akka/http/javadsl/unmarshalling/StringUnmarshallers.java
+++ b/akka-http/src/main/java/akka/http/javadsl/unmarshalling/StringUnmarshallers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.unmarshalling;

--- a/akka-http/src/main/java/akka/http/javadsl/unmarshalling/Unmarshallers.java
+++ b/akka-http/src/main/java/akka/http/javadsl/unmarshalling/Unmarshallers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.unmarshalling;

--- a/akka-http/src/main/scala/akka/http/javadsl/common/EntityStreamingSupport.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/common/EntityStreamingSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.common

--- a/akka-http/src/main/scala/akka/http/javadsl/common/PartialApplication.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/common/PartialApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.common

--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.marshalling

--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/sse/EventStreamMarshalling.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/sse/EventStreamMarshalling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/ExceptionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/PathMatchers.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/PathMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RequestContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RouteResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/CacheConditionDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/CacheConditionDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/CodingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/CodingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/CookieDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/CookieDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/DebuggingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/DebuggingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/ExecutionDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/ExecutionDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FileAndResourceDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FileAndResourceDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FileUploadDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FileUploadDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FormFieldDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FormFieldDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FutureDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FutureDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/HeaderDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/HostDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/HostDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/MarshallingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/MarshallingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/MethodDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/MethodDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/MiscDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/MiscDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/ParameterDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/PathDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RangeDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RangeDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RespondWithDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RespondWithDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/SchemeDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/SchemeDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/TimeoutDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/TimeoutDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server.directives

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/WebSocketDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/WebSocketDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.server

--- a/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/StringUnmarshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/StringUnmarshaller.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.unmarshalling

--- a/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl.unmarshalling

--- a/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/sse/EventStreamUnmarshalling.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/sse/EventStreamUnmarshalling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http/src/main/scala/akka/http/scaladsl/client/RequestBuilding.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/client/RequestBuilding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.client

--- a/akka-http/src/main/scala/akka/http/scaladsl/client/TransformerPipelineSupport.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/client/TransformerPipelineSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.client

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Coder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Coder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/DataMapper.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/DataMapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Deflate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Gzip.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Gzip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/NoCoding.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/NoCoding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.coding

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/CsvEntityStreamingSupport.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/CsvEntityStreamingSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.common

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/EntityStreamingSupport.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/EntityStreamingSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.common

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/JsonEntityStreamingSupport.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/JsonEntityStreamingSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.common

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.common

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.common

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ContentTypeOverrider.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ContentTypeOverrider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/EmptyValue.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/EmptyValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/GenericMarshallers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshal.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToRequestMarshallers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToResponseMarshallers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ToResponseMarshallable.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/ToResponseMarshallable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.marshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/package.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/sse/EventStreamMarshalling.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/sse/EventStreamMarshalling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ContentNegotation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Directives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Directives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteConcatenation.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteConcatenation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RoutingLog.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RoutingLog.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/StandardRoute.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/StandardRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CacheConditionDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CacheConditionDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CodingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CookieDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DebuggingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/DebuggingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ExecutionDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ExecutionDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FutureDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HostDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MarshallingDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/RangeDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/RangeDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/RespondWithDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/RouteDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SchemeDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SchemeDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.directives

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/WebSocketDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/WebSocketDirectives.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/package.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/ApplyConverter.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/ApplyConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.util

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/BinaryPolyFunc.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/BinaryPolyFunc.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.util

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/ClassMagnet.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/ClassMagnet.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.util

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/ConstructFromTuple.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/ConstructFromTuple.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.util

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/Tuple.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/Tuple.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.util

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/TupleOps.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/TupleOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.util

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/util/Tupler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/util/Tupler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server.util

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/GenericUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/GenericUnmarshallers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.unmarshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.unmarshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromEntityUnmarshallers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.unmarshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.unmarshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshal.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshal.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.unmarshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshaller.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/Unmarshaller.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.unmarshalling

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/package.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/EventStreamParser.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/EventStreamParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/EventStreamUnmarshalling.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/EventStreamUnmarshalling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParser.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParser.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/AlpnSwitch.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/AlpnSwitch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/BufferedOutletSupport.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/BufferedOutletSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ByteFlag.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ByteFlag.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Compliance.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Compliance.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Protocol.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Protocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/IncomingFlowController.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/IncomingFlowController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/PriorityTree.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/StreamPrioritizer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/StreamPrioritizer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameRendering.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2.framing

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/ByteStringInputStream.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/ByteStringInputStream.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2.hpack

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HandleOrPassOnStage.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HandleOrPassOnStage.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2.hpack

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2.hpack

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2.hpack

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/Http2Exception.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/Http2Exception.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.http2

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/Http2StreamIdHeader.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/Http2StreamIdHeader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.model.http2

--- a/akka-http2-support/src/test/java/akka/http/javadsl/Http2JavaServerTest.java
+++ b/akka-http2-support/src/test/java/akka/http/javadsl/Http2JavaServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.javadsl;

--- a/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.h2spec

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/HPackSpecExamples.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/HPackSpecExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/PriorityTreeSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/PriorityTreeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ResponseRenderingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ResponseRenderingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithInPendingUntilFixed.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithInPendingUntilFixed.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine.http2

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/package.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.impl.engine

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl

--- a/akka-parsing/src/main/scala/akka/macros/LogHelper.scala
+++ b/akka-parsing/src/main/scala/akka/macros/LogHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.macros

--- a/docs/src/test/java/docs/http/javadsl/ClientSingleRequestExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ClientSingleRequestExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/ComposeDirectivesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/ComposeDirectivesExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/CustomHeaderExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/CustomHeaderExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/CustomMediaTypesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/CustomMediaTypesExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/CustomStatusCodesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/CustomStatusCodesExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/ExceptionHandlerExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ExceptionHandlerExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/Http2Test.java
+++ b/docs/src/test/java/docs/http/javadsl/Http2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/HttpClientDecodingExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpClientDecodingExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/HttpServerDynamicRoutingExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerDynamicRoutingExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/HttpServerLowLevelExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerLowLevelExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/HttpServerStreamRandomNumbersTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerStreamRandomNumbersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/HttpsExamplesDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpsExamplesDocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/JacksonExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/JacksonExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/JacksonXmlExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/JacksonXmlExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/JacksonXmlSupport.java
+++ b/docs/src/test/java/docs/http/javadsl/JacksonXmlSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/ModelDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/ModelDocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/RespondWithHeaderHandlerExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/RespondWithHeaderHandlerExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
+++ b/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/UnmarshalTest.java
+++ b/docs/src/test/java/docs/http/javadsl/UnmarshalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/WebSocketClientExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/WebSocketClientExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl;

--- a/docs/src/test/java/docs/http/javadsl/server/BlockingInHttpExamples.java
+++ b/docs/src/test/java/docs/http/javadsl/server/BlockingInHttpExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/DirectiveExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/DirectiveExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/FileUploadExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/FileUploadExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/FormFieldRequestValsExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/FormFieldRequestValsExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/HeaderRequestValsExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HeaderRequestValsExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/HighLevelServerExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HighLevelServerExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/HttpBasicAuthenticatorExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpBasicAuthenticatorExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/HttpServerExampleDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpServerExampleDocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/HttpsServerExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpsServerExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/OAuth2AuthenticatorExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/OAuth2AuthenticatorExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/PathDirectiveExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/PathDirectiveExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/WebSocketRoutingExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/WebSocketRoutingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/BasicDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/BasicDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CodingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CodingDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CookieDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CookieDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CustomDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CustomDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/ExecutionDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/ExecutionDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/FileAndResourceDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FileAndResourceDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/FileUploadDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FileUploadDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/FormFieldDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FormFieldDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/HeaderDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/HeaderDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/HostDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/HostDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/JsonStreamingFullExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/JsonStreamingFullExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MarshallingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MarshallingDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MethodDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MethodDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/ParameterDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/ParameterDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/RespondWithDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/RouteDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/RouteDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/SecurityDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/SecurityDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/WebSocketDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/WebSocketDirectivesExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.directives;

--- a/docs/src/test/java/docs/http/javadsl/server/testkit/MyAppFragment.java
+++ b/docs/src/test/java/docs/http/javadsl/server/testkit/MyAppFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.testkit;

--- a/docs/src/test/java/docs/http/javadsl/server/testkit/MyAppService.java
+++ b/docs/src/test/java/docs/http/javadsl/server/testkit/MyAppService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.testkit;

--- a/docs/src/test/java/docs/http/javadsl/server/testkit/TestKitFragmentTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/testkit/TestKitFragmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.testkit;

--- a/docs/src/test/java/docs/http/javadsl/server/testkit/TestkitExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/testkit/TestkitExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.testkit;

--- a/docs/src/test/java/docs/http/javadsl/server/testkit/WithTimeoutTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/testkit/WithTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.javadsl.server.testkit;

--- a/docs/src/test/scala/docs/ApiMayChangeDocCheckerSpec.scala
+++ b/docs/src/test/scala/docs/ApiMayChangeDocCheckerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs

--- a/docs/src/test/scala/docs/CompileOnlySpec.scala
+++ b/docs/src/test/scala/docs/CompileOnlySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs

--- a/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientDecodingExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientDecodingExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/MarshalSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/MarshalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/ModelSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/ModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/RouteSealExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/RouteSealExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/ServerSentEventsExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/ServerSentEventsExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2014-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonPrettyMarshalSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonPrettyMarshalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/UnmarshalSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/UnmarshalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl

--- a/docs/src/test/scala/docs/http/scaladsl/server/BlockingInHttpExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/BlockingInHttpExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/CaseClassExtractionExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/CaseClassExtractionExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/DirectiveExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/DirectiveExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/FileUploadExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/FileUploadExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/FragmentExample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/FragmentExample.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/FullSpecs2TestKitExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/FullSpecs2TestKitExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/FullTestKitExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/FullTestKitExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/RoutingSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RoutingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/TestKitFragmentSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/TestKitFragmentSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CodingDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CodingDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CookieDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CookieDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/DebuggingDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/DebuggingDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/ExecutionDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/ExecutionDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FileAndResourceDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FileAndResourceDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FileUploadDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FileUploadDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2015-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FutureDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FutureDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/HeaderDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/HeaderDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/HostDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/HostDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/MarshallingDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/MarshallingDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/MethodDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/MethodDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/PathDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/PathDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/RangeDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/RangeDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/RespondWithDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/SecurityDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/WebSocketDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/WebSocketDirectivesExamplesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.http.scaladsl.server.directives


### PR DESCRIPTION
This change uses nulls as the default parameter for the connection pool
settings because it was extremely ugly to try to create a placeholder
object for the default connection pool that would then need to be
configured later.