### PR TITLE
Check that all akka-http modules have the same version, #2335

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val root = Project(
     }
   )
   .aggregate(
-    // When this is or other aggregates are updated the set of modules in Http.allModules should also be updated
+    // When this is or other aggregates are updated the set of modules in HttpExt.allModules should also be updated
     parsing,
     httpCore,
     http2Support,

--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,7 @@ lazy val root = Project(
     }
   )
   .aggregate(
+    // When this is or other aggregates are updated the set of modules in Http.allModules should also be updated
     parsing,
     httpCore,
     http2Support,


### PR DESCRIPTION
This is how the warning log looks like if you mess up:
```
[WARN] [12/20/2018 10:19:07.966] [run-main-0] [ManifestInfo(akka://helloAkkaHttpServer)] Detected possible incompatible versions on the classpath. Please note that a given Akka HTTP version MUST be the same across all modules of Akka HTTP that you are using, e.g. if you use [10.1.6+7-3560e987] all other modules that are released together MUST be of the same version. Make sure you're using a compatible set of libraries. Possibly conflicting versions [10.1.3, 10.1.6+7-3560e987] in libraries [akka-http-spray-json:10.1.3, akka-parsing:10.1.6+7-3560e987, akka-http-xml:10.1.6+7-3560e987, akka-http:10.1.6+7-3560e987, akka-http-core:10.1.6+7-3560e987]
```

Refs #2335