### PR TITLE
Loose the default response-entity-subscription-timeout to 5s; Make th…

### DIFF
--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -400,7 +400,7 @@ akka.http {
     # The "new" pool implementation will fail a connection early and clear the slot if a response entity was not
     # subscribed during the given time period after the response was dispatched. In busy systems the timeout might be
     # too tight if a response is not picked up quick enough after it was dispatched by the pool.
-    response-entity-subscription-timeout = 1.second
+    response-entity-subscription-timeout = 5.second
 
     # Modify this section to tweak client settings only for host connection pools APIs like `Http().superPool` or
     # `Http().singleRequest`.

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -303,7 +303,8 @@ private[pool] object SlotState {
 
     override def onTimeout(ctx: SlotContext): SlotState = {
       ctx.warning(
-        s"Response entity was not subscribed after $stateTimeout. Make sure to read the response entity body or call `discardBytes()` on it. " +
+        s"Response entity was not subscribed after $stateTimeout. Make sure to 1) read the response entity body or call `discardBytes()` on it. " +
+          s"2) eliminate the blocking operation in the stream pipeline. " +
           s"${ongoingRequest.request.debugString} -> ${ongoingResponse.debugString}")
       Unconnected
     }


### PR DESCRIPTION
Loose the default response-entity-subscription-timeout to 5s; Make the entity subscription timeout error message more accurate

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->