### PR TITLE
doc - move the "measurement" stuff to the section where it is explained in detail

### DIFF
--- a/docs/src/main/paradox/routing-dsl/source-streaming-support.md
+++ b/docs/src/main/paradox/routing-dsl/source-streaming-support.md
@@ -135,10 +135,10 @@ back pressure to the underlying TCP connection should the server be unable to co
 is automatically applied thanks to @extref[Akka Streams](akka-docs:scala/stream/index.html).
 
 Scala
-:   @@snip [JsonStreamingExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala) { #measurement-format }
+:   @@snip [JsonStreamingExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala) { #measurement-model #measurement-format }
 
 Java
-:   @@snip [JsonStreamingExamplesTest.java]($test$/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java) { #measurement-format }
+:   @@snip [JsonStreamingExamplesTest.java]($test$/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java) { #measurement-model #measurement-format }
 
 
 Scala

--- a/docs/src/main/paradox/routing-dsl/source-streaming-support.md
+++ b/docs/src/main/paradox/routing-dsl/source-streaming-support.md
@@ -17,26 +17,23 @@ objects as a continuous HTTP request or response. The elements are most often se
 however do not have to be. Concatenating elements side-by-side or emitting "very long" JSON array is also another
 use case.
 
-In the below examples, we'll be referring to the `Tweet` and `Measurement` case classes as our model, which are defined as:
+In the below examples, we'll be referring to the `Tweet` case class as our model, which is defined as:
 
 Scala
-:   @@snip [JsonStreamingExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala) { #models }
+:   @@snip [JsonStreamingExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala) { #tweet-model }
 
 Java
-:   @@snip [JsonStreamingExamplesTest.java]($test$/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java) { #models }
+:   @@snip [JsonStreamingExamplesTest.java]($test$/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java) { #tweet-model }
 
 @@@ div { .group-scala }
 
 And as always with `spray-json`, we provide our marshaller and unmarshaller instances as implicit values using the `jsonFormat##`
 method to generate them statically:
 
-@@@
-
 Scala
-:   @@snip [JsonStreamingExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala) { #formats }
+:   @@snip [JsonStreamingExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala) { #tweet-format }
 
-Java
-:   @@snip [JsonStreamingExamplesTest.java]($test$/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java) { #formats }
+@@@
 
 ## Responding with JSON Streams
 
@@ -138,10 +135,18 @@ back pressure to the underlying TCP connection should the server be unable to co
 is automatically applied thanks to @extref[Akka Streams](akka-docs:scala/stream/index.html).
 
 Scala
+:   @@snip [JsonStreamingExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala) { #measurement-format }
+
+Java
+:   @@snip [JsonStreamingExamplesTest.java]($test$/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java) { #measurement-format }
+
+
+Scala
 :   @@snip [JsonStreamingExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala) { #spray-json-request-streaming }
 
 Java
 :   @@snip [JsonStreamingExamplesTest.java]($test$/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java) { #incoming-request-streaming }
+
 
 ## Simple CSV streaming example
 

--- a/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
@@ -49,10 +49,6 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
 
   //#routes
   final Route tweets() {
-    //#formats
-    final Unmarshaller<ByteString, JavaTweet> JavaTweets = Jackson.byteStringUnmarshaller(JavaTweet.class);
-    //#formats
-
     //#response-streaming
 
     // Step 1: Enable JSON streaming
@@ -84,16 +80,23 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
       )
     );
     //#response-streaming
+    return responseStreaming;
+  }
+
+  final Route measurements() {
+    //#measurement-format
+    final Unmarshaller<ByteString, Measurement> Measurements = Jackson.byteStringUnmarshaller(Measurement.class);
+    //#measurement-format
 
     //#incoming-request-streaming
-    final Route incomingStreaming = path("tweets", () ->
+    final Route incomingStreaming = path("metrics", () ->
       post(() ->
         extractMaterializer(mat -> {
-          final JsonEntityStreamingSupport jsonSupport = EntityStreamingSupport.json();
+            final JsonEntityStreamingSupport jsonSupport = EntityStreamingSupport.json();
 
-          return entityAsSourceOf(JavaTweets, jsonSupport, sourceOfTweets -> {
-              final CompletionStage<Integer> tweetsCount = sourceOfTweets.runFold(0, (acc, tweet) -> acc + 1, mat);
-              return onComplete(tweetsCount, c -> complete("Total number of tweets: " + c));
+            return entityAsSourceOf(Measurements, jsonSupport, sourceOfMeasurements -> {
+              final CompletionStage<Integer> measurementCount = sourceOfMeasurements.runFold(0, (acc, measurement) -> acc + 1, mat);
+              return onComplete(measurementCount, c -> complete("Total number of measurements: " + c));
             });
           }
         )
@@ -101,7 +104,7 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
     );
     //#incoming-request-streaming
 
-    return responseStreaming.orElse(incomingStreaming);
+    return incomingStreaming;
   }
 
   final Route csvTweets() {
@@ -191,7 +194,7 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
     //#response-streaming
   }
 
-  //#models
+  //#tweet-model
   private static final class JavaTweet {
     private int id;
     private String message;
@@ -218,5 +221,34 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
     }
 
   }
-  //#models
+  //#tweet-model
+
+  //#measurement-model
+  private static final class Measurement {
+    private String id;
+    private int value;
+
+    public Measurement(String id, int value) {
+      this.id = id;
+      this.value = value;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public void setValue(int value) {
+      this.value = value;
+    }
+
+    public int getValue() {
+      return value;
+    }
+
+  }
+  //#measurement-model
 }

--- a/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/JsonStreamingExamplesTest.java
@@ -219,7 +219,6 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
     public String getMessage() {
       return message;
     }
-
   }
   //#tweet-model
 
@@ -248,7 +247,7 @@ public class JsonStreamingExamplesTest extends JUnitRouteTest {
     public int getValue() {
       return value;
     }
-
   }
+  
   //#measurement-model
 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala
@@ -18,10 +18,9 @@ import scala.concurrent.Future
 
 class JsonStreamingExamplesSpec extends RoutingSpec {
 
-  //#models
+  //#tweet-model
   case class Tweet(uid: Int, txt: String)
-  case class Measurement(id: String, value: Int)
-  //#models
+  //#tweet-model
 
   val tweets = List(
     Tweet(1, "#Akka rocks!"),
@@ -29,20 +28,19 @@ class JsonStreamingExamplesSpec extends RoutingSpec {
     Tweet(3, "You cannot enter the same river twice."))
   def getTweets = Source(tweets)
 
-  //#formats
-  object MyJsonProtocol
+  //#tweet-format
+  object MyTweetJsonProtocol
     extends akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
     with spray.json.DefaultJsonProtocol {
 
     implicit val tweetFormat = jsonFormat2(Tweet.apply)
-    implicit val measurementFormat = jsonFormat2(Measurement.apply)
   }
-  //#formats
+  //#tweet-format
 
   "spray-json-response-streaming" in {
     //#spray-json-response-streaming
     // [1] import "my protocol", for marshalling Tweet objects:
-    import MyJsonProtocol._
+    import MyTweetJsonProtocol._
 
     // [2] pick a Source rendering support trait:
     // Note that the default support renders the Source as JSON Array
@@ -78,7 +76,7 @@ class JsonStreamingExamplesSpec extends RoutingSpec {
 
   "line-by-line-json-response-streaming" in {
     //#line-by-line-json-response-streaming
-    import MyJsonProtocol._
+    import MyTweetJsonProtocol._
 
     // Configure the EntityStreamingSupport to render the elements as:
     // {"example":42}
@@ -142,10 +140,9 @@ class JsonStreamingExamplesSpec extends RoutingSpec {
   }
 
   "response-streaming-modes" in {
-
     {
       //#async-rendering
-      import MyJsonProtocol._
+      import MyTweetJsonProtocol._
       implicit val jsonStreamingSupport: JsonEntityStreamingSupport =
         EntityStreamingSupport.json()
           .withParallelMarshalling(parallelism = 8, unordered = false)
@@ -158,9 +155,8 @@ class JsonStreamingExamplesSpec extends RoutingSpec {
     }
 
     {
-
       //#async-unordered-rendering
-      import MyJsonProtocol._
+      import MyTweetJsonProtocol._
       implicit val jsonStreamingSupport: JsonEntityStreamingSupport =
         EntityStreamingSupport.json()
           .withParallelMarshalling(parallelism = 8, unordered = true)
@@ -173,10 +169,23 @@ class JsonStreamingExamplesSpec extends RoutingSpec {
     }
   }
 
+  //#measurement-model
+  case class Measurement(id: String, value: Int)
+  //#measurement-models
+
+  //#measurement-format
+  object MyMeasurementJsonProtocol
+    extends akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+    with spray.json.DefaultJsonProtocol {
+
+    implicit val measurementFormat = jsonFormat2(Measurement.apply)
+  }
+  //#measurement-format
+
   "spray-json-request-streaming" in {
     //#spray-json-request-streaming
     // [1] import "my protocol", for unmarshalling Measurement objects:
-    import MyJsonProtocol._
+    import MyMeasurementJsonProtocol._
 
     // [2] enable Json Streaming
     implicit val jsonStreamingSupport = EntityStreamingSupport.json()

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala
@@ -171,7 +171,8 @@ class JsonStreamingExamplesSpec extends RoutingSpec {
 
   //#measurement-model
   case class Measurement(id: String, value: Int)
-  //#measurement-models
+
+  //#measurement-model
 
   //#measurement-format
   object MyMeasurementJsonProtocol


### PR DESCRIPTION
I didn't open an issue for this, as this is small improvement to the documentation, but let me know if I should .

The rendered page is here: https://richard-akka-http-doc.firebaseapp.com/routing-dsl/source-streaming-support.html

At the beginning of the "JSON streaming" section, there is a mention to `Measurement`,

<img src="https://user-images.githubusercontent.com/7414320/43367784-a4da3ee6-938d-11e8-9941-b651980bd8f9.png" width=500>

but that is actually not used until much later in the "Consuming JSON streaming" section.

<img src="https://user-images.githubusercontent.com/7414320/43367798-c77acb32-938d-11e8-962d-cf6bb1e534c4.png" width=500>
