### PR TITLE
fix LfuCache ttl can be equal to tti

### DIFF
--- a/akka-http-caching/src/main/scala/akka/http/caching/LfuCache.scala
+++ b/akka-http-caching/src/main/scala/akka/http/caching/LfuCache.scala
@@ -69,8 +69,8 @@ object LfuCache {
   private def expiringLfuCache[K, V](maxCapacity: Long, initialCapacity: Int,
                                      timeToLive: Duration, timeToIdle: Duration): LfuCache[K, V] = {
     require(
-      !timeToLive.isFinite || !timeToIdle.isFinite || timeToLive > timeToIdle,
-      s"timeToLive($timeToLive) must be greater than timeToIdle($timeToIdle)")
+      !timeToLive.isFinite || !timeToIdle.isFinite || timeToLive >= timeToIdle,
+      s"timeToLive($timeToLive) must be >= than timeToIdle($timeToIdle)")
 
     def ttl: Caffeine[K, V] ⇒ Caffeine[K, V] = { builder ⇒
       if (timeToLive.isFinite) builder.expireAfterWrite(timeToLive.toMillis, TimeUnit.MILLISECONDS)

--- a/akka-http-caching/src/test/scala/akka/http/caching/ExpiringLfuCacheSpec.scala
+++ b/akka-http-caching/src/test/scala/akka/http/caching/ExpiringLfuCacheSpec.scala
@@ -108,6 +108,9 @@ class ExpiringLfuCacheSpec extends WordSpec with Matchers with BeforeAndAfterAll
         ints.filter(_ != 0).reduceLeft((a, b) ⇒ if (a == b) a else 0) should not be 0
       }
     }
+    "be created with the same ttl and tti" in {
+      lfuCache[Int](timeToLive = 5.seconds, timeToIdle = 5.seconds) shouldBe a[LfuCache[_, _]]
+    }
   }
 
   override def afterAll() = {

--- a/docs/src/main/paradox/common/caching.md
+++ b/docs/src/main/paradox/common/caching.md
@@ -54,12 +54,12 @@ store. After the maximum capacity is reached the cache will evicts entries that 
 less likely to be used again. For example, the cache may evict an entry
 because it hasn't been used recently or very often.
 
-Time-based entry expiration is enabled when a time-to-live and/or time-to-idle
+Time-based entry expiration is enabled when time-to-live and/or time-to-idle
 expirations are set to a finite duration. The former provides an
 upper limit to the time period an entry is allowed to remain in the cache while
 the latter limits the maximum time an entry is kept without having been
 accessed, ie. either read or updated. If both values are finite the time-to-live
-has to be strictly greater than the time-to-idle.
+has to be greater or equal than the time-to-idle.
 
 @@@ note
 


### PR DESCRIPTION
If you don't want to use tti you need to write some ugly `time-to-idle = 5 minutes - 1 seconds` to the config. So I fixed the requirement.

(Maybe if tti is not finite we should use ttl for both values. That would make easier setup in some use-cases. But that can be misleading too, so I did the minimal effort "fix" only.)

(Or maybe we should play with boolalgebra and change the whole thing to:
`!(timeToLive.isFinite && timeToIdle.isFinite && timeToLive < timeToIdle)` bcs the following implementation only set the desired finite values...)