### PR TITLE
Use ScalaTest 3.0.8 so new JUnitSuite is available from Java

### DIFF
--- a/akka-http-core/src/test/java/akka/http/javadsl/model/EntityDiscardingTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/EntityDiscardingTest.java
@@ -12,7 +12,7 @@ import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import scala.util.Try;
 

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
@@ -7,13 +7,9 @@ package akka.http.javadsl.model;
 import akka.http.scaladsl.model.IllegalUriException;
 import akka.japi.Pair;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 import java.util.Optional;
-import java.util.concurrent.TimeoutException;
-
-import static akka.http.javadsl.model.Uri.RELAXED;
-import static akka.http.javadsl.model.Uri.STRICT;
 import static org.junit.Assert.assertEquals;
 
 public class UriTest extends JUnitSuite {

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/sse/ServerSentEventTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/sse/ServerSentEventTest.java
@@ -19,10 +19,9 @@ package akka.http.javadsl.model.sse;
 import java.util.Optional;
 import java.util.OptionalInt;
 
-import akka.http.javadsl.model.sse.ServerSentEvent;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class ServerSentEventTest extends JUnitSuite {
 

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/ClientConnectionSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/ClientConnectionSettingsTest.java
@@ -6,7 +6,7 @@ package akka.http.javadsl.settings;
 
 import akka.actor.ActorSystem;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class ClientConnectionSettingsTest extends JUnitSuite {
 

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/ConnectionPoolSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/ConnectionPoolSettingsTest.java
@@ -6,7 +6,7 @@ package akka.http.javadsl.settings;
 
 import akka.actor.ActorSystem;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class ConnectionPoolSettingsTest extends JUnitSuite {
 

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/ParserSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/ParserSettingsTest.java
@@ -6,7 +6,7 @@ package akka.http.javadsl.settings;
 
 import akka.actor.ActorSystem;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class ParserSettingsTest extends JUnitSuite {
 

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/ServerSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/ServerSettingsTest.java
@@ -6,7 +6,7 @@ package akka.http.javadsl.settings;
 
 import akka.actor.ActorSystem;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class ServerSettingsTest extends JUnitSuite {
 

--- a/akka-http-tests/src/test/java/akka/http/javadsl/settings/RoutingSettingsTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/settings/RoutingSettingsTest.java
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 public class RoutingSettingsTest extends JUnitSuite {
 

--- a/akka-http-tests/src/test/java/akka/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 import static scala.compat.java8.FutureConverters.toJava;
 
 public class EventStreamUnmarshallingTest extends JUnitSuite {

--- a/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpAppExampleTest.java
@@ -16,7 +16,7 @@ import akka.http.javadsl.ServerBinding;
 import com.typesafe.config.ConfigFactory;
 //#imports
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 //#selfClosing
 import scala.concurrent.duration.Duration;

--- a/docs/src/test/java/docs/http/javadsl/server/HttpsServerExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpsServerExampleTest.java
@@ -7,7 +7,7 @@ package docs.http.javadsl.server;
 import akka.actor.ActorSystem;
 import com.typesafe.sslconfig.akka.AkkaSSLConfig;
 import org.junit.Test;
-import org.scalatest.junit.JUnitSuite;
+import org.scalatestplus.junit.JUnitSuite;
 
 /* COMPILE ONLY TEST */
 public class HttpsServerExampleTest extends JUnitSuite {


### PR DESCRIPTION
Trying the new RC from ScalaTest to see if Java code can see the new `JUnitSuite` class