### PR TITLE
Fix 500 error in conditional GET for non-etag response #1948

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CacheConditionDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/CacheConditionDirectives.scala
@@ -101,7 +101,7 @@ trait CacheConditionDirectives {
           header[`If-Match`] match {
             case Some(`If-Match`(im)) if eTag.isDefined ⇒
               if (matchesRange(eTag.get, im, weakComparison = false)) step3() else complete412()
-            case None ⇒ step2()
+            case _ ⇒ step2()
           }
         def step2(): Route =
           header[`If-Unmodified-Since`] match {
@@ -113,7 +113,7 @@ trait CacheConditionDirectives {
             case Some(`If-None-Match`(inm)) if eTag.isDefined ⇒
               if (!matchesRange(eTag.get, inm, weakComparison = true)) step5()
               else if (isGetOrHead) complete304() else complete412()
-            case None ⇒ step4()
+            case _ ⇒ step4()
           }
         def step4(): Route =
           if (isGetOrHead) {


### PR DESCRIPTION
Fix for #1948. To match `Some(If-None-Match)` and un-ETagged condition, the else-case `None` was modified to wild-card.

The HTTP application should ignore `If-None-Match` or `If-Match` request header if the resource hasn't available ETag. Therefore, if the `EntityTag` omitted in `conditional()` in app, this modification don't anything about ETag.

In CacheConditionDirectivesSpec.scala, I added two test cases to reproduce the problem #1948 and fixed them and be all green.