### PR TITLE
make code example in introduction doc self-contained

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
@@ -57,6 +57,8 @@ class SprayJsonExampleSpec extends WordSpec with Matchers {
     import akka.http.scaladsl.server.Route
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.model.StatusCodes
+    // for JSON serialization/deserialization following dependency is required:
+    // "com.typesafe.akka" %% "akka-http-spray-json" % "10.1.7"
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
     import spray.json.DefaultJsonProtocol._
 


### PR DESCRIPTION
This code snippet is referenced in the introduction documentation of akka-http:
https://doc.akka.io/docs/akka-http/current/introduction.html
It was a frustrating experience (again) with examples from the doc. I had to spend some time to find out why the code snippet didn't compile. Mentioning this required dependency for this snippet would save me and others time.