### PR TITLE
Fix limiting of chunk size in the NoCoding encoder

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -106,9 +106,9 @@ private[http] object StreamUtils {
 
         var remaining = ByteString.empty
 
-        def splitAndPush(elem: ByteString): Unit = {
-          val toPush = remaining.take(maxBytesPerChunk)
-          val toKeep = remaining.drop(maxBytesPerChunk)
+        def splitAndPush(data: ByteString): Unit = {
+          val toPush = data.take(maxBytesPerChunk)
+          val toKeep = data.drop(maxBytesPerChunk)
           push(out, toPush)
           remaining = toKeep
         }


### PR DESCRIPTION
This fixes an issue where the limitByteChunksStage function used by the NoCoding encoder was losing data if larger than the maximum chunk size. The tests have also been fixed to cover this scenario.

I don't know if this is an issue that affects people using the akka-http in the wild, but is quite subtle. I came across the issue trying to test out chunked StreamRefs in akka-cluster in a WIP PR https://github.com/akka/akka/pull/25643. That PR copies the broken code from akka-http verbatim, so is likely to be also broken.