### PR TITLE
Backport: Fix type parameters in Java API to work with latest Akka #1965

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Multiparts.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Multiparts.java
@@ -31,7 +31,7 @@ public final class Multiparts {
      * Constructor for `multipart/form-data` content as defined in http://tools.ietf.org/html/rfc2388.
      * All parts must have distinct names. (This is not verified!)
      */
-    public static Multipart.FormData createFormDataFromSourceParts(Source<Multipart.FormData.BodyPart, Object> parts) {
+    public static Multipart.FormData createFormDataFromSourceParts(Source<Multipart.FormData.BodyPart, ? extends Object> parts) {
         return akka.http.scaladsl.model.Multipart.FormData$.MODULE$.createSource(parts.asScala());
     }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -291,7 +291,7 @@ object Multipart {
 
       /** Java API */
       override def getParts: JSource[jm.Multipart.General.BodyPart.Strict, AnyRef] =
-        super.getParts.asInstanceOf[JSource[_ <: jm.Multipart.General.BodyPart.Strict, AnyRef]]
+        super.getParts.asInstanceOf[JSource[jm.Multipart.General.BodyPart.Strict, AnyRef]]
 
       /** Java API */
       override def getStrictParts: java.lang.Iterable[jm.Multipart.General.BodyPart.Strict] =
@@ -396,7 +396,7 @@ object Multipart {
     }
     /** INTERNAL API */
     @InternalApi
-    private[akka] def createSource(parts: Source[akka.http.javadsl.model.Multipart.FormData.BodyPart, Any]): Multipart.FormData = {
+    private[akka] def createSource(parts: Source[akka.http.javadsl.model.Multipart.FormData.BodyPart, _]): Multipart.FormData = {
       apply(parts.asInstanceOf[Source[Multipart.FormData.BodyPart, Any]])
     }
 

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/WSProbe.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/WSProbe.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration._
  */
 class WSProbe(delegate: st.WSProbe) {
 
-  def flow: Flow[Message, Message, Any] = {
+  def flow: Flow[Message, Message, NotUsed] = {
     val underlying = scaladsl.Flow[Message].map(_.asScala).via(delegate.flow).map(_.asJava)
     new Flow[Message, Message, NotUsed](underlying)
   }

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/WSTestRequestBuilding.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/WSTestRequestBuilding.scala
@@ -17,13 +17,13 @@ import akka.stream.{ Materializer, scaladsl }
 
 trait WSTestRequestBuilding {
 
-  def WS(uri: Uri, clientSideHandler: Flow[Message, Message, Any], materializer: Materializer): HttpRequest = {
+  def WS[T](uri: Uri, clientSideHandler: Flow[Message, Message, T], materializer: Materializer): HttpRequest = {
     WS(uri, clientSideHandler, materializer, java.util.Collections.emptyList())
   }
 
-  def WS(
+  def WS[T](
     uri:               Uri,
-    clientSideHandler: Flow[Message, Message, Any],
+    clientSideHandler: Flow[Message, Message, T],
     materializer:      Materializer,
     subprotocols:      java.util.List[String]): HttpRequest = {
 


### PR DESCRIPTION
Backport, refs #1952