### PR TITLE
Publish snapshots of every master commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ stages:
     if: repo=akka/akka-http AND ( ( branch = master AND type = push ) OR tag =~ ^v )
 
   - name: publish 
-    if: tag =~ ^v
+    if: repo=akka/akka-http AND ( ( branch = master AND type = push ) OR tag =~ ^v )
 
 env:
   global:

--- a/notes/release-train-issue-template.md
+++ b/notes/release-train-issue-template.md
@@ -38,6 +38,7 @@ Wind down PR queue. There has to be enough time after the last (non-trivial) PR 
 ### Cutting the release
 
 - [ ] Make sure there are no stray staging repos on sonatype
+- [ ] Wait until [master build finished](https://travis-ci.org/akka/akka-http/builds/) after merging the release notes
 - [ ] Create a [new release](https://github.com/akka/akka-http/releases/new) with the next tag version (e.g. `v13.3.7`), title and release description linking to announcement, release notes and milestone.
 - [ ] Check that the Travis CI release build has executed successfully
 - [ ] Go to https://bintray.com/akka/maven/com.typesafe.akka:akka-http_2.11 and select the just released version

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -30,7 +30,8 @@ object Publish extends AutoPlugin {
 
   override def projectSettings = Seq(
     bintrayOrganization := Some("akka"),
-    bintrayPackage := "com.typesafe.akka:akka-http_2.11"
+    bintrayPackage := "com.typesafe.akka:akka-http_2.11",
+    bintrayRepository := (if (isSnapshot.value) "snapshots" else "maven")
   )
 }
 


### PR DESCRIPTION
To consume snapshots, the following resolver is to be used:

```scala
resolvers += Resolver.bintrayRepo("akka", "snapshots")
```

Fixes #1254

Supersedes #1744