### PR TITLE
Cache docs: Add missing TimeUnits and duration imports

### DIFF
--- a/docs/src/main/paradox/common/caching.md
+++ b/docs/src/main/paradox/common/caching.md
@@ -76,7 +76,7 @@ For more advanced usage you can create an @unidoc[LfuCache$] with settings
 specialized for your use case:
 
 Java
-:  @@snip [CachingDirectivesExamplesTest.java]($root$/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java) { #create-cache-imports #caching-directives-import #time-unit-import #keyer-function #create-cache}
+:  @@snip [CachingDirectivesExamplesTest.java]($root$/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java) { #create-cache-imports #caching-directives-import #time-unit-import #keyer-function #create-cache }
 
 Scala
 :  @@snip [CachingDirectivesExamplesSpec.java]($root$/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala) { #keyer-function #create-cache }

--- a/docs/src/main/paradox/common/caching.md
+++ b/docs/src/main/paradox/common/caching.md
@@ -76,7 +76,7 @@ For more advanced usage you can create an @unidoc[LfuCache$] with settings
 specialized for your use case:
 
 Java
-:  @@snip [CachingDirectivesExamplesTest.java]($root$/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java) { #create-cache-imports #caching-directives-import #keyer-function #create-cache }
+:  @@snip [CachingDirectivesExamplesTest.java]($root$/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java) { #create-cache-imports #caching-directives-import #time-unit-import #keyer-function #create-cache}
 
 Scala
 :  @@snip [CachingDirectivesExamplesSpec.java]($root$/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala) { #keyer-function #create-cache }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CachingDirectivesExamplesTest.java
@@ -18,7 +18,9 @@ import akka.http.javadsl.server.RequestContext;
 import static akka.http.javadsl.server.directives.CachingDirectives.*;
 //#caching-directives-import
 import scala.concurrent.duration.Duration;
+//#time-unit-import
 import java.util.concurrent.TimeUnit;
+//#time-unit-import
 import akka.http.javadsl.testkit.JUnitRouteTest;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CachingDirectivesExamplesSpec.scala
@@ -14,7 +14,6 @@ import akka.http.scaladsl.server.directives.CachingDirectives._
 //#always-cache
 //#cache
 import akka.http.scaladsl.model.HttpMethods.GET
-import scala.concurrent.duration._
 
 class CachingDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
@@ -137,6 +136,7 @@ class CachingDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     import akka.http.scaladsl.server.RouteResult
     import akka.http.scaladsl.model.Uri
     import akka.http.scaladsl.server.directives.CachingDirectives._
+    import scala.concurrent.duration._
 
     // Use the request's URI as the cache's key
     val keyerFunction: PartialFunction[RequestContext, Uri] = {


### PR DESCRIPTION
#1955 Issue
Added missing imports
```java
import java.util.concurrent.TimeUnit;
```
```scala
import scala.concurrent.duration._
```

In caching docs
https://doc.akka.io/docs/akka-http/current/common/caching.html