### PR TITLE
Preserve http2 option when going from javadsl to scaladsl

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.3.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.3.backwards.excludes
@@ -10,3 +10,9 @@ ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.settin
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings#Http2ServerSettingsImpl.apply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings#Http2ServerSettingsImpl.copy")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings#Http2ServerSettingsImpl.this")
+
+# #2149: additions to @DoNotInherit classes
+
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.HttpsConnectionContext.withHttp2")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.HttpConnectionContext.withHttp2")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.ConnectionContext.withHttp2")

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
@@ -9,6 +9,7 @@ import java.util.Optional
 
 import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.http.javadsl.model.Uri
+import akka.http.scaladsl.HttpConnectionContext
 import akka.http.scaladsl.UseHttp2.Negotiated
 
 @DoNotInherit
@@ -23,7 +24,7 @@ abstract class ConnectHttp {
   final def effectiveHttpsConnectionContext(fallbackContext: HttpsConnectionContext): HttpsConnectionContext =
     connectionContext.orElse(fallbackContext)
 
-  final def effectiveConnectionContext(fallbackContext: ConnectionContext): ConnectionContext =
+  def effectiveConnectionContext(fallbackContext: ConnectionContext): ConnectionContext =
     if (connectionContext.isPresent) connectionContext.get()
     else fallbackContext
 
@@ -167,6 +168,9 @@ final class ConnectHttpImpl(val host: String, val port: Int, val http2: UseHttp2
   def isHttps: Boolean = false
 
   def connectionContext: Optional[HttpsConnectionContext] = Optional.empty()
+
+  override def effectiveConnectionContext(fallbackContext: ConnectionContext): ConnectionContext =
+    HttpConnectionContext(http2.asScala)
 }
 
 /** INTERNAL API */

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -65,6 +65,8 @@ abstract class ConnectionContext {
   def sslConfig: Option[AkkaSSLConfig]
   def http2: UseHttp2
 
+  def withHttp2(newValue: UseHttp2): ConnectionContext
+
   @deprecated("'default-http-port' and 'default-https-port' configuration properties are used instead", since = "10.0.11")
   def getDefaultPort: Int
 }
@@ -74,12 +76,16 @@ abstract class HttpConnectionContext(override val http2: UseHttp2) extends akka.
   override final def isSecure = false
   override final def getDefaultPort = 80
   override def sslConfig: Option[AkkaSSLConfig] = None
+
+  override def withHttp2(newValue: UseHttp2): HttpConnectionContext
 }
 
 @DoNotInherit
 abstract class HttpsConnectionContext(override val http2: UseHttp2) extends akka.http.javadsl.ConnectionContext {
   override final def isSecure = true
   override final def getDefaultPort = 443
+
+  override def withHttp2(newValue: UseHttp2): HttpsConnectionContext
 
   /** Java API */
   def getEnabledCipherSuites: Optional[JCollection[String]]

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -11,6 +11,7 @@ import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import scala.collection.JavaConverters._
 import java.util.{ Optional, Collection ⇒ JCollection }
 
+import akka.http.javadsl
 import akka.http.scaladsl.UseHttp2.Negotiated
 import javax.net.ssl._
 
@@ -93,10 +94,20 @@ final class HttpsConnectionContext(
   override def getEnabledProtocols: Optional[JCollection[String]] = enabledProtocols.map(_.asJavaCollection).asJava
   override def getClientAuth: Optional[TLSClientAuth] = clientAuth.asJava
   override def getSslParameters: Optional[SSLParameters] = sslParameters.asJava
+
+  override def withHttp2(newValue: javadsl.UseHttp2): javadsl.HttpsConnectionContext =
+    withHttp2(newValue.asScala)
+  def withHttp2(newValue: UseHttp2): javadsl.HttpsConnectionContext =
+    new HttpsConnectionContext(sslContext, sslConfig, enabledCipherSuites, enabledProtocols, clientAuth, sslParameters, newValue)
 }
 
 sealed class HttpConnectionContext(http2: UseHttp2) extends akka.http.javadsl.HttpConnectionContext(http2) with ConnectionContext {
   def this() = this(Negotiated)
+
+  override def withHttp2(newValue: javadsl.UseHttp2): javadsl.HttpConnectionContext =
+    withHttp2(newValue.asScala)
+  def withHttp2(newValue: UseHttp2): javadsl.HttpConnectionContext =
+    new HttpConnectionContext(newValue)
 }
 
 final object HttpConnectionContext extends HttpConnectionContext(Negotiated) {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -98,6 +98,7 @@ final class HttpsConnectionContext(
 sealed class HttpConnectionContext(http2: UseHttp2) extends akka.http.javadsl.HttpConnectionContext(http2) with ConnectionContext {
   def this() = this(Negotiated)
 }
+
 final object HttpConnectionContext extends HttpConnectionContext(Negotiated) {
   /** Java API */
   def getInstance() = this

--- a/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
@@ -99,5 +99,10 @@ class ConnectHttpSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       }
       ex.getMessage should include("non https scheme!")
     }
+    "connect toHost HTTP/2 only" in {
+      val connect = ConnectHttp.toHost("http://127.0.0.1", 8080, UseHttp2.always)
+      connect.effectiveConnectionContext(httpsContext).http2 should equal(UseHttp2.always)
+    }
+
   }
 }

--- a/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
@@ -103,6 +103,10 @@ class ConnectHttpSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       val connect = ConnectHttp.toHost("http://127.0.0.1", 8080, UseHttp2.always)
       connect.effectiveConnectionContext(httpsContext).http2 should equal(UseHttp2.always)
     }
+    "connect toHostHttps HTTP/2 only" in {
+      val connect = ConnectHttp.toHostHttps("https://127.0.0.1", 8080, UseHttp2.always)
+      connect.effectiveConnectionContext(httpsContext).http2 should equal(UseHttp2.always)
+    }
 
   }
 }


### PR DESCRIPTION
The only information passed from javadsl to the scaladsl in Http
was the context which for Http connections was always the default one
meaning that setting http2 always had no effect.

This seed the easiest way not to break the user facing API