### PR TITLE
Fix scheme validation logic to apply rule from start instead of end

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -765,10 +765,10 @@ object Uri {
     else sb.toString
 
   private[http] def normalizeScheme(scheme: String): String = {
-    @tailrec def verify(ix: Int = scheme.length - 1, allowed: CharPredicate = ALPHA, allLower: Boolean = true): Int =
-      if (ix >= 0) {
+    @tailrec def verify(ix: Int = 0, allowed: CharPredicate = ALPHA, allLower: Boolean = true): Int =
+      if (ix < scheme.length) {
         val c = scheme.charAt(ix)
-        if (allowed(c)) verify(ix - 1, `scheme-char`, allLower && !UPPER_ALPHA(c)) else ix
+        if (allowed(c)) verify(ix + 1, `scheme-char`, allLower && !UPPER_ALPHA(c)) else ix
       } else if (allLower) -1 else -2
     verify() match {
       case -2 ⇒ scheme.toLowerCase

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -468,6 +468,9 @@ class UriSpec extends WordSpec with Matchers {
       Uri("tel:+1-816-555-1212") shouldEqual
         Uri.from(scheme = "tel", path = "+1-816-555-1212")
 
+      Uri("s3:image.png") shouldEqual
+        Uri.from(scheme = "s3", path = "image.png")
+
       Uri("telnet://192.0.2.16:80/") shouldEqual
         Uri.from(scheme = "telnet", host = "192.0.2.16", port = 80, path = "/")
 


### PR DESCRIPTION
`Uri.normalizeScheme` applies the rule to check for. first letter to be alpha from last instead of start. Change that to apply rule from start

Fixes #2080