### PR TITLE
use scalaVersion from System property akka.build.scalaVersion

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
 
   val Versions = Seq(
     crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0-M5"),
-    scalaVersion := crossScalaVersions.value.head,
+    scalaVersion := System.getProperty("akka.build.scalaVersion", crossScalaVersions.value.head),
     scalaCheckVersion := System.getProperty("akka.build.scalaCheckVersion", "1.14.0"),
     scalaTestVersion := "3.0.7",
     specs2Version := "4.3.6"


### PR DESCRIPTION
* if it's defined, otherwise crossScalaVersions.head as before
* this is how the scalaVersion can be set for akka/akka and
  it's used from Jenkins/Travis jobs
* Scala 2.11 is not included in akka/akka crossScalaVersions any
  more because of trouble of mixing different such for different
  modules (excluding it only for -typed modules)
* need this for the akka-http-nightly build matrix
