### PR TITLE
Transparent websocket ping/pong

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.0.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.0.backwards.excludes
@@ -3,3 +3,4 @@ ProblemFilters.exclude[Problem]("akka.http.impl.*")
 
 # Uri conversion additions https://github.com/akka/akka-http/pull/1950
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.Uri.asScala")
+

--- a/akka-http-core/src/main/mima-filters/10.1.0.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.0.backwards.excludes
@@ -4,3 +4,7 @@ ProblemFilters.exclude[Problem]("akka.http.impl.*")
 # Uri conversion additions https://github.com/akka/akka-http/pull/1950
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.Uri.asScala")
 
+# #1938 Transparent websocket ping/pong
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ServerSettings.getWebsocketSettings")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ClientConnectionSettings.websocketSettings")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ServerSettings.websocketSettings")

--- a/akka-http-core/src/main/mima-filters/10.1.1.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.1.backwards.excludes
@@ -1,4 +1,0 @@
-# #1938 Transparent websocket ping/pong
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ServerSettings.getWebsocketSettings")
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ClientConnectionSettings.websocketSettings")
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ServerSettings.websocketSettings")

--- a/akka-http-core/src/main/mima-filters/10.1.1.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.1.backwards.excludes
@@ -1,0 +1,4 @@
+# #1938 Transparent websocket ping/pong
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ServerSettings.getWebsocketSettings")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ClientConnectionSettings.websocketSettings")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ServerSettings.websocketSettings")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -221,8 +221,9 @@ akka.http {
       periodic-keep-alive-mode = ping
 
       # Interval for sending periodic keep-alives
-      # The frame sent will be the onne configured in akka.http.server.websocket.periodic-keep-alive-mode
+      # The frame sent will be the one configured in akka.http.server.websocket.periodic-keep-alive-mode
       # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
+      # The value `infinite` means that *no* keep-alive heartbeat will be sent, as: "the allowed idle time is infinite"
       periodic-keep-alive-max-idle = infinite
     }
   }

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -206,6 +206,25 @@ akka.http {
       # be increased for high bandwidth-delay-product connections.
       incoming-stream-level-buffer-size = 512kB
     }
+
+    websocket {
+      # periodic keep alive may be implemented using by sending Ping frames
+      # upon which the other side is expected to reply with a Pong frame,
+      # or by sending a Pong frame, which serves as unidirectional heartbeat.
+      # Valid values:
+      #   ping - default, for bi-directional ping/pong keep-alive heartbeating
+      #   pong - for uni-directional pong keep-alive heartbeating
+      #
+      # It is also possible to provide a payload for each heartbeat message,
+      # this setting can be configured programatically by modifying the websocket settings.
+      # See: https://doc.akka.io/docs/akka-http/current/server-side/websocket-support.html
+      periodic-keep-alive-mode = ping
+
+      # Interval for sending periodic keep-alives
+      # The frame sent will be the onne configured in akka.http.server.websocket.periodic-keep-alive-mode
+      # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
+      periodic-keep-alive-max-idle = infinite
+    }
   }
 
   client {
@@ -259,6 +278,24 @@ akka.http {
     # `off` : no log messages are produced
     # Int   : determines how many bytes should be logged per data chunk
     log-unencrypted-network-bytes = off
+
+    websocket {
+      # periodic keep alive may be implemented using by sending Ping frames
+      # upon which the other side is expected to reply with a Pong frame,
+      # or by sending a Pong frame, which serves as unidirectional heartbeat.
+      # Valid values:
+      #   ping - default, for bi-directional ping/pong keep-alive heartbeating
+      #   pong - for uni-directional pong keep-alive heartbeating
+      #
+      # See https://tools.ietf.org/html/rfc6455#section-5.5.2
+      # and https://tools.ietf.org/html/rfc6455#section-5.5.3 for more information
+      periodic-keep-alive-mode = ping
+
+      # Interval for sending periodic keep-alives
+      # The frame sent will be the onne configured in akka.http.server.websocket.periodic-keep-alive-mode
+      # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
+      periodic-keep-alive-max-idle = infinite
+    }
   }
 
   host-connection-pool {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -639,7 +639,7 @@ private[http] object HttpServerBluePrint {
         val frameHandler = handlerFlow match {
           case Left(frameHandler) ⇒ frameHandler
           case Right(messageHandler) ⇒
-            WebSocket.stack(serverSide = true, maskingRandomFactory = settings.websocketRandomFactory, log = log).join(messageHandler)
+            WebSocket.stack(serverSide = true, settings.websocketSettings, log = log).join(messageHandler)
         }
 
         val sinkIn = new SubSinkInlet[ByteString]("FrameSink")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameHandler.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameHandler.scala
@@ -24,12 +24,6 @@ import scala.util.control.NonFatal
 @InternalApi
 private[http] object FrameHandler {
 
-  private val PingFullFrame: FrameStart = FrameEvent.fullFrame(Opcode.Ping, None, ByteString.empty, fin = true)
-  final val mkDirectAnswerPing = () ⇒ DirectAnswer(PingFullFrame)
-
-  private val PongFullFrame: FrameStart = FrameEvent.fullFrame(Opcode.Pong, None, ByteString.empty, fin = true)
-  final val mkDirectAnswerPong = () ⇒ DirectAnswer(PongFullFrame)
-
   def create(server: Boolean): Flow[FrameEventOrError, Output, NotUsed] =
     Flow[FrameEventOrError].via(new HandlerStage(server))
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Protocol.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Protocol.scala
@@ -13,16 +13,16 @@ import akka.annotation.InternalApi
  */
 @InternalApi
 private[http] object Protocol {
-  val FIN_MASK = 0x80
-  val RSV1_MASK = 0x40
-  val RSV2_MASK = 0x20
-  val RSV3_MASK = 0x10
+  final val FIN_MASK = 0x80
+  final val RSV1_MASK = 0x40
+  final val RSV2_MASK = 0x20
+  final val RSV3_MASK = 0x10
 
-  val FLAGS_MASK = 0xF0
-  val OP_MASK = 0x0F
+  final val FLAGS_MASK = 0xF0
+  final val OP_MASK = 0x0F
 
-  val MASK_MASK = 0x80
-  val LENGTH_MASK = 0x7F
+  final val MASK_MASK = 0x80
+  final val LENGTH_MASK = 0x7F
 
   sealed trait Opcode {
     def code: Byte

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocketClientBlueprint.scala
@@ -39,7 +39,7 @@ private[http] object WebSocketClientBlueprint {
     log:      LoggingAdapter): Http.WebSocketClientLayer =
     (simpleTls.atopMat(handshake(request, settings, log))(Keep.right) atop
       WebSocket.framing atop
-      WebSocket.stack(serverSide = false, maskingRandomFactory = settings.websocketRandomFactory, log = log)).reversed
+      WebSocket.stack(serverSide = false, settings.websocketSettings, log = log)).reversed
 
   /**
    * A bidi flow that injects and inspects the WS handshake and then goes out of the way. This BidiFlow

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
@@ -8,12 +8,11 @@ import java.net.InetSocketAddress
 import java.util.Random
 
 import akka.annotation.InternalApi
-import akka.http.impl.engine.ws.Randoms
 import akka.http.impl.util._
 import akka.http.scaladsl.ClientTransport
 import akka.http.scaladsl.model.headers.`User-Agent`
 import akka.http.scaladsl.settings.ClientConnectionSettings.LogUnencryptedNetworkBytes
-import akka.http.scaladsl.settings.ParserSettings
+import akka.http.scaladsl.settings.{ ParserSettings, WebSocketSettings }
 import akka.io.Inet.SocketOption
 import com.typesafe.config.Config
 
@@ -28,7 +27,7 @@ private[akka] final case class ClientConnectionSettingsImpl(
   idleTimeout:                Duration,
   requestHeaderSizeHint:      Int,
   logUnencryptedNetworkBytes: Option[Int],
-  websocketRandomFactory:     () ⇒ Random,
+  websocketSettings:          WebSocketSettings,
   socketOptions:              immutable.Seq[SocketOption],
   parserSettings:             ParserSettings,
   localAddress:               Option[InetSocketAddress],
@@ -39,10 +38,14 @@ private[akka] final case class ClientConnectionSettingsImpl(
   require(requestHeaderSizeHint > 0, "request-size-hint must be > 0")
 
   override def productPrefix = "ClientConnectionSettings"
+
+  override def websocketRandomFactory: () ⇒ Random = websocketSettings.randomFactory
 }
 
-object ClientConnectionSettingsImpl extends SettingsCompanion[ClientConnectionSettingsImpl]("akka.http.client") {
-  def fromSubConfig(root: Config, inner: Config) = {
+/** INTERNAL API */
+@InternalApi
+private[akka] object ClientConnectionSettingsImpl extends SettingsCompanion[ClientConnectionSettingsImpl]("akka.http.client") {
+  def fromSubConfig(root: Config, inner: Config): ClientConnectionSettingsImpl = {
     val c = inner.withFallback(root.getConfig(prefix))
     new ClientConnectionSettingsImpl(
       userAgentHeader = c.getString("user-agent-header").toOption.map(`User-Agent`(_)),
@@ -50,7 +53,7 @@ object ClientConnectionSettingsImpl extends SettingsCompanion[ClientConnectionSe
       idleTimeout = c getPotentiallyInfiniteDuration "idle-timeout",
       requestHeaderSizeHint = c getIntBytes "request-header-size-hint",
       logUnencryptedNetworkBytes = LogUnencryptedNetworkBytes(c getString "log-unencrypted-network-bytes"),
-      websocketRandomFactory = Randoms.SecureRandomInstances, // can currently only be overridden from code
+      websocketSettings = WebSocketSettingsImpl.client(c.getConfig("websocket")),
       socketOptions = SocketOptionSettings.fromSubConfig(root, c.getConfig("socket-options")),
       parserSettings = ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing")),
       localAddress = None,

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/WebSocketSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/WebSocketSettingsImpl.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.impl.settings
+
+import java.util.Random
+
+import akka.annotation.InternalApi
+import akka.http.impl.engine.ws.Randoms
+import akka.http.impl.util._
+import akka.util.ByteString
+import com.typesafe.config.Config
+
+import scala.concurrent.duration.Duration
+
+/** INTERNAL API */
+@InternalApi
+private[akka] final case class WebSocketSettingsImpl(
+  randomFactory:            () ⇒ Random,
+  periodicKeepAliveMode:    String,
+  periodicKeepAliveMaxIdle: Duration,
+  periodicKeepAliveData:    () ⇒ ByteString)
+  extends akka.http.scaladsl.settings.WebSocketSettings {
+
+  require(
+    WebSocketSettingsImpl.KeepAliveModes contains periodicKeepAliveMode,
+    s"Unsupported keep-alive mode detected! Was [$periodicKeepAliveMode], yet only: ${WebSocketSettingsImpl.KeepAliveModes} are supported.")
+
+  override def productPrefix = "WebSocketSettings"
+
+}
+
+/** INTERNAL API */
+@InternalApi
+private[akka] object WebSocketSettingsImpl { // on purpose not extending SettingsCompanion since this setting object exists on both server/client side
+
+  private val KeepAliveModes = Seq("ping", "pong")
+
+  // constant value used to identity check and avoid invoking the generation function if no data payload needed
+  private val NoPeriodicKeepAliveData = () ⇒ ByteString.empty
+  def hasNoCustomPeriodicKeepAliveData(settings: akka.http.javadsl.settings.WebSocketSettings): Boolean =
+    settings.asInstanceOf[WebSocketSettingsImpl].periodicKeepAliveData eq NoPeriodicKeepAliveData
+
+  def serverFromRoot(root: Config): WebSocketSettingsImpl =
+    server(root.getConfig("akka.http.server.websocket"))
+  def server(config: Config): WebSocketSettingsImpl =
+    fromConfig(config)
+
+  def clientFromRoot(root: Config): WebSocketSettingsImpl =
+    client(root.getConfig("akka.http.client.websocket"))
+  def client(config: Config): WebSocketSettingsImpl =
+    fromConfig(config)
+
+  private def fromConfig(inner: Config): WebSocketSettingsImpl = {
+    val c = inner
+    new WebSocketSettingsImpl(
+      Randoms.SecureRandomInstances,
+      c.getString("periodic-keep-alive-mode"), // mode could be extended to be a factory of pings, if we'd need control over the data field
+      c.getPotentiallyInfiniteDuration("periodic-keep-alive-max-idle"),
+      NoPeriodicKeepAliveData
+    )
+  }
+
+}
+

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
@@ -196,6 +196,7 @@ private[http] object JavaMapping {
   implicit object ServerSettingsT extends Inherited[js.ServerSettings.Timeouts, akka.http.scaladsl.settings.ServerSettings.Timeouts]
   implicit object Http2ServerSettingT extends Inherited[js.Http2ServerSettings, akka.http.scaladsl.settings.Http2ServerSettings]
   implicit object PoolImplementationT extends Inherited[js.PoolImplementation, akka.http.scaladsl.settings.PoolImplementation]
+  implicit object WebsocketSettings extends Inherited[js.WebSocketSettings, akka.http.scaladsl.settings.WebSocketSettings]
 
   implicit object OutgoingConnection extends JavaMapping[jdsl.OutgoingConnection, sdsl.Http.OutgoingConnection] {
     def toScala(javaObject: jdsl.OutgoingConnection): sdsl.Http.OutgoingConnection = javaObject.delegate

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
@@ -28,8 +28,8 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
  */
 @DoNotInherit
 abstract class ClientConnectionSettings private[akka] () { self: ClientConnectionSettingsImpl ⇒
-  /* JAVA APIs */
 
+  /* JAVA APIs */
   final def getConnectingTimeout: FiniteDuration = connectingTimeout
   final def getParserSettings: ParserSettings = parserSettings
   final def getIdleTimeout: Duration = idleTimeout
@@ -37,9 +37,8 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   final def getUserAgentHeader: Optional[UserAgent] = OptionConverters.toJava(userAgentHeader)
   final def getLogUnencryptedNetworkBytes: Optional[Int] = OptionConverters.toJava(logUnencryptedNetworkBytes)
   final def getRequestHeaderSizeHint: Int = requestHeaderSizeHint
-  final val getWebsocketRandomFactory: Supplier[Random] = new Supplier[Random] {
-    override def get(): Random = websocketRandomFactory()
-  }
+  final def getWebsocketSettings: WebSocketSettings = websocketSettings
+  final val getWebsocketRandomFactory: Supplier[Random] = () ⇒ websocketRandomFactory()
   final def getLocalAddress: Optional[InetSocketAddress] = OptionConverters.toJava(localAddress)
 
   /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
@@ -53,7 +52,8 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   def withIdleTimeout(newValue: Duration): ClientConnectionSettings = self.copy(idleTimeout = newValue)
   def withRequestHeaderSizeHint(newValue: Int): ClientConnectionSettings = self.copy(requestHeaderSizeHint = newValue)
   def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ClientConnectionSettings = self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
-  def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ClientConnectionSettings = self.copy(websocketRandomFactory = () ⇒ newValue.get())
+  def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ClientConnectionSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(() ⇒ newValue.get()))
+  def withWebsocketSettings(newValue: WebSocketSettings): ClientConnectionSettings = self.copy(websocketSettings = newValue.asScala)
   def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ClientConnectionSettings = self.copy(socketOptions = newValue.asScala.toList)
   def withParserSettings(newValue: ParserSettings): ClientConnectionSettings = self.copy(parserSettings = newValue.asScala)
   def withLocalAddress(newValue: Optional[InetSocketAddress]): ClientConnectionSettings = self.copy(localAddress = OptionConverters.toScala(newValue))

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
@@ -38,7 +38,9 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   final def getLogUnencryptedNetworkBytes: Optional[Int] = OptionConverters.toJava(logUnencryptedNetworkBytes)
   final def getRequestHeaderSizeHint: Int = requestHeaderSizeHint
   final def getWebsocketSettings: WebSocketSettings = websocketSettings
-  final val getWebsocketRandomFactory: Supplier[Random] = () ⇒ websocketRandomFactory()
+  final def getWebsocketRandomFactory: Supplier[Random] = new Supplier[Random] {
+    override def get(): Random = websocketRandomFactory()
+  }
   final def getLocalAddress: Optional[InetSocketAddress] = OptionConverters.toJava(localAddress)
 
   /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
@@ -52,7 +54,9 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   def withIdleTimeout(newValue: Duration): ClientConnectionSettings = self.copy(idleTimeout = newValue)
   def withRequestHeaderSizeHint(newValue: Int): ClientConnectionSettings = self.copy(requestHeaderSizeHint = newValue)
   def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ClientConnectionSettings = self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
-  def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ClientConnectionSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(() ⇒ newValue.get()))
+  def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ClientConnectionSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
+    override def get(): Random = newValue.get()
+  }))
   def withWebsocketSettings(newValue: WebSocketSettings): ClientConnectionSettings = self.copy(websocketSettings = newValue.asScala)
   def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ClientConnectionSettings = self.copy(socketOptions = newValue.asScala.toList)
   def withParserSettings(newValue: ParserSettings): ClientConnectionSettings = self.copy(parserSettings = newValue.asScala)

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
@@ -4,6 +4,7 @@
 
 package akka.http.javadsl.settings
 
+import java.util.function.Supplier
 import java.util.{ Optional, Random }
 
 import akka.actor.ActorSystem
@@ -61,7 +62,9 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ServerSettings = self.copy(socketOptions = newValue.asScala.toList)
   def withDefaultHostHeader(newValue: Host): ServerSettings = self.copy(defaultHostHeader = newValue.asScala)
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue.asScala)
-  def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(() ⇒ newValue.get()))
+  def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
+    override def get(): Random = newValue.get()
+  }))
   def withWebsocketSettings(newValue: WebSocketSettings): ServerSettings = self.copy(websocketSettings = newValue.asScala)
   def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ServerSettings = self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
   def withHttp2Settings(newValue: Http2ServerSettings): ServerSettings = self.copy(http2Settings = newValue.asScala)

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
@@ -38,6 +38,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def getSocketOptions: java.lang.Iterable[SocketOption]
   def getDefaultHostHeader: Host
   def getWebsocketRandomFactory: java.util.function.Supplier[Random]
+  def getWebsocketSettings: WebSocketSettings
   def getParserSettings: ParserSettings
   def getLogUnencryptedNetworkBytes: Optional[Int]
   def getHttp2Settings: Http2ServerSettings = self.http2Settings
@@ -60,7 +61,8 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ServerSettings = self.copy(socketOptions = newValue.asScala.toList)
   def withDefaultHostHeader(newValue: Host): ServerSettings = self.copy(defaultHostHeader = newValue.asScala)
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue.asScala)
-  def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketRandomFactory = () ⇒ newValue.get())
+  def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(() ⇒ newValue.get()))
+  def withWebsocketSettings(newValue: WebSocketSettings): ServerSettings = self.copy(websocketSettings = newValue.asScala)
   def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ServerSettings = self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
   def withHttp2Settings(newValue: Http2ServerSettings): ServerSettings = self.copy(http2Settings = newValue.asScala)
   def withDefaultHttpPort(newValue: Int): ServerSettings = self.copy(defaultHttpPort = newValue)

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/WebSocketSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/WebSocketSettings.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.javadsl.settings
+
+import java.util.Random
+import java.util.function.Supplier
+
+import akka.actor.ActorSystem
+import akka.annotation.DoNotInherit
+import akka.http.impl.settings.WebSocketSettingsImpl
+import akka.util.ByteString
+import com.typesafe.config.Config
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Public API but not intended for subclassing
+ */
+@DoNotInherit
+trait WebSocketSettings { self: WebSocketSettingsImpl ⇒
+  def getRandomFactory: Supplier[Random]
+  def periodicKeepAliveMode: String
+  def periodicKeepAliveMaxIdle: Duration
+  /**
+   * The provided supplier will be invoked for each new keep-alive frame that is sent.
+   * The ByteString will be included in the Ping or Pong frame sent as heartbeat,
+   * so keep in mind to keep it relatively small, in order not to make the frames too bloated.
+   */
+  def getPeriodicKeepAliveData: Supplier[ByteString]
+
+  def withRandomFactoryFactory(newValue: Supplier[Random]): WebSocketSettings =
+    copy(randomFactory = () ⇒ newValue.get())
+  def withPeriodicKeepAliveMode(newValue: String): WebSocketSettings =
+    copy(periodicKeepAliveMode = newValue)
+  def withPeriodicKeepAliveMaxIdle(newValue: Duration): WebSocketSettings =
+    copy(periodicKeepAliveMaxIdle = newValue)
+  def withPeriodicKeepAliveData(newValue: Supplier[ByteString]): WebSocketSettings =
+    copy(periodicKeepAliveData = () ⇒ newValue.get())
+}
+
+object WebSocketSettings {
+  def server(config: Config): WebSocketSettings = WebSocketSettingsImpl.server(config)
+  def server(system: ActorSystem): WebSocketSettings = server(system.settings.config)
+
+  def client(config: Config): WebSocketSettings = WebSocketSettingsImpl.client(config)
+  def client(system: ActorSystem): WebSocketSettings = client(system.settings.config)
+}

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
@@ -49,7 +49,9 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
 
   // overloads for idiomatic Scala use
   def withWebsocketSettings(newValue: WebSocketSettings): ClientConnectionSettings = self.copy(websocketSettings = newValue)
-  def withWebsocketRandomFactory(newValue: () ⇒ Random): ClientConnectionSettings = withWebsocketSettings(websocketSettings.withRandomFactoryFactory(() ⇒ newValue()))
+  def withWebsocketRandomFactory(newValue: () ⇒ Random): ClientConnectionSettings = withWebsocketSettings(websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
+    override def get(): Random = newValue()
+  }))
   def withUserAgentHeader(newValue: Option[`User-Agent`]): ClientConnectionSettings = self.copy(userAgentHeader = newValue)
   def withLogUnencryptedNetworkBytes(newValue: Option[Int]): ClientConnectionSettings = self.copy(logUnencryptedNetworkBytes = newValue)
   def withSocketOptions(newValue: immutable.Seq[SocketOption]): ClientConnectionSettings = self.copy(socketOptions = newValue)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
@@ -6,6 +6,7 @@ package akka.http.scaladsl.settings
 
 import java.net.InetSocketAddress
 import java.util.Random
+import java.util.function.Supplier
 
 import akka.annotation.ApiMayChange
 import akka.annotation.DoNotInherit
@@ -28,6 +29,7 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   def connectingTimeout: FiniteDuration
   def idleTimeout: Duration
   def requestHeaderSizeHint: Int
+  def websocketSettings: WebSocketSettings
   def websocketRandomFactory: () ⇒ Random
   def socketOptions: immutable.Seq[SocketOption]
   def parserSettings: ParserSettings
@@ -46,7 +48,8 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   override def withRequestHeaderSizeHint(newValue: Int): ClientConnectionSettings = self.copy(requestHeaderSizeHint = newValue)
 
   // overloads for idiomatic Scala use
-  def withWebsocketRandomFactory(newValue: () ⇒ Random): ClientConnectionSettings = self.copy(websocketRandomFactory = newValue)
+  def withWebsocketSettings(newValue: WebSocketSettings): ClientConnectionSettings = self.copy(websocketSettings = newValue)
+  def withWebsocketRandomFactory(newValue: () ⇒ Random): ClientConnectionSettings = withWebsocketSettings(websocketSettings.withRandomFactoryFactory(() ⇒ newValue()))
   def withUserAgentHeader(newValue: Option[`User-Agent`]): ClientConnectionSettings = self.copy(userAgentHeader = newValue)
   def withLogUnencryptedNetworkBytes(newValue: Option[Int]): ClientConnectionSettings = self.copy(logUnencryptedNetworkBytes = newValue)
   def withSocketOptions(newValue: immutable.Seq[SocketOption]): ClientConnectionSettings = self.copy(socketOptions = newValue)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -86,7 +86,9 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   override def withResponseHeaderSizeHint(newValue: Int): ServerSettings = self.copy(responseHeaderSizeHint = newValue)
   override def withBacklog(newValue: Int): ServerSettings = self.copy(backlog = newValue)
   override def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ServerSettings = self.copy(socketOptions = newValue.asScala.toList)
-  override def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(() ⇒ newValue.get()))
+  override def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
+    override def get(): Random = newValue.get()
+  }))
   override def getWebsocketSettings: WebSocketSettings = self.websocketSettings
   override def withDefaultHttpPort(newValue: Int): ServerSettings = self.copy(defaultHttpPort = newValue)
   override def withDefaultHttpsPort(newValue: Int): ServerSettings = self.copy(defaultHttpsPort = newValue)
@@ -97,7 +99,9 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def withLogUnencryptedNetworkBytes(newValue: Option[Int]): ServerSettings = self.copy(logUnencryptedNetworkBytes = newValue)
   def withDefaultHostHeader(newValue: Host): ServerSettings = self.copy(defaultHostHeader = newValue)
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue)
-  def withWebsocketRandomFactory(newValue: () ⇒ Random): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(() ⇒ newValue()))
+  def withWebsocketRandomFactory(newValue: () ⇒ Random): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
+    override def get(): Random = newValue()
+  }))
   def withWebsocketSettings(newValue: WebSocketSettings): ServerSettings = self.copy(websocketSettings = newValue)
   def withSocketOptions(newValue: immutable.Seq[SocketOption]): ServerSettings = self.copy(socketOptions = newValue)
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -41,7 +41,9 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def backlog: Int
   def socketOptions: immutable.Seq[SocketOption]
   def defaultHostHeader: Host
+  @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.randomFactory instead", since = "10.1.1")
   def websocketRandomFactory: () ⇒ Random
+  def websocketSettings: WebSocketSettings
   def parserSettings: ParserSettings
   def logUnencryptedNetworkBytes: Option[Int]
   def http2Settings: Http2ServerSettings
@@ -84,7 +86,8 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   override def withResponseHeaderSizeHint(newValue: Int): ServerSettings = self.copy(responseHeaderSizeHint = newValue)
   override def withBacklog(newValue: Int): ServerSettings = self.copy(backlog = newValue)
   override def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ServerSettings = self.copy(socketOptions = newValue.asScala.toList)
-  override def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketRandomFactory = () ⇒ newValue.get())
+  override def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(() ⇒ newValue.get()))
+  override def getWebsocketSettings: WebSocketSettings = self.websocketSettings
   override def withDefaultHttpPort(newValue: Int): ServerSettings = self.copy(defaultHttpPort = newValue)
   override def withDefaultHttpsPort(newValue: Int): ServerSettings = self.copy(defaultHttpsPort = newValue)
 
@@ -94,7 +97,8 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def withLogUnencryptedNetworkBytes(newValue: Option[Int]): ServerSettings = self.copy(logUnencryptedNetworkBytes = newValue)
   def withDefaultHostHeader(newValue: Host): ServerSettings = self.copy(defaultHostHeader = newValue)
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue)
-  def withWebsocketRandomFactory(newValue: () ⇒ Random): ServerSettings = self.copy(websocketRandomFactory = newValue)
+  def withWebsocketRandomFactory(newValue: () ⇒ Random): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(() ⇒ newValue()))
+  def withWebsocketSettings(newValue: WebSocketSettings): ServerSettings = self.copy(websocketSettings = newValue)
   def withSocketOptions(newValue: immutable.Seq[SocketOption]): ServerSettings = self.copy(socketOptions = newValue)
 
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/WebSocketSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/WebSocketSettings.scala
@@ -15,7 +15,9 @@ import scala.concurrent.duration._
 @DoNotInherit
 abstract class WebSocketSettings extends akka.http.javadsl.settings.WebSocketSettings { self: WebSocketSettingsImpl ⇒
   def randomFactory: () ⇒ Random
-  override final val getRandomFactory: Supplier[Random] = () ⇒ randomFactory()
+  override final val getRandomFactory: Supplier[Random] = new Supplier[Random] {
+    override def get(): Random = randomFactory()
+  }
   override def periodicKeepAliveMode: String
   override def periodicKeepAliveMaxIdle: Duration
   /**
@@ -24,7 +26,9 @@ abstract class WebSocketSettings extends akka.http.javadsl.settings.WebSocketSet
    * so keep in mind to keep it relatively small, in order not to make the frames too bloated.
    */
   def periodicKeepAliveData: () ⇒ ByteString
-  final def getPeriodicKeepAliveData: Supplier[ByteString] = () ⇒ periodicKeepAliveData()
+  final def getPeriodicKeepAliveData: Supplier[ByteString] = new Supplier[ByteString] {
+    override def get(): ByteString = periodicKeepAliveData()
+  }
 
   override def withRandomFactoryFactory(newValue: Supplier[Random]): WebSocketSettings =
     copy(randomFactory = () ⇒ newValue.get())

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/WebSocketSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/WebSocketSettings.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.settings
+import java.util.Random
+import java.util.function.Supplier
+
+import akka.annotation.DoNotInherit
+import akka.http.impl.settings.WebSocketSettingsImpl
+import akka.util.ByteString
+
+import scala.concurrent.duration._
+
+@DoNotInherit
+abstract class WebSocketSettings extends akka.http.javadsl.settings.WebSocketSettings { self: WebSocketSettingsImpl ⇒
+  def randomFactory: () ⇒ Random
+  override final val getRandomFactory: Supplier[Random] = () ⇒ randomFactory()
+  override def periodicKeepAliveMode: String
+  override def periodicKeepAliveMaxIdle: Duration
+  /**
+   * The provided function will be invoked for each new keep-alive frame that is sent.
+   * The ByteString will be included in the Ping or Pong frame sent as heartbeat,
+   * so keep in mind to keep it relatively small, in order not to make the frames too bloated.
+   */
+  def periodicKeepAliveData: () ⇒ ByteString
+  final def getPeriodicKeepAliveData: Supplier[ByteString] = () ⇒ periodicKeepAliveData()
+
+  override def withRandomFactoryFactory(newValue: Supplier[Random]): WebSocketSettings =
+    copy(randomFactory = () ⇒ newValue.get())
+  override def withPeriodicKeepAliveMode(newValue: String): WebSocketSettings =
+    copy(periodicKeepAliveMode = newValue)
+  override def withPeriodicKeepAliveMaxIdle(newValue: Duration): WebSocketSettings =
+    copy(periodicKeepAliveMaxIdle = newValue)
+  def withPeriodicKeepAliveData(newValue: () ⇒ ByteString): WebSocketSettings =
+    copy(periodicKeepAliveData = newValue)
+}

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
@@ -9,7 +9,7 @@ import akka.actor.ActorSystem
 import akka.annotation.InternalApi
 import akka.stream.scaladsl.Sink
 import akka.stream.testkit.TestSubscriber
-import akka.util.ByteString
+import akka.util.{ ByteString, PrettyByteString }
 
 import scala.annotation.tailrec
 import scala.concurrent.duration.FiniteDuration
@@ -73,7 +73,14 @@ private[http] object ByteStringSinkProbe {
 
       def expectBytes(expected: ByteString): Unit = {
         val got = expectBytes(expected.length)
-        assert(got == expected, s"expected ${expected.length} bytes '$expected' but got ${got.length} bytes '$got'")
+        val details =
+          "Expected: \n" +
+            PrettyByteString.asPretty(expected).prettyPrint(1024) +
+            "\n" +
+            "But got: \n" +
+            PrettyByteString.asPretty(got).prettyPrint(1024)
+
+        assert(got == expected, s"expected ${expected.length} bytes, but got ${got.length} bytes \n$details")
       }
 
       def expectUtf8EncodedString(expectedString: String): Unit = {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketServerSpec.scala
@@ -5,12 +5,15 @@
 package akka.http.impl.engine.ws
 
 import akka.http.scaladsl.model.ws._
-import akka.stream.scaladsl.{ Keep, Sink, Flow, Source }
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.stream.testkit.Utils
 import akka.util.ByteString
-import org.scalatest.{ Matchers, FreeSpec }
-
+import org.scalatest.{ FreeSpec, Matchers }
 import akka.http.impl.engine.server.HttpServerTestSetupBase
+import akka.stream.{ KillSwitches, UniqueKillSwitch }
+
+import scala.concurrent.duration._
+import scala.concurrent.Promise
 
 class WebSocketServerSpec extends FreeSpec with Matchers with WithMaterializerSpec { spec ⇒
 
@@ -102,6 +105,58 @@ class WebSocketServerSpec extends FreeSpec with Matchers with WithMaterializerSp
           expectWSFrame(Protocol.Opcode.Text, ByteString("Message 4"), fin = true)
           sendWSFrame(Protocol.Opcode.Text, ByteString("Message 5"), fin = true, mask = true)
           expectWSFrame(Protocol.Opcode.Text, ByteString("Message 5"), fin = true)
+
+          sendWSCloseFrame(Protocol.CloseCodes.Regular, mask = true)
+          expectWSCloseFrame(Protocol.CloseCodes.Regular)
+
+          closeNetworkInput()
+          expectNetworkClose()
+        }
+      }
+    }
+    "send Ping keep-alive heartbeat" - {
+      "on idle websocket connection" in Utils.assertAllStagesStopped {
+        new TestSetup {
+
+          override def settings = {
+            val defaults = super.settings.websocketSettings
+            super.settings.withWebsocketSettings(defaults
+              .withPeriodicKeepAliveMode("ping")
+              .withPeriodicKeepAliveMaxIdle(100.millis)
+            )
+          }
+
+          send(
+            """GET /echo HTTP/1.1
+              |Host: server.example.com
+              |Upgrade: websocket
+              |Connection: Upgrade
+              |Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+              |Origin: http://example.com
+              |Sec-WebSocket-Version: 13
+              |
+              |""")
+
+          val request = expectRequest()
+          val upgrade = request.header[UpgradeToWebSocket]
+
+          val handler = Flow.fromSinkAndSourceCoupled(Sink.ignore, Source.maybe[Message])
+
+          // since the handler is not doing anything, we expect the server to start sending Ping frames transparently
+          val response = upgrade.get.handleMessages(handler)
+          responses.sendNext(response)
+
+          expectResponseWithWipedDate(
+            """HTTP/1.1 101 Switching Protocols
+              |Upgrade: websocket
+              |Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
+              |Server: akka-http/test
+              |Date: XXXX
+              |Connection: upgrade
+              |
+              |""")
+
+          expectWSFrame(Protocol.Opcode.Ping, ByteString.empty, fin = true)
 
           sendWSCloseFrame(Protocol.CloseCodes.Regular, mask = true)
           expectWSCloseFrame(Protocol.CloseCodes.Regular)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WithMaterializerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WithMaterializerSpec.scala
@@ -13,7 +13,8 @@ import akka.testkit.TestKit
 trait WithMaterializerSpec extends BeforeAndAfterAll { _: Suite ⇒
   lazy val testConf: Config = ConfigFactory.parseString("""
   akka.event-handlers = ["akka.testkit.TestEventListener"]
-  akka.loglevel = WARNING""")
+  akka.loglevel = WARNING
+  """)
   implicit lazy val system = ActorSystem(getClass.getSimpleName, testConf)
 
   implicit lazy val materializer = ActorMaterializer()

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
@@ -12,7 +12,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ws._
 import akka.stream._
-import akka.stream.scaladsl.{ Flow, Source }
+import akka.stream.scaladsl.{ Flow, Sink, Source }
 import com.typesafe.config.{ Config, ConfigFactory }
 import HttpMethods._
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
@@ -4,8 +4,15 @@
 
 package docs.http.scaladsl.server
 
-import akka.http.scaladsl.model.ws.BinaryMessage
-import akka.stream.scaladsl.Sink
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.ws.{ BinaryMessage, Message, WebSocketRequest }
+import akka.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Flow, Sink }
+import akka.util.ByteString
 import docs.CompileOnlySpec
 import org.scalatest.{ Matchers, WordSpec }
 
@@ -109,5 +116,50 @@ class WebSocketExampleSpec extends WordSpec with Matchers with CompileOnlySpec {
     bindingFuture
       .flatMap(_.unbind()) // trigger unbinding from the port
       .onComplete(_ => system.terminate()) // and shutdown when done
+  }
+
+  "ping-server-example" in compileOnlySpec {
+    implicit val system: ActorSystem = ???
+    implicit val mat: ActorMaterializer = ???
+    //#websocket-ping-payload-server
+    val defaultSettings = ServerSettings(system)
+
+    val pingCounter = new AtomicInteger()
+    val customWebsocketSettings =
+      defaultSettings.websocketSettings
+        .withPeriodicKeepAliveData(() ⇒ ByteString(s"debug-${pingCounter.incrementAndGet()}"))
+
+    val customServerSettings =
+      defaultSettings.withWebsocketSettings(customWebsocketSettings)
+
+    Http().bindAndHandle(???, "127.0.0.1", settings = customServerSettings)
+    //#websocket-ping-payload-server
+  }
+
+  "ping-example" in compileOnlySpec {
+    implicit val system: ActorSystem = ???
+    implicit val mat: ActorMaterializer = ???
+    //#websocket-client-ping-payload
+    val defaultSettings = ClientConnectionSettings(system)
+
+    val pingCounter = new AtomicInteger()
+    val customWebsocketSettings =
+      defaultSettings.websocketSettings
+        .withPeriodicKeepAliveData(() ⇒ ByteString(s"debug-${pingCounter.incrementAndGet()}"))
+
+    val customSettings =
+      defaultSettings.withWebsocketSettings(customWebsocketSettings)
+
+    val request = WebSocketRequest("ws://127.0.0.1")
+
+    Http().singleWebSocketRequest(
+      request,
+      Flow[Message],
+      Http().defaultClientHttpsContext,
+      None,
+      customSettings,
+      system.log
+    )
+    //#websocket-client-ping-payload
   }
 }


### PR DESCRIPTION
Initial progress on https://github.com/akka/akka-http/issues/102

This is now ready for review; it does the basic automatic, ping keepalive, but also I allowed for the pong keep alive. We do not allow customising the data payload; I can add this if needed but it's likely good enough without payload for the basic use cases