### PR TITLE
Rfc7807 rejection handlers

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
@@ -29,6 +29,7 @@ public final class MediaTypes {
     public static final MediaType.WithFixedCharset APPLICATION_JSON = akka.http.scaladsl.model.MediaTypes.application$divjson();
     public static final MediaType.WithFixedCharset APPLICATION_JSON_PATCH_JSON = akka.http.scaladsl.model.MediaTypes.application$divjson$minuspatch$plusjson();
     public static final MediaType.WithFixedCharset APPLICATION_MERGE_PATCH_JSON = akka.http.scaladsl.model.MediaTypes.application$divmerge$minuspatch$plusjson();
+    public static final MediaType.WithFixedCharset APPLICATION_PROBLEM_JSON = akka.http.scaladsl.model.MediaTypes.application$divproblem$plusjson();
     public static final MediaType.Binary APPLICATION_LHA = akka.http.scaladsl.model.MediaTypes.application$divlha();
     public static final MediaType.Binary APPLICATION_LZX = akka.http.scaladsl.model.MediaTypes.application$divlzx();
     /**
@@ -106,6 +107,7 @@ public final class MediaTypes {
     public static final MediaType.WithOpenCharset APPLICATION_XHTML_XML = akka.http.scaladsl.model.MediaTypes.application$divxhtml$plusxml();
     public static final MediaType.WithOpenCharset APPLICATION_XML_DTD = akka.http.scaladsl.model.MediaTypes.application$divxml$minusdtd();
     public static final MediaType.WithOpenCharset APPLICATION_XML = akka.http.scaladsl.model.MediaTypes.application$divxml();
+    public static final MediaType.WithOpenCharset APPLICATION_PROBLEM_XML = akka.http.scaladsl.model.MediaTypes.application$divproblem$plusxml();
     public static final MediaType.Binary APPLICATION_ZIP = akka.http.scaladsl.model.MediaTypes.application$divzip();
 
     public static final MediaType.Binary AUDIO_AIFF = akka.http.scaladsl.model.MediaTypes.audio$divaiff();

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
@@ -20,6 +20,10 @@ object RejectionHandler {
   def newBuilder = new RejectionHandlerBuilder(server.RejectionHandler.newBuilder)
 
   def defaultHandler = new RejectionHandler(server.RejectionHandler.default)
+
+  def rfc7807JsonHandler = new RejectionHandler(server.RejectionHandler.rfc7807Json)
+
+  def rfc7807XmlHandler = new RejectionHandler(server.RejectionHandler.rfc7807Xml)
 }
 
 final class RejectionHandler(val asScala: server.RejectionHandler) {

--- a/docs/src/main/paradox/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/routing-dsl/rejections.md
@@ -84,6 +84,18 @@ rejection" to this most common failure a service is likely to produce.
 So, for example, if the @ref[path](directives/path-directives/path.md) directive rejects a request it does so with an empty rejection list. The
 @ref[host](directives/host-directives/host.md) directive behaves in the same way.
 
+## Use RFC 7807 Response Format
+
+If you want to use [RFC 7807 Response Format](https://tools.ietf.org/html/rfc7807) instead of default "text/plain" format,
+you can use predefined handlers.
+
+Scala
+:  @@snip [RejectionHandlerExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala) { #rfc7807json-rejection-handler-example }
+
+Java
+:  @@snip [RejectionHandlerExamplesTest.java]($test$/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java) { #rfc7807json-rejection-handler-example-java }
+
+
 ## Customizing Rejection Handling
 
 If you'd like to customize the way certain rejections are handled you'll have to write a custom

--- a/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
@@ -8,6 +8,7 @@ import akka.http.javadsl.coding.Coder;
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.HttpEntity;
 import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.MediaTypes;
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.AuthorizationFailedRejection;
 import akka.http.javadsl.server.MethodRejection;
@@ -29,6 +30,12 @@ import static akka.http.javadsl.server.Directives.post;
 import static akka.http.javadsl.server.Directives.route;
 
 //#example1
+//#rfc7807json-rejection-handler-example-java
+import static akka.http.javadsl.server.Directives.complete;
+import static akka.http.javadsl.server.Directives.path;
+import static akka.http.javadsl.server.Directives.handleRejections;
+
+//#rfc7807json-rejection-handler-example-java
 //#custom-handler-example-java
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
@@ -63,6 +70,28 @@ public class RejectionHandlerExamplesTest extends JUnitRouteTest {
         )
       ));
     //#example1
+  }
+
+  @Test
+  public void rfc7807jsonRejectionHandlerExample() {
+    //#rfc7807json-rejection-handler-example-java
+    final Route route = handleRejections(RejectionHandler.rfc7807JsonHandler(), () ->
+      path("order", () ->
+        concat(
+          get(() ->
+            complete("Received GET")
+          )
+        )
+      )
+    );
+
+    // tests:
+    testRoute(route)
+      .run(HttpRequest.GET("/nope"))
+      .assertStatusCode(StatusCodes.NOT_FOUND)
+      .assertContentType(MediaTypes.APPLICATION_PROBLEM_JSON.toContentType())
+      .assertEntity("{\"type\": \"about:blank\", \"title\": \"The requested resource could not be found.\"}");
+    //#rfc7807json-rejection-handler-example-java
   }
 
   void customRejectionHandler() {

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -88,6 +88,28 @@ class RejectionHandlerExamplesSpec extends RoutingSpec {
       }
     //#example-1
   }
+
+  "rfc7807json-rejection-handler-example" in {
+    //#rfc7807json-rejection-handler-example
+    import akka.http.scaladsl.model._
+    import akka.http.scaladsl.server.RejectionHandler
+
+    val route =
+      handleRejections(RejectionHandler.rfc7807Json) {
+        path("order") {
+          get {
+            complete("Received GET")
+          }
+        }
+      }
+
+    Get("/nope") ~> route ~> check {
+      status shouldEqual StatusCodes.NotFound
+      contentType shouldEqual ContentType(MediaTypes.`application/problem+json`)
+      responseAs[String] shouldEqual """{"type": "about:blank", "title": "The requested resource could not be found."}"""
+    }
+    //#rfc7807json-rejection-handler-example
+  }
   
   "example-2-all-exceptions-json" in {
     //#example-json


### PR DESCRIPTION
Resolve #2341 

I'm newbie as akka-http contributer, therefore I'm afraid of forgetting basic things.
Please tell me honest review.
For instance, there may be better names for variable "RejectionHandler.rfc7807Json" "RejectionHandler.rfc7807Xml".