### PR TITLE
=ht2 fix H2SpecIntegrationSpec xml test report generation

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
@@ -152,7 +152,7 @@ class H2SpecIntegrationSpec extends AkkaSpec(
         executable,
         "-k", "-t",
         "-p", port.toString,
-        "-j", "junitOutput"
+        "-j", junitOutput.getPath
       ) ++
         specSectionNumber.toList.flatMap(number ⇒ Seq("-s", number))
 


### PR DESCRIPTION
Number of tests run dropped quite a lot in the nightlies (~ 4000 to ~3000) since I enabled AdoptOpenJDK. Turns out for quite stupid reasons ;)

(Almost all of 1000 tests are maked as skipped but anyway...)