### PR TITLE
=ht2 harden h2spec execution against spaces in the executable path

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
@@ -24,10 +24,10 @@ class H2SpecIntegrationSpec extends AkkaSpec(
        loglevel = DEBUG
        loggers = ["akka.http.impl.util.SilenceAllTestEventListener"]
        http.server.log-unencrypted-network-bytes = off
-        
+
        actor.serialize-creators = off
        actor.serialize-messages = off
-       
+
        stream.materializer.debug.fuzzing-mode = off
      }
   """) with Directives with ScalaFutures with WithLogCapturing {
@@ -148,7 +148,14 @@ class H2SpecIntegrationSpec extends AkkaSpec(
       val stdout = new StringBuffer()
       val stderr = new StringBuffer()
 
-      val command = s"$executable -k -t -p $port -j $junitOutput" + specSectionNumber.map(" -s " + _).getOrElse("")
+      val command = Seq( // need to use Seq[String] form for command because executable path may contain spaces
+        executable,
+        "-k", "-t",
+        "-p", port.toString,
+        "-j", "junitOutput"
+      ) ++
+        specSectionNumber.toList.flatMap(number ⇒ Seq("-s", number))
+
       println(s"exec: $command")
       val aggregateTckLogs = ProcessLogger(
         out ⇒ {


### PR DESCRIPTION
The akka-http-nightly build is run from a path that contains the names of all the axis. The JVM axis is now "AdoptOpenJDK 8", i.e. containing a space. The h2spec needs to run an executable with full path that then includes a space which currently doesn't work.

Not sure if quoting works with the ProcessBuilder but let's try.

