### PR TITLE
htk: manage blocking in RouteTestResult to make starvation less likely

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
@@ -70,7 +70,7 @@ trait RouteTestResultComponent {
         } else failTest("Route completed/rejected more than once")
       }
 
-    private[testkit] def awaitResult: this.type = {
+    private[testkit] def awaitResult: this.type = scala.concurrent.blocking {
       latch.await(timeout.toMillis, MILLISECONDS)
       this
     }


### PR DESCRIPTION
One particular starvation case is if a test is run on the ActorSystem dispatcher
which might use a BatchingExecutor. In that case thunks might be scheduled to
be run on the currently running thread but be starved by the unmanaged blocking
in RouteTestResultComponent.awaitResult.

Fixes #2526.