### PR TITLE
HTTPS request to HTTP endpoint logging test

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -746,8 +746,9 @@ Host: example.com
       val binding = Http().bindAndHandle(dummyFlow, "127.0.0.1", port = 0).futureValue
       val uri = "https://" + binding.localAddress.getHostString + ":" + binding.localAddress.getPort
 
-      EventFilter.warning(pattern = "Perhaps this was an HTTPS request sent to an HTTP endpoint", occurrences = 6) intercept {
-        Await.ready(Http().singleRequest(HttpRequest(uri = uri)), 30.seconds)
+      EventFilter.warning(pattern = "Perhaps this was an HTTPS request sent to an HTTP endpoint", occurrences = 1) intercept {
+        // Test with a POST so auto-retry isn't triggered:
+        Await.ready(Http().singleRequest(HttpRequest(uri = uri, method = HttpMethods.POST)), 30.seconds)
       }
 
       Await.result(binding.unbind(), 10.seconds)


### PR DESCRIPTION
Refs #1886.

I suspect the failure was just a timing issue, where the idempotent GET request
is automatically retried 6 times, but that didn't happen within the 3 seconds
that `EventFilter` waits for this. Sidestepped by using a non-idempotent POST
request so it won't retry at all.