### PR TITLE
Correct object structure in cUrl

### DIFF
--- a/docs/src/main/paradox/introduction.md
+++ b/docs/src/main/paradox/introduction.md
@@ -134,7 +134,7 @@ Scala
 Java
 :   @@snip [JacksonExampleTest.java]($test$/java/docs/http/javadsl/JacksonExampleTest.java) { #second-jackson-example }
 
-When you run this server, you can update the inventory via `curl -H "Content-Type: application/json" -X POST -d '{"name":"hhgtg","id":42}' http://localhost:8080/create-order` on your terminal - adding an item named `"hhgtg"` and having an `id=42`; and then view the inventory either in a browser, at a url like: [http://localhost:8080/item/42](http://localhost:8080/item/42) - or on the terminal,
+When you run this server, you can update the inventory via `curl -H "Content-Type: application/json" -X POST -d '{"items": [{"name":"hhgtg","id":42}]}' http://localhost:8080/create-order` on your terminal - adding an item named `"hhgtg"` and having an `id=42`; and then view the inventory either in a browser, at a url like: [http://localhost:8080/item/42](http://localhost:8080/item/42) - or on the terminal,
 via `curl http://localhost:8080/item/42`.
 
 The logic for the marshalling and unmarshalling JSON in this example is provided by the @scala["spray-json"]@java["Jackson"] library


### PR DESCRIPTION
Order has the array items as a property, so it must be specified as array on JSON which contains one item with id 42.