### PR TITLE
Add test cases reproducing testkit bug with Futures

### DIFF
--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -105,7 +105,7 @@ object Routes {
       pathPrefix("quick") {
         complete(Future.successful("done-quick"))
       } ~ pathPrefix("buggy") {
-        complete(Future.successful(()).map(_ => "done-buggy"))
+        complete(Future.successful(()).map(_ ⇒ "done-buggy"))
       } ~ pathPrefix("long") {
         complete(longFuture("done-long"))
       }

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -81,10 +81,9 @@ class ScalatestRouteTestSpec extends FreeSpec with Matchers with ScalatestRouteT
       }
     }
 
-    def afterAsyncBoundary[A](a: => A): A = {
-      Await.result(Future.successful(()).map(_ => a), 10.seconds)
+    def afterAsyncBoundary[A](a: ⇒ A): A = {
+      Await.result(Future.successful(()).map(_ ⇒ a), 10.seconds)
     }
-
 
     "proper rejection collection" in {
       Post("/abc", "content") ~> {


### PR DESCRIPTION
## Purpose

Add failing test cases reproducing an issue I found in the route testkit.

## The bug

Passing a request through some routes causes them to never complete nor reject the request.

In particular, I found that the problematic routes are the ones that are completed with a Future that doesn't have a value straight away (i.e. anything that's not `Future.successful(marshallable)`.

I will look for ways to fix this issue, as it's a massive blocker to implement https://github.com/softwaremill/sttp/pull/208 and for testing routes that have extra logic on top of futures returned from the service layer (essentially anything that looks like `complete(logic(input).map(toDTO))`).

It would be awesome if I could get some guidance as to where to look for the potential cause of the problem. Thanks!

Note that the test failure claims that the request was neither completed nor rejected in 5 seconds, but executing *all* the tests takes less than a second. Example:

![image](https://user-images.githubusercontent.com/894884/57716336-0ea00800-7679-11e9-9d01-f8d4bf984c6e.png)
