### PR TITLE
Add Directive#tcollect and Directive1#collect

### DIFF
--- a/docs/src/main/paradox/routing-dsl/directives/custom-directives.md
+++ b/docs/src/main/paradox/routing-dsl/directives/custom-directives.md
@@ -154,6 +154,18 @@ One example of a predefined directive relying `recoverPF` is the `optionalHeader
 
 @@signature [HeaderDirectives.scala]($akka-http$/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala) { #optionalHeaderValue }
 
+### collect and tcollect
+
+With collect and tcollect you can filter and map in one go, it mimics the collect known from the regular Scala collections.
+
+Here is an example, first via map and filter and finally using collect:
+
+```
+parameter("a".as[Int]).filter(x => x != 0, MissingQueryParamRejection("a")).map(x => 42 / x)
+
+parameter("a".as[Int]).collect({ case x if x != 0 => 42 / x }, MissingQueryParamRejection("a"))
+```
+
 ## Directives from Scratch
 
 The third option for creating custom directives is to do it “from scratch”,
@@ -182,7 +194,7 @@ type Directive1[T] = Directive[Tuple1[T]]
 ```
 
 A `Directive[(String, Int)]` extracts a `String` value and an `Int` value
-(like a `parameters('a.as[String], 'b.as[Int])` directive). Such a directive can be defined to extract the 
+(like a `parameters('a.as[String], 'b.as[Int])` directive). Such a directive can be defined to extract the
 hostname and port of a request:
 
 @@snip [CustomDirectivesExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/CustomDirectivesExamplesSpec.scala) { #scratch-1 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomDirectivesExamplesSpec.scala
@@ -6,7 +6,7 @@ package docs.http.scaladsl.server.directives
 
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.Host
-import akka.http.scaladsl.server.{ Directive, Directive1, Route }
+import akka.http.scaladsl.server.{ Directive, Directive1, Route, MissingQueryParamRejection }
 import docs.http.scaladsl.server.RoutingSpec
 
 class CustomDirectivesExamplesSpec extends RoutingSpec {
@@ -58,6 +58,26 @@ class CustomDirectivesExamplesSpec extends RoutingSpec {
       responseAs[String] shouldEqual "7"
     }
     //#tmap-1
+  }
+
+  "collect-1" in {
+    //#collect-1
+    val intParameter: Directive1[Int] = parameter("x".as[Int])
+
+    val myRejection = MissingQueryParamRejection("test")
+
+    val myDirective: Directive1[Int] =
+      intParameter.collect({ case x if x % 2 == 0 => x + 1 }, myRejection)
+
+    // tests:
+    Get("/?x=2") ~> myDirective(x => complete(x.toString)) ~> check {
+      responseAs[String] shouldEqual "3"
+    }
+    Get("/?x=3") ~> myDirective(x => complete(x.toString)) ~> check {
+      rejection shouldEqual myRejection
+    }
+
+    //#collect-1
   }
 
   "flatMap-0" in {


### PR DESCRIPTION
This commit adds two new methods on `Directives`:

- Directive#ttransform the tupled variant of Future#transform that
  allows mapping and filtering at the same time
- Directive1#transform the equivalent of Future#transform for
  Directive1, the specialized version of Directive#ttransform

As an example, instead of writing:

```
parameter("x".as[Int]).filter(x => x >= 0, someRejection).map(x => Positive(x))
```

we can now write this in one go using Directive1#transform:

```
parameter("x".as[Int]).transform({ case x if x >= 0 => Positive(x) }, someRejection)
```

# Review Notes:

- composing `PartialFunction`s is really awkward, had to hack around it in `Directive1#transform` because there we have to nest two of them
- I would prefer a curried version of `transform` that takes the partial function as the second argument because it looks better, but I went with the two-parameter style as done in `Directive1#filter`