### PR TITLE
Always parse Content-Encoding and WebSocket headers

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -444,11 +444,16 @@ private[http] object HttpHeaderParser {
 
   private val alwaysParsedHeaders = Set[String](
     "connection",
+    "content-encoding",
     "content-length",
     "content-type",
     "expect",
     "host",
-    "transfer-encoding"
+    "sec-websocket-key",
+    "sec-websocket-protocol",
+    "sec-websocket-version",
+    "transfer-encoding",
+    "upgrade"
   )
 
   def apply(settings: HttpHeaderParser.Settings, log: LoggingAdapter) =


### PR DESCRIPTION
These headers are now always parsed, even when modeled header parsing is disabled. These headers are needed by Akka HTTP in order to populate `Request` objects and to support WebSockets. Both of these features are needed by Play's HTTP backend.

I'd like to have this patch available to Play 2.6 which uses Akka HTTP 10.0.x. Would it be possible to backport this to the the Akka HTTP 10.0.x branch? I've got a PR for Play that I'll submit once this is ready and once there's a new Akka HTTP release available to use.