### PR TITLE
make sure static method style works for AllDirectives

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/JavaRouteTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/JavaRouteTest.java
@@ -162,6 +162,13 @@ public class JavaRouteTest extends JUnitRouteTest {
   }
 
   @Test
+  public void allowUsingStaticMethodStyleForDirectives() {
+    Route route = AllDirectives.path("hello", () -> complete("world"));
+    runRoute(route, HttpRequest.GET("/hello"))
+      .assertEntity("world")
+  }
+
+  @Test
   public void requiredParamCauses404OnSealedRoute() {
     runRoute(route, HttpRequest.GET("/cookies"))
       .assertStatusCode(StatusCodes.NOT_FOUND)


### PR DESCRIPTION
Expected to fail, yet should work.
We need to fix this as we document this style as being an available one to use.

Reported in: https://discuss.lightbend.com/t/why-are-routing-directives-not-static-methods-in-java/757/3

Likely a problem on Scala 2.12 and static forwarders, which is weird since it is a class + companion so it should have worked