### PR TITLE
Add String to UUID unmarshaller to the predefined Scala unmarshallers

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.http.scaladsl.unmarshalling
 
+import java.util.UUID
+
 import akka.http.scaladsl.unmarshalling.Unmarshaller.EitherUnmarshallingException
 import org.scalatest.{ BeforeAndAfterAll, FreeSpec, Matchers }
 import akka.http.scaladsl.testkit.ScalatestUtils
@@ -39,6 +41,10 @@ class UnmarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll wi
     "booleanUnmarshaller should unmarshal '1' => true '0' => false" in {
       Unmarshal("1").to[Boolean] should evaluateTo(true)
       Unmarshal("0").to[Boolean] should evaluateTo(false)
+    }
+    "uuidUnmarshaller should unmarshal valid uuid" in {
+      val uuid = UUID.randomUUID()
+      Unmarshal(uuid.toString).to[UUID] should evaluateTo(uuid)
     }
   }
 

--- a/akka-http/src/main/mima-filters/10.1.8.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.1.8.backwards.excludes
@@ -1,0 +1,3 @@
+# Changes against 10.1.8
+# PredefinedFromStringUnmarshallers is a good candidate for @DoNotInherit anyway. See 10.1.1.backwards.excludes for similar.
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.unmarshalling.PredefinedFromStringUnmarshallers.*")

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
@@ -4,6 +4,8 @@
 
 package akka.http.scaladsl.unmarshalling
 
+import java.util.UUID
+
 import scala.collection.immutable
 import akka.http.scaladsl.util.FastFuture
 import akka.util.ByteString
@@ -40,6 +42,15 @@ trait PredefinedFromStringUnmarshallers {
         case "false" | "no" | "off" | "0" ⇒ false
         case ""                           ⇒ throw Unmarshaller.NoContentException
         case x                            ⇒ throw new IllegalArgumentException(s"'$x' is not a valid Boolean value")
+      }
+    }
+
+  implicit val uuidFromStringUnmarshaller: Unmarshaller[String, UUID] =
+    Unmarshaller.strict { string ⇒
+      try UUID.fromString(string)
+      catch {
+        case e: IllegalArgumentException ⇒
+          throw new IllegalArgumentException(s"'$string' is not a valid UUID value", e)
       }
     }
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Add ability to unmarshall Strings to UUIDs in Scala code via predefined implicit `Unmarshaller[String, UUID]`

## Background Context

So we have followings things already:
* [String -> UUID Java Unmarshaller](https://github.com/akka/akka-http/blob/master/akka-http/src/main/java/akka/http/javadsl/unmarshalling/StringUnmarshallers.java#L73)
* [UUID path matcher](https://github.com/akka/akka-http/blob/master/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala#L488)

But we don't have similar thing for Scala Unmarshaller, so one can't do stuff like this (that is actual use case which I needed):

```scala
parameter('id.as[UUID]) { id => ... }
```

While you can do this:
```scala
path(JavaUUID) { id => ... }
```

Seemed like a good thing, so I was surprised that it is not available out of the box for Scala, but is for Java, hence this PR. If I just looked in the wrong place and it is actually somewhere there, please guide me through it