### PR TITLE
Oversized requests should return 413 and not 500 #358

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
@@ -88,8 +88,10 @@ public class RouteDirectivesTest extends JUnitRouteTest {
 
     route
       .run(HttpRequest.create("/limit-5").withEntity("1234567890"))
-      .assertStatusCode(StatusCodes.INTERNAL_SERVER_ERROR)
-      .assertEntity("There was an internal server error.");
+      .assertStatusCode(StatusCodes.REQUEST_ENTITY_TOO_LARGE)
+      .assertEntity("EntityStreamSizeException: actual entity size (Some(10)) exceeded content length limit (5 bytes)! " +
+              "You can configure this by setting `akka.http.[server|client].parsing.max-content-length` " +
+              "or calling `HttpEntity.withSizeLimit` before materializing the dataBytes stream.");
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -51,6 +51,11 @@ object ExceptionHandler {
         ctx.request.discardEntityBytes(ctx.materializer)
         ctx.complete((status, info.format(settings.verboseErrorMessages)))
       }
+      case e: EntityStreamSizeException ⇒ ctx ⇒ {
+        ctx.log.error(e, ErrorMessageTemplate, e, RequestEntityTooLarge)
+        ctx.request.discardEntityBytes(ctx.materializer)
+        ctx.complete((RequestEntityTooLarge, e.toString.format(settings.verboseErrorMessages)))
+      }
       case e: ExceptionWithErrorInfo ⇒ ctx ⇒ {
         ctx.log.error(e, ErrorMessageTemplate, e.info.formatPretty, InternalServerError)
         ctx.request.discardEntityBytes(ctx.materializer)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -54,7 +54,7 @@ object ExceptionHandler {
       case e: EntityStreamSizeException ⇒ ctx ⇒ {
         ctx.log.error(e, ErrorMessageTemplate, e, RequestEntityTooLarge)
         ctx.request.discardEntityBytes(ctx.materializer)
-        ctx.complete((RequestEntityTooLarge, e.toString.format(settings.verboseErrorMessages)))
+        ctx.complete((RequestEntityTooLarge, e.getMessage))
       }
       case e: ExceptionWithErrorInfo ⇒ ctx ⇒ {
         ctx.log.error(e, ErrorMessageTemplate, e.info.formatPretty, InternalServerError)


### PR DESCRIPTION
Hi there!
To fix this bug I've followed the route suggested in the comments. A unit test was also patched.