### PR TITLE
Allow (but ignore) RST and WindowUpdate frames on closed HTTP/2 streams

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -131,7 +131,14 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
     }
   }
   case object Closed extends IncomingStreamState {
-    def handle(event: StreamFrameEvent): IncomingStreamState = receivedUnexpectedFrame(event)
+    def handle(event: StreamFrameEvent): IncomingStreamState = event match {
+      // https://http2.github.io/http2-spec/#StreamStates
+      // Endpoints MUST ignore WINDOW_UPDATE or RST_STREAM frames received in this state,
+      case _: RstStreamFrame | _: WindowUpdateFrame ⇒
+        Closed
+      case _ ⇒
+        receivedUnexpectedFrame(event)
+    }
   }
 
   class IncomingStreamBuffer(streamId: Int, outlet: SubSourceOutlet[ByteString]) extends OutHandler {


### PR DESCRIPTION
This is explicitly allowed by the spec, and indeed happens in the wild when
the Netty client tries to reset a response stream.

Identified while diagnosing https://github.com/akka/akka-grpc/issues/357