### PR TITLE
toStrict the entity when parsing multiple form fields

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/AllowMaterializationOnlyOnce.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/AllowMaterializationOnlyOnce.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.scaladsl.server.directives
 
 import java.util.concurrent.atomic.AtomicBoolean
@@ -8,7 +12,7 @@ import akka.stream.scaladsl.Flow
 object AllowMaterializationOnlyOnce {
   def apply[T, Mat](): Flow[T, T, NotUsed] = {
     val materialized = new AtomicBoolean(false)
-    Flow[T].mapMaterializedValue { mat =>
+    Flow[T].mapMaterializedValue { mat ⇒
       if (materialized.compareAndSet(false, true)) {
         mat
       } else {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/AllowMaterializationOnlyOnce.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/AllowMaterializationOnlyOnce.scala
@@ -1,0 +1,19 @@
+package akka.http.scaladsl.server.directives
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
+
+object AllowMaterializationOnlyOnce {
+  def apply[T, Mat](): Flow[T, T, NotUsed] = {
+    val materialized = new AtomicBoolean(false)
+    Flow[T].mapMaterializedValue { mat =>
+      if (materialized.compareAndSet(false, true)) {
+        mat
+      } else {
+        throw new IllegalStateException("Substream Source cannot be materialized more than once")
+      }
+    }
+  }
+}

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
@@ -40,6 +40,9 @@ sealed abstract class StrictForm {
 }
 
 object StrictForm {
+  // TODO: make timeout configurable
+  val toStrictTimeout = 10.seconds
+
   sealed trait Field
   object Field {
     private[http] def fromString(value: String): Field = FromString(value)
@@ -115,7 +118,7 @@ object StrictForm {
         def tryUnmarshalToMultipartForm: Future[StrictForm] =
           for {
             multiPartFD ← multipartUM(entity).fast
-            strictMultiPartFD ← multiPartFD.toStrict(10.seconds).fast // TODO: make timeout configurable
+            strictMultiPartFD ← multiPartFD.toStrict(toStrictTimeout).fast
           } yield {
             new StrictForm {
               val fields = strictMultiPartFD.strictParts.map {

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FormFieldDirectives.scala
@@ -217,7 +217,7 @@ object FormFieldDirectives extends FormFieldDirectives {
     import akka.http.scaladsl.server.util.TupleOps._
 
     implicit def forTuple[T](implicit fold: FoldLeft[Directive0, T, ConvertFieldDefAndConcatenate.type]): FieldDefAux[T, fold.Out] =
-      fieldDef[T, fold.Out](fold(pass, _))
+      fieldDef[T, fold.Out](fold(toStrictEntity(StrictForm.toStrictTimeout), _))
 
     object ConvertFieldDefAndConcatenate extends BinaryPolyFunc {
       implicit def from[P, TA, TB](implicit fdef: FieldDefAux[P, Directive[TB]], ev: Join[TA, TB]): BinaryPolyFunc.Case[Directive[TA], P, ConvertFieldDefAndConcatenate.type] { type Out = Directive[ev.Out] } =


### PR DESCRIPTION
Fixes the 'simple case' ('A') of #73

To avoid consuming the entity for each field. Of course slurping in the
entire entity is not very elegant, but this is what both the form-data and
the multipart marshallers already do further down the line.