### PR TITLE
Always parse Content-Encoding and WebSocket headers (#1937)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -444,11 +444,16 @@ private[http] object HttpHeaderParser {
 
   private val alwaysParsedHeaders = Set[String](
     "connection",
+    "content-encoding",
     "content-length",
     "content-type",
     "expect",
     "host",
-    "transfer-encoding"
+    "sec-websocket-key",
+    "sec-websocket-protocol",
+    "sec-websocket-version",
+    "transfer-encoding",
+    "upgrade"
   )
 
   def apply(settings: HttpHeaderParser.Settings, log: LoggingAdapter) =


### PR DESCRIPTION
Backport of ` Always parse Content-Encoding and WebSocket headers` #1937