### PR TITLE
Allow h2 SETTINGS with large max header table size

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -73,7 +73,10 @@ private[http2] object HeaderCompression extends GraphStage[FlowShape[FrameEvent,
         s foreach {
           case Setting(SettingIdentifier.SETTINGS_HEADER_TABLE_SIZE, size) ⇒
             log.debug("Applied SETTINGS_HEADER_TABLE_SIZE({}) in header compression", size)
-            encoder.setMaxHeaderTableSize(os, size)
+            // 'size' is strictly spoken unsigned, but the encoder is allowed to
+            // pick any size equal to or less than this value (6.5.2)
+            if (size >= 0) encoder.setMaxHeaderTableSize(os, size)
+            else encoder.setMaxHeaderTableSize(os, Int.MaxValue)
           case _ ⇒ // ignore, not applicable to this stage
         }
     }


### PR DESCRIPTION
We don't actually pick such large header table sizes, but now don't
crash when we're allowed one anymore either. Fixes the h2spec TCK
tests for section 6.5.