### PR TITLE
=doc Add Route.seal example to Exception Handling docs #266

### DIFF
--- a/docs/src/main/paradox/routing-dsl/exception-handling.md
+++ b/docs/src/main/paradox/routing-dsl/exception-handling.md
@@ -29,6 +29,14 @@ Once you have defined your custom @unidoc[ExceptionHandler] you have two options
 In the first case your handler will be "sealed" (which means that it will receive the default handler as a fallback for
 all cases your handler doesn't handle itself) and used for all exceptions that are not handled within the route
 structure itself.
+Here you can see an example of it:
+
+Scala
+:   @@snip [ExceptionHandlerExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala) { #seal-handler-example }
+
+Java
+:   @@snip [ExceptionHandlerExamplesTest.java]($test$/java/docs/http/javadsl/ExceptionHandlerInSealExample.java) { #seal-handler-example }
+
 
 The second case allows you to restrict the applicability of your handler to certain branches of your route structure.
 

--- a/docs/src/test/java/docs/http/javadsl/ExceptionHandlerExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ExceptionHandlerExample.java
@@ -4,6 +4,7 @@
 
 package docs.http.javadsl;
 
+//#explicit-handler-example
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.http.javadsl.ConnectHttp;
@@ -19,11 +20,9 @@ import akka.http.javadsl.Http;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
 
-import java.io.IOException;
 import java.util.concurrent.CompletionStage;
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 
-//#explicit-handler-example
 public class ExceptionHandlerExample extends AllDirectives {
   public static void main(String[] args) {
     final ActorSystem system = ActorSystem.create();

--- a/docs/src/test/java/docs/http/javadsl/ExceptionHandlerInSealExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ExceptionHandlerInSealExample.java
@@ -7,6 +7,7 @@ package docs.http.javadsl;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
@@ -14,23 +15,23 @@ import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.ExceptionHandler;
 import akka.http.javadsl.server.PathMatchers;
+import akka.http.javadsl.server.RejectionHandler;
 import akka.http.javadsl.server.Route;
-import akka.http.javadsl.Http;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
 
-import java.io.IOException;
 import java.util.concurrent.CompletionStage;
+
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 
-//#explicit-handler-example
-public class ExceptionHandlerExample extends AllDirectives {
+//#seal-handler-example
+public class ExceptionHandlerInSealExample extends AllDirectives {
   public static void main(String[] args) {
     final ActorSystem system = ActorSystem.create();
     final ActorMaterializer materializer = ActorMaterializer.create(system);
     final Http http = Http.get(system);
 
-    final ExceptionHandlerExample app = new ExceptionHandlerExample();
+    final ExceptionHandlerInSealExample app = new ExceptionHandlerInSealExample();
 
     final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
     final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
@@ -43,9 +44,11 @@ public class ExceptionHandlerExample extends AllDirectives {
         complete(StatusCodes.BAD_REQUEST, "You've got your arithmetic wrong, fool!"))
       .build();
 
+    final RejectionHandler defaultHandler = RejectionHandler.defaultHandler();
+
     return path(PathMatchers.segment("divide").slash(integerSegment()).slash(integerSegment()), (a, b) ->
-      handleExceptions(divByZeroHandler, () -> complete("The result is " + (a / b)))
-    );
+      complete("The result is " + (a / b))
+    ).seal(defaultHandler, divByZeroHandler);
   }
 }
-//#explicit-handler-example
+//#seal-handler-example

--- a/docs/src/test/java/docs/http/javadsl/ExceptionHandlerInSealExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ExceptionHandlerInSealExample.java
@@ -4,39 +4,17 @@
 
 package docs.http.javadsl;
 
-import akka.NotUsed;
-import akka.actor.ActorSystem;
-import akka.http.javadsl.ConnectHttp;
-import akka.http.javadsl.Http;
-import akka.http.javadsl.ServerBinding;
-import akka.http.javadsl.model.HttpRequest;
-import akka.http.javadsl.model.HttpResponse;
+//#seal-handler-example
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.ExceptionHandler;
 import akka.http.javadsl.server.PathMatchers;
 import akka.http.javadsl.server.RejectionHandler;
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
-import akka.stream.javadsl.Flow;
-
-import java.util.concurrent.CompletionStage;
 
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 
-//#seal-handler-example
 public class ExceptionHandlerInSealExample extends AllDirectives {
-  public static void main(String[] args) {
-    final ActorSystem system = ActorSystem.create();
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
-    final Http http = Http.get(system);
-
-    final ExceptionHandlerInSealExample app = new ExceptionHandlerInSealExample();
-
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
-    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
-  }
-
 
   public Route createRoute() {
     final ExceptionHandler divByZeroHandler = ExceptionHandler.newBuilder()

--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -77,6 +77,45 @@ object MyImplicitExceptionHandler {
   //#implicit-handler-example
 }
 
+object ExceptionHandlerInSealExample {
+  //#seal-handler-example
+  import akka.actor.ActorSystem
+  import akka.http.scaladsl.model.HttpResponse
+  import akka.http.scaladsl.model.StatusCodes._
+  import akka.http.scaladsl.server._
+  import Directives._
+  import akka.http.scaladsl.Http
+  import akka.stream.ActorMaterializer
+  import SealedRouteWithCustomExceptionHandler.route
+
+  object SealedRouteWithCustomExceptionHandler {
+
+    implicit def myExceptionHandler: ExceptionHandler =
+      ExceptionHandler {
+        case _: ArithmeticException =>
+          extractUri { uri =>
+            println(s"Request to $uri could not be handled normally")
+            complete(HttpResponse(InternalServerError, entity = "Bad numbers, bad result!!!"))
+          }
+      }
+
+    val route: Route = Route.seal(
+      path("divide") {
+        complete((1 / 0).toString) //Will throw ArithmeticException
+      }
+    ) // this one takes `myExceptionHandler` implicitly
+
+  }
+
+  object MyApp extends App {
+    implicit val system = ActorSystem()
+    implicit val materializer = ActorMaterializer()
+
+    Http().bindAndHandle(route, "localhost", 8080)
+  }
+  //#seal-handler-example
+}
+
 object RespondWithHeaderExceptionHandlerExample {
   //#respond-with-header-exceptionhandler-example
   import akka.actor.ActorSystem
@@ -91,7 +130,7 @@ object RespondWithHeaderExceptionHandlerExample {
 
 
   object RespondWithHeaderExceptionHandler {
-    implicit def myExceptionHandler: ExceptionHandler =
+    def myExceptionHandler: ExceptionHandler =
       ExceptionHandler {
         case _: ArithmeticException =>
           extractUri { uri =>
@@ -155,6 +194,14 @@ class ExceptionHandlerExamplesSpec extends RoutingSpec {
 
     Get("/divide") ~> route ~> check {
       header("X-Outer-Header") shouldEqual Some(RawHeader("X-Outer-Header", "outer"))
+      responseAs[String] shouldEqual "Bad numbers, bad result!!!"
+    }
+  }
+
+  "test sealed route" in {
+    import ExceptionHandlerInSealExample.SealedRouteWithCustomExceptionHandler.route
+
+    Get("/divide") ~> route ~> check {
       responseAs[String] shouldEqual "Bad numbers, bad result!!!"
     }
   }

--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -79,14 +79,10 @@ object MyImplicitExceptionHandler {
 
 object ExceptionHandlerInSealExample {
   //#seal-handler-example
-  import akka.actor.ActorSystem
   import akka.http.scaladsl.model.HttpResponse
   import akka.http.scaladsl.model.StatusCodes._
   import akka.http.scaladsl.server._
   import Directives._
-  import akka.http.scaladsl.Http
-  import akka.stream.ActorMaterializer
-  import SealedRouteWithCustomExceptionHandler.route
 
   object SealedRouteWithCustomExceptionHandler {
 
@@ -105,13 +101,6 @@ object ExceptionHandlerInSealExample {
       }
     ) // this one takes `myExceptionHandler` implicitly
 
-  }
-
-  object MyApp extends App {
-    implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
-
-    Http().bindAndHandle(route, "localhost", 8080)
   }
   //#seal-handler-example
 }


### PR DESCRIPTION
Add Route.seal example to Exception Handling docs
Removes extra `implicit` in example where it wasn't needed
Removes `throws IOException` declaration where it wasn't needed