### PR TITLE
Fix links to objects

### DIFF
--- a/docs/src/main/paradox/common/http-model.md
+++ b/docs/src/main/paradox/common/http-model.md
@@ -28,11 +28,11 @@ the type plus a trailing plural 's'.
 For example:
 
  * Defined @apidoc[HttpMethod] instances @scala[live in]@java[are defined as static fields of] the @scala[@apidoc[HttpMethods$]]@java[@apidoc[HttpMethods]] @scala[object]@java[class].
- * Defined @apidoc[HttpCharset] instances @scala[live in]@java[are defined as static fields of] the @scala[@apidoc[HttpCharsets$]]@java[@apidoc[HttpCharsets]] @scala[object]@java[class].
- * Defined @apidoc[HttpEncoding] instances @scala[live in]@java[are defined as static fields of] the @scala[@apidoc[HttpEncodings$]]@java[@apidoc[HttpEncodings]] @scala[object]@java[class].
- * Defined @apidoc[HttpProtocol] instances @scala[live in]@java[are defined as static fields of] the @scala[@apidoc[HttpProtocols$]]@java[@apidoc[HttpProtocols]] @scala[object]@java[class].
- * Defined @apidoc[MediaType] instances @scala[live in]@java[are defined as static fields of] the @scala[@apidoc[MediaTypes$]]@java[@apidoc[MediaTypes]] @scala[object]@java[class].
- * Defined @apidoc[StatusCode] instances @scala[live in]@java[are defined as static fields of] the @scala[@apidoc[StatusCodes$]]@java[@apidoc[StatusCodes]] @scala[object]@java[class].
+ * Defined @apidoc[HttpCharset] instances @scala[live in]@java[are defined as static fields of] the @apidoc[HttpCharsets$] @scala[object]@java[class].
+ * Defined @apidoc[HttpEncoding] instances @scala[live in]@java[are defined as static fields of] the @apidoc[HttpEncodings$] @scala[object]@java[class].
+ * Defined @apidoc[HttpProtocol] instances @scala[live in]@java[are defined as static fields of] the @apidoc[HttpProtocols$] @scala[object]@java[class].
+ * Defined @apidoc[MediaType] instances @scala[live in]@java[are defined as static fields of] the @apidoc[MediaTypes$] @scala[object]@java[class].
+ * Defined @apidoc[StatusCode] instances @scala[live in]@java[are defined as static fields of] the @apidoc[StatusCodes$] @scala[object]@java[class].
 
 ## HttpRequest
 

--- a/docs/src/main/paradox/release-notes/10.0.x.md
+++ b/docs/src/main/paradox/release-notes/10.0.x.md
@@ -111,7 +111,7 @@ the explicitly passed-in materializer argument.
  * Allow disabling of parsing to modeled headers ([#1550](https://github.com/akka/akka-http/issues/1550))
  * Convert RFC references in documents in model classes to scaladoc ([#1514](https://github.com/akka/akka-http/issues/1514))
  * Allow configuration of default http and https ports ([#1449](https://github.com/akka/akka-http/issues/1449))
- * Remove unnecessary implicit `materializer` parameter in several top-level @scala[@apidoc[Http$]]@java[@apidoc[Http]] entry point APIs ([#1464](https://github.com/akka/akka-http/issues/1464))
+ * Remove unnecessary implicit `materializer` parameter in several top-level @scala[@apidoc[Http](HttpExt$)]@java[@apidoc[Http]] entry point APIs ([#1464](https://github.com/akka/akka-http/issues/1464))
  * Add `X-Forwarded-Proto` and `X-Forwarded-Host` header models ([#1377](https://github.com/akka/akka-http/issues/1377))
  * Lookup predefined header parsers as early as possible ([#1424](https://github.com/akka/akka-http/issues/1424))
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.18")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "0.1+6-ff00ea16")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-apidoc" % "0.1+7-9b5a4054")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.13")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
 


### PR DESCRIPTION
Link to companion object for Scala, to class (which has static forwarders)
for Java.