### PR TITLE
=pro disable scaladoc generation for 2.13.0-M5 for now, #2416

### DIFF
--- a/akka-http-core/src/main/scala-2.13+/akka/http/ccompat/imm/package.scala
+++ b/akka-http-core/src/main/scala-2.13+/akka/http/ccompat/imm/package.scala
@@ -4,8 +4,6 @@
 
 package akka.http.ccompat
 
-import scala.collection.immutable
-
 /**
  * INTERNAL API
  */


### PR DESCRIPTION
That's because it's broken in 2.13.0-M5 with `-Ymacro-annotations` enabled.
See #2416.

Fixes #2416.