### PR TITLE
=htc,htp improve colliding hashCode tests by taking minimum of multiple runs

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/HashCodeCollider.scala
+++ b/akka-http-core/src/test/scala/akka/http/HashCodeCollider.scala
@@ -10,7 +10,7 @@ package akka.http
  * Adapted from MIT-licensed code by Andriy Plokhotnyuk
  * at https://github.com/plokhotnyuk/jsoniter-scala/blob/26b5ecdd4f8c2ab7e97bd8106cefdda4c1e701ce/jsoniter-scala-benchmark/src/main/scala/com/github/plokhotnyuk/jsoniter_scala/macros/HashCodeCollider.scala#L6.
  */
-object HashCodeColliderr {
+object HashCodeCollider {
   val visibleChars = (33 until 127).filterNot(c ⇒ c == '\\' || c == '"')
   def asciiChars: Iterator[Int] = visibleChars.toIterator
   def asciiCharsAndHash(previousHash: Int): Iterator[(Int, Int)] = visibleChars.toIterator.map(c ⇒ c -> (previousHash + c) * 31)

--- a/akka-http-core/src/test/scala/akka/http/impl/util/BenchUtils.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/BenchUtils.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.impl.util
+
+private[akka] object BenchUtils {
+  /**
+   * Races f1 against f2 for attempts times (after 10 warmup runs) and returns the minimum factor
+   * between f1 time and f2 time.
+   *
+   * Multiple attempts are more resilient against one time disruptions.
+   */
+  def nanoRace(f1: ⇒ Unit, f2: ⇒ Unit, attempts: Int = 3): Double = {
+    // warmup to remove some of the JIT-related variance
+    (1 to 10).foreach { _ ⇒
+      f1
+      f2
+    }
+
+    def nanoTime(f: () ⇒ Unit): Long = {
+      val start = System.nanoTime()
+      f()
+      val end = System.nanoTime()
+      end - start
+    }
+
+    def oneAttempt(): Double = {
+      val f1Time = nanoTime(f1 _)
+      val f2Time = nanoTime(f2 _)
+      val factor = f1Time.toDouble / f2Time
+      factor
+    }
+
+    Seq.fill(attempts)(oneAttempt()).min
+  }
+}


### PR DESCRIPTION
This should be statistically much more reliable and guards against one-time
interruptions.

Fixes #2340, #2386.