### PR TITLE
Set a more descriptive message to the RejectionError exception

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -285,4 +285,4 @@ final case class CircuitBreakerOpenRejection(cause: CircuitBreakerOpenException)
  * rejection rather than an Exception that is handled by the nearest ExceptionHandler.
  * (Custom marshallers can of course use it as well.)
  */
-final case class RejectionError(rejection: Rejection) extends RuntimeException
+final case class RejectionError(rejection: Rejection) extends RuntimeException(rejection.toString)


### PR DESCRIPTION
The toString implementation inherited by java.lang.Throwable only prints
the class name followed by the result of the getMessage method (which,
by default, returns null). As a consequence, the rejection carried by a
RejectionError instance is not shown.

We pass the given rejection to the RuntimeException constructor so that
it is shown as the exception message.