### PR TITLE
Fixes bug in SlotState for akka/akka-http#2138

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -282,6 +282,11 @@ private[pool] object SlotState {
         Unconnected
       else
         Idle
+
+    override def onRequestEntityCompleted(ctx: SlotContext): SlotState = {
+      require(waitingForEndOfRequestEntity)
+      WaitingForEndOfResponseEntity(ongoingRequest, ongoingResponse, waitingForEndOfRequestEntity = false)
+    }
   }
   final case object WaitingForEndOfRequestEntity extends ConnectedState {
     final override def isIdle = false


### PR DESCRIPTION
Fixes bug in SlotState for akka/akka-http#2138

Accepting `onRequestEntityCompleted` when in `WaitingForEndOfResponseEntity`. Staying in the same state, marking request as ended (`waitingForEndOfRequestEntity = false`)