### PR TITLE
=htc don't log AbruptTerminationException in client connections

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -96,7 +96,13 @@ private[http] object OutgoingConnectionBlueprint {
 
       val terminationFanout = b.add(Broadcast[HttpResponse](2))
 
-      val logger = b.add(Flow[ByteString].mapError { case t => log.error(t, "Outgoing request stream error"); t }.named("errorLogger"))
+      val logger = b.add(Flow[ByteString].mapError {
+        case ate: AbruptTerminationException => ate // don't log, because it's likely because of shutdown of the ActorSystem
+        case t =>
+          log.error(t, "Outgoing request stream error")
+          t
+      }.named("errorLogger"))
+
       val wrapTls = b.add(Flow[ByteString].map(SendBytes))
 
       val collectSessionBytes = b.add(Flow[SslTlsInbound].collect { case s: SessionBytes => s })


### PR DESCRIPTION
As it is expected when the ActorSystem shuts down while a client pool is running.