### PR TITLE
 htp: fix case of nested FormField if first formField usage is with single parameter

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -106,18 +106,38 @@ class FormFieldDirectivesSpec extends RoutingSpec {
         responseAs[String] shouldEqual "Mike42None<b>no</b>"
       }
     }
-    "work even when the entity is streaming rather than strict" in {
-      val charset = HttpCharsets.`UTF-8`
-      val render: StringRendering = UriRendering.renderQuery(new StringRendering, urlEncodedForm.fields, charset.nioCharset, CharacterClasses.unreserved)
-      val streamingForm: RequestEntity = HttpEntity.Chunked(
-        `application/x-www-form-urlencoded`,
-        Source.single(ChunkStreamPart(render.get)).via(AllowMaterializationOnlyOnce())
-      )
+    "work even when the entity is not strict" in {
+      val request: HttpRequest =
+        Post("/", urlEncodedForm)
+          // transformEntityDataBytes will convert the entity to chunked
+          .transformEntityDataBytes(AllowMaterializationOnlyOnce())
 
-      streamingForm.getContentType shouldEqual ContentTypes.`application/x-www-form-urlencoded`
-      Post("/", streamingForm) ~> {
-        formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) { (firstName, age, sex, vip) =>
+      request.entity.contentType shouldEqual ContentTypes.`application/x-www-form-urlencoded`
+      request.entity shouldNot be('strict)
+
+      request ~> {
+        formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) { (firstName, age, sex, vip) ⇒
           complete(firstName + age + sex + vip)
+        }
+      } ~> check { responseAs[String] shouldEqual "Mike42Nonefalse" }
+    }
+
+    "work even with nested directives when the entity is not strict" in {
+      val request: HttpRequest =
+        Post("/", urlEncodedForm)
+          // transformEntityDataBytes will convert the entity to chunked
+          .transformEntityDataBytes(AllowMaterializationOnlyOnce())
+
+      request.entity.contentType shouldEqual ContentTypes.`application/x-www-form-urlencoded`
+      request.entity shouldNot be('strict)
+
+      request ~> {
+        formFields('firstName) { firstName ⇒
+          formFields("age".as[Int], 'sex.?) { (age, sex) ⇒
+            formFields("VIP" ? false) { vip ⇒
+              complete(firstName + age + sex + vip)
+            }
+          }
         }
       } ~> check { responseAs[String] shouldEqual "Mike42Nonefalse" }
     }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
@@ -66,12 +66,12 @@ class HeaderDirectivesSpec extends RoutingSpec with Inside {
       }
     }
     "reject a request if no header matches a custom one, and use the custom header's name for the rejection " in {
-      val route = headerValueByType[XCustomHeader]() { customValue ⇒
+      val route = headerValueByType[XCustomHeader]() { customValue =>
         complete(s"Custom-Value: $customValue")
       }
       Get("abc") ~> route ~> check {
         inside(rejection) {
-          case MissingHeaderRejection("X-Custom-Header") ⇒
+          case MissingHeaderRejection("X-Custom-Header") =>
         }
       }
     }

--- a/akka-http/src/main/mima-filters/10.1.8.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.1.8.backwards.excludes
@@ -1,3 +1,15 @@
 # Changes against 10.1.8
 # PredefinedFromStringUnmarshallers is a good candidate for @DoNotInherit anyway. See 10.1.1.backwards.excludes for similar.
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.unmarshalling.PredefinedFromStringUnmarshallers.*")
+
+# Fixing some aspects of form fields wrt to streamed entities
+
+# Added new superclass to FormFieldDirectives. Would only be a problem if FormFieldDirectives was extended by a third party.
+ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.scaladsl.server.directives.FormFieldDirectivesCompat.formFields")
+ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.scaladsl.server.directives.FormFieldDirectivesCompat.formField")
+
+# FieldMagnet / FieldDef should not be extended or called by third-part code.
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.server.directives.FormFieldDirectives#FieldMagnet.apply")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.FormFieldDirectives#FieldMagnet.apply")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.server.directives.FormFieldDirectives#FieldDef.apply")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.FormFieldDirectives#FieldDef.apply")

--- a/akka-http/src/main/mima-filters/10.1.8.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.1.8.backwards.excludes
@@ -4,12 +4,9 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.unmarsh
 
 # Fixing some aspects of form fields wrt to streamed entities
 
-# Added new superclass to FormFieldDirectives. Would only be a problem if FormFieldDirectives was extended by a third party.
-ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.scaladsl.server.directives.FormFieldDirectivesCompat.formFields")
-ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.scaladsl.server.directives.FormFieldDirectivesCompat.formField")
-
-# FieldMagnet / FieldDef should not be extended or called by third-part code.
+# FieldMagnet / FieldDef should not be extended or called by third-party code.
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.server.directives.FormFieldDirectives#FieldMagnet.apply")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.FormFieldDirectives#FieldMagnet.apply")
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.scaladsl.server.directives.FormFieldDirectives#FieldDef.apply")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.FormFieldDirectives#FieldDef.apply")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.directives.FormFieldDirectives#FieldMagnet.convert")

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Directive.scala
@@ -144,6 +144,16 @@ object Directive {
     r => directive.tapply(_ => r)
 
   /**
+   * Adds helper functions to `Directive0`
+   */
+  implicit class Directive0Support(val underlying: Directive0) extends AnyVal {
+    def wrap[R](f: => Directive[R]): Directive[R] =
+      underlying.tflatMap { _ =>
+        f
+      }(Tuple.yes[R]) // we will create a Directive[R], so we know it will be tupled correctly
+  }
+
+  /**
    * "Standard" transformers for [[Directive1]].
    * Easier to use than `tmap`, `tflatMap`, etc. defined on [[Directive]] itself,
    * because they provide transparent conversion from [[Tuple1]].

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
@@ -29,7 +29,7 @@ class WithPriorKnowledgeSpec extends AkkaSpec("""
     implicit val mat = ActorMaterializer()
 
     val binding = Http().bindAndHandleAsync(
-      _ ⇒ Future.successful(HttpResponse(status = StatusCodes.ImATeapot)),
+      _ => Future.successful(HttpResponse(status = StatusCodes.ImATeapot)),
       "127.0.0.1",
       port = 0
     ).futureValue

--- a/project/Formatting.scala
+++ b/project/Formatting.scala
@@ -26,7 +26,7 @@ object Formatting {
   )
 
   def setPreferences(preferences: IFormattingPreferences) = preferences
-    .setPreference(RewriteArrowSymbols, false)
+    .setPreference(RewriteArrowSymbols, true)
     .setPreference(UseUnicodeArrows, false)
     .setPreference(AlignParameters, true)
     .setPreference(AlignSingleLineCaseStatements, true)


### PR DESCRIPTION
So far, in #2283 the case for tuples was fixed which also worked for nested `formField` directives in most of the cases but not when the first usage was with a single argument.

Refs #73.