### PR TITLE
Support parameters for custom media types

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -42,7 +42,6 @@ private[http] class HeaderParser(
   import CharacterClasses._
 
   override def customMediaTypes = settings.customMediaTypes
-  override def areNoCustomMediaTypesDefined: Boolean = settings.areNoCustomMediaTypesDefined
 
   // http://www.rfc-editor.org/errata_search.php?rfc=7230 errata id 4189
   def `header-field-value`: Rule1[String] = rule {
@@ -190,7 +189,6 @@ private[http] object HeaderParser {
     def uriParsingMode: Uri.ParsingMode
     def cookieParsingMode: ParserSettings.CookieParsingMode
     def customMediaTypes: MediaTypes.FindCustom
-    def areNoCustomMediaTypesDefined: Boolean
     def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode
   }
   def Settings(
@@ -208,7 +206,6 @@ private[http] object HeaderParser {
       def uriParsingMode: Uri.ParsingMode = _uriParsingMode
       def cookieParsingMode: CookieParsingMode = _cookieParsingMode
       def customMediaTypes: MediaTypes.FindCustom = _customMediaTypes
-      def areNoCustomMediaTypesDefined: Boolean = _customMediaTypes eq ConstantFun.scalaAnyToNone
 
       def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode =
         _illegalResponseHeaderValueProcessingMode

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -54,9 +54,6 @@ private[akka] final case class ParserSettingsImpl(
     headerValueCacheLimits.getOrElse(headerName, defaultHeaderValueCacheLimit)
 
   override def productPrefix = "ParserSettings"
-
-  // optimization: if we see the default value as defined below, we know it hasn't been changed
-  override def areNoCustomMediaTypesDefined: Boolean = customMediaTypes eq ParserSettingsImpl.noCustomMediaTypes
 }
 
 object ParserSettingsImpl extends SettingsCompanion[ParserSettingsImpl]("akka.http.parsing") {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -286,6 +286,8 @@ object MediaType {
 }
 
 object MediaTypes extends ObjectRegistry[(String, String), MediaType] {
+
+  /** Function used to find a custom media type. Called before the predefined media types. Strings will be lowercase. */
   type FindCustom = (String, String) ⇒ Option[MediaType]
 
   private[this] var extensionMap = Map.empty[String, MediaType]


### PR DESCRIPTION
When a custom media type is matched we now add parameters. In particular this now means that users can support the `charset` parameter in custom media types.

This change will be used downstream in Play's Akka HTTP backend. Play will be able to override the `application/json` media type to support an explicit `charset` parameter instead of having an implicit, fixed `charset` of UTF-8. Allowing an explicit `charset` parameter will fix several Play bugs related to interop with other HTTP agents.

See:
- https://github.com/playframework/playframework/issues/8239
- https://github.com/playframework/play-ws/issues/150