### PR TITLE
Optimize few java to scala conversions

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
@@ -52,8 +52,11 @@ abstract class SecurityDirectives extends SchemeDirectives {
    * Extracts the potentially present [[HttpCredentials]] provided with the request's [[akka.http.javadsl.model.headers.Authorization]] header.
    */
   def extractCredentials(inner: JFunction[Optional[HttpCredentials], Route]): Route = RouteAdapter {
-    D.extractCredentials { cred =>
-      inner.apply(cred.map(_.asJava).asJava).delegate // TODO attempt to not need map()
+    D.extractCredentials { credOpt =>
+      (credOpt match {
+        case Some(cred) => inner.apply(Optional.of(cred.asJava))
+        case None       => inner.apply(Optional.empty())
+      }).delegate
     }
   }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -113,8 +113,7 @@ final case class InvalidOriginRejection(allowedOrigins: immutable.Seq[SHttpOrigi
  */
 final case class UnsupportedRequestContentTypeRejection(supported: immutable.Set[ContentTypeRange])
   extends jserver.UnsupportedRequestContentTypeRejection with Rejection {
-  override def getSupported: java.util.Set[model.ContentTypeRange] =
-    scala.collection.mutable.Set(supported.map(_.asJava).toVector: _*).asJava // TODO optimise
+  override def getSupported: java.util.Set[model.ContentTypeRange] = supported.map(_.asJava).asJava
 }
 
 /**
@@ -174,8 +173,7 @@ final case class UnacceptedResponseContentTypeRejection(supported: immutable.Set
  */
 final case class UnacceptedResponseEncodingRejection(supported: immutable.Set[HttpEncoding])
   extends jserver.UnacceptedResponseEncodingRejection with Rejection {
-  override def getSupported: java.util.Set[model.headers.HttpEncoding] =
-    scala.collection.mutable.Set(supported.map(_.asJava).toVector: _*).asJava // TODO optimise
+  override def getSupported: java.util.Set[model.headers.HttpEncoding] = supported.map(_.asJava).asJava
 }
 object UnacceptedResponseEncodingRejection {
   def apply(supported: HttpEncoding): UnacceptedResponseEncodingRejection = UnacceptedResponseEncodingRejection(Set(supported))


### PR DESCRIPTION
## Purpose

Found some TODOs

## Changes

optimize few java to scala conversions

## In addition

Also I have found usages of expressions like this:
```Util.immutableSeq(someJavaCollectionOfJavaStructure).map(_.asScala)``` where immutableSeq is
```def immutableSeq[T](iterable: java.lang.Iterable[T]): immutable.Seq[T]```
What if we add to akka JavaAPI object method like
``` def immutableSeq[J, S](iterable: java.lang.Iterable[J])(implicit mapping JavaMapping[J,S]): immutable.Seq[S] ```? It will be better to use it in such situations. what do you think?


