### PR TITLE
Fix several minor typos detected by github.com/client9/misspell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ To use the task simply type, and the output should include entries like shown be
 ```
 > validatePullRequest
 [info] Diffing [HEAD] to determine changed modules in PR...
-[info] Detected uncomitted changes in directories (including in dependency analysis): [akka-protobuf,project]
+[info] Detected uncommitted changes in directories (including in dependency analysis): [akka-protobuf,project]
 [info] Detected changes in directories: [docs, project, akka-http-tests, akka-protobuf, akka-http-testkit, akka-http, akka-http-core, akka-stream]
 ```
 

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -386,7 +386,7 @@ akka.http {
   # Modify to tweak default parsing settings.
   #
   # IMPORTANT:
-  # Please note that this sections settings can be overriden by the corresponding settings in:
+  # Please note that this sections settings can be overridden by the corresponding settings in:
   # `akka.http.server.parsing`, `akka.http.client.parsing` or `akka.http.host-connection-pool.client.parsing`.
   parsing {
     # The limits for the various parts of the HTTP message parser.

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
@@ -124,7 +124,7 @@ private final class HttpsProxyGraphStage(
                 val parseResult = parser.onPull()
                 require(parseResult == ParserOutput.MessageEnd, s"parseResult should be MessageEnd but was $parseResult")
                 parser.onPull() match {
-                  // NeedMoreData is what we emit in overriden `parseMessage` in case input.size == offset
+                  // NeedMoreData is what we emit in overridden `parseMessage` in case input.size == offset
                   case NeedMoreData ⇒
                   case RemainingBytes(bytes) ⇒
                     push(sslOut, bytes) // parser already read more than expected, forward that data directly

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -335,7 +335,7 @@ private[client] object NewHostConnectionPool {
 
             // bit of a HACK: pushing the request may cause a onRequestEntityCompleted event on the current thread.
 
-            // To accomodate this we first do an 'early' update of the state:
+            // To accommodate this we first do an 'early' update of the state:
             state = nextState
             // Then execute the action that might cause the 'inline' state change:
             connection.pushRequest(request)

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/SettingsCompanion.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/SettingsCompanion.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.Config
 trait SettingsCompanion[T] {
 
   /**
-   * WARNING: This MUST overriden in sub-classes as otherwise won't be usable (return type) from Java.
+   * WARNING: This MUST overridden in sub-classes as otherwise won't be usable (return type) from Java.
    * Creates an instance of settings using the configuration provided by the given ActorSystem.
    *
    * Java API

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
@@ -33,7 +33,7 @@ class TightRequestTimeoutSpec extends WordSpec with Matchers with BeforeAndAfter
 
   "Tight request timeout" should {
 
-    "not cause double push error caused by the late response attemting to push" in {
+    "not cause double push error caused by the late response attempting to push" in {
       val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
       val slowHandler = Flow[HttpRequest].map(_ ⇒ HttpResponse()).delay(500.millis.dilated, OverflowStrategy.backpressure)
       val binding = Http().bindAndHandle(slowHandler, hostname, port)

--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -224,15 +224,15 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
         10 → tenXResponseLength,
         100 → hundredXResponseLength
       ) foreach {
-          case (n, lenght) ⇒
-            s"have good Latency (streaming-response($lenght), keep-alive)" taggedAs LongRunningTest in {
-              val id = s"Latency_stream($lenght)_R:${rate}_C:${connections}_p:"
+          case (n, length) ⇒
+            s"have good Latency (streaming-response($length), keep-alive)" taggedAs LongRunningTest in {
+              val id = s"Latency_stream($length)_R:${rate}_C:${connections}_p:"
 
               val wrkOptions = s"""-d ${testDuration}s -R $rate -c $connections -t $connections --u_latency"""
               runLoadTest(id)(s"""wrk $wrkOptions ${url_longResponseStream(n)}""")
             }
-            s"have good Latency (array-response($lenght), keep-alive)" taggedAs LongRunningTest in {
-              val id = s"Latency_array($lenght)_R:${rate}_C:${connections}_p:"
+            s"have good Latency (array-response($length), keep-alive)" taggedAs LongRunningTest in {
+              val id = s"Latency_array($length)_R:${rate}_C:${connections}_p:"
 
               val wrkOptions = s"""-d ${testDuration}s -R $rate -c $connections -t $connections --u_latency"""
               runLoadTest(id)(s"""wrk $wrkOptions ${url_longResponseArray(n)}""")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -26,7 +26,7 @@ class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
 
       //#application-custom
 
-      // similarily in Java: `akka.http.javadsl.settings.[...]`
+      // similarly in Java: `akka.http.javadsl.settings.[...]`
       import akka.http.scaladsl.settings.ParserSettings
       import akka.http.scaladsl.settings.ServerSettings
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
@@ -24,7 +24,7 @@ class CustomStatusCodesSpec extends AkkaSpec with ScalaFutures
       val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
 
       //#application-custom
-      // similarily in Java: `akka.http.javadsl.settings.[...]`
+      // similarly in Java: `akka.http.javadsl.settings.[...]`
       import akka.http.scaladsl.settings.{ ParserSettings, ServerSettings }
 
       // define custom status code:

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala
@@ -181,14 +181,14 @@ class CacheConditionDirectivesSpec extends RoutingSpec {
       }
     }
 
-    "ignore `If-Match` if the ETag is ommitted" in {
+    "ignore `If-Match` if the ETag is omitted" in {
       Get() ~> `If-Match`(EntityTag("old")) ~> timestampedOnly ~> check {
         status shouldEqual OK
         headers should contain theSameElementsAs (List(`Last-Modified`(timestamp)))
       }
     }
 
-    "ignore `If-None-Match` if the ETag is ommitted" in {
+    "ignore `If-None-Match` if the ETag is omitted" in {
       Get() ~> `If-None-Match`(EntityTag("old")) ~> timestampedOnly ~> check {
         status shouldEqual OK
         headers should contain theSameElementsAs (List(`Last-Modified`(timestamp)))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /**
- * Has to excercise the entire stack, tgus an IntegrationRoutingSpec (not reproducable using just RouteTest).
+ * Has to exercise the entire stack, tgus an IntegrationRoutingSpec (not reproduciable using just RouteTest).
  */
 class IllegalHeadersIntegrationSpec extends IntegrationRoutingSpec {
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
@@ -33,10 +33,10 @@ final class ServerSentEventParserSpec extends AsyncWordSpec with Matchers with B
                      |:no data means event gets ignored
                      |
                      |data
-                     |:emtpy data means event gets ignored
+                     |:empty data means event gets ignored
                      |
                      |data:
-                     |:emtpy data means event gets ignored
+                     |:empty data means event gets ignored
                      |
                      |data: event 3
                      |id

--- a/akka-http/src/main/scala/akka/http/javadsl/common/EntityStreamingSupport.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/common/EntityStreamingSupport.scala
@@ -73,7 +73,7 @@ abstract class EntityStreamingSupport {
   def parallelism: Int
 
   /**
-   * Write-side / read-side, defines if (un)marshalling of incoming stream elements should be perserved or not.
+   * Write-side / read-side, defines if (un)marshalling of incoming stream elements should be preserved or not.
    *
    * Allowing for parallel and unordered (un)marshalling often yields higher throughput and also allows avoiding
    * head-of-line blocking if some elements are much larger than others.

--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -98,7 +98,7 @@ object Marshaller {
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    *
-   * Please note that all passed in marshallers will actualy be invoked in order to get the Marshalling object
+   * Please note that all passed in marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
    * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Akka HTTP.
@@ -111,7 +111,7 @@ object Marshaller {
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    *
-   * Please note that all marshallers will actualy be invoked in order to get the Marshalling object
+   * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
    * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Akka HTTP.
@@ -124,7 +124,7 @@ object Marshaller {
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    *
-   * Please note that all marshallers will actualy be invoked in order to get the Marshalling object
+   * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
    * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Akka HTTP.
@@ -137,7 +137,7 @@ object Marshaller {
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    *
-   * Please note that all marshallers will actualy be invoked in order to get the Marshalling object
+   * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
    * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Akka HTTP.
@@ -150,7 +150,7 @@ object Marshaller {
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    *
-   * Please note that all marshallers will actualy be invoked in order to get the Marshalling object
+   * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
    * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Akka HTTP.

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -54,7 +54,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
   }
 
   /**
-   * Rejects the request with an empty rejection (usualy used for "no directive matched").
+   * Rejects the request with an empty rejection (usually used for "no directive matched").
    */
   def reject(): Route = RouteAdapter {
     D.reject()

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala
@@ -103,7 +103,7 @@ object Marshaller
    * Helper for creating a "super-marshaller" from a number of "sub-marshallers".
    * Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    *
-   * Please note that all marshallers will actualy be invoked in order to get the Marshalling object
+   * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
    * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Akka HTTP.
@@ -115,7 +115,7 @@ object Marshaller
    * Helper for creating a "super-marshaller" from a number of values and a function producing "sub-marshallers"
    * from these values. Content-negotiation determines, which "sub-marshaller" eventually gets to do the job.
    *
-   * Please note that all marshallers will actualy be invoked in order to get the Marshalling object
+   * Please note that all marshallers will actually be invoked in order to get the Marshalling object
    * out of them, and later decide which of the marshallings should be returned. This is by-design,
    * however in ticket as discussed in ticket https://github.com/akka/akka-http/issues/243 it MAY be
    * changed in later versions of Akka HTTP.

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala
@@ -20,7 +20,7 @@ trait MultipartMarshallers {
     }
 
   /**
-   * The random instance that is used to create multipart boundaries. This can be overriden (e.g. in tests) to
+   * The random instance that is used to create multipart boundaries. This can be overridden (e.g. in tests) to
    * choose how a boundary is created.
    */
   protected def multipartBoundaryRandom: java.util.Random = ThreadLocalRandom.current()

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -101,7 +101,7 @@ class Http2ServerSpec extends AkkaSpec("""
         val incorrectHeaderBlock = hex"00 00 01 01 05 00 00 00 01 40"
         sendHEADERS(3, endStream = false, endHeaders = true, headerBlockFragment = incorrectHeaderBlock)
 
-        val (_, errorCode) = expectGOAWAY(1) // since we have sucessfully started processing stream `1`
+        val (_, errorCode) = expectGOAWAY(1) // since we have successfully started processing stream `1`
         errorCode should ===(ErrorCode.COMPRESSION_ERROR)
       }
       "Three consecutive GET requests" in new SimpleRequestResponseRoundtripSetup {

--- a/akka-parsing/src/main/java/akka/parboiled2/util/Base64.java
+++ b/akka-parsing/src/main/java/akka/parboiled2/util/Base64.java
@@ -557,7 +557,7 @@ public class Base64 {
 
         // Encode even 24-bits
         for (int s = 0, d = 0, cc = 0; s < eLen;) {
-            // Copy next three bytes into lower 24 bits of int, paying attension to sign.
+            // Copy next three bytes into lower 24 bits of int, paying attention to sign.
             int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
 
             // Encode the int into four chars
@@ -634,7 +634,7 @@ public class Base64 {
 
         // Encode even 24-bits
         for (int s = 0, d = 0, cc = 0; s < eLen;) {
-            // Copy next three bytes into lower 24 bits of int, paying attension to sign.
+            // Copy next three bytes into lower 24 bits of int, paying attention to sign.
             int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
 
             // Encode the int into four chars

--- a/docs/src/main/paradox/common/http-model.md
+++ b/docs/src/main/paradox/common/http-model.md
@@ -399,7 +399,7 @@ in the right style / place.
 
 Similarly to media types, Akka HTTP @scala[@scaladoc:[predefines](akka.http.scaladsl.model.StatusCodes$)]@java[@javadoc:[predefines](akka.http.javaadsl.model.StatusCodes)]
 well-known status codes, however sometimes you may need to use a custom one (or are forced to use an API which returns custom status codes).
-Similarily to the media types registration, you can register custom status codes by configuring @unidoc[ParserSettings] like this:
+Similarly to the media types registration, you can register custom status codes by configuring @unidoc[ParserSettings] like this:
 
 Scala
 :   @@snip [CustomStatusCodesSpec.scala]($akka-http$/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala) { #application-custom }

--- a/docs/src/main/paradox/contributing.md
+++ b/docs/src/main/paradox/contributing.md
@@ -111,7 +111,7 @@ To use the task simply type, and the output should include entries like shown be
 ```
 > validatePullRequest
 [info] Diffing [HEAD] to determine changed modules in PR...
-[info] Detected uncomitted changes in directories (including in dependency analysis): [akka-protobuf,project]
+[info] Detected uncommitted changes in directories (including in dependency analysis): [akka-protobuf,project]
 [info] Detected changes in directories: [docs, project, akka-http-tests, akka-protobuf, akka-http-testkit, akka-http, akka-http-core, akka-stream]
 ```
 

--- a/docs/src/main/paradox/routing-dsl/directives/marshalling-directives/handleWith.md
+++ b/docs/src/main/paradox/routing-dsl/directives/marshalling-directives/handleWith.md
@@ -24,7 +24,7 @@ to a given function without requiring any akka-http-specific functionality.
 
 `handleWith` is similar to `produce`.  The main difference is `handleWith` automatically
 calls `complete` when the function passed to `handleWith` returns. Using `produce` you
-must explicity call the completion function passed from the `produce` function.
+must explicitly call the completion function passed from the `produce` function.
 
 See @ref[marshalling](../../../common/marshalling.md) and @ref[unmarshalling](../../../common/unmarshalling.md) for guidance
 on marshalling entities with akka-http.

--- a/docs/src/main/paradox/routing-dsl/path-matchers.md
+++ b/docs/src/main/paradox/routing-dsl/path-matchers.md
@@ -226,7 +226,7 @@ Pipe Operator (`|`)
 : This operator combines two matcher alternatives in that the second one is only tried if the first one did *not* match.
 The two sub-matchers must have compatible types.
 For example: `"foo" | "bar"` will match either "foo" *or* "bar".
-When combining an alternative expressed using this operator with an `/` operator, make sure to surround the alternative with parentheses, like so: `("foo" | "bar") / "bom"`. Otherwise, the `/` operator takes precendence and would only apply to the right-hand side of the alternative.
+When combining an alternative expressed using this operator with an `/` operator, make sure to surround the alternative with parentheses, like so: `("foo" | "bar") / "bom"`. Otherwise, the `/` operator takes precedence and would only apply to the right-hand side of the alternative.
 
 ## Modifiers
 

--- a/docs/src/test/java/docs/http/javadsl/server/DirectiveExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/DirectiveExamplesTest.java
@@ -95,7 +95,7 @@ public class DirectiveExamplesTest extends JUnitRouteTest {
     return path(segment("order").slash(integerSegment()), id ->
       get(() -> complete("Received GET request for order " + id))
         .orElse(
-          put(() -> complete("Recieved PUT request for order " + id)))
+          put(() -> complete("Received PUT request for order " + id)))
     );
   }
   //#example1

--- a/docs/src/test/java/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java
@@ -177,7 +177,7 @@ public class DebuggingDirectivesExamplesTest extends JUnitRouteTest {
           "Logged Request:" + request.method().name() + ":" + request.getUri() + ":" + response.status() + ":" + elapsedTime,
           InfoLevel()));
     } else {
-      return Optional.empty();  //not a successfull response
+      return Optional.empty();  //not a successful response
     }
   }
 }

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -192,7 +192,7 @@ object ValidatePullRequest extends AutoPlugin {
             .map(_.takeWhile(_ != '/'))
             .filter(dir => dir.startsWith("akka-") || dir.startsWith("docs") || BuildFilesAndDirectories.contains(dir))
             .toSet
-          log.info("Detected uncomitted changes in directories (including in dependency analysis): " + dirtyDirectories.mkString("[", ",", "]"))
+          log.info("Detected uncommitted changes in directories (including in dependency analysis): " + dirtyDirectories.mkString("[", ",", "]"))
           dirtyDirectories
         }
 


### PR DESCRIPTION
As with https://github.com/akka/akka/pull/25448, I've fixed typos detected by https://github.com/client9/misspell 

```
$ misspell .
akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala:101:53: "actualy" is a misspelling of "actually"
akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala:114:43: "actualy" is a misspelling of "actually"
akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala:127:43: "actualy" is a misspelling of "actually"
akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala:140:43: "actualy" is a misspelling of "actually"
akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala:153:43: "actualy" is a misspelling of "actually"
akka-http/src/main/scala/akka/http/javadsl/common/EntityStreamingSupport.scala:76:94: "perserved" is a misspelling of "preserved"
CONTRIBUTING.md:112:16: "uncomitted" is a misspelling of "uncommitted"
akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala:57:50: "usualy" is a misspelling of "usually"
akka-http/src/main/scala/akka/http/scaladsl/marshalling/MultipartMarshallers.scala:23:82: "overriden" is a misspelling of "overridden"
akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala:106:43: "actualy" is a misspelling of "actually"
akka-http/src/main/scala/akka/http/scaladsl/marshalling/Marshaller.scala:118:43: "actualy" is a misspelling of "actually"
akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala:127:53: "overriden" is a misspelling of "overridden"
akka-http-core/src/main/resources/reference.conf:389:51: "overriden" is a misspelling of "overridden"
akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala:338:18: "accomodate" is a misspelling of "accommodate"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala:160:89: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala:181:8: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala:213:87: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala:122:94: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala:173:19: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala:205:87: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:48:88: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:119:48: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:131:105: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:136:74: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:139:106: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:140:98: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:144:106: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:145:98: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:148:40: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:153:110: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:154:117: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:157:97: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:160:105: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:162:105: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:168:94: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:170:75: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala:335:86: "teh" is a misspelling of "the"
akka-http-core/src/main/scala/akka/http/javadsl/settings/SettingsCompanion.scala:13:24: "overriden" is a misspelling of "overridden"
akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala:36:61: "attemting" is a misspelling of "attempting"
akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala:227:19: "lenght" is a misspelling of "length"
akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala:228:53: "lenght" is a misspelling of "length"
akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala:229:41: "lenght" is a misspelling of "length"
akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala:234:49: "lenght" is a misspelling of "length"
akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala:235:40: "lenght" is a misspelling of "length"
akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala:29:9: "similarily" is a misspelling of "similarly"
akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala:27:9: "similarily" is a misspelling of "similarly"
akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala:43:24: "facilisi" is a misspelling of "facilities"
akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala:49:35: "facilisi" is a misspelling of "facilities"
akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala:184:38: "ommitted" is a misspelling of "omitted"
akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CacheConditionDirectivesSpec.scala:191:43: "ommitted" is a misspelling of "omitted"
akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala:15:10: "excercise" is a misspelling of "exercise"
akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/IllegalHeadersIntegrationSpec.scala:15:74: "reproducable" is a misspelling of "reproducible"
akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala:36:23: "emtpy" is a misspelling of "empty"
akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala:39:23: "emtpy" is a misspelling of "empty"
akka-parsing/src/main/java/akka/parboiled2/util/Base64.java:560:71: "attension" is a misspelling of "attention"
akka-parsing/src/main/java/akka/parboiled2/util/Base64.java:637:71: "attension" is a misspelling of "attention"
akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala:104:62: "sucessfully" is a misspelling of "successfully"
docs/src/main/paradox/common/http-model.md:402:0: "Similarily" is a misspelling of "Similarly"
docs/src/main/paradox/contributing.md:114:16: "uncomitted" is a misspelling of "uncommitted"
docs/src/main/paradox/routing-dsl/directives/marshalling-directives/handleWith.md:27:5: "explicity" is a misspelling of "explicitly"
docs/src/main/paradox/routing-dsl/path-matchers.md:229:208: "precendence" is a misspelling of "precedence"
docs/src/test/java/docs/http/javadsl/server/DirectiveExamplesTest.java:98:30: "Recieved" is a misspelling of "Received"
docs/src/test/java/docs/http/javadsl/server/directives/DebuggingDirectivesExamplesTest.java:180:40: "successfull" is a misspelling of "successful"
project/ValidatePullRequest.scala:195:29: "uncomitted" is a misspelling of "uncommitted"
```