### PR TITLE
Remove not needed implicits from Route.seal #1898

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -96,9 +96,11 @@ trait Route {
    *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.
-   *  @deprecated Use the variant without [[RoutingSettings]] and [[ParserSettings]]
+   *
+   * @deprecated Use the variant without [[RoutingSettings]] and [[ParserSettings]]
    */
   @Deprecated
+  @deprecated("Use the variant without RoutingSettings, ParserSettings parameters.", since = "10.1.1")
   def seal(
     routingSettings:  RoutingSettings,
     parserSettings:   ParserSettings,

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -46,7 +46,7 @@ trait Route {
    *
    * A sealed route has these properties:
    *  - The result of the route will always be a complete response, i.e. the result of the future is a
-   *    ``Success(RouteResult.Complete(response))``, never a failed future and never a rejected route. These
+   *    `Success(RouteResult.Complete(response))`, never a failed future and never a rejected route. These
    *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.
@@ -60,7 +60,7 @@ trait Route {
    *
    * A sealed route has these properties:
    *  - The result of the route will always be a complete response, i.e. the result of the future is a
-   *    ``Success(RouteResult.Complete(response))``, never a failed future and never a rejected route. These
+   *    `Success(RouteResult.Complete(response))`, never a failed future and never a rejected route. These
    *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.
@@ -72,7 +72,7 @@ trait Route {
    *
    * A sealed route has these properties:
    *  - The result of the route will always be a complete response, i.e. the result of the future is a
-   *    ``Success(RouteResult.Complete(response))``, never a failed future and never a rejected route. These
+   *    `Success(RouteResult.Complete(response))`, never a failed future and never a rejected route. These
    *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.
@@ -92,7 +92,7 @@ trait Route {
    *
    * A sealed route has these properties:
    *  - The result of the route will always be a complete response, i.e. the result of the future is a
-   *    ``Success(RouteResult.Complete(response))``, never a failed future and never a rejected route. These
+   *    `Success(RouteResult.Complete(response))`, never a failed future and never a rejected route. These
    *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.
@@ -112,7 +112,7 @@ trait Route {
    *
    * A sealed route has these properties:
    *  - The result of the route will always be a complete response, i.e. the result of the future is a
-   *    ``Success(RouteResult.Complete(response))``, never a failed future and never a rejected route. These
+   *    `Success(RouteResult.Complete(response))`, never a failed future and never a rejected route. These
    *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -96,10 +96,26 @@ trait Route {
    *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
    *    the default handlers if none are given or can be found implicitly).
    *  - Consequently, no route alternatives will be tried that were combined with this route.
+   *  @deprecated Use the variant without [[RoutingSettings]] and [[ParserSettings]]
    */
+  @Deprecated
   def seal(
     routingSettings:  RoutingSettings,
     parserSettings:   ParserSettings,
+    rejectionHandler: RejectionHandler,
+    exceptionHandler: ExceptionHandler): Route
+
+  /**
+   * Seals a route by wrapping it with explicit exception handling and rejection conversion.
+   *
+   * A sealed route has these properties:
+   *  - The result of the route will always be a complete response, i.e. the result of the future is a
+   *    ``Success(RouteResult.Complete(response))``, never a failed future and never a rejected route. These
+   *    will be already be handled using the implicitly given [[RejectionHandler]] and [[ExceptionHandler]] (or
+   *    the default handlers if none are given or can be found implicitly).
+   *  - Consequently, no route alternatives will be tried that were combined with this route.
+   */
+  def seal(
     rejectionHandler: RejectionHandler,
     exceptionHandler: ExceptionHandler): Route
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -55,8 +55,8 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
 
   override def seal(rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler): Route = {
     RouteAdapter(scaladsl.server.Route.seal(delegate)(
-      rejectionHandler.asScala,
-      exceptionHandler.asScala))
+      rejectionHandler = rejectionHandler.asScala,
+      exceptionHandler = exceptionHandler.asScala))
   }
 
   override def toString = s"akka.http.javadsl.server.Route($delegate)"

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -9,8 +9,7 @@ import akka.actor.ActorSystem
 import akka.http.javadsl.model.HttpRequest
 import akka.http.javadsl.model.HttpResponse
 import akka.http.impl.util.JavaMapping.Implicits._
-import akka.http.javadsl.server.{ ExceptionHandler, RejectionHandler, Route, RoutingJavaMapping }
-import RoutingJavaMapping._
+import akka.http.javadsl.server.{ ExceptionHandler, RejectionHandler, Route }
 import akka.annotation.InternalApi
 import akka.http.javadsl.settings.{ ParserSettings, RoutingSettings }
 import akka.http.scaladsl
@@ -42,12 +41,8 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
   }
 
   override def seal(): Route = {
-    // TODO: scaladsl.server.Route.seal shouldn't require an implicit RoutingSettings when it can retrieve it itself. See https://github.com/akka/akka-http/issues/1898
-    RouteAdapter {
-      akka.http.scaladsl.server.directives.BasicDirectives.extractSettings { implicit settings ⇒
-        scaladsl.server.Route.seal(delegate)
-      }
-    }
+    RouteAdapter(scaladsl.server.Route.seal(delegate))
+
   }
 
   override def seal(routingSettings: RoutingSettings, parserSettings: ParserSettings, rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler, system: ActorSystem, materializer: Materializer): Route = {
@@ -55,9 +50,11 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
   }
 
   override def seal(routingSettings: RoutingSettings, parserSettings: ParserSettings, rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler): Route = {
+    seal(rejectionHandler, exceptionHandler)
+  }
+
+  override def seal(rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler): Route = {
     RouteAdapter(scaladsl.server.Route.seal(delegate)(
-      routingSettings.asScala,
-      parserSettings.asScala,
       rejectionHandler.asScala,
       exceptionHandler.asScala))
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -5,13 +5,14 @@
 package akka.http.scaladsl.server
 
 import akka.NotUsed
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.http.scaladsl.server.directives.BasicDirectives
 import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
+import akka.http.scaladsl.util.FastFuture._
+import akka.stream.scaladsl.Flow
 import akka.stream.{ ActorMaterializerHelper, Materializer }
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
-import akka.stream.scaladsl.Flow
-import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
-import akka.http.scaladsl.util.FastFuture._
 
 object Route {
 
@@ -31,15 +32,23 @@ object Route {
    *  - Consequently, no route alternatives will be tried that were combined with this route
    *    using the ``~`` on routes or the [[Directive.|]] operator on directives.
    */
-  def seal(route: Route)(implicit
+  protected[this] def seal(route: Route)(implicit
     routingSettings: RoutingSettings,
-                         parserSettings:   ParserSettings   = null,
-                         rejectionHandler: RejectionHandler = RejectionHandler.default,
+                                         parserSettings:   ParserSettings,
+                                         rejectionHandler: RejectionHandler,
+                                         exceptionHandler: ExceptionHandler): Route = {
+    Route.seal(route)
+  }
+
+  def seal(route: Route)(implicit
+    rejectionHandler: RejectionHandler = RejectionHandler.default,
                          exceptionHandler: ExceptionHandler = null): Route = {
     import directives.ExecutionDirectives._
     // optimized as this is the root handler for all akka-http applications
-    (handleExceptions(ExceptionHandler.seal(exceptionHandler)) & handleRejections(rejectionHandler.seal))
-      .tapply(_ ⇒ route) // execute above directives eagerly, avoiding useless laziness of Directive.addByNameNullaryApply
+    BasicDirectives.extractSettings { implicit settings ⇒
+      (handleExceptions(ExceptionHandler.seal(exceptionHandler)) & handleRejections(rejectionHandler.seal))
+        .tapply(_ ⇒ route) // execute above directives eagerly, avoiding useless laziness of Directive.addByNameNullaryApply
+    }
   }
 
   /**
@@ -73,8 +82,8 @@ object Route {
     {
       implicit val executionContext = effectiveEC // overrides parameter
       val effectiveParserSettings = if (parserSettings ne null) parserSettings else ParserSettings(ActorMaterializerHelper.downcast(materializer).system)
-
-      val sealedRoute = seal(route)
+      // Need to reference the right seal method
+      val sealedRoute = Route.seal(route)(rejectionHandler, exceptionHandler)
       request ⇒
         sealedRoute(new RequestContextImpl(request, routingLog.requestLog(request), routingSettings, effectiveParserSettings)).fast
           .map {


### PR DESCRIPTION
Refs: #1898
Initial attempt to remove not needed implicits
MiMa is not happy about the removal of the defaults
If deafaults stay, Scalac complaints about having multiple overloaded alternatives of method seal define default arguments.