### PR TITLE
=pro when detecting master branch also check TRAVIS_BRANCH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
     - stage: mima
       script: sbt -J-XX:ReservedCodeCacheSize=256m +mimaReportBinaryIssues
     - stage: whitesource
-      script: sbt whitesourceCheckPolicies whitesourceUpdate
+      script: git branch -f "$TRAVIS_BRANCH" && git checkout "$TRAVIS_BRANCH" && sbt whitesourceCheckPolicies whitesourceUpdate
     - stage: publish
       script: sbt -J-XX:ReservedCodeCacheSize=256m +publish
 


### PR DESCRIPTION
As Travis doesn't seem to check out the branch but a certain hash instead.