### PR TITLE
Add Java DSL optionMarshaller #1247

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -4,15 +4,15 @@
 
 package akka.http.javadsl.marshalling
 
-import java.util.{Optional, function}
+import java.util.{ Optional, function }
 
 import akka.annotation.InternalApi
 import akka.http.impl.util.JavaMapping
-import akka.http.javadsl.model.{ContentType, HttpHeader, HttpResponse, MediaType, RequestEntity, StatusCode}
+import akka.http.javadsl.model.{ ContentType, HttpHeader, HttpResponse, MediaType, RequestEntity, StatusCode }
 import akka.http.scaladsl
 import akka.http.scaladsl.marshalling
 import akka.http.scaladsl.marshalling._
-import akka.http.scaladsl.model.{FormData, HttpCharset, HttpEntity}
+import akka.http.scaladsl.model.{ FormData, HttpCharset }
 import akka.japi.Util
 import akka.util.ByteString
 

--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -57,6 +57,9 @@ object Marshaller {
   def byteStringMarshaller(t: ContentType): Marshaller[ByteString, RequestEntity] =
     fromScala(scaladsl.marshalling.Marshaller.byteStringMarshaller(t.asScala))
 
+  /**
+   * Marshals an Optional[A] to a RequestEntity an empty optional will yield an empty entity.
+   */
   def optionMarshaller[A](m: Marshaller[A, RequestEntity]): Marshaller[Optional[A], RequestEntity] = {
     val scalaMarshaller = m.asScalaCastOutput
     fromScala(marshalling.Marshaller.optionMarshaller(scalaMarshaller, EmptyValue.emptyEntity).compose(toOption))

--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -4,15 +4,15 @@
 
 package akka.http.javadsl.marshalling
 
-import java.util.function
+import java.util.{Optional, function}
 
 import akka.annotation.InternalApi
 import akka.http.impl.util.JavaMapping
-import akka.http.javadsl.model.{ ContentType, HttpHeader, HttpResponse, MediaType, RequestEntity, StatusCode }
+import akka.http.javadsl.model.{ContentType, HttpHeader, HttpResponse, MediaType, RequestEntity, StatusCode}
 import akka.http.scaladsl
 import akka.http.scaladsl.marshalling
 import akka.http.scaladsl.marshalling._
-import akka.http.scaladsl.model.{ FormData, HttpCharset }
+import akka.http.scaladsl.model.{FormData, HttpCharset, HttpEntity}
 import akka.japi.Util
 import akka.util.ByteString
 
@@ -25,6 +25,8 @@ object Marshaller {
   import JavaMapping.Implicits._
 
   def fromScala[A, B](scalaMarshaller: marshalling.Marshaller[A, B]): Marshaller[A, B] = new Marshaller()(scalaMarshaller)
+
+  def toOption[T](opt: Optional[T]): Option[T] = if (opt.isPresent) Some(opt.get()) else None
 
   /**
    * Safe downcasting of the output type of the marshaller to a superclass.
@@ -55,8 +57,13 @@ object Marshaller {
   def byteStringMarshaller(t: ContentType): Marshaller[ByteString, RequestEntity] =
     fromScala(scaladsl.marshalling.Marshaller.byteStringMarshaller(t.asScala))
 
-  // TODO make sure these are actually usable in a sane way
+  def optionMarshaller[A](m: Marshaller[A, RequestEntity]): Marshaller[Optional[A], RequestEntity] = {
+    val scalaMarshaller = m.asScalaCastOutput
+    fromScala(marshalling.Marshaller.optionMarshaller(scalaMarshaller, EmptyValue.emptyEntity).compose(toOption))
+  }
 
+
+  // TODO make sure these are actually usable in a sane way
   def wrapEntity[A, C](f: function.BiFunction[ExecutionContext, C, A], m: Marshaller[A, RequestEntity], mediaType: MediaType): Marshaller[C, RequestEntity] = {
     val scalaMarshaller = m.asScalaCastOutput
     fromScala(scalaMarshaller.wrapWithEC(mediaType.asScala) { ctx ⇒ c: C ⇒ f(ctx, c) }(ContentTypeOverrider.forEntity))

--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -62,7 +62,6 @@ object Marshaller {
     fromScala(marshalling.Marshaller.optionMarshaller(scalaMarshaller, EmptyValue.emptyEntity).compose(toOption))
   }
 
-
   // TODO make sure these are actually usable in a sane way
   def wrapEntity[A, C](f: function.BiFunction[ExecutionContext, C, A], m: Marshaller[A, RequestEntity], mediaType: MediaType): Marshaller[C, RequestEntity] = {
     val scalaMarshaller = m.asScalaCastOutput

--- a/docs/src/main/paradox/common/marshalling.md
+++ b/docs/src/main/paradox/common/marshalling.md
@@ -94,6 +94,7 @@ Specifically these are:
     * `char[]`
     * `String`
     * @unidoc[FormData]
+    * `Optional<T>` using an existing @unidoc[RequestEntity] marshaller for `T`. An empty optional will yield an empty entity.
  * Predefined @unidoc[HttpResponse] marshallers:
     * `T` using an existing @unidoc[RequestEntity] marshaller for `T`
     * `T` and @unidoc[StatusCode] using an existing @unidoc[RequestEntity] marshaller for `T`


### PR DESCRIPTION
Fixes #1247 by adding a `Marshaller<Optional<A>, RequestEntity>` that is usable from Java.