### PR TITLE
Ensure Java & Scala code is compiled targeting JVM 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ inThisBuild(Def.settings(
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8", // yes, this is 2 args
+    "-target:jvm-1.8",
     "-unchecked",
     "-Xlint",
     // "-Yno-adapted-args", //akka-http heavily depends on adapted args and => Unit implicits break otherwise
@@ -41,7 +42,9 @@ inThisBuild(Def.settings(
     // "-Xfuture" // breaks => Unit implicits
   ),
   javacOptions ++= Seq(
-    "-encoding", "UTF-8"
+    "-encoding", "UTF-8",
+    "-source", "1.8",
+    "-target", "1.8",
   ),
   testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v"),
   Dependencies.Versions,


### PR DESCRIPTION
Before:

    11:48:49 $ javap -verbose ./akka-http-core/target/scala-2.12/classes/akka/http/javadsl/model/HttpRequest.class | grep major
      major version: 55

After:

    10:49:25 ! javap -verbose ./akka-http-core/target/scala-2.12/classes/akka/http/javadsl/model/HttpRequest.class | grep major
      major version: 52