### PR TITLE
=doc document client-side for streaming JSON

### DIFF
--- a/docs/src/main/paradox/common/json-support.md
+++ b/docs/src/main/paradox/common/json-support.md
@@ -58,6 +58,7 @@ Once you have done this (un)marshalling between JSON and your type `T` should wo
 
 @@@ 
 
+<a id="json-streaming-client-side"></a>
 ## Consuming JSON Streaming style APIs
 
 A popular way of implementing streaming APIs is [JSON Streaming](https://en.wikipedia.org/wiki/JSON_Streaming) (see [Source Streaming](./routing-dsl/source-streaming-support.md)

--- a/docs/src/main/paradox/common/json-support.md
+++ b/docs/src/main/paradox/common/json-support.md
@@ -5,43 +5,6 @@ Integration with @scala[[spray-json]]@java[[Jackson]] is provided out of the box
 Integration with other JSON libraries are supported by the community.
 See [the list of current community extensions for Akka HTTP](https://akka.io/community/#extensions-to-akka-http).
 
-@@@ div { .group-scala }
-
-## spray-json Support
-
-The @scaladoc[SprayJsonSupport](akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport) trait provides a `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` for every type `T`
-that an implicit `spray.json.RootJsonReader` and/or `spray.json.RootJsonWriter` (respectively) is available for.
-
-To enable automatic support for (un)marshalling from and to JSON with [spray-json], add a library dependency onto:
-
-@@dependency [sbt,Gradle,Maven] {
-  group="com.typesafe.akka"
-  artifact="akka-http-spray-json_$scala.binary.version$"
-  version="$project.version$"
-}
-
-Next, provide a `RootJsonFormat[T]` for your type and bring it into scope. Check out the [spray-json] documentation for more info on how to do this.
-
-Finally, import the `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` implicits directly from `SprayJsonSupport` as shown in the example below or mix the `akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport` trait into your JSON support module.
-
-Once you have done this (un)marshalling between JSON and your type `T` should work nicely and transparently.
-
-@@snip [SprayJsonExampleSpec.scala]($test$/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala) { #minimal-spray-json-example }
-
-### Pretty printing
-
-By default, spray-json marshals your types to compact printed JSON by implicit conversion using `CompactPrinter`, as defined in:
-
-@@snip [SprayJsonSupport.scala]($akka-http$/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala) { #sprayJsonMarshallerConverter }
-
-Alternatively to marshal your types to pretty printed JSON, bring a `PrettyPrinter` in scope to perform implicit conversion.
-
-@@snip [SprayJsonPrettyMarshalSpec.scala]($test$/scala/docs/http/scaladsl/SprayJsonPrettyMarshalSpec.scala) { #example }
-
-To learn more about how spray-json works please refer to its [documentation][spray-json].
-
-@@@
-
 @@@ div { .group-java }
 
 <a id="json-jackson-support-java"></a>
@@ -66,6 +29,84 @@ Use `akka.http.javadsl.marshallers.jackson.Jackson.marshaller(T.class)` to creat
 @@snip [PetStoreExample.java]($akka-http$/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java) { #imports #marshall }
 
 Refer to @github[this file](/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java) in the sources for the complete example.
+
+@@@
+
+
+@@@ div { .group-scala }
+
+## spray-json Support
+
+The @scaladoc[SprayJsonSupport](akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport) trait provides a `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` for every type `T`
+that an implicit `spray.json.RootJsonReader` and/or `spray.json.RootJsonWriter` (respectively) is available for.
+
+To enable automatic support for (un)marshalling from and to JSON with [spray-json], add a library dependency onto:
+
+@@dependency [sbt,Gradle,Maven] {
+  group="com.typesafe.akka"
+  artifact="akka-http-spray-json_$scala.binary.version$"
+  version="$project.version$"
+}
+
+Next, provide a `RootJsonFormat[T]` for your type and bring it into scope. Check out the [spray-json] documentation for more info on how to do this.
+
+Finally, import the `FromEntityUnmarshaller[T]` and `ToEntityMarshaller[T]` implicits directly from `SprayJsonSupport` as shown in the example below or mix the `akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport` trait into your JSON support module.
+
+Once you have done this (un)marshalling between JSON and your type `T` should work nicely and transparently.
+
+@@snip [SprayJsonExampleSpec.scala]($test$/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala) { #minimal-spray-json-example }
+
+@@@ 
+
+## Consuming JSON Streaming style APIs
+
+A popular way of implementing streaming APIs is [JSON Streaming](https://en.wikipedia.org/wiki/JSON_Streaming) (see [Source Streaming](./routing-dsl/source-streaming-support.md)
+for documentation on building server-side of such API).
+
+Depending on the way the API returns the streamed JSON (newline delimited, raw sequence of objects, or "infinite array") 
+you may have to apply a different framing mechanism, but the general idea remains the same: consuming the infinite entity stream
+and applying a framing to it, such that the single objects can be easily deserialized using the usual marshalling infrastructure:
+
+Scala
+:   @@snip [EntityStreamingSpec.scala]($akka-http$/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala) { #json-streaming-client-example }
+ 
+Java
+:   @@snip [HttpClientExampleDocTest.java]($test$/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java) { #json-streaming-client-example-raw }
+
+@@@ div { .group-scala }
+
+In the above example the marshalling is handled by the implicitly provided `JsonEntityStreamingSupport`, which is also used when building server-side streaming APIs.
+You can also achieve the same more explicitly, by manually connecting the entity byte stream through a framing and then deserialization stage: 
+
+Scala
+:   @@snip [EntityStreamingSpec.scala]($akka-http$/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala) { #json-streaming-client-example-raw }
+ 
+@@@
+
+@@@ div { .group-java }
+
+In the above example the `JsonEntityStreamingSupport` class is used to obtain the proper framing, though you could also
+pick the framing manually by using `akka.stream.javadsl.Framing` or `akka.stream.javadsl.JsonFraming`. 
+Framing stages are used to "chunk up" the pieces of incoming bytes into appropriately sized pieces of valid JSON,
+which then can be handled easily by a not-streaming JSON serializer such as jackson in the example. This technique is simpler to use
+and often good enough rather than writing a fully streaming JSON parser (which also is possible). 
+
+@@@ 
+
+
+@@@ div { .group-scala }
+
+## Pretty printing
+
+By default, spray-json marshals your types to compact printed JSON by implicit conversion using `CompactPrinter`, as defined in:
+
+@@snip [SprayJsonSupport.scala]($akka-http$/akka-http-marshallers-scala/akka-http-spray-json/src/main/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupport.scala) { #sprayJsonMarshallerConverter }
+
+Alternatively to marshal your types to pretty printed JSON, bring a `PrettyPrinter` in scope to perform implicit conversion.
+
+@@snip [SprayJsonPrettyMarshalSpec.scala]($test$/scala/docs/http/scaladsl/SprayJsonPrettyMarshalSpec.scala) { #example }
+
+To learn more about how spray-json works please refer to its [documentation][spray-json].
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/source-streaming-support.md
+++ b/docs/src/main/paradox/routing-dsl/source-streaming-support.md
@@ -183,3 +183,8 @@ Scala
 :   @@snip [JsonStreamingFullExamples.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala) { #custom-content-type }
 
 @@@
+
+## Consuming streaming JSON on client-side
+
+For consuming such streaming APIs with, for example, JSON responses refer to @ref[Consuming JSON Streaming style APIs](../common/json-support.md#consuming-json-streaming-style-apis)
+documentation in the JSON support section.

--- a/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
@@ -33,7 +33,7 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
     //#formats
 
     //#response-streaming
-    
+
     // Step 1: Enable JSON streaming
     // we're not using this in the example, but it's the simplest way to start:
     // The default rendering is a JSON array: `[el, el, el , ...]`
@@ -43,9 +43,9 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
     final ByteString start = ByteString.fromString("[");
     final ByteString between = ByteString.fromString(",");
     final ByteString end = ByteString.fromString("]");
-    final Flow<ByteString, ByteString, NotUsed> compactArrayRendering = 
+    final Flow<ByteString, ByteString, NotUsed> compactArrayRendering =
       Flow.of(ByteString.class).intersperse(start, between, end);
-    
+
     final JsonEntityStreamingSupport compactJsonSupport = EntityStreamingSupport.json()
       .withFramingRendererFlow(compactArrayRendering);
 
@@ -56,7 +56,7 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
         parameter(StringUnmarshallers.INTEGER, "n", n -> {
           final Source<JavaTweet, NotUsed> tws =
             Source.repeat(new JavaTweet(12, "Hello World!")).take(n);
-          
+
           // Step 3: call complete* with your source, marshaller, and stream rendering mode
           return completeOKWithSource(tws, Jackson.marshaller(), compactJsonSupport);
         })
@@ -76,17 +76,17 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
             });
           }
         )
-      )  
+      )
     );
     //#incoming-request-streaming
-    
+
     return responseStreaming.orElse(incomingStreaming);
   }
-  
+
   final Route csvTweets() {
     //#csv-example
-    final Marshaller<JavaTweet, ByteString> renderAsCsv = 
-      Marshaller.withFixedContentType(ContentTypes.TEXT_CSV_UTF8, t -> 
+    final Marshaller<JavaTweet, ByteString> renderAsCsv =
+      Marshaller.withFixedContentType(ContentTypes.TEXT_CSV_UTF8, t ->
         ByteString.fromString(t.getId() + "," + t.getMessage())
       );
 
@@ -102,17 +102,39 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
       )
     );
     //#csv-example
-    
+
     return responseStreaming;
   }
   //#routes
-  
+
+  final void clientStreamingJsonExample() {
+    //#json-streaming-client-example-raw
+    Unmarshaller<ByteString, JavaTweet> unmarshal = Jackson.byteStringUnmarshaller(JavaTweet.class);
+    JsonEntityStreamingSupport support = EntityStreamingSupport.json();
+
+    // imagine receiving such response from a service:
+    String payload = "{\"uid\":1,\"txt\":\"#Akka rocks!\"}\n" +
+        "{\"uid\":2,\"txt\":\"Streaming is so hot right now!\"}\n" +
+        "{\"uid\":3,\"txt\":\"You cannot enter the same river twice.\"}";
+    HttpEntity.Strict entity = HttpEntities.create(ContentTypes.APPLICATION_JSON, payload);
+    HttpResponse response = HttpResponse.create().withEntity(entity);
+
+    Source<JavaTweet, Object> tweets =
+        response.entity().getDataBytes()
+        .via(support.framingDecoder()) // apply JSON framing
+        .mapAsync(1, // unmarshal each element
+            bs -> unmarshal.unmarshal(bs, materializer())
+        );
+
+    //#json-streaming-client-example-raw
+  }
+
   @Test
   public void getTweetsTest() {
     //#response-streaming
     // tests:
     final TestRoute routes = testRoute(tweets());
-    
+
     // test happy path
     final Accept acceptApplication = Accept.create(MediaRanges.create(MediaTypes.APPLICATION_JSON));
     routes.run(HttpRequest.GET("/tweets?n=2").addHeader(acceptApplication))
@@ -126,13 +148,13 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
       .assertEntity("Resource representation is only available with these types:\napplication/json");
     //#response-streaming
   }
-  
+
   @Test
   public void csvExampleTweetsTest() {
     //#response-streaming
     // tests --------------------------------------------
     final TestRoute routes = testRoute(csvTweets());
-    
+
     // test happy path
     final Accept acceptCsv = Accept.create(MediaRanges.create(MediaTypes.TEXT_CSV));
     routes.run(HttpRequest.GET("/tweets?n=2").addHeader(acceptCsv))
@@ -150,7 +172,7 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
 
   //#models
   private static final class JavaTweet {
-    private int id; 
+    private int id;
     private String message;
 
     public JavaTweet(int id, String message) {


### PR DESCRIPTION
It was pointed out on akka-user that we didn't document the client-side for consuming streaming JSON responses nicely; I added those docs.

`Re: [akka-user][deprecated] Akka Http and consuming a response of "application/stream+json" type`