### PR TITLE
Introduce HTTP/2 max-concurrent-streams settings

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.3.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.3.backwards.excludes
@@ -1,0 +1,12 @@
+# #2146: changes to (now) @DoNotInherit classes
+
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.Http2ServerSettings.withMaxConcurrentStreams")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.Http2ServerSettings.getMaxConcurrentStreams")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings.maxConcurrentStreams")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings.withMaxConcurrentStreams")
+
+# #2146: changes to implementation classes
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.settings.Http2ServerSettings#Http2ServerSettingsImpl.copy$default$4")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings#Http2ServerSettingsImpl.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings#Http2ServerSettingsImpl.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings#Http2ServerSettingsImpl.this")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -188,6 +188,9 @@ akka.http {
     log-unencrypted-network-bytes = off
 
     http2 {
+      # The maximum number of request per connection concurrently dispatched to the request handler.
+      max-concurrent-streams = 256
+
       # The maximum number of bytes to receive from a request entity in a single chunk.
       #
       # The reasoning to limit that amount (instead of delivering all buffered data for a stream) is that

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
@@ -4,9 +4,11 @@
 
 package akka.http.javadsl.settings
 
+import akka.annotation.DoNotInherit
 import akka.http.scaladsl
 import com.typesafe.config.Config
 
+@DoNotInherit
 trait Http2ServerSettings { self: scaladsl.settings.Http2ServerSettings ⇒
   def getRequestEntityChunkSize: Int = requestEntityChunkSize
   def withRequestEntityChunkSize(newRequestEntityChunkSize: Int): Http2ServerSettings
@@ -16,6 +18,9 @@ trait Http2ServerSettings { self: scaladsl.settings.Http2ServerSettings ⇒
 
   def getIncomingStreamLevelBufferSize: Int = incomingStreamLevelBufferSize
   def withIncomingStreamLevelBufferSize(newIncomingStreamLevelBufferSize: Int): Http2ServerSettings
+
+  def getMaxConcurrentStreams: Int = maxConcurrentStreams
+  def withMaxConcurrentStreams(newValue: Int): Http2ServerSettings
 }
 object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
   def create(config: Config): Http2ServerSettings = scaladsl.settings.Http2ServerSettings(config)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/UseHttp2.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/UseHttp2.scala
@@ -8,7 +8,7 @@ package akka.http.scaladsl
  * Specify whether to support HTTP/2: never, negotiated, or always.
  */
 sealed trait UseHttp2 extends akka.http.javadsl.UseHttp2 {
-  override def asScala = this.asInstanceOf[UseHttp2]
+  override def asScala: UseHttp2 = this
 }
 object UseHttp2 {
   object Never extends UseHttp2

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
@@ -4,6 +4,7 @@
 
 package akka.http.scaladsl.settings
 
+import akka.annotation.DoNotInherit
 import akka.annotation.{ ApiMayChange, InternalApi }
 import akka.http.javadsl
 import akka.http.impl.util._
@@ -13,21 +14,23 @@ import com.typesafe.config.Config
  * Placeholder for any kind of internal settings that might be interesting for HTTP/2 (like custom strategies)
  */
 @InternalApi
+@DoNotInherit
 private[http] trait Http2InternalServerSettings
 
 @ApiMayChange
+@DoNotInherit
 trait Http2ServerSettings extends javadsl.settings.Http2ServerSettings { self: Http2ServerSettings.Http2ServerSettingsImpl ⇒
   def requestEntityChunkSize: Int
-  def withRequestEntityChunkSize(newValue: Int): Http2ServerSettings =
-    copy(requestEntityChunkSize = newValue)
+  def withRequestEntityChunkSize(newValue: Int): Http2ServerSettings = copy(requestEntityChunkSize = newValue)
 
   def incomingConnectionLevelBufferSize: Int
-  def withIncomingConnectionLevelBufferSize(newValue: Int): Http2ServerSettings =
-    copy(incomingConnectionLevelBufferSize = newValue)
+  def withIncomingConnectionLevelBufferSize(newValue: Int): Http2ServerSettings = copy(incomingConnectionLevelBufferSize = newValue)
 
   def incomingStreamLevelBufferSize: Int
-  def withIncomingStreamLevelBufferSize(newValue: Int): Http2ServerSettings =
-    copy(incomingStreamLevelBufferSize = newValue)
+  def withIncomingStreamLevelBufferSize(newValue: Int): Http2ServerSettings = copy(incomingStreamLevelBufferSize = newValue)
+
+  def maxConcurrentStreams: Int
+  override def withMaxConcurrentStreams(newValue: Int): Http2ServerSettings = copy(maxConcurrentStreams = newValue)
 
   @InternalApi
   private[http] def internalSettings: Option[Http2InternalServerSettings]
@@ -42,6 +45,7 @@ object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
   def apply(configOverrides: String): Http2ServerSettings = Http2ServerSettingsImpl(configOverrides)
 
   private[http] case class Http2ServerSettingsImpl(
+    maxConcurrentStreams:              Int,
     requestEntityChunkSize:            Int,
     incomingConnectionLevelBufferSize: Int,
     incomingStreamLevelBufferSize:     Int,
@@ -54,6 +58,7 @@ object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
 
   private[http] object Http2ServerSettingsImpl extends akka.http.impl.util.SettingsCompanion[Http2ServerSettingsImpl]("akka.http.server.http2") {
     def fromSubConfig(root: Config, c: Config): Http2ServerSettingsImpl = Http2ServerSettingsImpl(
+      maxConcurrentStreams = c getInt "max-concurrent-streams",
       requestEntityChunkSize = c getIntBytes "request-entity-chunk-size",
       incomingConnectionLevelBufferSize = c getIntBytes "incoming-connection-level-buffer-size",
       incomingStreamLevelBufferSize = c getIntBytes "incoming-stream-level-buffer-size",

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -109,7 +109,13 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   }))
   def withWebsocketSettings(newValue: WebSocketSettings): ServerSettings = self.copy(websocketSettings = newValue)
   def withSocketOptions(newValue: immutable.Seq[SocketOption]): ServerSettings = self.copy(socketOptions = newValue)
+  def withHttp2Settings(newValue: Http2ServerSettings): ServerSettings = copy(http2Settings = newValue)
 
+  // Scala-only lenses
+  def mapHttp2Settings(f: Http2ServerSettings ⇒ Http2ServerSettings): ServerSettings = withHttp2Settings(f(http2Settings))
+  def mapParserSettings(f: ParserSettings ⇒ ParserSettings): ServerSettings = withParserSettings(f(parserSettings))
+  def mapPreviewServerSettings(f: PreviewServerSettings ⇒ PreviewServerSettings): ServerSettings = withPreviewServerSettings(f(previewServerSettings))
+  def mapWebsocketSettings(f: WebSocketSettings ⇒ WebSocketSettings): ServerSettings = withWebsocketSettings(f(websocketSettings))
 }
 
 object ServerSettings extends SettingsCompanion[ServerSettings] {

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -45,6 +45,10 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
     settings:    ServerSettings,
     parallelism: Int,
     log:         LoggingAdapter)(implicit fm: Materializer): Future[ServerBinding] = {
+    if (parallelism == 1)
+      log.warning("HTTP/2 `bindAndHandleAsync` was called with default parallelism = 1. This means that request handling " +
+        "concurrency per connection is disabled. This is likely not what you want with HTTP/2.")
+
     val effectivePort = if (port >= 0) port else 80
 
     val serverLayer: Flow[ByteString, ByteString, Future[Done]] = Flow.fromGraph(


### PR DESCRIPTION
Refs #2145 

The idea is to change the default for the `bindAndHandleAsync` `parallelism` parameter to `0`, which means "take the value from the configuration".

We then take different values for HTTP/1 and HTTP/2:

 * for HTTP/1 take `pipelining-limit` because that's even stronger than parallelism
 * for HTTP/2 take a new setting `http2.max-concurrent-streams`