### PR TITLE
Support conversion between scaladsl.Uri and javadsl.Uri

### DIFF
--- a/akka-http-core/src/main/java/akka/http/impl/util/Util.java
+++ b/akka-http-core/src/main/java/akka/http/impl/util/Util.java
@@ -4,8 +4,6 @@
 
 package akka.http.impl.util;
 
-import akka.http.impl.model.JavaUri;
-import akka.http.javadsl.model.Uri;
 import scala.compat.java8.OptionConverters;
 import scala.None$;
 import scala.collection.immutable.Map$;
@@ -59,10 +57,6 @@ public abstract class Util {
     }
     public static <T, U extends T> Seq<U> convertArray(T[] els) {
         return Util.<T, U>convertIterable(Arrays.asList(els));
-    }
-
-    public static akka.http.scaladsl.model.Uri convertUriToScala(Uri uri) {
-        return ((JavaUri) uri).uri();
     }
 
     public static <J, V extends J> Optional<J> lookupInRegistry(ObjectRegistry<Object, V> registry, int key) {

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Uri.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Uri.java
@@ -172,7 +172,7 @@ public abstract class Uri {
   public abstract String getPathString();
 
   /**
-   * Returns the scaladsl view of this instance
+   * Returns the Scala DSL representation of this Uri.
    */
   public abstract akka.http.scaladsl.model.Uri asScala();
 
@@ -193,7 +193,7 @@ public abstract class Uri {
   }
 
   /**
-   * Returns an Uri wrapping the scaladsl representation.
+   * Returns the Java DSL representation of a Scala DSL Uri.
    */
   public static Uri create(akka.http.scaladsl.model.Uri uri) {
     return new JavaUri(uri);

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Uri.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Uri.java
@@ -171,6 +171,12 @@ public abstract class Uri {
    */
   public abstract String getPathString();
 
+  /**
+   * Returns the scaladsl view of this instance
+   */
+  public abstract akka.http.scaladsl.model.Uri asScala();
+
+
   public static final akka.http.scaladsl.model.Uri.ParsingMode STRICT = UriJavaAccessor.pmStrict();
   public static final akka.http.scaladsl.model.Uri.ParsingMode RELAXED = UriJavaAccessor.pmRelaxed();
 
@@ -184,6 +190,13 @@ public abstract class Uri {
    */
   public static Uri create(String uri) {
     return new JavaUri(akka.http.scaladsl.model.Uri.apply(uri));
+  }
+
+  /**
+   * Returns an Uri wrapping the scaladsl representation.
+   */
+  public static Uri create(akka.http.scaladsl.model.Uri uri) {
+    return new JavaUri(uri);
   }
 
   /**

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkParams.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkParams.java
@@ -20,7 +20,7 @@ public final class LinkParams {
         return new akka.http.scaladsl.model.headers.LinkParams.rel(value);
     }
     public static LinkParam anchor(Uri uri) {
-        return new akka.http.scaladsl.model.headers.LinkParams.anchor(Util.convertUriToScala(uri));
+        return new akka.http.scaladsl.model.headers.LinkParams.anchor(uri.asScala());
     }
     public static LinkParam rev(String value) {
         return new akka.http.scaladsl.model.headers.LinkParams.rev(value);

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkValue.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/LinkValue.java
@@ -13,7 +13,7 @@ public abstract class LinkValue {
 
     public static LinkValue create(Uri uri, LinkParam... params) {
         return new akka.http.scaladsl.model.headers.LinkValue(
-                Util.convertUriToScala(uri),
+                uri.asScala(),
                 Util.<LinkParam, akka.http.scaladsl.model.headers.LinkParam>convertArray(params));
     }
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Location.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Location.java
@@ -14,7 +14,7 @@ public abstract class Location extends akka.http.scaladsl.model.HttpHeader {
     public abstract Uri getUri();
 
     public static Location create(Uri uri) {
-        return new akka.http.scaladsl.model.headers.Location(akka.http.impl.util.Util.convertUriToScala(uri));
+        return new akka.http.scaladsl.model.headers.Location(uri.asScala());
     }
     public static Location create(String uri) {
         return create(Uri.create(uri));

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Referer.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/Referer.java
@@ -14,6 +14,6 @@ public abstract class Referer extends akka.http.scaladsl.model.HttpHeader {
     public abstract Uri getUri();
 
     public static Referer create(Uri uri) {
-        return new akka.http.scaladsl.model.headers.Referer(akka.http.impl.util.Util.convertUriToScala(uri));
+        return new akka.http.scaladsl.model.headers.Referer(uri.asScala());
     }
 }

--- a/akka-http-core/src/main/mima-filters/10.1.0.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.0.backwards.excludes
@@ -1,0 +1,5 @@
+# Don't monitor changes to internal API
+ProblemFilters.exclude[Problem]("akka.http.impl.*")
+
+# Uri conversion additions https://github.com/akka/akka-http/pull/1950
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.Uri.asScala")

--- a/akka-http-core/src/main/scala/akka/http/impl/model/JavaUri.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/JavaUri.scala
@@ -33,6 +33,7 @@ private[http] case class JavaUri(uri: sm.Uri) extends jm.Uri {
   override def getPort(): Int = port()
   override def getUserInfo(): String = userInfo()
   override def getPathString(): String = path()
+  override def asScala(): sm.Uri = uri
 
   def pathSegments(): jl.Iterable[String] = {
     import sm.Uri.Path._


### PR DESCRIPTION
Adds `javadsl.model.Uri.asScala()`
Adds `static javadsl.model.Uri.create(scaladsl.model.Uri)`
Removes the internal conversion method from `akka.http.impl.util.Util`.

Fixes #1949 