### PR TITLE
Disable to append charset=UTF-8 by default in `Content-Type: application/x-www-form-urlencoded` FormData

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/ContentTypes.java
@@ -30,6 +30,8 @@ public final class ContentTypes {
           akka.http.scaladsl.model.ContentTypes.text$divcsv$u0028UTF$minus8$u0029();
 
   public static final ContentType.Binary APPLICATION_GRPC_PROTO = MediaTypes.APPLICATION_GRPC_PROTO.toContentType();
+  public static final ContentType.WithFixedCharset APPLICATION_X_WWW_FORM_URLENCODED =
+      akka.http.scaladsl.model.ContentTypes.application$divx$minuswww$minusform$minusurlencoded();
 
   public static final ContentType.Binary NO_CONTENT_TYPE =
           akka.http.scaladsl.model.ContentTypes.NoContentType();

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/FormData.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/FormData.java
@@ -28,9 +28,13 @@ public final class FormData {
 
   /**
    * Converts this FormData to a RequestEntity using the given encoding.
+   *
+   * @deprecated FormData always uses charset UTF-8 without appending the charset to
+   *             'Content-Type: application/x-www-form-urlencoded', use toEntity() instead.
    */
+  @Deprecated
   public RequestEntity toEntity(HttpCharset charset) {
-    return HttpEntities.create(ContentTypes.create(MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED, charset), fields.render(charset));
+    return HttpEntities.create(ContentTypes.APPLICATION_X_WWW_FORM_URLENCODED, fields.render(charset));
   }
 
   /**

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/MediaTypes.java
@@ -105,7 +105,7 @@ public final class MediaTypes {
     public static final MediaType.Binary APPLICATION_X_TEX = akka.http.scaladsl.model.MediaTypes.application$divx$minustex();
     public static final MediaType.Binary APPLICATION_X_TEXINFO = akka.http.scaladsl.model.MediaTypes.application$divx$minustexinfo();
     public static final MediaType.WithOpenCharset APPLICATION_X_VRML = akka.http.scaladsl.model.MediaTypes.application$divx$minusvrml();
-    public static final MediaType.WithOpenCharset APPLICATION_X_WWW_FORM_URLENCODED = akka.http.scaladsl.model.MediaTypes.application$divx$minuswww$minusform$minusurlencoded();
+    public static final MediaType.WithFixedCharset APPLICATION_X_WWW_FORM_URLENCODED = akka.http.scaladsl.model.MediaTypes.application$divx$minuswww$minusform$minusurlencoded();
     public static final MediaType.Binary APPLICATION_X_X509_CA_CERT = akka.http.scaladsl.model.MediaTypes.application$divx$minusx509$minusca$minuscert();
     public static final MediaType.Binary APPLICATION_X_XPINSTALL = akka.http.scaladsl.model.MediaTypes.application$divx$minusxpinstall();
     public static final MediaType.WithOpenCharset APPLICATION_XHTML_XML = akka.http.scaladsl.model.MediaTypes.application$divxhtml$plusxml();

--- a/akka-http-core/src/main/mima-filters/10.1.7.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.7.backwards.excludes
@@ -20,3 +20,8 @@ ProblemFilters.exclude[MissingTypesProblem]("akka.http.impl.engine.rendering.Res
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.engine.rendering.ResponseRenderingContext.apply$default$4")
 ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.impl.engine.rendering.ResponseRenderingContext.apply")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.engine.rendering.ResponseRenderingContext.<init>$default$4")
+
+# FormData uses WithFixedCharset with UTF-8 instead of WithOpenCharset https://github.com/akka/akka-http/pull/2402
+# This change is binary incompatible but there's no other way to fix it.
+ProblemFilters.exclude[IncompatibleFieldTypeProblem]("akka.http.javadsl.model.MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.model.MediaTypes.application/x-www-form-urlencoded")

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
@@ -118,6 +118,7 @@ object ContentType {
 object ContentTypes {
   val `application/json` = ContentType(MediaTypes.`application/json`)
   val `application/octet-stream` = ContentType(MediaTypes.`application/octet-stream`)
+  val `application/x-www-form-urlencoded` = ContentType(MediaTypes.`application/x-www-form-urlencoded`)
   val `text/plain(UTF-8)` = MediaTypes.`text/plain` withCharset HttpCharsets.`UTF-8`
   val `text/html(UTF-8)` = MediaTypes.`text/html` withCharset HttpCharsets.`UTF-8`
   val `text/xml(UTF-8)` = MediaTypes.`text/xml` withCharset HttpCharsets.`UTF-8`

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/FormData.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/FormData.scala
@@ -13,11 +13,12 @@ import akka.http.scaladsl.model.MediaTypes._
  */
 final case class FormData(fields: Uri.Query) {
   def toEntity: akka.http.scaladsl.model.RequestEntity =
-    toEntity(HttpCharsets.`UTF-8`)
+    toEntity(`application/x-www-form-urlencoded`.charset)
 
+  @deprecated("FormData always uses charset UTF-8 without appending the charset to 'Content-Type: application/x-www-form-urlencoded', use toEntity() instead.", "10.1.7")
   def toEntity(charset: HttpCharset): akka.http.scaladsl.model.RequestEntity = {
     val render: StringRendering = UriRendering.renderQuery(new StringRendering, this.fields, charset.nioCharset, CharacterClasses.unreserved)
-    HttpEntity(`application/x-www-form-urlencoded` withCharset charset, render.get)
+    HttpEntity(`application/x-www-form-urlencoded`, render.get)
   }
 }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -278,6 +278,8 @@ object HttpEntity {
   implicit def apply(data: ByteString): HttpEntity.Strict = apply(ContentTypes.`application/octet-stream`, data)
   def apply(contentType: ContentType.NonBinary, string: String): HttpEntity.Strict =
     if (string.isEmpty) empty(contentType) else apply(contentType, ByteString(string.getBytes(contentType.charset.nioCharset)))
+  def apply(contentType: ContentType.WithFixedCharset, string: String): HttpEntity.Strict =
+    if (string.isEmpty) empty(contentType) else apply(contentType, ByteString(string.getBytes(contentType.charset.nioCharset)))
   def apply(contentType: ContentType, bytes: Array[Byte]): HttpEntity.Strict =
     if (bytes.length == 0) empty(contentType) else apply(contentType, ByteString(bytes))
   def apply(contentType: ContentType, data: ByteString): HttpEntity.Strict =

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -411,7 +411,7 @@ object MediaTypes extends ObjectRegistry[(String, String), MediaType] {
   val `application/x-tex`                                                         = abin("x-tex", Compressible, "tex")
   val `application/x-texinfo`                                                     = abin("x-texinfo", Compressible, "texi", "texinfo")
   val `application/x-vrml`                                                        = awoc("x-vrml", "vrml")
-  val `application/x-www-form-urlencoded`                                         = awoc("x-www-form-urlencoded")
+  val `application/x-www-form-urlencoded`                                         = awfc("x-www-form-urlencoded", HttpCharsets.`UTF-8`)
   val `application/x-x509-ca-cert`                                                = abin("x-x509-ca-cert", Compressible, "der")
   val `application/x-xpinstall`                                                   = abin("x-xpinstall", NotCompressible, "xpi")
   val `application/xhtml+xml`                                                     = awoc("xhtml+xml")

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/values/FormFieldsTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/values/FormFieldsTest.java
@@ -4,6 +4,7 @@
 
 package akka.http.javadsl.server.values;
 
+import akka.http.javadsl.model.ContentTypes;
 import org.junit.Test;
 
 import akka.http.javadsl.model.HttpCharsets;
@@ -37,7 +38,7 @@ public class FormFieldsTest extends JUnitRouteTest {
 
         return
             HttpRequest.POST("/test")
-                .withEntity(MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED.toContentType(HttpCharsets.UTF_8), sb.toString());
+                .withEntity(ContentTypes.APPLICATION_X_WWW_FORM_URLENCODED, sb.toString());
     }
     private HttpRequest singleParameterUrlEncodedRequest(String name, String value) {
         return urlEncodedRequest(param(name, value));

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
@@ -17,18 +17,25 @@ class FormDataSpec extends AkkaSpec {
   val formData = FormData(Map("surname" → "Smith", "age" → "42"))
 
   "The FormData infrastructure" should {
-    "properly round-trip the fields of www-urlencoded forms" in {
+    "properly round-trip the fields of x-www-urlencoded forms" in {
       Marshal(formData).to[HttpEntity]
         .flatMap(Unmarshal(_).to[FormData]).futureValue shouldEqual formData
     }
 
-    "properly marshal www-urlencoded forms containing special chars" in {
-      Marshal(FormData(Map("name" → "Smith&Wesson"))).to[HttpEntity]
-        .flatMap(Unmarshal(_).to[String]).futureValue shouldEqual "name=Smith%26Wesson"
+    "properly marshal x-www-urlencoded forms containing special chars" in {
+      val entity = Marshal(FormData(Map("name" → "Smith&Wesson"))).to[HttpEntity]
+      entity.flatMap(Unmarshal(_).to[String]).futureValue shouldEqual "name=Smith%26Wesson"
+      entity.flatMap(Unmarshal(_).to[HttpEntity]).futureValue.getContentType shouldEqual ContentTypes.`application/x-www-form-urlencoded`
 
-      Marshal(FormData(Map("name" → "Smith+Wesson; hopefully!"))).to[HttpEntity]
-        .flatMap(Unmarshal(_).to[String]).futureValue shouldEqual "name=Smith%2BWesson%3B+hopefully%21"
+      val entity2 = Marshal(FormData(Map("name" → "Smith+Wesson; hopefully!"))).to[HttpEntity]
+      entity2.flatMap(Unmarshal(_).to[String]).futureValue shouldEqual "name=Smith%2BWesson%3B+hopefully%21"
+      entity2.flatMap(Unmarshal(_).to[HttpEntity]).futureValue.getContentType shouldEqual ContentTypes.`application/x-www-form-urlencoded`
+    }
+
+    "properly marshal empty x-www-urlencoded form" in {
+      val entity = Marshal(FormData(Map.empty[String, String])).to[HttpEntity]
+      entity.flatMap(Unmarshal(_).to[String]).futureValue shouldBe empty
+      entity.flatMap(Unmarshal(_).to[HttpEntity]).futureValue.getContentType shouldEqual ContentTypes.`application/x-www-form-urlencoded`
     }
   }
-
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -41,7 +41,7 @@ class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
     }
     "FormDataMarshaller should marshal FormData instances to application/x-www-form-urlencoded content" in {
       marshal(FormData(Map("name" → "Bob", "pass" → "hällo", "admin" → ""))) shouldEqual
-        HttpEntity(`application/x-www-form-urlencoded` withCharset `UTF-8`, "name=Bob&pass=h%C3%A4llo&admin=")
+        HttpEntity(`application/x-www-form-urlencoded`, "name=Bob&pass=h%C3%A4llo&admin=")
     }
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -126,9 +126,11 @@ class FormFieldDirectivesSpec extends RoutingSpec {
       val charset = HttpCharsets.`UTF-8`
       val render: StringRendering = UriRendering.renderQuery(new StringRendering, urlEncodedForm.fields, charset.nioCharset, CharacterClasses.unreserved)
       val streamingForm: RequestEntity = HttpEntity.Chunked(
-        `application/x-www-form-urlencoded` withCharset charset,
+        `application/x-www-form-urlencoded`,
         Source.single(ChunkStreamPart(render.get)).via(AllowMaterializationOnlyOnce())
       )
+
+      streamingForm.getContentType shouldEqual ContentTypes.`application/x-www-form-urlencoded`
       Post("/", streamingForm) ~> {
         formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) { (firstName, age, sex, vip) ⇒
           complete(firstName + age + sex + vip)

--- a/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/marshalling/PredefinedToEntityMarshallers.scala
@@ -48,7 +48,7 @@ trait PredefinedToEntityMarshallers extends MultipartMarshallers {
     Marshaller.withFixedContentType(mediaType) { s ⇒ HttpEntity(mediaType, s) }
 
   implicit val FormDataMarshaller: ToEntityMarshaller[FormData] =
-    Marshaller.withOpenCharset(`application/x-www-form-urlencoded`) { _ toEntity _ }
+    Marshaller.withFixedContentType(`application/x-www-form-urlencoded`) { _ toEntity }
 
   implicit val MessageEntityMarshaller: ToEntityMarshaller[MessageEntity] =
     Marshaller strict { value ⇒ Marshalling.WithFixedContentType(value.contentType, () ⇒ value) }


### PR DESCRIPTION
Closes #91

Currently `charset=UTF-8` is added to `Content-Type: application/x-www-form-urlencoded` by default. This mime-type, however, takes no charset parameter as IANA describes [its specification](https://www.iana.org/assignments/media-types/application/x-www-form-urlencoded). ~As [W3 application-x-www-form-urlencoded encoding algorithm](https://www.w3.org/TR/html5/sec-forms.html#application-x-www-form-urlencoded-encoding-algorithm) describes, `charset` is not expected.~ Thus we don't append `charset=UTF-8` in `Content-Type: application/x-www-form-urlencoded` FormData.