### PR TITLE
Use new sbt-api-mappings plugin version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.1")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.1.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0") // for advanced PR validation features
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")


### PR DESCRIPTION
New version does not override apiMappings when they come from dependencies. So scaladoc links to akka classes now go to https://doc.akka.io/api/akka/2.5.11/ and links to java dependency (like typesafe-config) classes go to sonatype mirror.