### PR TITLE
=htc #1391 client pool: exponential backoff after failed connection attempts

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.5.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.5.backwards.excludes
@@ -5,3 +5,7 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.H
 
 # Internal API
 ProblemFilters.exclude[Problem]("akka.http.impl.*")
+
+# New setting in @DoNotInherit class
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.baseConnectionBackoff")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.maxConnectionBackoff")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -372,9 +372,14 @@ akka.http {
     #   - After 7th, between 3200ms and 6400ms
     #   - After 8th, between 5000ms and 10 seconds (max capped by max-connection-backoff, min by half of that)
     #   - After 9th, etc., stays between 5000ms and 10 seconds
+    #
+    # This setting only applies to the new pool implementation and is ignored for the legacy one.
     base-connection-backoff = 100ms
 
-    # Maximum backoff duration between failed connection attempts.
+    # Maximum backoff duration between failed connection attempts. For more information see the above comment for the
+    # `base-connection-backoff` setting.
+    #
+    # This setting only applies to the new pool implementation and is ignored for the legacy one.
     max-connection-backoff = 2 min
 
     # The time after which an idle connection pool (without pending requests)

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -350,6 +350,33 @@ akka.http {
     # Client-side pipelining is not currently supported. See https://github.com/akka/akka-http/issues/32
     pipelining-limit = 1
 
+    # The minimum duration to backoff new connection attempts after the previous connection attempt failed.
+    #
+    # The pool uses an exponential randomized backoff scheme. After the first failure, the next attempt will only be
+    # tried after a random duration between the base connection backoff and twice the base connection backoff. If that
+    # attempt fails as well, the next attempt will be delayed by twice that amount. The total delay is capped using the
+    # `max-connection-backoff` setting.
+    #
+    # The backoff applies for the complete pool. I.e. after one failed connection attempt, further connection attempts
+    # to that host will backoff for all connections of the pool. After the service recovered, connections will come out
+    # of backoff one by one due to the random extra backoff time. This is to avoid overloading just recently recovered
+    # services with new connections ("thundering herd").
+    #
+    # Example: base-connection-backoff = 100ms, max-connection-backoff = 10 seconds
+    #   - After 1st failure, backoff somewhere between 100ms and 200ms
+    #   - After 2nd, between  200ms and  400ms
+    #   - After 3rd, between  200ms and  400ms
+    #   - After 4th, between  400ms and  800ms
+    #   - After 5th, between  800ms and 1600ms
+    #   - After 6th, between 1600ms and 3200ms
+    #   - After 7th, between 3200ms and 6400ms
+    #   - After 8th, between 5000ms and 10 seconds (max capped by max-connection-backoff, min by half of that)
+    #   - After 9th, etc., stays between 5000ms and 10 seconds
+    base-connection-backoff = 100ms
+
+    # Maximum backoff duration between failed connection attempts.
+    max-connection-backoff = 2 min
+
     # The time after which an idle connection pool (without pending requests)
     # will automatically terminate itself. Set to `infinite` to completely disable idle timeouts.
     idle-timeout = 30 s

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -156,11 +156,14 @@ private[pool] object SlotState {
 
     override val stateTimeout: Duration = newLevelTimeout()
 
-    private def newLevelTimeout(): FiniteDuration = {
-      val minMillis = embargoDuration.toMillis
-      val maxMillis = minMillis * 2
-      ThreadLocalRandom.current().nextLong(minMillis, maxMillis).millis
-    }
+    private def newLevelTimeout(): FiniteDuration =
+      if (embargoDuration.toMillis > 0) {
+        val minMillis = embargoDuration.toMillis
+        val maxMillis = minMillis * 2
+        ThreadLocalRandom.current().nextLong(minMillis, maxMillis).millis
+      } else
+        Duration.Zero
+
     override def onTimeout(ctx: SlotContext): SlotState = OutOfEmbargo
 
     override def onNewConnectionEmbargo(ctx: SlotContext, embargoDuration: FiniteDuration): SlotState =

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -36,6 +36,10 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   require((maxOpenRequests & (maxOpenRequests - 1)) == 0, "max-open-requests must be a power of 2. " + suggestPowerOfTwo(maxOpenRequests))
   require(pipeliningLimit > 0, "pipelining-limit must be > 0")
   require(idleTimeout >= Duration.Zero, "idle-timeout must be >= 0")
+  require(
+    minConnections == 0 || (baseConnectionBackoff.toMillis > 0 && maxConnectionBackoff.toMillis > 10),
+    "If min-connections > 0, you need to set a base-connection-backoff must be > 0 and max-connection-backoff must be > 10 millis " +
+      "to avoid client pools excessively trying to open up new connections.")
 
   override def productPrefix = "ConnectionPoolSettings"
 

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -10,6 +10,7 @@ import akka.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSet
 import com.typesafe.config.Config
 
 import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 /** INTERNAL API */
 @InternalApi
@@ -19,6 +20,8 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   maxRetries:                        Int,
   maxOpenRequests:                   Int,
   pipeliningLimit:                   Int,
+  baseConnectionBackoff:             FiniteDuration,
+  maxConnectionBackoff:              FiniteDuration,
   idleTimeout:                       Duration,
   connectionSettings:                ClientConnectionSettings,
   poolImplementation:                PoolImplementation,
@@ -49,7 +52,9 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   }
 }
 
-object ConnectionPoolSettingsImpl extends SettingsCompanion[ConnectionPoolSettingsImpl]("akka.http.host-connection-pool") {
+/** INTERNAL API */
+@InternalApi
+private[akka] object ConnectionPoolSettingsImpl extends SettingsCompanion[ConnectionPoolSettingsImpl]("akka.http.host-connection-pool") {
   def fromSubConfig(root: Config, c: Config) = {
     new ConnectionPoolSettingsImpl(
       c getInt "max-connections",
@@ -57,6 +62,8 @@ object ConnectionPoolSettingsImpl extends SettingsCompanion[ConnectionPoolSettin
       c getInt "max-retries",
       c getInt "max-open-requests",
       c getInt "pipelining-limit",
+      c getFiniteDuration "base-connection-backoff",
+      c getFiniteDuration "max-connection-backoff",
       c getPotentiallyInfiniteDuration "idle-timeout",
       ClientConnectionSettingsImpl.fromSubConfig(root, c.getConfig("client")),
       c.getString("pool-implementation").toLowerCase match {

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -13,6 +13,8 @@ import scala.concurrent.duration.Duration
 import akka.http.impl.util.JavaMapping.Implicits._
 import akka.http.javadsl.ClientTransport
 
+import scala.concurrent.duration.FiniteDuration
+
 @ApiMayChange
 trait PoolImplementation
 @ApiMayChange
@@ -31,6 +33,8 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def getMaxRetries: Int = maxRetries
   def getMaxOpenRequests: Int = maxOpenRequests
   def getPipeliningLimit: Int = pipeliningLimit
+  def getBaseConnectionBackoff: FiniteDuration = baseConnectionBackoff
+  def getMaxConnectionBackoff: FiniteDuration = maxConnectionBackoff
   def getIdleTimeout: Duration = idleTimeout
   def getConnectionSettings: ClientConnectionSettings = connectionSettings
 
@@ -55,6 +59,8 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copy(maxOpenRequests = newValue)
   /** Client-side pipelining is not currently supported, see https://github.com/akka/akka-http/issues/32 */
   def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue)
+  def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(baseConnectionBackoff = newValue)
+  def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(maxConnectionBackoff = newValue)
   def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue)
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala)
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -11,6 +11,7 @@ import akka.http.scaladsl.ClientTransport
 import com.typesafe.config.Config
 
 import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 @ApiMayChange
 sealed trait PoolImplementation extends js.PoolImplementation
@@ -30,6 +31,8 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   def maxRetries: Int
   def maxOpenRequests: Int
   def pipeliningLimit: Int
+  def baseConnectionBackoff: FiniteDuration
+  def maxConnectionBackoff: FiniteDuration
   def idleTimeout: Duration
   def connectionSettings: ClientConnectionSettings
 
@@ -54,6 +57,9 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   override def withMaxRetries(n: Int): ConnectionPoolSettings = self.copy(maxRetries = n)
   override def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copy(maxOpenRequests = newValue)
   override def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue)
+  override def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(baseConnectionBackoff = newValue)
+  override def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(maxConnectionBackoff = newValue)
+
   override def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue)
 
   // overloads for idiomatic Scala use

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -248,14 +248,17 @@ class GracefulTerminationSpec extends WordSpec with Matchers with BeforeAndAfter
         .bindAndHandle(routes, hostname, port, connectionContext = serverConnectionContext, settings = serverSettings)
         .futureValue
 
+    val basePoolSettings = ConnectionPoolSettings(system).withBaseConnectionBackoff(Duration.Zero)
+
     def makeRequest(ensureNewConnection: Boolean = false): Future[HttpResponse] = {
       if (ensureNewConnection) {
         // by changing the settings, we ensure we'll hit a new connection pool, which means it will be a new connection for sure.
         idleTimeoutBaseForUniqueness += 1
-        val clientSettings = ConnectionPoolSettings(system).withIdleTimeout(idleTimeoutBaseForUniqueness.seconds)
+        val clientSettings = basePoolSettings.withIdleTimeout(idleTimeoutBaseForUniqueness.seconds)
+
         Http().singleRequest(nextRequest, connectionContext = clientConnectionContext, settings = clientSettings)
       } else {
-        Http().singleRequest(nextRequest, connectionContext = clientConnectionContext)
+        Http().singleRequest(nextRequest, connectionContext = clientConnectionContext, settings = basePoolSettings)
       }
     }
   }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -32,6 +32,8 @@ abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String
       loggers = ["akka.http.impl.util.SilenceAllTestEventListener"]
 
       http.host-connection-pool.pool-implementation = $poolImplementation
+
+      http.host-connection-pool.base-connection-backoff = 0 ms
     }""").withFallback(ConfigFactory.load())
   implicit val system = ActorSystem("DontLeakActorsOnFailingConnectionSpecs-" + poolImplementation, config)
   implicit val materializer = ActorMaterializer()

--- a/docs/src/main/paradox/client-side/host-level.md
+++ b/docs/src/main/paradox/client-side/host-level.md
@@ -121,6 +121,11 @@ Since the host connector cannot know which one of these possible reasons caused 
 In these cases, as well as when all retries have not yielded a proper response, the pool produces a failed `Try`
 (i.e. a `scala.util.Failure`) together with the custom request context.
 
+If a request fails during connecting to the server, for example, because the DNS name cannot be resolved or the server
+is currently unavailable, retries are attempted with exponential backoff delay. See the documentation of the
+`akka.http.host-connection-pool.base-connection-backoff` setting in the @ref[configuration](../configuration.md).
+
+
 ## Pool Shutdown
 
 Completing a pool client flow will simply detach the flow from the pool. The connection pool itself will continue to run


### PR DESCRIPTION
Fixes #1391.

It works but I might want to tweak the implementation a bit. The settings file describes the feature quite well.

TODO:
 * [x] add mima excludes
 * [x] add docs section
 * [x] add comment to config that setting only applies to new pool impl
 * [x] enforce non-zero backoff for connections that were created by min-connections (to avoid the loop if misconfigured)
 * [x] fix race in test where second connection is still attempted because failure only came back a bit later