### PR TITLE
#2279 Fix status code in case of EntityStreamSizeException

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
@@ -88,7 +88,7 @@ public class MiscDirectivesTest extends JUnitRouteTest {
 
     route
       .run(withEntityOfSize(501))
-      .assertStatusCode(StatusCodes.BAD_REQUEST);
+      .assertStatusCode(StatusCodes.REQUEST_ENTITY_TOO_LARGE);
 
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -62,7 +62,7 @@ class SizeLimitSpec extends WordSpec with Matchers with RequestBuilding with Bef
 
     "not accept entities bigger than configured with akka.http.parsing.max-content-length" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength + 1)))
-        .futureValue.status shouldEqual StatusCodes.BadRequest
+        .futureValue.status shouldEqual StatusCodes.RequestEntityTooLarge
     }
   }
 
@@ -98,7 +98,7 @@ class SizeLimitSpec extends WordSpec with Matchers with RequestBuilding with Bef
       data.size should be > decodeMaxSize
 
       Http().singleRequest(request)
-        .futureValue.status shouldEqual StatusCodes.BadRequest
+        .futureValue.status shouldEqual StatusCodes.RequestEntityTooLarge
     }
   }
 
@@ -120,7 +120,7 @@ class SizeLimitSpec extends WordSpec with Matchers with RequestBuilding with Bef
     "reject a small request that decodes into a large chunked entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
       val response = Http().singleRequest(request).futureValue
-      response.status shouldEqual StatusCodes.BadRequest
+      response.status shouldEqual StatusCodes.RequestEntityTooLarge
     }
   }
 
@@ -142,7 +142,7 @@ class SizeLimitSpec extends WordSpec with Matchers with RequestBuilding with Bef
     "reject a small request that decodes into a large non-chunked streaming entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
       val response = Http().singleRequest(request).futureValue
-      response.status shouldEqual StatusCodes.BadRequest
+      response.status shouldEqual StatusCodes.RequestEntityTooLarge
     }
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -100,7 +100,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", entityOfSize(501)) ~> Route.seal(route) ~> check {
-        status shouldEqual StatusCodes.BadRequest
+        status shouldEqual StatusCodes.RequestEntityTooLarge
         entityAs[String] should include("exceeded content length limit")
       }
     }
@@ -118,7 +118,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", formDataOfSize(128)) ~> Route.seal(route) ~> check {
-        status shouldEqual StatusCodes.BadRequest
+        status shouldEqual StatusCodes.RequestEntityTooLarge
         responseAs[String] shouldEqual "The request content was malformed:\n" +
           "EntityStreamSizeException: actual entity size (Some(134)) " +
           "exceeded content length limit (64 bytes)! " +
@@ -142,7 +142,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", entityOfSize(801)) ~> Route.seal(route) ~> check {
-        status shouldEqual StatusCodes.BadRequest
+        status shouldEqual StatusCodes.RequestEntityTooLarge
         entityAs[String] should include("exceeded content length limit")
       }
 
@@ -160,7 +160,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", entityOfSize(401)) ~> Route.seal(route2) ~> check {
-        status shouldEqual StatusCodes.BadRequest
+        status shouldEqual StatusCodes.RequestEntityTooLarge
         entityAs[String] should include("exceeded content length limit")
       }
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -187,8 +187,13 @@ object RejectionHandler {
           rejectRequestEntityAndComplete((BadRequest, "The query parameter '" + name + "' was malformed:\n" + msg))
       }
       .handle {
-        case MalformedRequestContentRejection(msg, _) ⇒
-          rejectRequestEntityAndComplete((BadRequest, "The request content was malformed:\n" + msg))
+        case MalformedRequestContentRejection(msg, throwable) ⇒ {
+          val rejectionMessage = "The request content was malformed:\n" + msg
+          throwable match {
+            case _: EntityStreamSizeException ⇒ rejectRequestEntityAndComplete((RequestEntityTooLarge, rejectionMessage))
+            case _                            ⇒ rejectRequestEntityAndComplete((BadRequest, rejectionMessage))
+          }
+        }
       }
       .handle {
         case MissingCookieRejection(cookieName) ⇒

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -89,7 +89,7 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
       .assertStatusCode(StatusCodes.OK);
 
     testRoute(route).run(withEntityOfSize.apply(501))
-      .assertStatusCode(StatusCodes.BAD_REQUEST);
+      .assertStatusCode(StatusCodes.REQUEST_ENTITY_TOO_LARGE);
     //#withSizeLimitExample
   }
 
@@ -114,7 +114,7 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
             .assertStatusCode(StatusCodes.OK);
 
     testRoute(route).run(withEntityOfSize.apply(801))
-            .assertStatusCode(StatusCodes.BAD_REQUEST);
+            .assertStatusCode(StatusCodes.REQUEST_ENTITY_TOO_LARGE);
     //#withSizeLimitExampleNested
   }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
@@ -126,7 +126,7 @@ class MiscDirectivesExamplesSpec extends RoutingSpec {
     }
 
     Post("/abc", entityOfSize(501)) ~> Route.seal(route) ~> check {
-      status shouldEqual StatusCodes.BadRequest
+      status shouldEqual StatusCodes.RequestEntityTooLarge
     }
 
     //#withSizeLimit-example
@@ -171,7 +171,7 @@ class MiscDirectivesExamplesSpec extends RoutingSpec {
     }
 
     Post("/abc", entityOfSize(801)) ~> Route.seal(route) ~> check {
-      status shouldEqual StatusCodes.BadRequest
+      status shouldEqual StatusCodes.RequestEntityTooLarge
     }
     //#withSizeLimit-nested-example
   }


### PR DESCRIPTION
#2279 Modify RejectionHandler to complete request which encounter EntityStreamSizeException with RequestEntityTooLarge status code instead of BadRequest