### PR TITLE
Update ScalaTest to a binary compatible with 3.0.X series version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
     crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0-M5"),
     scalaVersion := crossScalaVersions.value.head,
     scalaCheckVersion := System.getProperty("akka.build.scalaCheckVersion", "1.14.0"),
-    scalaTestVersion := "3.0.6",
+    scalaTestVersion := "3.0.7",
     specs2Version := "4.3.6"
   )
 


### PR DESCRIPTION
Update to a 3.0.x series binary compatible version.

From the release notes:
> This release has the same functionality as 3.0.6, and should be source compatible with 3.0.6, but unlike 3.0.6, is binary compatible with 3.0.5. Please see the release notes for 3.0.6 to find out the details of what the release contains. The goal with this release it to achieve binary compatibility with 3.0.5. Unfortunately although 3.0.6 should be source compatible with 3.0.5, it was not binary compatible.

https://github.com/scalatest/scalatest/releases/tag/release-3.0.7