### PR TITLE
htc: remove warning expectation in ClientServerSpec

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -608,12 +608,10 @@ Host: example.com
           .bindAndHandle(routes, hostname, port, connectionContext = serverConnectionContext, settings = serverSettings)
           .futureValue
 
-      EventFilter.warning(pattern = "Hostname verification failed", occurrences = 1) intercept {
-        Http()
-          .singleRequest(request, connectionContext = clientConnectionContext, settings = clientSettings)
-          .futureValue
-          .entity.dataBytes.runFold(ByteString.empty)(_ ++ _).futureValue.utf8String shouldEqual entity
-      }
+      Http()
+        .singleRequest(request, connectionContext = clientConnectionContext, settings = clientSettings)
+        .futureValue
+        .entity.dataBytes.runFold(ByteString.empty)(_ ++ _).futureValue.utf8String shouldEqual entity
 
       serverBinding.unbind()
     }


### PR DESCRIPTION
The "Hostname verification failed" warning was emitted by ssl-config when
hostname verification is disabled. In version ssl-config 0.4.0 (which is
transitively pulled in by akka-stream 2.5.22 for Scala 2.13), this warning
isn't shown any more.