### PR TITLE
Replace existing HTTP Status Code 425 with TOO_EARLY

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
@@ -68,6 +68,13 @@ public final class StatusCodes {
     public static final StatusCode UNPROCESSABLE_ENTITY = akka.http.scaladsl.model.StatusCodes.UnprocessableEntity();
     public static final StatusCode LOCKED = akka.http.scaladsl.model.StatusCodes.Locked();
     public static final StatusCode FAILED_DEPENDENCY = akka.http.scaladsl.model.StatusCodes.FailedDependency();
+
+    /**
+     * @deprecated Non-standard Unordered Collection should not be used, deprecated in favor of Too Early
+     */
+    @Deprecated
+    public static final StatusCode UNORDERED_COLLECTION = akka.http.scaladsl.model.StatusCodes.UnorderedCollection();
+
     public static final StatusCode TOO_EARLY = akka.http.scaladsl.model.StatusCodes.TooEarly();
     public static final StatusCode UPGRADE_REQUIRED = akka.http.scaladsl.model.StatusCodes.UpgradeRequired();
     public static final StatusCode PRECONDITION_REQUIRED = akka.http.scaladsl.model.StatusCodes.PreconditionRequired();

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
@@ -68,7 +68,7 @@ public final class StatusCodes {
     public static final StatusCode UNPROCESSABLE_ENTITY = akka.http.scaladsl.model.StatusCodes.UnprocessableEntity();
     public static final StatusCode LOCKED = akka.http.scaladsl.model.StatusCodes.Locked();
     public static final StatusCode FAILED_DEPENDENCY = akka.http.scaladsl.model.StatusCodes.FailedDependency();
-    public static final StatusCode UNORDERED_COLLECTION = akka.http.scaladsl.model.StatusCodes.UnorderedCollection();
+    public static final StatusCode TOO_EARLY = akka.http.scaladsl.model.StatusCodes.TooEarly();
     public static final StatusCode UPGRADE_REQUIRED = akka.http.scaladsl.model.StatusCodes.UpgradeRequired();
     public static final StatusCode PRECONDITION_REQUIRED = akka.http.scaladsl.model.StatusCodes.PreconditionRequired();
     public static final StatusCode TOO_MANY_REQUESTS = akka.http.scaladsl.model.StatusCodes.TooManyRequests();

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
@@ -152,7 +152,7 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val UnprocessableEntity          = reg(c(422)("Unprocessable Entity", "The request was well-formed but was unable to be followed due to semantic errors."))
   val Locked                       = reg(c(423)("Locked", "The resource that is being accessed is locked."))
   val FailedDependency             = reg(c(424)("Failed Dependency", "The request failed due to failure of a previous request."))
-  val UnorderedCollection          = reg(c(425)("Unordered Collection", "The collection is unordered."))
+  val TooEarly                     = reg(c(425)("Too Early", "The server is unwilling to risk processing a request that might be replayed.")) // RFC 8470
   val UpgradeRequired              = reg(c(426)("Upgrade Required", "The client should switch to a different protocol."))
   val PreconditionRequired         = reg(c(428)("Precondition Required", "The server requires the request to be conditional."))
   val TooManyRequests              = reg(c(429)("Too Many Requests", "The user has sent too many requests in a given amount of time."))

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
@@ -152,6 +152,10 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val UnprocessableEntity          = reg(c(422)("Unprocessable Entity", "The request was well-formed but was unable to be followed due to semantic errors."))
   val Locked                       = reg(c(423)("Locked", "The resource that is being accessed is locked."))
   val FailedDependency             = reg(c(424)("Failed Dependency", "The request failed due to failure of a previous request."))
+
+  @deprecated("Non-standard Unordered Collection should not be used, deprecated in favor of Too Early", "10.1.6")
+  val UnorderedCollection          = TooEarly
+
   val TooEarly                     = reg(c(425)("Too Early", "The server is unwilling to risk processing a request that might be replayed.")) // RFC 8470
   val UpgradeRequired              = reg(c(426)("Upgrade Required", "The client should switch to a different protocol."))
   val PreconditionRequired         = reg(c(428)("Precondition Required", "The server requires the request to be conditional."))


### PR DESCRIPTION
I think this should be safe to just replace as `Unordered Collection` was only ever present in WebDAV drafts and should have no implementations, but of course it is a breaking change.
See https://tools.ietf.org/html/rfc8470 for details on `Too Early`.