### PR TITLE
Implement HSTS header support conform spec #2122

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -202,7 +202,7 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
           | ignoreCase("max-age=") ~ `delta-seconds` ~> (MaxAge(_))
       )
     def ignoredDirective = rule {
-      token ~ optional(ws("=") ~ word) ~> ((k: String, v: Option[String]) => IgnoredDirective(k + v.getOrElse("")))
+      token ~ optional(ws("=") ~ word) ~> ((k: String, v: Option[String]) ⇒ IgnoredDirective(k + v.getOrElse("")))
     }
 
     rule {

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -194,8 +194,18 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
   // http://tools.ietf.org/html/rfc7231#section-7.4.2
   def server = rule { products ~ EOI ~> (Server(_)) }
 
-  def `strict-transport-security` = rule {
-    ignoreCase("max-age=") ~ `delta-seconds` ~ optional(ws(";") ~ ignoreCase("includesubdomains") ~ push(true)) ~ zeroOrMore(ws(";") ~ token0) ~ EOI ~> (`Strict-Transport-Security`(_, _))
+  // https://tools.ietf.org/html/rfc6797#section-6
+  def `strict-transport-security` = {
+    def directives =
+      rule(
+        ignoreCase("includesubdomains") ~ push(IncludeSubDomains)
+          | ignoreCase("max-age=") ~ `delta-seconds` ~> (MaxAge(_))
+          | word ~> (IgnoredDirective(_))
+      )
+
+    rule {
+      oneOrMore(directives).separatedBy(oneOrMore(ws(";"))) ~ zeroOrMore(ws(";")) ~ EOI ~> (`Strict-Transport-Security`(_: _*))
+    }
   }
 
   // http://tools.ietf.org/html/rfc7230#section-3.3.1

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -206,7 +206,8 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
     }
 
     rule {
-      oneOrMore(directives | ignoredDirective).separatedBy(oneOrMore(ws(";"))) ~ zeroOrMore(ws(";")) ~ EOI ~> (`Strict-Transport-Security`(_: _*))
+      oneOrMore(directives | ignoredDirective).separatedBy(oneOrMore(ws(";"))) ~ zeroOrMore(ws(";")) ~ EOI ~>
+        (`Strict-Transport-Security`.fromDirectives(_: _*))
     }
   }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -200,11 +200,13 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
       rule(
         ignoreCase("includesubdomains") ~ push(IncludeSubDomains)
           | ignoreCase("max-age=") ~ `delta-seconds` ~> (MaxAge(_))
-          | word ~> (IgnoredDirective(_))
       )
+    def ignoredDirective = rule {
+      token ~ optional(ws("=") ~ word) ~> ((k: String, v: Option[String]) => IgnoredDirective(k + v.getOrElse("")))
+    }
 
     rule {
-      oneOrMore(directives).separatedBy(oneOrMore(ws(";"))) ~ zeroOrMore(ws(";")) ~ EOI ~> (`Strict-Transport-Security`(_: _*))
+      oneOrMore(directives | ignoredDirective).separatedBy(oneOrMore(ws(";"))) ~ zeroOrMore(ws(";")) ~ EOI ~> (`Strict-Transport-Security`(_: _*))
     }
   }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.scaladsl.model.headers
 
 sealed abstract class StrictTransportSecurityDirective

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
@@ -5,6 +5,6 @@
 package akka.http.scaladsl.model.headers
 
 sealed abstract class StrictTransportSecurityDirective
-case class IgnoredDirective(value: String) extends StrictTransportSecurityDirective
+final case class IgnoredDirective(value: String) extends StrictTransportSecurityDirective
 case object IncludeSubDomains extends StrictTransportSecurityDirective
-case class MaxAge(value: Long) extends StrictTransportSecurityDirective
+final case class MaxAge(value: Long) extends StrictTransportSecurityDirective

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
@@ -1,0 +1,6 @@
+package akka.http.scaladsl.model.headers
+
+sealed abstract class StrictTransportSecurityDirective
+case class IgnoredDirective(value: String) extends StrictTransportSecurityDirective
+case object IncludeSubDomains extends StrictTransportSecurityDirective
+case class MaxAge(value: Long) extends StrictTransportSecurityDirective

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/StrictTransportSecurityDirective.scala
@@ -4,6 +4,10 @@
 
 package akka.http.scaladsl.model.headers
 
+import akka.annotation.DoNotInherit
+
+/** Not for user extension */
+@DoNotInherit
 sealed abstract class StrictTransportSecurityDirective
 final case class IgnoredDirective(value: String) extends StrictTransportSecurityDirective
 case object IncludeSubDomains extends StrictTransportSecurityDirective

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -863,14 +863,16 @@ final case class Server(products: immutable.Seq[ProductVersion]) extends jm.head
 
 // https://tools.ietf.org/html/rfc6797
 object `Strict-Transport-Security` extends ModeledCompanion[`Strict-Transport-Security`] {
-  def apply(directives: StrictTransportSecurityDirective*) = {
+  def apply(maxAge: Long, includeSubDomains: Option[Boolean]) = new `Strict-Transport-Security`(maxAge, includeSubDomains.getOrElse(false))
+
+  def fromDirectives(directives: StrictTransportSecurityDirective*) = {
     val maxAgeDirectives = directives.filter(_.isInstanceOf[MaxAge])
     require(maxAgeDirectives.size == 1, "exactly one 'max-age' directive required")
 
     val includeSubDomainsDirectives = directives.filter(_.equals(IncludeSubDomains))
     require(includeSubDomainsDirectives.size <= 1, "at most one 'includeSubDomains' directive allowed")
 
-    new `Strict-Transport-Security`(maxAgeDirectives.head.asInstanceOf[MaxAge].value, !includeSubDomainsDirectives.isEmpty)
+    new `Strict-Transport-Security`(maxAgeDirectives.head.asInstanceOf[MaxAge].value, includeSubDomainsDirectives.nonEmpty)
   }
 }
 final case class `Strict-Transport-Security`(maxAge: Long, includeSubDomains: Boolean = false) extends jm.headers.StrictTransportSecurity with ResponseHeader {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -867,10 +867,10 @@ object `Strict-Transport-Security` extends ModeledCompanion[`Strict-Transport-Se
 
   def fromDirectives(directives: StrictTransportSecurityDirective*) = {
     val maxAgeDirectives = directives.filter(_.isInstanceOf[MaxAge])
-    require(maxAgeDirectives.size == 1, "exactly one 'max-age' directive required")
+    if (maxAgeDirectives.size != 1) throw new IllegalArgumentException("exactly one 'max-age' directive required")
 
     val includeSubDomainsDirectives = directives.filter(_.equals(IncludeSubDomains))
-    require(includeSubDomainsDirectives.size <= 1, "at most one 'includeSubDomains' directive allowed")
+    if (includeSubDomainsDirectives.size > 1) throw new IllegalArgumentException("at most one 'includeSubDomains' directive allowed")
 
     new `Strict-Transport-Security`(maxAgeDirectives.head.asInstanceOf[MaxAge].value, includeSubDomainsDirectives.nonEmpty)
   }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -865,14 +865,15 @@ final case class Server(products: immutable.Seq[ProductVersion]) extends jm.head
 object `Strict-Transport-Security` extends ModeledCompanion[`Strict-Transport-Security`] {
   def apply(maxAge: Long, includeSubDomains: Option[Boolean]) = new `Strict-Transport-Security`(maxAge, includeSubDomains.getOrElse(false))
 
+  private val maxAges: PartialFunction[StrictTransportSecurityDirective, MaxAge] = { case m: MaxAge ⇒ m }
   def fromDirectives(directives: StrictTransportSecurityDirective*) = {
-    val maxAgeDirectives = directives.filter(_.isInstanceOf[MaxAge])
+    val maxAgeDirectives = directives.collect(maxAges)
     if (maxAgeDirectives.size != 1) throw new IllegalArgumentException("exactly one 'max-age' directive required")
 
     val includeSubDomainsDirectives = directives.filter(_.equals(IncludeSubDomains))
     if (includeSubDomainsDirectives.size > 1) throw new IllegalArgumentException("at most one 'includeSubDomains' directive allowed")
 
-    new `Strict-Transport-Security`(maxAgeDirectives.head.asInstanceOf[MaxAge].value, includeSubDomainsDirectives.nonEmpty)
+    new `Strict-Transport-Security`(maxAgeDirectives.head.value, includeSubDomainsDirectives.nonEmpty)
   }
 }
 final case class `Strict-Transport-Security`(maxAge: Long, includeSubDomains: Boolean = false) extends jm.headers.StrictTransportSecurity with ResponseHeader {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -865,11 +865,10 @@ final case class Server(products: immutable.Seq[ProductVersion]) extends jm.head
 object `Strict-Transport-Security` extends ModeledCompanion[`Strict-Transport-Security`] {
   def apply(directives: StrictTransportSecurityDirective*) = {
     val maxAgeDirectives = directives.filter(_.isInstanceOf[MaxAge])
-    if (maxAgeDirectives.size == 0) throw new IllegalArgumentException("Missing 'max-age' directive!")
-    else if (maxAgeDirectives.size > 1) throw new IllegalArgumentException("Too many 'max-age' directives!")
+    require(maxAgeDirectives.size == 1, "exactly one 'max-age' directive required")
 
     val includeSubDomainsDirectives = directives.filter(_.equals(IncludeSubDomains))
-    if (includeSubDomainsDirectives.size > 1) throw new IllegalArgumentException("Too many 'includeSubDomains' directives!")
+    require(includeSubDomainsDirectives.size <= 1, "at most one 'includeSubDomains' directive allowed")
 
     new `Strict-Transport-Security`(maxAgeDirectives.head.asInstanceOf[MaxAge].value, !includeSubDomainsDirectives.isEmpty)
   }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -866,14 +866,15 @@ object `Strict-Transport-Security` extends ModeledCompanion[`Strict-Transport-Se
   def apply(maxAge: Long, includeSubDomains: Option[Boolean]) = new `Strict-Transport-Security`(maxAge, includeSubDomains.getOrElse(false))
 
   private val maxAges: PartialFunction[StrictTransportSecurityDirective, MaxAge] = { case m: MaxAge ⇒ m }
+  private val isIncludeSubDomains: StrictTransportSecurityDirective ⇒ Boolean = { _ eq IncludeSubDomains }
   def fromDirectives(directives: StrictTransportSecurityDirective*) = {
     val maxAgeDirectives = directives.collect(maxAges)
     if (maxAgeDirectives.size != 1) throw new IllegalArgumentException("exactly one 'max-age' directive required")
 
-    val includeSubDomainsDirectives = directives.filter(_.equals(IncludeSubDomains))
-    if (includeSubDomainsDirectives.size > 1) throw new IllegalArgumentException("at most one 'includeSubDomains' directive allowed")
+    val includeSubDomainsDirectivesCount = directives.count(isIncludeSubDomains)
+    if (includeSubDomainsDirectivesCount > 1) throw new IllegalArgumentException("at most one 'includeSubDomains' directive allowed")
 
-    new `Strict-Transport-Security`(maxAgeDirectives.head.value, includeSubDomainsDirectives.nonEmpty)
+    new `Strict-Transport-Security`(maxAgeDirectives.head.value, includeSubDomainsDirectivesCount == 1)
   }
 }
 final case class `Strict-Transport-Security`(maxAge: Long, includeSubDomains: Boolean = false) extends jm.headers.StrictTransportSecurity with ResponseHeader {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -187,7 +187,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
           |""" should parseTo(HttpRequest(
           GET,
           "/hsts",
-          headers = List(Host("x"), `Strict-Transport-Security`(1, None)),
+          headers = List(Host("x"), `Strict-Transport-Security`(MaxAge(1))),
           protocol = `HTTP/1.1`))
 
         """GET /hsts HTTP/1.1
@@ -197,7 +197,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
           |""" should parseTo(HttpRequest(
           GET,
           "/hsts",
-          headers = List(Host("x"), `Strict-Transport-Security`(1, None)),
+          headers = List(Host("x"), `Strict-Transport-Security`(MaxAge(1))),
           protocol = `HTTP/1.1`))
       }
     }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -187,7 +187,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
           |""" should parseTo(HttpRequest(
           GET,
           "/hsts",
-          headers = List(Host("x"), `Strict-Transport-Security`(MaxAge(1))),
+          headers = List(Host("x"), `Strict-Transport-Security`(1, None)),
           protocol = `HTTP/1.1`))
 
         """GET /hsts HTTP/1.1
@@ -197,7 +197,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
           |""" should parseTo(HttpRequest(
           GET,
           "/hsts",
-          headers = List(Host("x"), `Strict-Transport-Security`(MaxAge(1))),
+          headers = List(Host("x"), `Strict-Transport-Security`(1, None)),
           protocol = `HTTP/1.1`))
       }
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -84,18 +84,34 @@ class HeaderSpec extends FreeSpec with Matchers {
   "Strict-Transport-Security should" - {
     "provide parseFromValueString method" - {
       "successful parse run" in {
+        headers.`Strict-Transport-Security`.parseFromValueString("max-age=30") shouldEqual Right(headers.`Strict-Transport-Security`(30, false))
         headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains") shouldEqual Right(headers.`Strict-Transport-Security`(30, true))
-        headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; preload") shouldEqual Right(headers.`Strict-Transport-Security`(30, true))
+        headers.`Strict-Transport-Security`.parseFromValueString("includeSubDomains; max-age=30") shouldEqual Right(headers.`Strict-Transport-Security`(30, true))
       }
-      "successful parse run with additional values" in {
+      "successful parse run with ignored directives" in {
         headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; preload; dummy") shouldEqual
           Right(headers.`Strict-Transport-Security`(30, true))
         headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; dummy; preload") shouldEqual
           Right(headers.`Strict-Transport-Security`(30, true))
       }
-      "failing parse run" in {
-        val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; preload;")
-        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security': Invalid input 'EOI', expected OWS or token0 (line 1, column 40)"
+      "successful parse run with trailing semicolons" in {
+        headers.`Strict-Transport-Security`.parseFromValueString("max-age=30;") shouldEqual Right(headers.`Strict-Transport-Security`(30, false))
+        headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains;;;") shouldEqual Right(headers.`Strict-Transport-Security`(30, true))
+      }
+      "failing parse run because of missing max-age directive" in {
+        val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("includeSubDomains")
+        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security'"
+        detail shouldEqual "Missing 'max-age' directive!"
+      }
+      "failing parse run because of too many max-age directives" in {
+        val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("max-age=30; max-age=30")
+        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security'"
+        detail shouldEqual "Too many 'max-age' directives!"
+      }
+      "failing parse run because of too many includeSubDomains directives" in {
+        val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; includeSubDomains")
+        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security'"
+        detail shouldEqual "Too many 'includeSubDomains' directives!"
       }
     }
   }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -100,17 +100,17 @@ class HeaderSpec extends FreeSpec with Matchers {
       }
       "failing parse run because of missing max-age directive" in {
         val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("includeSubDomains")
-        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security': requirement failed"
+        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security'"
         detail shouldEqual "exactly one 'max-age' directive required"
       }
       "failing parse run because of too many max-age directives" in {
         val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("max-age=30; max-age=30")
-        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security': requirement failed"
+        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security'"
         detail shouldEqual "exactly one 'max-age' directive required"
       }
       "failing parse run because of too many includeSubDomains directives" in {
         val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; includeSubDomains")
-        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security': requirement failed"
+        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security'"
         detail shouldEqual "at most one 'includeSubDomains' directive allowed"
       }
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -100,18 +100,18 @@ class HeaderSpec extends FreeSpec with Matchers {
       }
       "failing parse run because of missing max-age directive" in {
         val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("includeSubDomains")
-        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security'"
-        detail shouldEqual "Missing 'max-age' directive!"
+        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security': requirement failed"
+        detail shouldEqual "exactly one 'max-age' directive required"
       }
       "failing parse run because of too many max-age directives" in {
         val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("max-age=30; max-age=30")
-        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security'"
-        detail shouldEqual "Too many 'max-age' directives!"
+        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security': requirement failed"
+        detail shouldEqual "exactly one 'max-age' directive required"
       }
       "failing parse run because of too many includeSubDomains directives" in {
         val Left(List(ErrorInfo(summary, detail))) = `Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; includeSubDomains")
-        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security'"
-        detail shouldEqual "Too many 'includeSubDomains' directives!"
+        summary shouldEqual "Illegal HTTP header 'Strict-Transport-Security': requirement failed"
+        detail shouldEqual "at most one 'includeSubDomains' directive allowed"
       }
     }
   }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -91,7 +91,7 @@ class HeaderSpec extends FreeSpec with Matchers {
       "successful parse run with ignored directives" in {
         headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; preload; dummy") shouldEqual
           Right(headers.`Strict-Transport-Security`(30, true))
-        headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; dummy; preload") shouldEqual
+        headers.`Strict-Transport-Security`.parseFromValueString("max-age=30; includeSubDomains; foo=bar; preload") shouldEqual
           Right(headers.`Strict-Transport-Security`(30, true))
       }
       "successful parse run with trailing semicolons" in {


### PR DESCRIPTION
Fixes issue [#2122](https://github.com/akka/akka-http/issues/2122) so that HSTS header support is conform spec. Specifically:
- Trailing semicolons are allowed.
- Order of directives is not important.
- 'max-age' directive must occur exactly once.
- 'includeSubDomains' directive may not occur more than once.