### PR TITLE
fix for #2520

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
@@ -83,9 +83,10 @@ private[http2] object ResponseRendering {
     serverHeader: Option[(String, String)],
     log:          LoggingAdapter
   ): Unit = {
-    def suppressionWarning(h: HttpHeader, msg: String): Unit =
-      log.warning("Explicitly set HTTP header '{}' is ignored, {}", h, msg)
-
+    def suppressionWarning(h: HttpHeader, settings: ServerSetttings, msg: String): Unit =
+      if (settings.verboseErrorMessages) {
+        log.warning("Explicitly set HTTP header '{}' is ignored, {}", h, msg)
+      }
     // optimized, as it is done for every response
     val headers = headersSeq.toArray
     var serverSeen, dateSeen = false


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

This change is an attempt at fixing https://github.com/akka/akka-http/issues/2520 by giving users the option to suppress warning messages from RenderResponses.scala

## References

References #2520 

## Changes

* `ResponseRendering.scala`

## Background Context

I use akka-http at work and we had to put in a hack that strips certain headers from our server-side responses so that our logs don't blow up with superfluous.  I'd love to have the ability to just turn off these types of warnings at the config level so that we don't have to write any additional parsing layers in our service.
