### PR TITLE
Publish 10.0.14 release notes also on master

### DIFF
--- a/docs/src/main/paradox/migration-guide/migration-guide-10.0.x.md
+++ b/docs/src/main/paradox/migration-guide/migration-guide-10.0.x.md
@@ -9,7 +9,16 @@ See @extref:[The @DoNotInherit and @ApiMayChange markers](akka-docs:common/binar
 This migration guide aims to help developers who use these bleeding-edge APIs to migrate between their evolving versions
 within patch releases.
 
-## Akka HTTP 10.0.7 -> 10.0.8
+## 10.0.13 -> 10.0.14
+
+To avoid excessive memory usage we introduced two new limits that apply per default:
+
+ * `akka.http.routing.decode-max-size`: This limit applies when you use `decodeRequest` to limit the amount of decompressed data. The default limit is 8 megabytes.
+ * `akka.http.parsing.max-to-strict-bytes`: This limit applies when you use `HttpEntity.toStrict` or the `toStrictEntity` directive (and related directives). It will only collect up to the given amount data and fail otherwise. The default limit is 8 megabytes.
+
+Depending on your application requirements, you may want to change these settings.
+
+## 10.0.7 -> 10.0.8
 
 ### ClientTransport SPI / API Changes
 
@@ -18,7 +27,7 @@ and doesn't take any parameters any more. `ClientTransport.connectTo` now has a 
 This is a binary and source incompatible change to an `@ApiMayChange` API. So far, this API was not documented or
 exposed so we hope that only few users are affected.
 
-## Akka HTTP 10.0.6 -> 10.0.7
+## 10.0.6 -> 10.0.7
 
 ### `HttpApp#route` has been renamed to `HttpApp#routes`
 

--- a/docs/src/main/paradox/release-notes/10.0.x.md
+++ b/docs/src/main/paradox/release-notes/10.0.x.md
@@ -1,5 +1,28 @@
 # 10.0.x Release Notes
 
+## 10.0.14
+
+See the [announcement](https://akka.io/blog/news/2018/09/06/akka-http-10.1.5-10.0.14-security-fix-released.html) and
+closed tickets on the [10.0.14 milestone](https://github.com/akka/akka-http/milestone/38?closed=1).
+
+This release fixes the [DoS vulnerability](https://doc.akka.io/docs/akka-http/current/security/2018-09-05-denial-of-service-via-decodeRequest.html)
+in the `decodeRequest` directive. Please update as soon as possible.
+
+### Migration Notes
+
+To avoid excessive memory usage we introduced two new limits that apply per default:
+
+ * `akka.http.routing.decode-max-size`: This limit applies when you use `decodeRequest` to limit the amount of decompressed data. The default limit is 8 megabytes.
+ * `akka.http.parsing.max-to-strict-bytes`: This limit applies when you use `HttpEntity.toStrict` or the `toStrictEntity` directive (and related directives). It will only collect up to the given amount data and fail otherwise. The default limit is 8 megabytes.
+
+Depending on your application requirements, you may want to change these settings.
+
+### List of Changes
+
+ * Restrict the maximum size of a request entity after uncompressing it with `decodeRequest` [#2137](https://github.com/akka/akka-http/issues/2137)
+ * Restrict the maximum size of a request entity when reading it into memory with `toStrict` [#2186](https://github.com/akka/akka-http/pull/2186)
+ * Support parameters for custom media types ([#2005](https://github.com/akka/akka-http/issues/2005))
+
 ## 10.0.11
 
 See the [announcement](https://akka.io/blog/news/2017/12/01/akka-http-10.0.11-released.html) and


### PR DESCRIPTION
Because people will more likely see them on the `current` page.