### PR TITLE
`HttpMessage#withStringRepresentation`

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -181,6 +181,9 @@ public interface HttpMessage {
          */
         <T> Self transformEntityDataBytes(Graph<FlowShape<ByteString, ByteString>, T> transformer);
 
+        /** Returns a copy of this message where `f` is used to generate its string representation. **/
+        Self withStringRepresentation(java.util.function.Function<Self, String> f);
+
         /**
          * Returns a CompletionStage of Self message with strict entity that contains the same data as this entity
          * which is only completed when the complete entity has been collected. As the

--- a/akka-http-core/src/main/mima-filters/10.1.8.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.8.backwards.excludes
@@ -1,0 +1,6 @@
+# HttpMessage declares new methods to represent and set its string representation
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.withStringRepresentation")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.stringRepresentation")
+
+# jm.HttpMessage declares new methods to set its string representation
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage#MessageTransformations.withStringRepresentation")

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -271,17 +271,27 @@ object HttpMessage {
  * The immutable model HTTP request model.
  */
 final class HttpRequest(
-  val method:   HttpMethod,
-  val uri:      Uri,
-  val headers:  immutable.Seq[HttpHeader],
-  val entity:   RequestEntity,
-  val protocol: HttpProtocol,
-  val stringRepresentation: HttpRequest ⇒ String = { request ⇒
-    import request._
-    s"""HttpRequest(${_1},${_2},${_3},${_4},${_5})"""
-  }
+  val method:               HttpMethod,
+  val uri:                  Uri,
+  val headers:              immutable.Seq[HttpHeader],
+  val entity:               RequestEntity,
+  val protocol:             HttpProtocol,
+  val stringRepresentation: HttpRequest ⇒ String
 ) extends jm.HttpRequest
   with HttpMessage {
+
+  def this(
+    method:   HttpMethod,
+    uri:      Uri,
+    headers:  immutable.Seq[HttpHeader],
+    entity:   RequestEntity,
+    protocol: HttpProtocol
+  ) = this(method, uri, headers, entity, protocol,
+    stringRepresentation = { request: HttpRequest ⇒
+      import request._
+      s"""HttpRequest(${_1},${_2},${_3},${_4},${_5})"""
+    }
+  )
 
   HttpRequest.verifyUri(uri)
   require(entity.isKnownEmpty || method.isEntityAccepted, s"Requests with method '${method.value}' must have an empty entity")
@@ -362,7 +372,16 @@ final class HttpRequest(
     entity:               RequestEntity             = entity,
     protocol:             HttpProtocol              = protocol,
     stringRepresentation: HttpRequest ⇒ String      = stringRepresentation
-  ) = new HttpRequest(method, uri, headers, entity, protocol, stringRepresentation)
+  ): HttpRequest = new HttpRequest(method, uri, headers, entity, protocol, stringRepresentation)
+
+  @deprecated("for binary-compatibility", "10.1.8")
+  def copy(
+    method:   HttpMethod,
+    uri:      Uri,
+    headers:  immutable.Seq[HttpHeader],
+    entity:   RequestEntity,
+    protocol: HttpProtocol): HttpRequest =
+    copy(method, uri, headers, entity, protocol, stringRepresentation)
 
   override def hashCode(): Int = {
     var result = HashCode.SEED
@@ -468,16 +487,25 @@ object HttpRequest {
  * The immutable HTTP response model.
  */
 final class HttpResponse(
-  val status:   StatusCode,
-  val headers:  immutable.Seq[HttpHeader],
-  val entity:   ResponseEntity,
-  val protocol: HttpProtocol,
-  val stringRepresentation: HttpResponse ⇒ String = { response ⇒
-    import response._
-    s"""HttpResponse(${_1},${_2},${_3},${_4})"""
-  }
+  val status:               StatusCode,
+  val headers:              immutable.Seq[HttpHeader],
+  val entity:               ResponseEntity,
+  val protocol:             HttpProtocol,
+  val stringRepresentation: HttpResponse ⇒ String
 ) extends jm.HttpResponse
   with HttpMessage {
+
+  def this(
+    status:   StatusCode,
+    headers:  immutable.Seq[HttpHeader],
+    entity:   ResponseEntity,
+    protocol: HttpProtocol
+  ) = this(status, headers, entity, protocol,
+    stringRepresentation = { response: HttpResponse ⇒
+      import response._
+      s"""HttpResponse(${_1},${_2},${_3},${_4})"""
+    }
+  )
 
   require(entity.isKnownEmpty || status.allowsEntity, "Responses with this status code must have an empty entity")
   require(
@@ -523,7 +551,15 @@ final class HttpResponse(
     entity:               ResponseEntity            = entity,
     protocol:             HttpProtocol              = protocol,
     stringRepresentation: HttpResponse ⇒ String     = stringRepresentation
-  ) = new HttpResponse(status, headers, entity, protocol, stringRepresentation)
+  ): HttpResponse = new HttpResponse(status, headers, entity, protocol, stringRepresentation)
+
+  @deprecated("for binary-compatibility", "10.1.8")
+  def copy(
+    status:   StatusCode,
+    headers:  immutable.Seq[HttpHeader],
+    entity:   ResponseEntity,
+    protocol: HttpProtocol
+  ): HttpResponse = copy(status, headers, entity, protocol)
 
   override def equals(obj: scala.Any): Boolean = obj match {
     case HttpResponse(_status, _headers, _entity, _protocol) ⇒

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -212,6 +212,7 @@ sealed trait HttpMessage extends jm.HttpMessage {
     val ex = ExecutionContext.fromExecutor(ec)
     toStrict(timeoutMillis.millis, maxBytes)(ex, materializer).toJava
   }
+
 }
 
 object HttpMessage {
@@ -347,6 +348,10 @@ final class HttpRequest(
 
   /** Java API */
   override def withUri(uri: jm.Uri): HttpRequest = copy(uri = uri.asScala)
+
+  /** Java API **/
+  override def withStringRepresentation(f: java.util.function.Function[jm.HttpRequest, String]): jm.HttpRequest =
+    withStringRepresentation((request: HttpRequest) ⇒ f(request))
 
   /* Manual Case Class things, to easen bin-compat */
 
@@ -505,6 +510,10 @@ final class HttpResponse(
 
   /** Returns a copy of this message where `f` is used to generate its string representation. **/
   override def withStringRepresentation(f: HttpResponse ⇒ String): HttpResponse = copy(stringRepresentation = f)
+
+  /** Java API **/
+  override def withStringRepresentation(f: java.util.function.Function[jm.HttpResponse, String]): jm.HttpResponse =
+    withStringRepresentation((response: HttpResponse) ⇒ f(response))
 
   /* Manual Case Class things, to ease bin-compat */
 

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RequestDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RequestDirectivesTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.javadsl.server.directives;
+
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import akka.http.javadsl.testkit.TestRoute;
+import org.junit.Test;
+
+public class RequestDirectivesTest extends JUnitRouteTest {
+
+  @Test
+  public void testMapRequest() {
+    TestRoute route =
+        testRoute(
+            get(() ->
+                mapRequest(request -> request.withStringRepresentation(rq -> "123"), () ->
+                    path("abc", () ->
+                        extractRequest(req ->
+                            complete(req.toString())
+                        )))));
+
+    HttpRequest request =
+        HttpRequest.GET("/abc");
+
+    route.run(request)
+        .assertStatusCode(StatusCodes.OK)
+        .assertEntity("123");
+  }
+
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
@@ -183,4 +183,18 @@ class BasicDirectivesSpec extends RoutingSpec {
       } ~> check { responseAs[String] shouldEqual "1" }
     }
   }
+
+  "The `mapRequest` directive" should {
+    "change request to use a custom string representation" in {
+      Get("/abc") ~> {
+        mapRequest(_.withStringRepresentation(_ ⇒ "123")) {
+          path("abc") {
+            extractRequest { request ⇒
+              complete(request.toString)
+            }
+          }
+        }
+      } ~> check { responseAs[String] shouldEqual "123" }
+    }
+  }
 }


### PR DESCRIPTION
Closes https://github.com/akka/akka-http/issues/2409

Allow custom string representations for `HttpRequest` and `HttpResponse`. These representations are provided as functions from `HttpRequest` (or `HttpResponse`) to `String` and default to the representation so far provided by `toString`. e.g:

```scala
val stringRepresentation: HttpRequest ⇒ String = { request ⇒
    import request._
    s"""HttpRequest(${_1},${_2},${_3},${_4},${_5})"""
  }
```

This possibilities the reduction of the risk of leaking headers in logs or forgotten traces by, for example, using `mapRequest` at the top level route:

```scala
        mapRequest(_.withStringRepresentation(rq ⇒ s"""HttpRequest(${rq._1},${rq._2},${rq._4},${rq._5})""")) {
          path("abc") {
            extractRequest { request ⇒
              complete(request.toString)
            }
          }
        }
```

