### PR TITLE
[+doc] Document entity discarding in default rejection handler

### DIFF
--- a/docs/src/main/paradox/release-notes/10.1.x.md
+++ b/docs/src/main/paradox/release-notes/10.1.x.md
@@ -1,5 +1,66 @@
 # 10.1.x Release Notes
 
+## 10.1.2
+
+10.1.2 is the thrid release in the 10.1.x series of Akka HTTP.
+
+#### Fixes in akka-http-core
+ * Default rejection handlers do now discard entity bytes when rejecting a request ([#38](https://github.com/akka/akka-http/issues/38))
+
+
+## 10.1.1
+
+See the [announcement](https://akka.io/blog/news/2018/03/27/akka-http-10.1.1-released.html) and
+closed tickets on the [10.1.1 milestone](https://github.com/akka/akka-http/milestone/36?closed=1).
+
+10.1.1 is the second release in the 10.1.x series of Akka HTTP.
+
+
+This release brings a number of small, yet long requested features, including: 
+
+ * automatic WebSocket keep-alive using `Ping` frames,
+ * removing the need for implicit parameters in order to call `Route.seal` (in Scala DSL)
+
+As usual, the release is backwards compatible as outlined in our [binary compatibility guidelines](https://doc.akka.io/docs/akka-http/current/compatibility-guidelines.html). 
+
+### **List of changes (since 10.1.0)**
+
+#### Fixes in akka-http-core
+
+ * Emit entity truncation errors before completing graph stage ([#1947](https://github.com/akka/akka-http/issues/1947))
+ * Fix type parameters in Java API to work with latest Akka ([#1965](https://github.com/akka/akka-http/issues/1965))
+
+#### Improvements in akka-http-core
+
+ * Transparent websocket ping/pong (keep alive) ([#1938](https://github.com/akka/akka-http/issues/1938))
+ * Fix a few Scala 2.13.0-M3 compilation issues ([#1918](https://github.com/akka/akka-http/issues/1918))
+ * Always parse Content-Encoding and WebSocket headers ([#1937](https://github.com/akka/akka-http/issues/1937))
+ * Support conversion between scaladsl.Uri and javadsl.Uri ([#1950](https://github.com/akka/akka-http/issues/1950))
+
+#### Improvements in akka-http
+
+ * Remove not needed implicits from Route.seal ([#1928](https://github.com/akka/akka-http/issues/1928))
+
+#### Improvements in akka-http-testkit
+
+ * Fix type parameter variance in Java API to work with latest Akka ([#1965](https://github.com/akka/akka-http/issues/1965))
+
+#### Improvements in documentation
+
+ * Document client-side for streaming JSON ([#1964](https://github.com/akka/akka-http/issues/1964))
+ * Add package name to `PathMatcher` javadsl docs ([#1933](https://github.com/akka/akka-http/issues/1933))
+ * Fix paradox error for discard entity bytes ([#1944](https://github.com/akka/akka-http/issues/1944))
+ * Minor correction in rejections.md ([#1924](https://github.com/akka/akka-http/issues/1924))
+ * Cache docs: more explicit imports, create cache once ([#1955](https://github.com/akka/akka-http/issues/1955))
+ * Better caching example for Java 
+
+#### Infrastructure and build fixes
+
+ * Fully remove OSGi support ([#1943](https://github.com/akka/akka-http/issues/1943))
+   * Which was already removed and discussed in 10.1.0
+    
+
+
 ## 10.1.0
 
 See the [announcement](https://akka.io/blog/news/2018/03/08/akka-http-10.1.0-released.html) and

--- a/docs/src/main/paradox/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/routing-dsl/rejections.md
@@ -40,6 +40,14 @@ The default `RejectionHandler` applied by the top-level glue code that turns a @
 @scala[(via `Route.handlerFlow` or `Route.asyncHandler`)]
 will handle *all* rejections that reach it.
 
+
+@@@ note
+Please note that since version `10.1.2`, the default `RejectionHandler` will also discard the entity bytes automatically. If you want to change this behavior,
+please refer to @ref[Customising rejection HTTP Responses](rejections.md#customising-rejections) if you want to change this behavior; however, might cause connections to stall 
+if the entity is not properly rejected or cancelled on the client side.
+@@@
+
+
 ## Rejection Cancellation
 
 As mentioned above, the `RejectionHandler` doesn't handle single rejections but a whole list of
@@ -121,6 +129,7 @@ itself.
 
 The second case allows you to restrict the applicability of your handler to certain branches of your route structure.
 
+<a id="customising-rejections"></a>
 ### Customising rejection HTTP Responses
 
 It is also possible to customise just the responses that are returned by a defined rejection handler.


### PR DESCRIPTION
Document that default `RejectionHandler` is not discarding the entity.
Also added release notes for version 10.1.1 that were missing (oops!)