### PR TITLE
Overriden `getForKeyCaseInsensitive` in `HttpMethods` #2303

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMethod.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMethod.scala
@@ -4,6 +4,8 @@
 
 package akka.http.scaladsl.model
 
+import java.util.Locale
+
 import akka.http.impl.util._
 import akka.http.javadsl.{ model ⇒ jm }
 import akka.http.scaladsl.model.RequestEntityAcceptance._
@@ -67,4 +69,7 @@ object HttpMethods extends ObjectRegistry[String, HttpMethod] {
   val PUT     = register(HttpMethod("PUT"    , isSafe = false, isIdempotent = true , requestEntityAcceptance = Expected))
   val TRACE   = register(HttpMethod("TRACE"  , isSafe = true , isIdempotent = true , requestEntityAcceptance = Disallowed))
   // format: ON
+
+  override def getForKeyCaseInsensitive(key: String)(implicit conv: String <:< String): Option[HttpMethod] =
+    getForKey(conv(key.toUpperCase(Locale.ROOT)))
 }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMethodsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMethodsSpec.scala
@@ -1,0 +1,23 @@
+package akka.http.scaladsl.model
+
+import org.scalatest.{ FlatSpec, WordSpec }
+
+class HttpMethodsSpec extends WordSpec {
+  "HttpMethods.getForKeyCaseInsensitive()" must {
+    "return HttpMethods.CONNECT" in {
+      assert(HttpMethods.getForKeyCaseInsensitive("CONNECT") == Option(HttpMethods.CONNECT))
+    }
+    "return HttpMethods.DELETE" in {
+      assert(HttpMethods.getForKeyCaseInsensitive("Delete") == Option(HttpMethods.DELETE))
+    }
+    "return HttpMethods.GET" in {
+      assert(HttpMethods.getForKeyCaseInsensitive("get") == Option(HttpMethods.GET))
+    }
+    "return HttpMethods.HEAD" in {
+      assert(HttpMethods.getForKeyCaseInsensitive("HeaD") == Option(HttpMethods.HEAD))
+    }
+    "return HttpMethods.OPTIONS" in {
+      assert(HttpMethods.getForKeyCaseInsensitive("oPtIoNs") == Option(HttpMethods.OPTIONS))
+    }
+  }
+}

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMethodsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMethodsSpec.scala
@@ -1,6 +1,10 @@
+/*
+ * Copyright (C) 2009-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.scaladsl.model
 
-import org.scalatest.{ FlatSpec, WordSpec }
+import org.scalatest.WordSpec
 
 class HttpMethodsSpec extends WordSpec {
   "HttpMethods.getForKeyCaseInsensitive()" must {


### PR DESCRIPTION
Fixes #2303