### PR TITLE
Clean up ALPN when the stream is stopped

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
@@ -101,4 +101,8 @@ private[http] object Http2AlpnSupport {
     newParameters.setWantClientAuth(old.getWantClientAuth)
     newParameters
   }
+
+  def cleanupForServer(engine: SSLEngine): Unit =
+    if (!isAlpnSupportedByJDK) ALPN.remove(engine)
+
 }

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -152,11 +152,10 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
       val removeEngineOnTerminate: BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] = {
         implicit val ec = fm.executionContext
         BidiFlow.fromFlows(
-          Flow.fromFunction(identity),
-          Flow
-            .fromFunction[ByteString, ByteString](identity)
-            .watchTermination()((n, fd) => {
-              fd.onComplete(_ => eng.foreach(Http2AlpnSupport.cleanupForServer))
+          Flow[ByteString],
+          Flow[ByteString]
+            .watchTermination()((n, fd) ⇒ {
+              fd.onComplete(_ ⇒ eng.foreach(Http2AlpnSupport.cleanupForServer))
               n
             })
         )


### PR DESCRIPTION
Refs #2462

Manually tested by running Http2ServerTest, doing a
`curl http://localhost:9001` (speaking HTTP to the HTTPS port)
and inspecting the Jetty ALPN map with a debugger.