### PR TITLE
replace logRequestResponse with logRequestResult

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/DebuggingDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/DebuggingDirectivesExamplesSpec.scala
@@ -44,7 +44,7 @@ class DebuggingDirectivesExamplesSpec extends RoutingSpec {
   }
   "logRequestResult" in {
     //#logRequestResult
-    // different possibilities of using logRequestResponse
+    // different possibilities of using logRequestResult
 
     // The first alternatives use an implicitly available LoggingContext for logging
     // marks with "get-user", log with debug level, HttpRequest.toString, HttpResponse.toString


### PR DESCRIPTION
I guess there was a rename and the comment got left behind?