### PR TITLE
Add realm to provided credentials

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
@@ -23,11 +23,16 @@ object SecurityDirectives {
   /**
    * Represents HTTP Basic or OAuth2 authentication credentials supplied with a request.
    */
-  case class ProvidedCredentials(private val asScala: scaladsl.server.directives.Credentials.Provided) {
+  case class ProvidedCredentials(private val asScala: scaladsl.server.directives.Credentials.Provided.InRealm) {
     /**
      * The username or token provided with the credentials
      */
     def identifier: String = asScala.identifier
+
+    /**
+     * The realm to evaluate the provided credentials in
+     */
+    def realm: String = asScala.realm
 
     /**
      * Safely compares the passed in `secret` with the received secret part of the Credentials.
@@ -39,7 +44,7 @@ object SecurityDirectives {
   }
 
   private def toJava(cred: scaladsl.server.directives.Credentials): Optional[ProvidedCredentials] = cred match {
-    case provided: scaladsl.server.directives.Credentials.Provided ⇒ Optional.of(ProvidedCredentials(provided))
+    case provided: scaladsl.server.directives.Credentials.Provided.InRealm ⇒ Optional.of(ProvidedCredentials(provided))
     case _ ⇒ Optional.empty()
   }
 }

--- a/docs/src/main/paradox/routing-dsl/directives/security-directives/index.md
+++ b/docs/src/main/paradox/routing-dsl/directives/security-directives/index.md
@@ -65,5 +65,5 @@ checking the secret (password) would be a regular string comparison, but doing t
 timing attacks. See for example [Timing Attacks Explained](http://emerose.com/timing-attacks-explained) for an explanation of the problem.
 
 To protect users of the library from that mistake the secret is not available through the API, instead the method
-`Credentials.Provided.verify(String)` should be used. It does a constant time comparison rather than returning early
+`Credentials.ProvidedInRealm.verify(String)` should be used. It does a constant time comparison rather than returning early
 upon finding the first non-equal character.


### PR DESCRIPTION
This enables authenticators to access both the realm and 
identifier used for authentication.

For extracting only the identifier like before this change, 
an extractor is provided using the previous name (`Provided`).