### PR TITLE
Revert "!pro make akka-actor / akka-stream a provided dependency (#1582)"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ lazy val root = Project(
   )
 
 lazy val parsing = project("akka-parsing")
-  .addAkkaModuleDependency("akka-actor", "provided")
+  .addAkkaModuleDependency("akka-actor")
   .settings(Dependencies.parsing)
   .settings(
     scalacOptions := scalacOptions.value.filterNot(Set("-Xfatal-warnings", "-Xlint", "-Ywarn-dead-code").contains), // disable warnings for parboiled code
@@ -87,7 +87,7 @@ lazy val parsing = project("akka-parsing")
 
 lazy val httpCore = project("akka-http-core")
   .dependsOn(parsing)
-  .addAkkaModuleDependency("akka-stream", "provided")
+  .addAkkaModuleDependency("akka-stream")
   .addAkkaModuleDependency("akka-stream-testkit", "test")
   .settings(Dependencies.httpCore)
   .settings(VersionGenerator.versionSettings)
@@ -95,7 +95,7 @@ lazy val httpCore = project("akka-http-core")
 
 lazy val http = project("akka-http")
   .dependsOn(httpCore)
-  .addAkkaModuleDependency("akka-stream", "provided")
+  .addAkkaModuleDependency("akka-stream")
   .settings(Dependencies.http)
   .settings(
     scalacOptions in Compile += "-language:_"
@@ -104,7 +104,7 @@ lazy val http = project("akka-http")
 
 lazy val http2Support = project("akka-http2-support")
   .dependsOn(httpCore, httpTestkit % "test", httpCore % "test->test")
-  .addAkkaModuleDependency("akka-stream", "provided")
+  .addAkkaModuleDependency("akka-stream")
   .addAkkaModuleDependency("akka-stream-testkit", "test")
   .settings(Dependencies.http2)
   .settings(Dependencies.http2Support)
@@ -163,9 +163,9 @@ lazy val httpTests = project("akka-http-tests")
   .enablePlugins(MultiNode)
   .disablePlugins(MimaPlugin) // this is only tests
   .configs(MultiJvm)
-  .settings(headerSettings(MultiJvm))
-  .settings(additionalTasks in ValidatePR += headerCheck in MultiJvm)
-  .addAkkaModuleDependency("akka-stream", "provided")
+
+
+  .addAkkaModuleDependency("akka-stream")
   .addAkkaModuleDependency("akka-multi-node-testkit", "test")
 
 lazy val httpJmhBench = project("akka-http-bench-jmh")
@@ -182,12 +182,12 @@ lazy val httpMarshallersScala = project("akka-http-marshallers-scala")
 
 lazy val httpXml =
   httpMarshallersScalaSubproject("xml")
-    .addAkkaModuleDependency("akka-stream", "provided")
+    .addAkkaModuleDependency("akka-stream")
     .settings(Dependencies.httpXml)
 
 lazy val httpSprayJson =
   httpMarshallersScalaSubproject("spray-json")
-    .addAkkaModuleDependency("akka-stream", "provided")
+    .addAkkaModuleDependency("akka-stream")
     .settings(Dependencies.httpSprayJson)
 
 lazy val httpMarshallersJava = project("akka-http-marshallers-java")
@@ -197,12 +197,12 @@ lazy val httpMarshallersJava = project("akka-http-marshallers-java")
 
 lazy val httpJackson =
   httpMarshallersJavaSubproject("jackson")
-    .addAkkaModuleDependency("akka-stream", "provided")
     .settings(Dependencies.httpJackson)
+    .addAkkaModuleDependency("akka-stream")
     .enablePlugins(ScaladocNoVerificationOfDiagrams)
 
 lazy val httpCaching = project("akka-http-caching")
-  .addAkkaModuleDependency("akka-stream", "provided")
+  .addAkkaModuleDependency("akka-stream")
   .settings(Dependencies.httpCaching)
   .dependsOn(http, httpCore, httpTestkit % "test")
 
@@ -228,7 +228,6 @@ def httpMarshallersJavaSubproject(name: String) =
 lazy val docs = project("docs")
   .enablePlugins(AkkaParadoxPlugin, NoPublish, DeployRsync)
   .disablePlugins(BintrayPlugin, MimaPlugin)
-  .addAkkaModuleDependency("akka-stream", "provided")
   .dependsOn(
     httpCore, http, httpXml, http2Support, httpMarshallersJava, httpMarshallersScala, httpCaching,
     httpTests % "compile;test->test", httpTestkit % "compile;test->test"

--- a/docs/src/main/paradox/compatibility-guidelines.md
+++ b/docs/src/main/paradox/compatibility-guidelines.md
@@ -20,13 +20,15 @@ of your libraries: `Detected java.lang.NoSuchMethodError error, which MAY be cau
 
 ### Akka HTTP 10.0.x with Akka 2.5.x
 
-Akka HTTP 10.0.x is (binary) compatible with *both* Akka `2.4.x` as well as Akka `2.5.x`. However, using Akka HTTP with Akka 2.5 used to be
-a bit confusing, because Akka HTTP explicitly depended on Akka 2.4. Trying to use it together with Akka 2.5,
-running an Akka HTTP application could fail with class loading issues like the above if you forgot to add a dependency to
-both `akka-actor` *and* `akka-stream` of the same version. For that reason, we changed the policy not to depend on `akka-stream`
-explicitly any more but mark it as a `provided` dependency in our build. That means that you will *always* have to add
-a manual dependency to `akka-stream`. Please make sure you have chosen and added a dependency to `akka-stream` when
-updating to the new version. (Old timers may remember this policy from spray.)
+Akka HTTP 10.0.x is (binary) compatible with *both* Akka `2.4.x` as well as Akka `2.5.x`, however in order to facilitate 
+this the build (and thus released artifacts) depend on the `2.4` series. Depending on how you structure your dependencies,
+you may encounter a situation where you depended on `akka-actor` of the `2.5` series, and you depend on `akka-http`
+from the `10.0` series, which in turn would transitively pull in the `akka-streams` dependency in version `2.4` which 
+breaks the binary compatibility requirement that all Akka modules must be of the same version, so the `akka-streams` 
+dependency MUST be the same version as `akka-actor` (so the exact version from the `2.5` series).
+
+In order to resolve this dependency issue, you must depend on akka-streams explicitly, and make it the same version as
+the rest of your Akka environment, for example like this:
 
 sbt
 :   @@@vars
@@ -45,11 +47,11 @@ sbt
 Gradle
 :   @@@vars
     ```
-    compile group: 'com.typesafe.akka', name: 'akka-http_$scala.binary_version$',   version: '$project.version$'
-    compile group: 'com.typesafe.akka', name: 'akka-actor_$scala.binary_version$',  version: '$akka25.version$'
+    compile group: 'com.typesafe.akka', name: 'akka-http_$scala.binary_version$', version: '$project.version$'
+    compile group: 'com.typesafe.akka', name: 'akka-actor_$scala.binary_version$', version: '$akka25.version$'
     compile group: 'com.typesafe.akka', name: 'akka-stream_$scala.binary_version$', version: '$akka25.version$'
     // If testkit used, explicitly declare dependency on akka-streams-testkit in same version as akka-actor
-    testCompile group: 'com.typesafe.akka', name: 'akka-http-testkit_$scala.binary_version$',   version: '$project.version$'
+    testCompile group: 'com.typesafe.akka', name: 'akka-http-testkit_$scala.binary_version$', version: '$project.version$'
     testCompile group: 'com.typesafe.akka', name: 'akka-stream-testkit_$scala.binary_version$', version: '$akka25.version$'
     ```
     @@@

--- a/docs/src/main/paradox/introduction.md
+++ b/docs/src/main/paradox/introduction.md
@@ -25,16 +25,16 @@ On the other hand, if you prefer to build your applications with the guidance of
 
 ## Using Akka HTTP
 
-Akka HTTP is provided as independent modules from Akka itself under its own release cycle. Akka HTTP is @ref[compatible](compatibility-guidelines.md)
-with Akka 2.4 and 2.5. The modules, however, do *not* depend on `akka-actor` or `akka-stream`, so the user is required to
-choose an Akka version to run against and add a manual dependency to `akka-stream` of the chosen version.
+Akka HTTP is provided in a separate jar file, to use it make sure to include the following dependency:
 
 sbt
 :   @@@vars
     ```
     // For Akka 2.4.x or 2.5.x
-    "com.typesafe.akka" %% "akka-http"   % "$project.version$" $crossString$
+    "com.typesafe.akka" %% "akka-http" % "$project.version$" $crossString$
+    // Only when running against Akka 2.5 explicitly depend on akka-streams in same version as akka-actor
     "com.typesafe.akka" %% "akka-stream" % "$akka25.version$" // or whatever the latest version is
+    "com.typesafe.akka" %% "akka-actor"  % "$akka25.version$" // or whatever the latest version is
     ```
     @@@
 
@@ -42,8 +42,10 @@ Gradle
 :   @@@vars
     ```
     // For Akka 2.4.x or 2.5.x
-    compile group: 'com.typesafe.akka', name: 'akka-http_$scala.binary_version$',   version: '$project.version$'
+    compile group: 'com.typesafe.akka', name: 'akka-http_$scala.binary_version$', version: '$project.version$'
+    // Only when running against Akka 2.5 explicitly depend on akka-streams in same version as akka-actor
     compile group: 'com.typesafe.akka', name: 'akka-stream_$scala.binary_version$', version: '$akka25.version$'
+    compile group: 'com.typesafe.akka', name: 'akka-actor_$scala.binary_version$', version: '$akka25.version$'
     ```
     @@@
 
@@ -56,10 +58,16 @@ Maven
       <artifactId>akka-http_$scala.binary_version$</artifactId>
       <version>$project.version$</version>
     </dependency>
+    <!-- Only when running against Akka 2.5 explicitly depend on akka-streams in same version as akka-actor -->
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-stream_$scala.binary_version$</artifactId>
       <version>$akka25.version$</version> <!-- Or whatever the latest version is -->
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-actor_$scala.binary_version$</artifactId>
+      <version>$akka25.version$</version>
     </dependency>
     ```
     @@@


### PR DESCRIPTION
This reverts commit dc708850193244eb3c67f34d77bc4401c2fa36a3.

We accidentally backported the change to the build file which made akka-stream not depended on automatically; This is fine and documented in 10.1, however such change should not exist on 10.0.

This PR reverts this commit