### PR TITLE
make route concatentation lazy and save some allocations

### DIFF
--- a/akka-http/src/main/mima-filters/10.1.3.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.1.3.backwards.excludes
@@ -2,3 +2,12 @@
 
 # Removal of deprecated methods in 10.0.1 and 10.0.2
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.server.Route.asScala")
+
+# Make RouteWithConcatentation a value class
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.server.RouteConcatenation._enhanceRouteWithConcatenation")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.server.Directives._enhanceRouteWithConcatenation")
+ProblemFilters.exclude[FinalClassProblem]("akka.http.scaladsl.server.RouteConcatenation$RouteWithConcatenation")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.server.HttpApp._enhanceRouteWithConcatenation")
+
+# Change argument of "~" method to be a by name argument
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.scaladsl.server.RouteConcatenation#RouteWithConcatenation.~")

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteConcatenation.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteConcatenation.scala
@@ -34,12 +34,12 @@ trait RouteConcatenation {
 
 object RouteConcatenation extends RouteConcatenation {
 
-  class RouteWithConcatenation(route: Route) {
+  class RouteWithConcatenation(val route: Route) extends AnyVal {
     /**
      * Returns a Route that chains two Routes. If the first Route rejects the request the second route is given a
      * chance to act upon the request.
      */
-    def ~(other: Route): Route = { ctx ⇒
+    def ~(other: ⇒ Route): Route = { ctx ⇒
       import ctx.executionContext
       route(ctx).fast.flatMap {
         case x: RouteResult.Complete ⇒ FastFuture.successful(x)


### PR DESCRIPTION
This pull request is a follow up on the proposal [Route concatenation operator should use value class and possibly be by name in its second argument](https://discuss.lightbend.com/t/route-concatenation-operator-should-use-value-class-and-possibly-be-by-name-in-its-second-argument/1540).
It makes two slight modifications to the `RouteWithConcatenation` class that provides the `~` extension method to routes:

1. The first modification makes `RouteWithConcatenation` a value class.
1. The second modification makes the argument to the `~` method a by-name argument.

Both modifications require binary compatibility exception rules.