### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,0 @@
-<!-- 
-We use the issue tracker for bugs and feature requests. For general questions and discussion please use https://discuss.akka.io or https://gitter.im/akka/akka instead.
-
-Please explain your issue precisely, and if possible provide a reproducer snippet (this helps resolve issues much quicker).
-
-Thanks, happy hakking!
--->
-

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -5,6 +5,12 @@ about: Create a report to help us improve
 ---
 
 <!-- 
+Please report issues regarding specific projects in their respective issue trackers, e.g.:
+ - Akka HTTP: https://github.com/akka/akka-http/issues
+ - Alpakka:   https://github.com/akka/alpakka/issues
+ - Akka Persistence Cassandra Plugin: https://github.com/akka/akka-persistence-cassandra/issues
+ - ...
+ 
 Please explain your issue precisely, and if possible provide a reproducer snippet (this helps resolve issues much quicker).
 
 Thanks, happy hakking!

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -6,7 +6,7 @@ about: Create a report to help us improve
 
 <!-- 
 Please report issues regarding specific projects in their respective issue trackers, e.g.:
- - Akka HTTP: https://github.com/akka/akka-http/issues
+ - Akka: https://github.com/akka/akka/issues
  - Alpakka:   https://github.com/akka/alpakka/issues
  - Akka Persistence Cassandra Plugin: https://github.com/akka/akka-persistence-cassandra/issues
  - ...

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,11 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve
+
+---
+
+<!-- 
+Please explain your issue precisely, and if possible provide a reproducer snippet (this helps resolve issues much quicker).
+
+Thanks, happy hakking!
+-->

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -6,7 +6,7 @@ about: Suggest an idea for this project
 
 <!--
 Please report issues regarding specific projects in their respective issue trackers, e.g.:
- - Akka HTTP: https://github.com/akka/akka-http/issues
+ - Akka: https://github.com/akka/akka/issues
  - Alpakka:   https://github.com/akka/alpakka/issues
  - Akka Persistence Cassandra Plugin: https://github.com/akka/akka-persistence-cassandra/issues
  - ...

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -5,6 +5,12 @@ about: Suggest an idea for this project
 ---
 
 <!--
+Please report issues regarding specific projects in their respective issue trackers, e.g.:
+ - Akka HTTP: https://github.com/akka/akka-http/issues
+ - Alpakka:   https://github.com/akka/alpakka/issues
+ - Akka Persistence Cassandra Plugin: https://github.com/akka/akka-persistence-cassandra/issues
+ - ...
+ 
 Please explain your use case precisely, and if possible provide an example snippet.
 
 Thanks, happy hakking!

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,11 @@
+---
+name: "\U0001F389 Feature request"
+about: Suggest an idea for this project
+
+---
+
+<!--
+Please explain your use case precisely, and if possible provide an example snippet.
+
+Thanks, happy hakking!
+-->

--- a/.github/ISSUE_TEMPLATE/---question.md
+++ b/.github/ISSUE_TEMPLATE/---question.md
@@ -1,0 +1,7 @@
+---
+name: "❓ Question"
+about: Please use https://discuss.akka.io for questions
+
+---
+
+Please use https://discuss.akka.io or https://gitter.im/akka/akka for questions instead of posting them to the issue tracker.


### PR DESCRIPTION
I directly copied the ones for Akka (thanks @raboof!) and removed the hint to other repos,
as we never get issues or feature requests for the wrong repo in Akka HTTP.