### PR TITLE
use splitAfter in Websocket implementation

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
@@ -138,7 +138,7 @@ private[http] object WebSocket {
     val collectMessage: Flow[MessageDataPart, Message, NotUsed] =
       Flow[MessageDataPart]
         .prefixAndTail(1)
-        .collect {
+        .map {
           case (TextMessagePart(text, true) +: Nil, remaining) ⇒
             StreamUtils.cancelSource(remaining)(StreamUtils.OnlyRunInGraphInterpreterContext)
             TextMessage.Strict(text)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
@@ -138,36 +138,27 @@ private[http] object WebSocket {
     val collectMessage: Flow[MessageDataPart, Message, NotUsed] =
       Flow[MessageDataPart]
         .prefixAndTail(1)
-        .mapConcat {
-          // happens if we get a MessageEnd first which creates a new substream but which is then
-          // filtered out by collect in `prepareMessages` below
-          case (Nil, _) ⇒ Nil
-          case (first +: Nil, remaining) ⇒ (first match {
-            case TextMessagePart(text, true) ⇒
-              StreamUtils.cancelSource(remaining)(StreamUtils.OnlyRunInGraphInterpreterContext)
-              TextMessage.Strict(text)
-            case first @ TextMessagePart(text, false) ⇒
-              TextMessage(
-                (Source.single(first) ++ remaining)
-                  .collect {
-                    case t: TextMessagePart if t.data.nonEmpty ⇒ t.data
-                  })
-            case BinaryMessagePart(data, true) ⇒
-              StreamUtils.cancelSource(remaining)(StreamUtils.OnlyRunInGraphInterpreterContext)
-              BinaryMessage.Strict(data)
-            case first @ BinaryMessagePart(data, false) ⇒
-              BinaryMessage(
-                (Source.single(first) ++ remaining)
-                  .collect {
-                    case t: BinaryMessagePart if t.data.nonEmpty ⇒ t.data
-                  })
-          }) :: Nil
+        .collect {
+          case ((first: TextMessagePart) +: Nil, remaining) ⇒
+            TextMessage(
+              (Source.single(first) ++ remaining)
+                .collect {
+                  case t: TextMessagePart if t.data.nonEmpty ⇒ t.data
+                }
+            )
+          case ((first: BinaryMessagePart) +: Nil, remaining) ⇒
+            BinaryMessage(
+              (Source.single(first) ++ remaining)
+                .collect {
+                  case b: BinaryMessagePart if b.data.nonEmpty ⇒ b.data
+                }
+            )
         }
 
     def prepareMessages: Flow[MessagePart, Message, NotUsed] =
       Flow[MessagePart]
         .via(PrepareForUserHandler)
-        .splitWhen(_.isMessageEnd) // FIXME using splitAfter from #16885 would simplify protocol a lot
+        .splitAfter(_.isMessageEnd)
         .collect {
           case m: MessageDataPart ⇒ m
         }


### PR DESCRIPTION
## Purpose
I found a FIXME in code and willing to fix it. This FIXME has reference to https://github.com/akka/akka/issues/16885

## References
https://github.com/akka/akka/issues/16885

## Problems
now I have 20 failed tests. 19 of them fail with error message that they expect strict message but get source (obviously why). Is it ok to fix those tests?
and one is complaining:
```
"for echoing user handler"
java.lang.AssertionError: assertion failed: expected 11 bytes, but got 11 bytes 
Expected: 
   ByteString(11 bytes)

     81 09 4D 65 73 73 61 67 65 20 31                 | ..Message 1
But got: 
   ByteString(11 bytes)

     01 09 4D 65 73 73 61 67 65 20 31                 | ..Message 1
	at scala.Predef$.assert(Predef.scala:223)
	at akka.http.impl.engine.ws.ByteStringSinkProbe$$anon$1.expectBytes(ByteStringSinkProbe.scala:83)
	at akka.http.impl.engine.ws.WebSocketServerSpec$TestSetup.expectBytes(WebSocketServerSpec.scala:183)
```
i have the same text messages but different bytes sequence. I suppose this is not ok, but I couldn't find the reason