### PR TITLE
Change the link of Scalariform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,7 +293,7 @@ Note, that `OK TO TEST` will only be picked up when the user asking for it is co
 
 ### Scala style 
 
-Akka-http uses [Scalariform](https://github.com/daniel-trinh/scalariform) to enforce some of the code style rules.
+Akka-http uses [Scalariform](https://github.com/scala-ide/scalariform) to enforce some of the code style rules.
 
 ### Java style
 
@@ -338,4 +338,4 @@ The cluster is made out of real bare-metal boxes, and maintained by the Akka tea
 
 * [Akka Contributor License Agreement](http://www.lightbend.com/contribute/cla)
 * [Akka HTTP Issue Tracker](https://github.com/akka/akka-http/issues)
-* [Scalariform](https://github.com/daniel-trinh/scalariform)
+* [Scalariform](https://github.com/scala-ide/scalariform)

--- a/docs/src/main/paradox/contributing.md
+++ b/docs/src/main/paradox/contributing.md
@@ -295,7 +295,7 @@ Note, that `OK TO TEST` will only be picked up when the user asking for it is co
 
 ### Scala style
 
-Akka-http uses [Scalariform](https://github.com/daniel-trinh/scalariform) to enforce some of the code style rules.
+Akka-http uses [Scalariform](https://github.com/scala-ide/scalariform) to enforce some of the code style rules.
 
 ### Java style
 
@@ -340,4 +340,4 @@ The cluster is made out of real bare-metal boxes, and maintained by the Akka tea
 
 * [Akka Contributor License Agreement](http://www.lightbend.com/contribute/cla)
 * [Akka HTTP Issue Tracker](https://github.com/akka/akka-http/issues)
-* [Scalariform](https://github.com/daniel-trinh/scalariform)
+* [Scalariform](https://github.com/scala-ide/scalariform)


### PR DESCRIPTION
Since Scalariform is already maintained by scala-ide, I changed to the new repository.