### PR TITLE
Fail with unwrapped exception when using CompletionStage #2054

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/CompleteTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/CompleteTest.java
@@ -9,6 +9,7 @@ import static akka.http.javadsl.unmarshalling.StringUnmarshallers.INTEGER;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import akka.http.javadsl.model.StatusCodes;
 import org.junit.Test;
 
 import akka.http.javadsl.marshallers.jackson.Jackson;
@@ -69,5 +70,65 @@ public class CompleteTest extends JUnitRouteTest {
         runRoute(route, HttpRequest.GET("add?x=42&y=23"))
             .assertStatusCode(200)
             .assertEntity("42 + 23 = 65");
+    }
+
+
+    private ExceptionHandler customExceptionHandler() {
+        return ExceptionHandler.newBuilder()
+                .match(IllegalStateException.class, ex ->
+                        complete(StatusCodes.SERVICE_UNAVAILABLE, "Custom Error"))
+                .build();
+    }
+
+    private void checkRoute(Route route) {
+        Route sealedRoute = route.seal(RejectionHandler.defaultHandler(), customExceptionHandler());
+        runRoute(sealedRoute, HttpRequest.GET("/crash"))
+                .assertStatusCode(StatusCodes.SERVICE_UNAVAILABLE)
+                .assertEntity("Custom Error");
+    }
+
+    @Test
+    public void completeOKWithFutureStringFailing() {
+        Route route = path("crash", () ->
+                completeOKWithFutureString(CompletableFuture.supplyAsync(() -> {
+                    throw new IllegalStateException("Boom!");
+                })));
+        checkRoute(route);
+    }
+
+    @Test
+    public void completeWithFutureStatusFailing() {
+        Route route = path("crash", () ->
+                completeWithFutureStatus(CompletableFuture.supplyAsync(() -> {
+                    throw new IllegalStateException("Boom!");
+                })));
+        checkRoute(route);
+    }
+
+    @Test
+    public void completeWithFutureFailing() {
+        Route route = path("crash", () ->
+                completeWithFuture(CompletableFuture.supplyAsync(() -> {
+                    throw new IllegalStateException("Boom!");
+                })));
+        checkRoute(route);
+    }
+
+    @Test
+    public void completeOKWithFutureFailing() {
+        Route route = path("crash", () ->
+                completeOKWithFuture(CompletableFuture.supplyAsync(() -> {
+                    throw new IllegalStateException("Boom!");
+                })));
+        checkRoute(route);
+    }
+
+    @Test
+    public void completeOKWithFutureTFailing() {
+        Route route = path("crash", () ->
+                completeOKWithFuture(CompletableFuture.<Integer>supplyAsync(() -> {
+                    throw new IllegalStateException("Boom!");
+                }), Jackson.marshaller()));
+        checkRoute(route);
     }
 }


### PR DESCRIPTION
Refs: #2054
Unwraps the original exception that caused the `CompletionStage` to fail.
This original exception can then be used on the custom `ExceptionHandler`.

Please note that the unwrapping is only done for the methods that take a `CompletionStage` not for the ones getting a Scala `Future`.