### PR TITLE
Ignore case for MediaType.hashCode

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -56,7 +56,7 @@ sealed abstract class MediaType extends jm.MediaType with LazyValueBytesRenderab
       case _            ⇒ false
     }
 
-  override def hashCode(): Int = value.hashCode
+  override def hashCode(): Int = value.toLowerCase.hashCode
 
   /**
    * JAVA API

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -20,6 +20,20 @@ class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
   implicit val mat = ActorMaterializer()
 
   "Http" should {
+    "find media types in a set if they differ in casing" in {
+      val set: java.util.Set[MediaType] = new java.util.HashSet
+      set.add(MediaTypes.`application/excel`)
+      set.add(MediaTypes.`application/mspowerpoint`)
+      set.add(MediaTypes.`application/msword`)
+      set.add(MediaType.customBinary("application", "x-Akka-TEST", MediaType.NotCompressible))
+
+      set.contains(MediaType.parse("application/msword").right.get) should ===(true)
+      set.contains(MediaType.parse("application/MsWord").right.get) should ===(true)
+      set.contains(MediaType.parse("application/EXCEL").right.get) should ===(true)
+      set.contains(MediaType.parse("application/x-akka-test").right.get) should ===(true)
+      set.contains(MediaType.parse("application/x-Akka-TEST").right.get) should ===(true)
+    }
+
     "allow registering custom media type" in {
       import system.dispatcher
       val (host, port) = SocketUtil.temporaryServerHostnameAndPort()


### PR DESCRIPTION
If MediaType instances are used with a hashset or hashmap,
equivalent (equal) objects should go into the same buckets. Since
MediaType's equals() method correctly is case insensitive, do should its
hashCode.

Fixes #2144.