### PR TITLE
Injection vulnerability: raw query in error message.

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ParameterDirectivesTest.java
@@ -34,7 +34,7 @@ public class ParameterDirectivesTest extends JUnitRouteTest {
     route
         .run(HttpRequest.create().withUri("/abc?stringParam=a%b"))
         .assertStatusCode(400)
-        .assertEntity("The request content was malformed:\nThe request's query string is invalid: stringParam=a%b");
+        .assertEntity("The request content was malformed:\nThe request's query string is invalid.");
 
     route
       .run(HttpRequest.create().withUri("/abc?stringParam=a=b"))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -54,7 +54,7 @@ class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Insi
           parameter("amount".as[Int].?) { echoComplete }
         } ~> check {
           inside(rejection) {
-            case MalformedRequestContentRejection("The request's query string is invalid: amount=1%2", _) ⇒
+            case MalformedRequestContentRejection("The request's query string is invalid.", _) ⇒
           }
         }
       }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -125,7 +125,7 @@ object ParameterDirectives extends ParameterDirectives {
         import ctx.materializer
         Try(ctx.request.uri.query()) match {
           case Success(query) ⇒ handleParamResult(paramName, fsou(query.get(paramName)))
-          case Failure(t)     ⇒ reject(MalformedRequestContentRejection(s"The request's query string is invalid: ${ctx.request.uri.rawQueryString.getOrElse("")}", t))
+          case Failure(t)     ⇒ reject(MalformedRequestContentRejection("The request's query string is invalid.", t))
         }
       }
     implicit def forString(implicit fsu: FSU[String]): ParamDefAux[String, Directive1[String]] =


### PR DESCRIPTION
Removed raw query from error message, because including it can facilitate injection attacks such as cross-site scripting (XSS).