### PR TITLE
Improve message parsing

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.7.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.7.backwards.excludes
@@ -25,3 +25,6 @@ ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.engine.ren
 # This change is binary incompatible but there's no other way to fix it.
 ProblemFilters.exclude[IncompatibleFieldTypeProblem]("akka.http.javadsl.model.MediaTypes.APPLICATION_X_WWW_FORM_URLENCODED")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.model.MediaTypes.application/x-www-form-urlencoded")
+
+# Changes to implementation internals
+ProblemFilters.exclude[Problem]("akka.http.impl.engine.parsing.*")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
@@ -34,21 +34,9 @@ private[http] class HttpResponseParser(protected val settings: ParserSettings, p
   final def setContextForNextResponse(responseContext: ResponseContext): Unit =
     if (contextForCurrentResponse.isEmpty) contextForCurrentResponse = Some(responseContext)
 
-  final def onPull(): ResponseOutput =
-    if (result.nonEmpty) {
-      val head = result.head
-      result.remove(0) // faster than `ListBuffer::drop`
-      head
-    } else if (terminated) StreamEnd else NeedMoreData
+  final def onPull(): ResponseOutput = doPull()
 
-  final def onUpstreamFinish(): Boolean = {
-    completionHandling() match {
-      case Some(x) ⇒ emit(x)
-      case None    ⇒ // nothing to do
-    }
-    terminated = true
-    result.isEmpty
-  }
+  final def onUpstreamFinish(): Boolean = shouldComplete()
 
   override final def emit(output: ResponseOutput): Unit = {
     if (output == MessageEnd) contextForCurrentResponse = None


### PR DESCRIPTION
 * Prevent a round-trip of throwing and catching exceptions after having read a full request (default case)
 * Prevent buffering single elements in the output buffer