### PR TITLE
More descriptive error message for actorSystem

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
@@ -31,7 +31,7 @@ package object util {
     refFactory match {
       case x: ActorContext        ⇒ actorSystem(x.system)
       case x: ExtendedActorSystem ⇒ x
-      case _                      ⇒ throw new IllegalStateException
+      case x                      ⇒ throw new IllegalStateException(s"Unknown factory $x")
     }
 
   private[http] implicit def enhanceByteArray(array: Array[Byte]): EnhancedByteArray = new EnhancedByteArray(array)


### PR DESCRIPTION
When using `Route.seal` on a route, I get the following exception

```
[error] Exception in thread "main" java.lang.ExceptionInInitializerError
[error] 	at sbux.ucp.canary.Main$.main(Main.scala:42)
[error] 	at sbux.ucp.canary.Main.main(Main.scala)
[error] Caused by: java.lang.IllegalStateException
[error] 	at akka.http.impl.util.package$.actorSystem(package.scala:34)
[error] 	at akka.http.scaladsl.settings.SettingsCompanion.default(SettingsCompanion.scala:20)
[error] 	at akka.http.scaladsl.settings.SettingsCompanion.default$(SettingsCompanion.scala:20)
[error] 	at akka.http.scaladsl.settings.RoutingSettings$.default(RoutingSettings.scala:42)
[error] 	... 2 more
```

This isn't great, because it doesn't tell me what object was picked up as an actorRef factory.  Adding in the object in the argument.