### PR TITLE
=pro Fix Mima rules for forked release branches

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@
    - Run a test against the staging repository to make sure the release went well, for example by using https://github.com/akka/akka-http-scala-seed.g8 and adding the sonatype staging repo with `resolvers += "Staging Repo" at "https://oss.sonatype.org/content/repositories/comtypesafe-xxx"`
    - Release the staging repository to Maven Central.
 1. Create a new milestone for the next version at https://github.com/akka/akka-http/milestones , move all unclosed issues there and close the version you're releasing
-1. Add the released version to `project/MiMa.scala` to the `mimaPreviousArtifacts` key.
+1. Add the released version to `project/MiMa.scala` to the `mimaPreviousArtifacts` key *of all current compatible branches*.
 1. Send a release notification to akka-user and tweet using the akka account (or ask someone to) about the new release
 1. Log into gustav.akka.io as akkarepo and update the `current` links on repo.akka.io to point to the latest version with `ln -nsf <latestversion> www/docs/akka-http/current; ln -nsf <latestversion> www/api/akka-http/current; ln -nsf <latestversion> www/japi/akka-http/current`.
 

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -6,8 +6,11 @@ package akka
 
 import sbt._
 import sbt.Keys._
+import com.typesafe.tools.mima.core.ProblemFilter
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
+
+import scala.util.Try
 
 object MiMa extends AutoPlugin {
 
@@ -18,6 +21,10 @@ object MiMa extends AutoPlugin {
   private val ignoredModules = Map(
     "akka-http-caching" -> Set("10.0.0", "10.0.1", "10.0.2", "10.0.3", "10.0.4", "10.0.5", "10.0.6", "10.0.7", "10.0.8", "10.0.9", "10.0.10")
   )
+
+  // A fork is a branch of the project where new releases are created that are not ancestors of the current release line
+  val forks = Seq("10.0.")
+  val currentFork = "10.1."
 
   override val projectSettings = Seq(
     mimaPreviousArtifacts :=
@@ -35,6 +42,8 @@ object MiMa extends AutoPlugin {
           "10.0.9",
           "10.0.10",
           "10.0.11",
+          "10.0.12",
+          "10.0.13",
           "10.1.0",
           "10.1.1",
           "10.1.2",
@@ -43,6 +52,38 @@ object MiMa extends AutoPlugin {
       )
         .collect { case version if !ignoredModules.get(name.value).exists(_.contains(version)) =>
           organization.value %% name.value % version
+        },
+      mimaBackwardIssueFilters := {
+        val filters = mimaBackwardIssueFilters.value
+        val allVersions = (mimaPreviousArtifacts.value.map(_.revision) ++ filters.keys).toSeq
+
+        /**
+         * Collect filters for all versions of a fork and add them as filters for the latest version of the fork.
+         * Otherwise, new versions in the fork that are listed above will reintroduce issues that were already filtered
+         * out before. We basically rebase this release line on top of the fork from the view of Mima.
+         */
+        def forkFilter(fork: String): Option[(String, Seq[ProblemFilter])] = {
+          val forkVersions = filters.keys.filter(_.startsWith(fork)).toSeq
+          val collectedFilterOption = forkVersions.map(filters).reduceOption(_ ++ _)
+          collectedFilterOption.map(latestForkVersion(fork, allVersions) -> _)
         }
+
+        forks.flatMap(forkFilter).toMap ++
+        filters.filterKeys(_ startsWith currentFork)
+      }
   )
+
+  def latestForkVersion(fork: String, allVersions: Seq[String]): String =
+    allVersions
+      .filter(_.startsWith(fork))
+      .sorted(versionOrdering)
+      .last
+
+  // copied from https://github.com/lightbend/migration-manager/blob/e54f3914741b7f528da5507e515cc84db60abdd5/core/src/main/scala/com/typesafe/tools/mima/core/ProblemReporting.scala#L14-L19
+  private val versionOrdering = Ordering[(Int, Int, Int)].on { version: String =>
+    val ModuleVersion = """(\d+)\.?(\d+)?\.?(.*)?""".r
+    val ModuleVersion(epoch, major, minor) = version
+    val toNumeric = (revision: String) => Try(revision.replace("x", Short.MaxValue.toString).filter(_.isDigit).toInt).getOrElse(0)
+    (toNumeric(epoch), toNumeric(major), toNumeric(minor))
+  }
 }


### PR DESCRIPTION
In these cases like looking from 10.1.x to 10.0.x, when branching, we
defined a set of mima filters between 10.1 and 10.0. However, from Mima's
perspective a new 10.0.x version will reintroduce the incompatibilities.

For that reason, we collect all old filters (i.e. filters for released versions of
forked branches) and only keep an entry for the latest version of the forked
branch.

In our case, all filters for 10.0.x are collected and then registered as a
single entry for 10.0.13 (mima already reuses newer filters for older versions
so that this covers all older versions).

An alternative approach would be to collect mima filters for forked branches
when doing the branch in a single file like `10.0.x.backwards.excludes`.