### PR TITLE
Add support for strict websocket message handling #1979

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.7.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.7.backwards.excludes
@@ -1,0 +1,5 @@
+# Websocket API #1979
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ws.UpgradeToWebSocket.handleWsMessages")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ws.UpgradeToWebSocket.handleMessagesWith")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.ws.UpgradeToWebSocket.handleMessagesWith")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ws.Message.toStrict")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -239,6 +239,13 @@ akka.http {
       # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
       # The value `infinite` means that *no* keep-alive heartbeat will be sent, as: "the allowed idle time is infinite"
       periodic-keep-alive-max-idle = infinite
+
+      # The maximum number of bytes to allow when reading a websocket message into memory with `maxStrictSize`
+      # method of the builder when using `handleWsMessages` directive.
+      max-to-strict-bytes = 1m
+
+      # The time period within which a message is converted to `Strict` form
+      to-strict-timeout = 60s
     }
   }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
@@ -268,6 +268,9 @@ private[http] object JavaMapping {
     def toScala(javaObject: J): WsMessage.S = javaObject.asScala
     def toJava(scalaObject: S): WsMessage.J = jm.ws.Message.adapt(scalaObject)
   }
+  implicit object StrictMessage extends Inherited[jm.ws.StrictMessage, sm.ws.StrictMessage]
+  implicit object TextMessage extends Inherited[jm.ws.TextMessage, sm.ws.TextMessage]
+  implicit object BinaryMessage extends Inherited[jm.ws.BinaryMessage, sm.ws.BinaryMessage]
 
   implicit object Uri extends JavaMapping[jm.Uri, sm.Uri] {
     def toScala(javaObject: J): Uri.S = cast[JavaUri](javaObject).uri

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
@@ -47,14 +47,14 @@ object Message {
 /**
  * Represents a WebSocket message that contains complete data.
  */
-trait StrictMessage extends Message {
+trait StrictMessage {
   def isStrict: Boolean = true
 }
 
 /**
  * Represents a WebSocket message that needs to be streamed.
  */
-trait StreamedMessage extends Message {
+trait StreamedMessage {
   def isStrict: Boolean = false
 }
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
@@ -45,6 +45,20 @@ object Message {
 }
 
 /**
+ * Represents a WebSocket message that contains complete data.
+ */
+trait StrictMessage extends Message {
+  def isStrict: Boolean = true
+}
+
+/**
+ * Represents a WebSocket message that needs to be streamed.
+ */
+trait StreamedMessage extends Message {
+  def isStrict: Boolean = false
+}
+
+/**
  * Represents a WebSocket text message. A text message can either be strict in which case
  * the complete data is already available or it can be streamed in which case [[getStreamedText]]
  * will return a Source streaming the data as it comes in.
@@ -78,8 +92,7 @@ object TextMessage {
    * Creates a strict text message.
    */
   def create(text: String): TextMessage =
-    new TextMessage {
-      def isStrict: Boolean = true
+    new TextMessage with StrictMessage {
       def getStreamedText: Source[String, _] = Source.single(text)
       def getStrictText: String = text
 
@@ -93,8 +106,7 @@ object TextMessage {
    * Creates a streamed text message.
    */
   def create(textStream: Source[String, _]): TextMessage =
-    new TextMessage {
-      def isStrict: Boolean = false
+    new TextMessage with StreamedMessage {
       def getStrictText: String = throw new IllegalStateException("Cannot get strict text for streamed message.")
       def getStreamedText: Source[String, _] = textStream
 
@@ -142,8 +154,7 @@ object BinaryMessage {
    * Creates a strict binary message.
    */
   def create(data: ByteString): BinaryMessage =
-    new BinaryMessage {
-      def isStrict: Boolean = true
+    new BinaryMessage with StrictMessage {
       def getStreamedData: Source[ByteString, _] = Source.single(data)
       def getStrictData: ByteString = data
 
@@ -158,8 +169,7 @@ object BinaryMessage {
    * Creates a streamed binary message.
    */
   def create(dataStream: Source[ByteString, _]): BinaryMessage =
-    new BinaryMessage {
-      def isStrict: Boolean = false
+    new BinaryMessage with StreamedMessage {
       def getStrictData: ByteString = throw new IllegalStateException("Cannot get strict data for streamed message.")
       def getStreamedData: Source[ByteString, _] = dataStream
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
@@ -5,8 +5,8 @@
 package akka.http.javadsl.model.ws
 
 import java.lang.{ Iterable ⇒ JIterable }
-import java.util.Optional
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.{ model ⇒ sm }
 import akka.http.javadsl.model._
 
@@ -51,9 +51,9 @@ trait UpgradeToWebSocket extends sm.HttpHeader {
    */
   def handleMessagesWith(inSink: Graph[SinkShape[Message], _ <: Any], outSource: Graph[SourceShape[Message], _ <: Any], subprotocol: String): HttpResponse
 
-  def handleStrictMessagesWith(
-    handlerFlow:  Graph[FlowShape[StrictMessage, Message], Any],
-    materializer: Materializer,
-    timeout:      Long,
-    subprotocol:  Optional[String]): HttpResponse
+  /**
+   * Returns a builder that can be used to answer a WebSocket handshake request. The builder is used to generate a handler flow which
+   * the connection will afterwards use to handle WebSocket messages from the client.
+   */
+  def handleMessagesWith(system: ActorSystem): WebSocketResponseBuilder
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
@@ -5,6 +5,8 @@
 package akka.http.javadsl.model.ws
 
 import java.lang.{ Iterable ⇒ JIterable }
+import java.util.Optional
+
 import akka.http.scaladsl.{ model ⇒ sm }
 import akka.http.javadsl.model._
 
@@ -48,4 +50,10 @@ trait UpgradeToWebSocket extends sm.HttpHeader {
    * The given subprotocol must be one of the ones offered by the client.
    */
   def handleMessagesWith(inSink: Graph[SinkShape[Message], _ <: Any], outSource: Graph[SourceShape[Message], _ <: Any], subprotocol: String): HttpResponse
+
+  def handleStrictMessagesWith(
+    handlerFlow:  Graph[FlowShape[StrictMessage, Message], Any],
+    materializer: Materializer,
+    timeout:      Long,
+    subprotocol:  Optional[String]): HttpResponse
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocketResponseBuilder.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/WebSocketResponseBuilder.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.javadsl.model.ws
+
+import akka.actor.ActorSystem
+import akka.http.javadsl.model.HttpResponse
+import akka.stream.{ FlowShape, Graph }
+import akka.http.impl.util.JavaMapping
+import akka.http.scaladsl.model.{ ws ⇒ s }
+
+import scala.concurrent.duration._
+
+private[http] class WebSocketResponseBuilder private (
+  private val upgrade:     s.UpgradeToWebSocket,
+  private val timeout:     Option[FiniteDuration],
+  private val maxBytes:    Option[Long],
+  private val subprotocol: Option[String])(implicit _system: ActorSystem) {
+
+  def handleTextMessagesWith(flow: Graph[FlowShape[TextMessage, Message], _ <: Any]): HttpResponse =
+    scalaBuilder.only[s.TextMessage].handleWith(JavaMapping.toScala(flow))
+
+  def handleBinaryMessagesWith(flow: Graph[FlowShape[BinaryMessage, Message], _ <: Any]): HttpResponse =
+    scalaBuilder.only[s.BinaryMessage].handleWith(JavaMapping.toScala(flow))
+
+  def handleWith(flow: Graph[FlowShape[StrictMessage, Message], _ <: Any]): HttpResponse =
+    scalaBuilder.handleWith(JavaMapping.toScala(flow))
+
+  def forProtocol(protocol: String): WebSocketResponseBuilder =
+    copy(subprotocol = Some(protocol))
+
+  def toStrictTimeout(strictTimeoutInMillis: Long): WebSocketResponseBuilder =
+    copy(timeout = Some(strictTimeoutInMillis.milliseconds))
+
+  def maxStrictSize(bytes: Long): WebSocketResponseBuilder =
+    copy(maxBytes = Some(bytes))
+
+  private def copy(
+    upgrade:     s.UpgradeToWebSocket   = upgrade,
+    timeout:     Option[FiniteDuration] = timeout,
+    maxBytes:    Option[Long]           = maxBytes,
+    subprotocol: Option[String]         = subprotocol): WebSocketResponseBuilder =
+    new WebSocketResponseBuilder(upgrade, timeout, maxBytes, subprotocol)
+
+  private def scalaBuilder = s.WebSocketResponseBuilder[s.Message](upgrade, timeout, maxBytes, subprotocol)
+}
+
+private[http] object WebSocketResponseBuilder {
+  def apply(upgrade: s.UpgradeToWebSocket)(implicit system: ActorSystem): WebSocketResponseBuilder =
+    new WebSocketResponseBuilder(upgrade, timeout = None, maxBytes = None, subprotocol = None)
+}

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
@@ -106,6 +106,11 @@ object EntityStreamException {
   def apply(summary: String, detail: String = ""): EntityStreamException = apply(ErrorInfo(summary, detail))
 }
 
+case class WebSocketStreamException(override val info: ErrorInfo) extends ExceptionWithErrorInfo(info)
+object WebSocketStreamException {
+  def apply(summary: String, detail: String = ""): WebSocketStreamException = apply(ErrorInfo(summary, detail))
+}
+
 /**
  * This exception is thrown when the size of the HTTP Entity exceeds the configured limit.
  * It is possible to configure the limit using configuration options `akka.http.parsing.max-content-length`

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala
@@ -21,6 +21,16 @@ import scala.compat.java8.FutureConverters._
 sealed trait Message extends akka.http.javadsl.model.ws.Message
 
 /**
+ * Represents a WebSocket message that contains complete data.
+ */
+sealed trait StrictMessage extends akka.http.javadsl.model.ws.StrictMessage
+
+/**
+ * Represents a WebSocket message that needs to be streamed.
+ */
+sealed trait StreamedMessage extends akka.http.javadsl.model.ws.StreamedMessage
+
+/**
  * Represents a WebSocket text message. A text message can either be a [[TextMessage.Strict]] in which case
  * the complete data is already available or it can be [[TextMessage.Streamed]] in which case `textStream`
  * will return a Source streaming the data as it comes in.
@@ -59,21 +69,19 @@ object TextMessage {
   /**
    * A strict [[TextMessage]] that contains the complete data as a [[String]].
    */
-  final case class Strict(text: String) extends TextMessage {
+  final case class Strict(text: String) extends TextMessage with StrictMessage {
     def textStream: Source[String, _] = Source.single(text)
     override def toString: String = s"TextMessage.Strict($text)"
 
     /** Java API */
     override def getStrictText: String = text
-    override def isStrict: Boolean = true
   }
 
-  final case class Streamed(textStream: Source[String, _]) extends TextMessage {
+  final case class Streamed(textStream: Source[String, _]) extends TextMessage with StreamedMessage {
     override def toString: String = s"TextMessage.Streamed($textStream)"
 
     /** Java API */
     override def getStrictText: String = throw new IllegalStateException("Cannot get strict text for streamed message.")
-    override def isStrict: Boolean = false
   }
 }
 
@@ -117,19 +125,17 @@ object BinaryMessage {
   /**
    * A strict [[BinaryMessage]] that contains the complete data as a [[akka.util.ByteString]].
    */
-  final case class Strict(data: ByteString) extends BinaryMessage {
+  final case class Strict(data: ByteString) extends BinaryMessage with StrictMessage {
     def dataStream: Source[ByteString, _] = Source.single(data)
     override def toString: String = s"BinaryMessage.Strict($data)"
 
     /** Java API */
     override def getStrictData: ByteString = data
-    override def isStrict: Boolean = true
   }
-  final case class Streamed(dataStream: Source[ByteString, _]) extends BinaryMessage {
+  final case class Streamed(dataStream: Source[ByteString, _]) extends BinaryMessage with StreamedMessage {
     override def toString: String = s"BinaryMessage.Streamed($dataStream)"
 
     /** Java API */
     override def getStrictData: ByteString = throw new IllegalStateException("Cannot get strict data for streamed message.")
-    override def isStrict: Boolean = false
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/UpgradeToWebSocket.scala
@@ -7,13 +7,11 @@ package akka.http.scaladsl.model.ws
 import java.lang.Iterable
 import scala.collection.immutable
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.stream._
 import akka.http.impl.util.JavaMapping
 import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.scaladsl.model.HttpResponse
-
-import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
 
 /**
  * A custom header that will be added to an WebSocket upgrade HttpRequest that
@@ -57,30 +55,13 @@ trait UpgradeToWebSocket extends jm.ws.UpgradeToWebSocket {
     subprotocol: Option[String]                   = None): HttpResponse =
     handleMessages(scaladsl.Flow.fromSinkAndSource(inSink, outSource), subprotocol)
 
-  def handleStrictMessages(
-    handlerFlow: Graph[FlowShape[StrictMessage, Message], Any],
-    subprotocol: Option[String]                                = None)(implicit mat: Materializer, timeout: FiniteDuration): HttpResponse =
-    handleMessages(scaladsl.Flow[Message].mapAsync(1) {
-      case streamed: TextMessage.Streamed   ⇒ streamed.toStrict(timeout)
-      case streamed: BinaryMessage.Streamed ⇒ streamed.toStrict(timeout)
-      case strict: StrictMessage            ⇒ Future.successful(strict)
-    }.via(handlerFlow), subprotocol)
-
-  def handleStrictTextMessages(
-    handlerFlow: Graph[FlowShape[TextMessage.Strict, Message], Any],
-    subprotocol: Option[String]                                     = None)(implicit mat: Materializer, timeout: FiniteDuration): HttpResponse =
-    handleStrictMessages(scaladsl.Flow[StrictMessage].map {
-      case textMessage: TextMessage.Strict ⇒ textMessage
-      case _: BinaryMessage                ⇒ throw new RuntimeException("Received BinaryMessage while expecting TextMessage.")
-    }.via(handlerFlow), subprotocol)
-
-  def handleStrictBinaryMessages(
-    handlerFlow: Graph[FlowShape[BinaryMessage.Strict, Message], Any],
-    subprotocol: Option[String]                                       = None)(implicit mat: Materializer, timeout: FiniteDuration): HttpResponse =
-    handleStrictMessages(scaladsl.Flow[StrictMessage].map {
-      case binaryMessage: BinaryMessage.Strict ⇒ binaryMessage
-      case _: TextMessage                      ⇒ throw new RuntimeException("Received TextMessage while expecting BinaryMessage.")
-    }.via(handlerFlow), subprotocol)
+  /**
+   * The high-level interface to create a WebSocket server based on "messages".
+   *
+   * Returns a builder that can be used to answer a WebSocket handshake request. The builder is used to generate a handler flow which
+   * the connection will afterwards use to handle WebSocket messages from the client.
+   */
+  def handleWsMessages()(implicit system: ActorSystem): WebSocketResponseBuilder[Message] = WebSocketResponseBuilder.apply(this)
 
   import scala.collection.JavaConverters._
 
@@ -119,14 +100,7 @@ trait UpgradeToWebSocket extends jm.ws.UpgradeToWebSocket {
   /**
    * Java API
    */
-  def handleStrictMessagesWith(
-    handlerFlow:  Graph[FlowShape[jm.ws.StrictMessage, jm.ws.Message], Any],
-    materializer: Materializer,
-    timeout:      Long,
-    subprotocol:  java.util.Optional[String]): HttpResponse = {
-    import scala.concurrent.duration._
-    handleStrictMessages(JavaMapping.toScala(handlerFlow), JavaMapping.toScala(subprotocol))(materializer, timeout.millis)
-  }
+  def handleMessagesWith(system: ActorSystem): jm.ws.WebSocketResponseBuilder = jm.ws.WebSocketResponseBuilder.apply(this)(system)
 
   private[this] def createScalaFlow(inSink: Graph[SinkShape[jm.ws.Message], _ <: Any], outSource: Graph[SourceShape[jm.ws.Message], _ <: Any]): Graph[FlowShape[Message, Message], NotUsed] =
     JavaMapping.toScala(scaladsl.Flow.fromSinkAndSourceMat(inSink, outSource)(scaladsl.Keep.none): Graph[FlowShape[jm.ws.Message, jm.ws.Message], NotUsed])

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/WebSocketResponseBuilder.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/WebSocketResponseBuilder.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.model.ws
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.impl.util._
+import akka.stream.{ FlowShape, Graph, scaladsl }
+import WebSocketResponseBuilder._
+
+import scala.collection.immutable.Seq
+import scala.concurrent.duration._
+
+/**
+ * Used to build a [[HttpResponse]] to handle websocket requests. Converts all the messages coming from request into their strict forms ([[Message.Strict]]
+ * within a configurable timeout and makes sure a message size cannot exceed the configurable maximum bytes value.
+ *
+ * It is possible to define subprotocol and accepted [[Message]] subtype in addition to timeout and maximum bytes.
+ */
+private[http] case class WebSocketResponseBuilder[M <: Message: ToStrictFlow] private[http] (
+  private val upgrade:     UpgradeToWebSocket,
+  private val timeout:     Option[FiniteDuration],
+  private val maxBytes:    Option[Long],
+  private val subprotocol: Option[String])(implicit _system: ActorSystem) {
+
+  def handleWith(flow: Graph[FlowShape[M#Strict, Message], Any]): HttpResponse = {
+    val handlerFlow = ToStrictFlow[M].flow(timeout.getOrElse(defaultTimeout), maxBytes.getOrElse(defaultMaxBytes)).via(flow)
+    try upgrade.handleMessages(handlerFlow, subprotocol) catch {
+      // checks if IllegalArgumentException is thrown for invalid subprotocol by UpgradeToWebSocket#handleMessages
+      case e: IllegalArgumentException if subprotocol.isDefined ⇒
+        throw WebSocketUnsupportedSubprotocolException(subprotocol.get, upgrade.requestedProtocols, e.getMessage)
+    }
+  }
+
+  def only[T <: Message: ToStrictFlow]: WebSocketResponseBuilder[T] = new WebSocketResponseBuilder[T](upgrade, timeout, maxBytes, subprotocol)
+
+  def forProtocol(protocol: String): WebSocketResponseBuilder[M] = copy(subprotocol = Some(protocol))
+
+  def toStrictTimeout(strictTimeout: FiniteDuration): WebSocketResponseBuilder[M] = copy(timeout = Some(strictTimeout))
+
+  def maxStrictSize(bytes: Long): WebSocketResponseBuilder[M] = copy(maxBytes = Some(bytes))
+
+  private def defaultTimeout: FiniteDuration = _system.settings.config.getFiniteDuration("akka.http.server.websocket.to-strict-timeout")
+  private def defaultMaxBytes: Long = _system.settings.config.getPossiblyInfiniteBytes("akka.http.server.websocket.max-to-strict-bytes")
+}
+
+private[http] object WebSocketResponseBuilder {
+  private[scaladsl] def apply(upgrade: UpgradeToWebSocket)(implicit system: ActorSystem): WebSocketResponseBuilder[Message] =
+    WebSocketResponseBuilder[Message](upgrade, timeout = None, maxBytes = None, subprotocol = None)
+
+  sealed trait ToStrictFlow[M <: Message] {
+    def flow(timeout: FiniteDuration, maxBytes: Long): scaladsl.Flow[Message, M#Strict, Any]
+  }
+
+  object ToStrictFlow {
+    private[ws] def apply[M <: Message](implicit toStrictFlow: ToStrictFlow[M]) = toStrictFlow
+
+    implicit val textToStrict: ToStrictFlow[TextMessage] = new ToStrictFlow[TextMessage] {
+      override def flow(timeout: FiniteDuration, maxBytes: Long): scaladsl.Flow[Message, TextMessage.Strict, Any] =
+        scaladsl.Flow[Message].map {
+          case textMessage: TextMessage ⇒ textMessage
+          case _                        ⇒ throw new RuntimeException("Received BinaryMessage while expecting TextMessage.")
+        }.flatMapConcat(textMessage ⇒ textMessage.toStrict(timeout, maxBytes))
+    }
+
+    implicit val binaryToStrict: ToStrictFlow[BinaryMessage] = new ToStrictFlow[BinaryMessage] {
+      override def flow(timeout: FiniteDuration, maxBytes: Long): scaladsl.Flow[Message, BinaryMessage.Strict, Any] =
+        scaladsl.Flow[Message].map {
+          case binaryMessage: BinaryMessage ⇒ binaryMessage
+          case _                            ⇒ throw new RuntimeException("Received TextMessage while expecting BinaryMessage.")
+        }.flatMapConcat(binaryMessage ⇒ binaryMessage.toStrict(timeout, maxBytes))
+    }
+
+    implicit val messageToStrict: ToStrictFlow[Message] = new ToStrictFlow[Message] {
+      override def flow(timeout: FiniteDuration, maxBytes: Long): scaladsl.Flow[Message, Message#Strict, Any] =
+        scaladsl.Flow[Message].flatMapConcat(message ⇒ message.toStrict(timeout, maxBytes))
+    }
+  }
+}
+
+/**
+ * Thrown when subprotocol is not in the list of client requested protocols.
+ *
+ * The exception ([[IllegalArgumentException]]) and the message are same
+ * to what [[akka.http.scaladsl.model.ws.UpgradeToWebSocket#handleMessages()]] throws in the same case.
+ */
+final case class WebSocketUnsupportedSubprotocolException(subprotocol: String, requestedProtocols: Seq[String], message: String)
+  extends IllegalArgumentException(message)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/package.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.model
+
+import akka.annotation.InternalApi
+import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
+import akka.stream.stage._
+import akka.util.ByteString
+
+import scala.concurrent.duration.FiniteDuration
+
+package ws {
+
+  /** INTERNAL API */
+  @InternalApi
+  private[ws] class BinaryToStrict(timeout: FiniteDuration, maxBytes: Long) extends GraphStage[FlowShape[ByteString, BinaryMessage.Strict]] {
+    private val byteStringIn = Inlet[ByteString]("BinaryToStrict.byteStringIn")
+    private val strictMessageOut = Outlet[BinaryMessage.Strict]("BinaryToStrict.strictMessageOut")
+
+    override def initialAttributes: Attributes = Attributes.name("BinaryToStrict")
+
+    override val shape = FlowShape(byteStringIn, strictMessageOut)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) {
+      private val builder = ByteString.newBuilder
+      private var emptyStream = false
+
+      override def preStart(): Unit = scheduleOnce("BinaryToStrictTimeoutTimer", timeout)
+
+      setHandler(strictMessageOut, new OutHandler {
+        override def onPull(): Unit = {
+          if (emptyStream) {
+            push(strictMessageOut, BinaryMessage.Strict(ByteString.empty))
+            completeStage()
+          } else pull(byteStringIn)
+        }
+      })
+
+      setHandler(byteStringIn, new InHandler {
+        override def onPush(): Unit = {
+          builder ++= grab(byteStringIn)
+          if (builder.length > maxBytes) {
+            failStage(new WebSocketStreamException(new ErrorInfo("WebSocket message too large", s"Message was larger than the maximum of $maxBytes")))
+          } else pull(byteStringIn)
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          if (isAvailable(strictMessageOut)) {
+            push(strictMessageOut, BinaryMessage.Strict(builder.result()))
+            completeStage()
+          } else emptyStream = true
+        }
+      })
+
+      override def onTimer(key: Any): Unit =
+        failStage(new java.util.concurrent.TimeoutException(s"The stream has not been completed in $timeout for WebSocket message."))
+    }
+
+    override def toString = "BinaryToStrict"
+  }
+
+  /** INTERNAL API */
+  @InternalApi
+  private[ws] class TextToStrict(timeout: FiniteDuration, maxBytes: Long) extends GraphStage[FlowShape[String, TextMessage.Strict]] {
+    private val stringIn = Inlet[String]("TextToStrict.stringIn")
+    private val strictMessageOut = Outlet[TextMessage.Strict]("TextToStrict.strictMessageOut")
+
+    override def initialAttributes: Attributes = Attributes.name("TextToStrict")
+
+    override val shape = FlowShape(stringIn, strictMessageOut)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) {
+      private val builder = StringBuilder.newBuilder
+      private var byteSize: Int = 0
+      private var emptyStream = false
+
+      override def preStart(): Unit = scheduleOnce("TextToStrictTimeoutTimer", timeout)
+
+      setHandler(strictMessageOut, new OutHandler {
+        override def onPull(): Unit = {
+          if (emptyStream) {
+            push(strictMessageOut, TextMessage.Strict(""))
+            completeStage()
+          } else pull(stringIn)
+        }
+      })
+
+      setHandler(stringIn, new InHandler {
+        override def onPush(): Unit = {
+          val in = grab(stringIn)
+          builder ++= in
+          byteSize += in.getBytes.length
+          if (byteSize > maxBytes) {
+            failStage(new WebSocketStreamException(new ErrorInfo("WebSocket message too large", s"Message was larger than the maximum of $maxBytes")))
+          } else pull(stringIn)
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          if (isAvailable(strictMessageOut)) {
+            push(strictMessageOut, TextMessage.Strict(builder.result()))
+            completeStage()
+          } else emptyStream = true
+        }
+      })
+
+      override def onTimer(key: Any): Unit =
+        failStage(new java.util.concurrent.TimeoutException(s"The stream has not been completed in $timeout for WebSocket message."))
+    }
+
+    override def toString = "TextToStrict"
+  }
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/WebSocketDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/WebSocketDirectivesSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.http.scaladsl.server.directives
 
+import java.util.concurrent.TimeoutException
+
 import akka.util.ByteString
 
 import akka.stream.OverflowStrategy
@@ -15,6 +17,8 @@ import akka.http.scaladsl.model.headers.`Sec-WebSocket-Protocol`
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.ws._
 import akka.http.scaladsl.server.{ UnsupportedWebSocketSubprotocolRejection, ExpectedWebSocketRequestRejection, Route, RoutingSpec }
+
+import scala.concurrent.duration._
 
 class WebSocketDirectivesSpec extends RoutingSpec {
   "the handleWebSocketMessages directive" should {
@@ -84,10 +88,177 @@ class WebSocketDirectivesSpec extends RoutingSpec {
     }
   }
 
+  "the handleWebSocketStrictMessages directive" should {
+    "handle websocket requests by converting them to Strict" in {
+      val wsClient = WSProbe()
+
+      WS("http://localhost/", wsClient.flow) ~> strictWebsocketRoute ~>
+        check {
+          isWebSocketUpgrade shouldEqual true
+          wsClient.sendMessage(TextMessage(Source.single("John")))
+          wsClient.expectMessage("Hello John!")
+
+          wsClient.sendMessage(BinaryMessage(Source.single(ByteString("abcdef"))))
+          wsClient.expectMessage(ByteString("Binary message received: abcdef"))
+
+          wsClient.sendMessage("John")
+          wsClient.expectMessage("Hello John!")
+
+          wsClient.sendCompletion()
+          wsClient.expectCompletion()
+        }
+    }
+    "fail flow with TimeoutException when a message cannot be consumed within the timeout" in {
+      val wsClient = WSProbe()
+
+      WS("http://localhost/", wsClient.flow) ~> strictWebsocketRoute(1.millisecond) ~>
+        check {
+          isWebSocketUpgrade shouldEqual true
+
+          wsClient.sendMessage(TextMessage(Source.repeat("John")))
+          val error = wsClient.inProbe.expectSubscriptionAndError()
+          error.getClass should be(classOf[TimeoutException])
+        }
+    }
+    "choose subprotocol from offered ones" in {
+      val wsClient = WSProbe()
+
+      WS("http://localhost/", wsClient.flow, List("other", "echo", "greeter")) ~> strictWebsocketMultipleProtocolRoute ~>
+        check {
+          expectWebSocketUpgradeWithProtocol { protocol ⇒
+            protocol shouldEqual "echo"
+
+            wsClient.sendMessage(TextMessage(Source.single("Peter")))
+            wsClient.expectMessage("Peter")
+
+            wsClient.sendMessage(BinaryMessage(Source.single(ByteString("abcdef"))))
+            wsClient.expectMessage(ByteString("abcdef"))
+
+            wsClient.sendMessage("John")
+            wsClient.expectMessage("John")
+
+            wsClient.sendCompletion()
+            wsClient.expectCompletion()
+          }
+        }
+    }
+    "reject websocket requests if no subprotocol matches" in {
+      WS("http://localhost/", Flow[Message], List("other")) ~> strictWebsocketMultipleProtocolRoute ~> check {
+        rejections.collect {
+          case UnsupportedWebSocketSubprotocolRejection(p) ⇒ p
+        }.toSet shouldEqual Set("greeter", "echo")
+      }
+
+      WS("http://localhost/", Flow[Message], List("other")) ~> Route.seal(websocketMultipleProtocolRoute) ~> check {
+        status shouldEqual StatusCodes.BadRequest
+        responseAs[String] shouldEqual "None of the websocket subprotocols offered in the request are supported. Supported are 'echo','greeter'."
+        header[`Sec-WebSocket-Protocol`].get.protocols.toSet shouldEqual Set("greeter", "echo")
+      }
+    }
+    "reject non-websocket requests" in {
+      Get("http://localhost/") ~> strictWebsocketRoute ~> check {
+        rejection shouldEqual ExpectedWebSocketRequestRejection
+      }
+
+      Get("http://localhost/") ~> Route.seal(strictWebsocketRoute) ~> check {
+        status shouldEqual StatusCodes.BadRequest
+        responseAs[String] shouldEqual "Expected WebSocket Upgrade request"
+      }
+    }
+  }
+
+  "the handleWebSocketStrictTextMessages directive" should {
+    "handle text messages by converting them to strict form" in {
+      val wsClient = WSProbe()
+
+      WS("http://localhost/", wsClient.flow) ~> strictTextWebsocketRoute ~>
+        check {
+          isWebSocketUpgrade shouldEqual true
+          wsClient.sendMessage(TextMessage(Source.single("John")))
+          wsClient.expectMessage("Hello John!")
+
+          wsClient.sendMessage("Peter")
+          wsClient.expectMessage("Hello Peter!")
+
+          wsClient.sendCompletion()
+          wsClient.expectCompletion()
+        }
+    }
+    "fail flow with MatchError when a binary message received" in {
+      val wsClient = WSProbe()
+
+      WS("http://localhost/", wsClient.flow) ~> strictTextWebsocketRoute ~>
+        check {
+          wsClient.sendMessage(BinaryMessage(ByteString("abcdef")))
+          val error = wsClient.inProbe.expectSubscriptionAndError()
+          error.getClass should be(classOf[RuntimeException])
+        }
+    }
+    "fail flow with TimeoutException when a text message cannot be consumed within the timeout" in {
+      val wsClient = WSProbe()
+
+      WS("http://localhost/", wsClient.flow) ~> strictTextWebsocketRoute(1.millisecond) ~>
+        check {
+          isWebSocketUpgrade shouldEqual true
+
+          wsClient.sendMessage(TextMessage(Source.repeat("John")))
+          val error = wsClient.inProbe.expectSubscriptionAndError()
+          error.getClass should be(classOf[TimeoutException])
+        }
+    }
+  }
+
+  "the handleWebSocketStrictBinaryMessages directive" should {
+    "handle text messages by converting them to strict form" in {
+      val wsClient = WSProbe()
+
+      WS("http://localhost/", wsClient.flow) ~> strictBinaryWebsocketRoute ~>
+        check {
+          isWebSocketUpgrade shouldEqual true
+          wsClient.sendMessage(BinaryMessage(Source.single(ByteString("abcdef"))))
+          wsClient.expectMessage(ByteString("Binary message received: abcdef"))
+
+          wsClient.sendMessage(BinaryMessage(ByteString("123")))
+          wsClient.expectMessage(ByteString("Binary message received: 123"))
+
+          wsClient.sendCompletion()
+          wsClient.expectCompletion()
+        }
+    }
+    "fail flow with MatchError when a text message received" in {
+      val wsClient = WSProbe()
+
+      WS("http://localhost/", wsClient.flow) ~> strictBinaryWebsocketRoute ~>
+        check {
+          wsClient.sendMessage(TextMessage("Peter"))
+          val error = wsClient.inProbe.expectSubscriptionAndError()
+          error.getClass should be(classOf[RuntimeException])
+        }
+    }
+    "fail flow with TimeoutException when a text message cannot be consumed within the timeout" in {
+      val wsClient = WSProbe()
+
+      WS("http://localhost/", wsClient.flow) ~> strictBinaryWebsocketRoute(1.millisecond) ~>
+        check {
+          isWebSocketUpgrade shouldEqual true
+
+          wsClient.sendMessage(BinaryMessage(Source.repeat(ByteString("abcdef"))))
+          val error = wsClient.inProbe.expectSubscriptionAndError()
+          error.getClass should be(classOf[TimeoutException])
+        }
+    }
+  }
+
   def websocketRoute = handleWebSocketMessages(greeter)
+  def strictWebsocketRoute(implicit timeout: FiniteDuration = 1.second) = handleWebSocketStrictMessages(strictGreeter)
+  def strictTextWebsocketRoute(implicit timeout: FiniteDuration = 1.second) = handleWebSocketStrictTextMessages(strictGreeter)
+  def strictBinaryWebsocketRoute(implicit timeout: FiniteDuration = 1.second) = handleWebSocketStrictBinaryMessages(strictGreeter)
   def websocketMultipleProtocolRoute =
     handleWebSocketMessagesForProtocol(echo, "echo") ~
       handleWebSocketMessagesForProtocol(greeter, "greeter")
+  def strictWebsocketMultipleProtocolRoute(implicit timeout: FiniteDuration = 1.second) =
+    handleWebSocketStrictMessages(strictEcho, Some("echo")) ~
+      handleWebSocketStrictMessages(strictGreeter, Some("greeter"))
 
   def greeter: Flow[Message, Message, Any] =
     Flow[Message].mapConcat {
@@ -97,7 +268,17 @@ class WebSocketDirectivesSpec extends RoutingSpec {
         Nil
     }
 
+  def strictGreeter: Flow[StrictMessage, Message, Any] =
+    Flow[StrictMessage].mapConcat {
+      case TextMessage.Strict(text)     ⇒ TextMessage("Hello " + text + "!") :: Nil
+      case BinaryMessage.Strict(binary) ⇒ BinaryMessage(ByteString("Binary message received: ") ++ binary) :: Nil
+    }
+
   def echo: Flow[Message, Message, Any] =
     Flow[Message]
+      .buffer(1, OverflowStrategy.backpressure) // needed because a noop flow hasn't any buffer that would start processing
+
+  def strictEcho: Flow[StrictMessage, Message, Any] =
+    Flow[StrictMessage].map(_.asScala)
       .buffer(1, OverflowStrategy.backpressure) // needed because a noop flow hasn't any buffer that would start processing
 }

--- a/akka-http/src/main/mima-filters/10.1.3.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.1.3.backwards.excludes
@@ -2,3 +2,8 @@
 
 # Removal of deprecated methods in 10.0.1 and 10.0.2
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.server.Route.asScala")
+
+# #1979 Improved handle APIs for websockets that automatically accumulate messages etc
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.WebSocketDirectives.handleWebSocketStrictMessages*")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.WebSocketDirectives.handleWebSocketStrictTextMessages*")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.WebSocketDirectives.handleWebSocketStrictBinaryMessages*")

--- a/akka-http/src/main/mima-filters/10.1.7.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.1.7.backwards.excludes
@@ -1,3 +1,6 @@
 # Changes against 10.1.7
 
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.unmarshalling.sse.EventStreamUnmarshalling.fromEventsStream")
+
+# Websocket API #1979
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.WebSocketDirectives.handleWsMessages")

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/WebSocketDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/WebSocketDirectives.scala
@@ -6,9 +6,11 @@ package akka.http.scaladsl.server
 package directives
 
 import scala.collection.immutable
-
-import akka.http.scaladsl.model.ws.{ UpgradeToWebSocket, Message }
+import akka.http.scaladsl.model.ws._
+import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
+
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * @groupname websocket WebSocket directives
@@ -70,9 +72,64 @@ trait WebSocketDirectives {
    * @group websocket
    */
   def handleWebSocketMessagesForOptionalProtocol(handler: Flow[Message, Message, Any], subprotocol: Option[String]): Route =
+    extractWebsocketForOptionalProtocol(upgrade ⇒ complete(upgrade.handleMessages(handler, subprotocol)), subprotocol)
+
+  /**
+   * Handles WebSocket requests with the given handler by transforming [[Message]] to [[StrictMessage]] within the given `timeout`.
+   * Rejects other requests with an [[ExpectedWebSocketRequestRejection]].
+   *
+   * If the `subprotocol` parameter is None any WebSocket request is accepted. If the `subprotocol` parameter is
+   * `Some(protocol)` a WebSocket request is only accepted if the list of subprotocols supported by the client (as
+   * announced in the WebSocket request) contains `protocol`. If the client did not offer the protocol in question
+   * the request is rejected with an [[UnsupportedWebSocketSubprotocolRejection]] rejection.
+   *
+   * To support several subprotocols you may chain several `handleWebSocketStrictMessages` routes.
+   *
+   * @group websocket
+   */
+  def handleWebSocketStrictMessages(handler: Flow[StrictMessage, Message, Any], subprotocol: Option[String] = None)(implicit mat: Materializer, timeout: FiniteDuration): Route =
+    extractWebsocketForOptionalProtocol(upgrade ⇒ complete(upgrade.handleStrictMessages(handler, subprotocol)), subprotocol)
+
+  /**
+   * Handles WebSocket requests with the given handler for message type [[TextMessage]]. Transforms any [[TextMessage]] to [[TextMessage.Strict]] within the
+   * given `timeout`.
+   * Fails the `handler` flow if [[BinaryMessage]] is received.
+   * Rejects other requests with an [[ExpectedWebSocketRequestRejection]].
+   *
+   * If the `subprotocol` parameter is None any WebSocket request is accepted. If the `subprotocol` parameter is
+   * `Some(protocol)` a WebSocket request is only accepted if the list of subprotocols supported by the client (as
+   * announced in the WebSocket request) contains `protocol`. If the client did not offer the protocol in question
+   * the request is rejected with an [[UnsupportedWebSocketSubprotocolRejection]] rejection.
+   *
+   * To support several subprotocols you may chain several `handleWebSocketStrictMessages` routes.
+   *
+   * @group websocket
+   */
+  def handleWebSocketStrictTextMessages(handler: Flow[TextMessage.Strict, Message, Any], subprotocol: Option[String] = None)(implicit mat: Materializer, timeout: FiniteDuration): Route =
+    extractWebsocketForOptionalProtocol(upgrade ⇒ complete(upgrade.handleStrictTextMessages(handler, subprotocol)), subprotocol)
+
+  /**
+   * Handles WebSocket requests with the given handler for message type [[BinaryMessage]]. Transforms any [[BinaryMessage]] to [[BinaryMessage.Strict]] within
+   * the given `timeout`.
+   * Fails the `handler` flow if [[TextMessage]] is received.
+   * Rejects other requests with an [[ExpectedWebSocketRequestRejection]].
+   *
+   * If the `subprotocol` parameter is None any WebSocket request is accepted. If the `subprotocol` parameter is
+   * `Some(protocol)` a WebSocket request is only accepted if the list of subprotocols supported by the client (as
+   * announced in the WebSocket request) contains `protocol`. If the client did not offer the protocol in question
+   * the request is rejected with an [[UnsupportedWebSocketSubprotocolRejection]] rejection.
+   *
+   * To support several subprotocols you may chain several `handleWebSocketStrictMessages` routes.
+   *
+   * @group websocket
+   */
+  def handleWebSocketStrictBinaryMessages(handler: Flow[BinaryMessage.Strict, Message, Any], subprotocol: Option[String] = None)(implicit mat: Materializer, timeout: FiniteDuration): Route =
+    extractWebsocketForOptionalProtocol(upgrade ⇒ complete(upgrade.handleStrictBinaryMessages(handler, subprotocol)), subprotocol)
+
+  private def extractWebsocketForOptionalProtocol(onSuccess: UpgradeToWebSocket ⇒ Route, subprotocol: Option[String]): Route =
     extractUpgradeToWebSocket { upgrade ⇒
       if (subprotocol.forall(sub ⇒ upgrade.requestedProtocols.exists(_ equalsIgnoreCase sub)))
-        complete(upgrade.handleMessages(handler, subprotocol))
+        onSuccess(upgrade)
       else
         reject(UnsupportedWebSocketSubprotocolRejection(subprotocol.get)) // None.forall == true
     }


### PR DESCRIPTION
As #1979 suggests, this PR
- adds `handleStrictMessages`, `handleStrictTextMessages` and `handleStrictBinaryMessages` methods to `UpgradeToWebSocket`
- defines `StrictMessage` and `StreamedMessage` as new subtypes of `Message`
- also adds directives to `WebSocketDirectives`.

This helps users to
- operate with `StrictMessage` by using akka-streams API.
- avoid [scenarios that “work fine” in tests but fail in production](https://github.com/akka/akka-http/issues/65#issuecomment-245641551).