### PR TITLE
Prefer concat in samples #2537

### DIFF
--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -127,25 +127,24 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
   val tenXResponseLength = array_10x.length
   val hundredXResponseLength = array_100x.length
 
-  // format: OFF
   val routes: Route = {
     import Directives._
-
-    path("ping") {
-      complete("PONG!")
-    } ~
-    path("long-response-array" / IntNumber) { n =>
-      if (n == 10) complete(HttpEntity(ContentTypes.`text/plain(UTF-8)`, array_10x))
-      else if (n == 100) complete(HttpEntity(ContentTypes.`text/plain(UTF-8)`, array_10x))
-      else throw new RuntimeException(s"Not implemented for ${n}")
-    } ~
-    path("long-response-stream" / IntNumber) { n =>
-      if (n == 10) complete(HttpEntity(ContentTypes.`text/plain(UTF-8)`, source_100x))
-      else if (n == 100) complete(HttpEntity(ContentTypes.`text/plain(UTF-8)`, source_100x))
-      else throw new RuntimeException(s"Not implemented for ${n}")
-    }
+    concat(
+      path("ping") {
+        complete("PONG!")
+      },
+      path("long-response-array" / IntNumber) { n =>
+        if (n == 10) complete(HttpEntity(ContentTypes.`text/plain(UTF-8)`, array_10x))
+        else if (n == 100) complete(HttpEntity(ContentTypes.`text/plain(UTF-8)`, array_10x))
+        else throw new RuntimeException(s"Not implemented for ${n}")
+      },
+      path("long-response-stream" / IntNumber) { n =>
+        if (n == 10) complete(HttpEntity(ContentTypes.`text/plain(UTF-8)`, source_100x))
+        else if (n == 100) complete(HttpEntity(ContentTypes.`text/plain(UTF-8)`, source_100x))
+        else throw new RuntimeException(s"Not implemented for ${n}")
+      }
+    )
   }
-  // format: ON
 
   val enableSpec = system.settings.config.getBoolean("akka.test.AkkaHttpServerLatencySpec.enable")
   val totalRequestsFactor = system.settings.config.getDouble("akka.test.AkkaHttpServerLatencySpec.totalRequestsFactor")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/PathDirectives.scala
@@ -54,12 +54,14 @@ abstract class PathDirectives extends ParameterDirectives {
    *   // redirect '/users/' to '/users', '/users/:userId/' to '/users/:userId'
    *   redirectToNoTrailingSlashIfPresent(Found) {
    *     pathPrefix("users") {
-   *       pathEnd {
-   *         // user list ...
-   *       } ~
-   *       path(UUID) { userId =>
-   *         // user profile ...
-   *       }
+   *       concat(
+   *         pathEnd {
+   *           // user list ...
+   *         },
+   *         path(UUID) { userId =>
+   *           // user profile ...
+   *         }
+   *       )
    *     }
    *   }
    * }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
@@ -135,12 +135,14 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    *   // redirect '/users/' to '/users', '/users/:userId/' to '/users/:userId'
    *   redirectToNoTrailingSlashIfPresent(Found) {
    *     pathPrefix("users") {
-   *       pathEnd {
-   *         // user list ...
-   *       } ~
-   *       path(UUID) { userId =>
-   *         // user profile ...
-   *       }
+   *       concat(
+   *         pathEnd {
+   *           // user list ...
+   *         },
+   *         path(UUID) { userId =>
+   *           // user profile ...
+   *         }
+   *       )
    *     }
    *   }
    * }

--- a/docs/src/main/paradox/routing-dsl/directives/index.md
+++ b/docs/src/main/paradox/routing-dsl/directives/index.md
@@ -332,7 +332,7 @@ Scala code that compiles but does not work as expected. What would be intended a
 
 @@@ div { .group-scala }
 
-Alternatively we can combine directives using `~` operator where we pass each directive as an argument to the combinator function instead of chaining them with `concat` . Let's take a look at the usage of this combinator:
+Alternatively we can combine directives using the `~` operator where we chain them together instead of passing each directive as a separate argument. Let's take a look at the usage of this combinator:
 
 @@snip [DirectiveExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/DirectiveExamplesSpec.scala) { #example-8 }
 

--- a/docs/src/main/paradox/routing-dsl/directives/index.md
+++ b/docs/src/main/paradox/routing-dsl/directives/index.md
@@ -113,10 +113,12 @@ Using the @ref[get](method-directives/get.md) and @ref[complete](route-directive
 
 ```scala
 val route =
-  get {
-    complete("Received GET")
-  } ~
-  complete("Received something else")
+  concat(
+    get {
+      complete("Received GET")
+    },
+    complete("Received something else")
+  )
 ```
 
 Again, the produced routes will behave identically in all cases.
@@ -125,10 +127,12 @@ Note that, if you wish, you can also mix the two styles of route creation:
 
 ```scala
 val route =
-  get { ctx =>
-    ctx.complete("Received GET")
-  } ~
-  complete("Received something else")
+  concat(
+    get { ctx =>
+      ctx.complete("Received GET")
+    },
+    complete("Received something else")
+  )
 ```
 
 Here, the inner route of the @ref[get](method-directives/get.md) directive is written as an explicit function literal.
@@ -210,11 +214,6 @@ transformations, both (or either) on the request and on the response side.
 
 ## Composing Directives
 
-@@@ note { .group-scala }
-Gotcha: forgetting the `~` (tilde) character in between directives can result in perfectly valid
-Scala code that compiles but does not work as expected. What would be intended as a single expression would actually be multiple expressions, and only the final one would be used as the result of the parent directive. Alternatively, you might choose to use the `concat` combinator. `concat(a, b, c)` is the same as `a ~ b ~ c`.
-@@@
-
 As you have seen from the examples presented so far the "normal" way of composing directives is nesting.
 Let's take a look at this concrete example:
 
@@ -224,7 +223,7 @@ Scala
 Java
 :  @@snip [DirectiveExamplesTest.java]($test$/java/docs/http/javadsl/server/DirectiveExamplesTest.java) { #example1 }
 
-Here the `get` and `put` directives are chained together @scala[with the `~` operator]@java[using the `orElse` method] to form a higher-level route that
+Here the `get` and `put` directives are chained together @scala[with the `concat` combinator]@java[using the `orElse` method] to form a higher-level route that
 serves as the inner route of the `path` directive. Let's rewrite it in the following way:
 
 Scala
@@ -322,9 +321,18 @@ use their power to define your web service behavior at the level of abstraction 
 
 @@@ div { .group-scala }
 
-### Composing Directives with `concat` Combinator
+### Composing Directives with `~` Operator
 
-Alternatively we can combine directives using `concat` combinator where we pass each directive as an argument to the combinator function instead of chaining them with `~` . Let's take a look at the usage of this combinator:
+@@@ 
+
+@@@ note { .group-scala }
+Gotcha: forgetting the `~` (tilde) character in between directives can result in perfectly valid
+Scala code that compiles but does not work as expected. What would be intended as a single expression would actually be multiple expressions, and only the final one would be used as the result of the parent directive. Because of this, the recommended way to compose routes is with the the `concat` combinator.
+@@@
+
+@@@ div { .group-scala }
+
+Alternatively we can combine directives using `~` operator where we pass each directive as an argument to the combinator function instead of chaining them with `concat` . Let's take a look at the usage of this combinator:
 
 @@snip [DirectiveExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/DirectiveExamplesSpec.scala) { #example-8 }
 

--- a/docs/src/main/paradox/routing-dsl/routes.md
+++ b/docs/src/main/paradox/routing-dsl/routes.md
@@ -97,7 +97,7 @@ HTTP and which you can also easily create yourself.
 <a id="the-routing-tree"></a>
 ## The Routing Tree
 
-Essentially, when you combine directives and custom routes via nesting and the @scala[`~` operator]@java[alternative], you build a routing
+Essentially, when you combine directives and custom routes via the `concat` method, you build a routing
 structure that forms a tree. When a request comes in it is injected into this tree at the root and flows down through
 all the branches in a depth-first manner until either some node completes it or it is fully rejected.
 
@@ -108,18 +108,22 @@ Consider this schematic example:
 ```scala
 val route =
   a {
-    b {
-      c {
-        ... // route 1
-      } ~
-      d {
-        ... // route 2
-      } ~
-      ... // route 3
-    } ~
-    e {
-      ... // route 4
-    }
+    concat(
+      b {
+        concat(
+          c {
+            ... // route 1
+          },
+          d {
+            ... // route 2
+          },
+          ... // route 3
+        )
+      },
+      e {
+        ... // route 4
+      }
+    )
   }
 ```
 
@@ -131,8 +135,8 @@ val route =
 import static akka.http.javadsl.server.Directives.*;
 
 Route route =
-  directiveA(route(() ->
-    directiveB(route(() ->
+  directiveA(concat(() ->
+    directiveB(concat(() ->
       directiveC(
         ... // route 1
       ),

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -270,13 +270,11 @@ class HttpServerExampleSpec extends WordSpec with Matchers
     //#low-level-server-example
   }
 
-  // format: OFF
-
   "high-level-server-example" in compileOnlySpec {
     //#high-level-server-example
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
-    import akka.http.scaladsl.model.{ContentTypes, HttpEntity}
+    import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
     import akka.http.scaladsl.server.Directives._
     import akka.stream.ActorMaterializer
     import scala.io.StdIn
@@ -290,15 +288,17 @@ class HttpServerExampleSpec extends WordSpec with Matchers
 
         val route =
           get {
-            pathSingleSlash {
-              complete(HttpEntity(ContentTypes.`text/html(UTF-8)`,"<html><body>Hello world!</body></html>"))
-            } ~
-            path("ping") {
-              complete("PONG!")
-            } ~
-            path("crash") {
-              sys.error("BOOM!")
-            }
+            concat(
+              pathSingleSlash {
+                complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<html><body>Hello world!</body></html>"))
+              },
+              path("ping") {
+                complete("PONG!")
+              },
+              path("crash") {
+                sys.error("BOOM!")
+              }
+            )
           }
 
         // `route` will be implicitly converted to `Flow` using `RouteResult.route2HandlerFlow`
@@ -351,7 +351,7 @@ class HttpServerExampleSpec extends WordSpec with Matchers
 
   "long-routing-example" in compileOnlySpec {
     //#long-routing-example
-    import akka.actor.{ActorRef, ActorSystem}
+    import akka.actor.{ ActorRef, ActorSystem }
     import akka.http.scaladsl.coding.Deflate
     import akka.http.scaladsl.marshalling.ToResponseMarshaller
     import akka.http.scaladsl.model.StatusCodes.MovedPermanently
@@ -384,66 +384,69 @@ class HttpServerExampleSpec extends WordSpec with Matchers
     def myDbActor: ActorRef = ???
     def processOrderRequest(id: Int, complete: Order => Unit): Unit = ???
 
-    val route = {
+    val route = concat(
       path("orders") {
         authenticateBasic(realm = "admin area", myAuthenticator) { user =>
-          get {
-            encodeResponseWith(Deflate) {
-              complete {
-                // marshal custom object with in-scope marshaller
-                retrieveOrdersFromDB
-              }
-            }
-          } ~
-          post {
-            // decompress gzipped or deflated requests if required
-            decodeRequest {
-              // unmarshal with in-scope unmarshaller
-              entity(as[Order]) { order =>
+          concat(
+            get {
+              encodeResponseWith(Deflate) {
                 complete {
-                  // ... write order to DB
-                  "Order received"
+                  // marshal custom object with in-scope marshaller
+                  retrieveOrdersFromDB
                 }
               }
-            }
-          }
+            },
+            post {
+              // decompress gzipped or deflated requests if required
+              decodeRequest {
+                // unmarshal with in-scope unmarshaller
+                entity(as[Order]) { order =>
+                  complete {
+                    // ... write order to DB
+                    "Order received"
+                  }
+                }
+              }
+            })
         }
-      } ~
+      },
       // extract URI path element as Int
       pathPrefix("order" / IntNumber) { orderId =>
-        pathEnd {
-          (put | parameter('method ! "put")) {
-            // form extraction from multipart or www-url-encoded forms
-            formFields(('email, 'total.as[Money])).as(Order) { order =>
-              complete {
-                // complete with serialized Future result
-                (myDbActor ? Update(order)).mapTo[TransactionResult]
-              }
+        concat(
+          pathEnd {
+            concat(
+              (put | parameter('method ! "put")) {
+                // form extraction from multipart or www-url-encoded forms
+                formFields(('email, 'total.as[Money])).as(Order) { order =>
+                  complete {
+                    // complete with serialized Future result
+                    (myDbActor ? Update(order)).mapTo[TransactionResult]
+                  }
+                }
+              },
+              get {
+                // debugging helper
+                logRequest("GET-ORDER") {
+                  // use in-scope marshaller to create completer function
+                  completeWith(instanceOf[Order]) { completer =>
+                    // custom
+                    processOrderRequest(orderId, completer)
+                  }
+                }
+              })
+          },
+          path("items") {
+            get {
+              // parameters to case class extraction
+              parameters(('size.as[Int], 'color ?, 'dangerous ? "no"))
+                .as(OrderItem) { orderItem =>
+                  // ... route using case class instance created from
+                  // required and optional query parameters
+                  complete("") // #hide
+                }
             }
-          } ~
-          get {
-            // debugging helper
-            logRequest("GET-ORDER") {
-              // use in-scope marshaller to create completer function
-              completeWith(instanceOf[Order]) { completer =>
-                // custom
-                processOrderRequest(orderId, completer)
-              }
-            }
-          }
-        } ~
-        path("items") {
-          get {
-            // parameters to case class extraction
-            parameters(('size.as[Int], 'color ?, 'dangerous ? "no"))
-              .as(OrderItem) { orderItem =>
-                // ... route using case class instance created from
-                // required and optional query parameters
-                complete("") // #hide
-              }
-          }
-        }
-      } ~
+          })
+      },
       pathPrefix("documentation") {
         // optionally compresses the response with Gzip or Deflate
         // if the client accepts compressed responses
@@ -451,11 +454,11 @@ class HttpServerExampleSpec extends WordSpec with Matchers
           // serve up static content from a JAR resource
           getFromResourceDirectory("docs")
         }
-      } ~
+      },
       path("oldApi" / Remaining) { pathRest =>
         redirect("http://oldapi.example.com/" + pathRest, MovedPermanently)
       }
-    }
+    )
     //#long-routing-example
   }
 
@@ -465,7 +468,7 @@ class HttpServerExampleSpec extends WordSpec with Matchers
     import akka.stream.scaladsl._
     import akka.util.ByteString
     import akka.http.scaladsl.Http
-    import akka.http.scaladsl.model.{HttpEntity, ContentTypes}
+    import akka.http.scaladsl.model.{ HttpEntity, ContentTypes }
     import akka.http.scaladsl.server.Directives._
     import akka.stream.ActorMaterializer
     import scala.util.Random
@@ -511,7 +514,7 @@ class HttpServerExampleSpec extends WordSpec with Matchers
 
   "interact with an actor" in compileOnlySpec {
     //#actor-interaction
-    import akka.actor.{Actor, ActorSystem, Props, ActorLogging}
+    import akka.actor.{ Actor, ActorSystem, Props, ActorLogging }
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.StatusCodes
     import akka.http.scaladsl.server.Directives._
@@ -537,7 +540,7 @@ class HttpServerExampleSpec extends WordSpec with Matchers
             bids = bids :+ bid
             log.info(s"Bid complete: $userId, $offer")
           case GetBids => sender() ! Bids(bids)
-          case _ => log.info("Invalid message")
+          case _       => log.info("Invalid message")
         }
       }
 
@@ -555,20 +558,22 @@ class HttpServerExampleSpec extends WordSpec with Matchers
 
         val route =
           path("auction") {
-            put {
-              parameter("bid".as[Int], "user") { (bid, user) =>
-                // place a bid, fire-and-forget
-                auction ! Bid(user, bid)
-                complete((StatusCodes.Accepted, "bid placed"))
-              }
-            } ~
-            get {
-              implicit val timeout: Timeout = 5.seconds
+            concat(
+              put {
+                parameter("bid".as[Int], "user") { (bid, user) =>
+                  // place a bid, fire-and-forget
+                  auction ! Bid(user, bid)
+                  complete((StatusCodes.Accepted, "bid placed"))
+                }
+              },
+              get {
+                implicit val timeout: Timeout = 5.seconds
 
-              // query the actor for the current auction state
-              val bids: Future[Bids] = (auction ? GetBids).mapTo[Bids]
-              complete(bids)
-            }
+                // query the actor for the current auction state
+                val bids: Future[Bids] = (auction ? GetBids).mapTo[Bids]
+                complete(bids)
+              }
+            )
           }
 
         val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
@@ -733,14 +738,15 @@ class HttpServerExampleSpec extends WordSpec with Matchers
 
     // dynamic routing based on current state
     val dynamicRoute: Route = ctx => {
-      val routes = state.map { case (segment, responses) =>
-        post {
-          path(segment) {
-            entity(as[JsValue]) { input =>
-              complete(responses.get(input))
+      val routes = state.map {
+        case (segment, responses) =>
+          post {
+            path(segment) {
+              entity(as[JsValue]) { input =>
+                complete(responses.get(input))
+              }
             }
           }
-        }
       }
       concat(routes.toList: _*)(ctx)
     }
@@ -766,13 +772,13 @@ class HttpServerExampleSpec extends WordSpec with Matchers
     }
 
     val binding: Future[Http.ServerBinding] =
-        Http().bindAndHandle(routes, "127.0.0.1", 8080)
+      Http().bindAndHandle(routes, "127.0.0.1", 8080)
 
     // ...
     // once ready to terminate the server, invoke terminate:
     val onceAllConnectionsTerminated: Future[Http.HttpTerminated] =
-    Await.result(binding, 10.seconds)
-      .terminate(hardDeadline = 3.seconds)
+      Await.result(binding, 10.seconds)
+        .terminate(hardDeadline = 3.seconds)
 
     // once all connections are terminated,
     // - you can invoke coordinated shutdown to tear down the rest of the system:

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
@@ -29,21 +29,21 @@ class SprayJsonExampleSpec extends WordSpec with Matchers {
     // use it wherever json (un)marshalling is needed
     class MyJsonService extends Directives with JsonSupport {
 
-      // format: OFF
       val route =
-        get {
-          pathSingleSlash {
-            complete(Item("thing", 42)) // will render as JSON
+        concat(
+          get {
+            pathSingleSlash {
+              complete(Item("thing", 42)) // will render as JSON
+            }
+          },
+          post {
+            entity(as[Order]) { order => // will unmarshal JSON to Order
+              val itemsCount = order.items.size
+              val itemNames = order.items.map(_.name).mkString(", ")
+              complete(s"Ordered $itemsCount items: $itemNames")
+            }
           }
-        } ~
-        post {
-          entity(as[Order]) { order => // will unmarshal JSON to Order
-            val itemsCount = order.items.size
-            val itemNames = order.items.map(_.name).mkString(", ")
-            complete(s"Ordered $itemsCount items: $itemNames")
-          }
-        }
-      // format: ON
+        )
     }
     //#minimal-spray-json-example
   }
@@ -99,17 +99,18 @@ class SprayJsonExampleSpec extends WordSpec with Matchers {
       def main(args: Array[String]) {
 
         val route: Route =
-          get {
-            pathPrefix("item" / LongNumber) { id =>
-              // there might be no item for a given id
-              val maybeItem: Future[Option[Item]] = fetchItem(id)
+          concat(
+            get {
+              pathPrefix("item" / LongNumber) { id =>
+                // there might be no item for a given id
+                val maybeItem: Future[Option[Item]] = fetchItem(id)
 
-              onSuccess(maybeItem) {
-                case Some(item) => complete(item)
-                case None       => complete(StatusCodes.NotFound)
+                onSuccess(maybeItem) {
+                  case Some(item) => complete(item)
+                  case None       => complete(StatusCodes.NotFound)
+                }
               }
-            }
-          } ~
+            },
             post {
               path("create-order") {
                 entity(as[Order]) { order =>
@@ -120,6 +121,7 @@ class SprayJsonExampleSpec extends WordSpec with Matchers {
                 }
               }
             }
+          )
 
         val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
         println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")

--- a/docs/src/test/scala/docs/http/scaladsl/server/DirectiveExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/DirectiveExamplesSpec.scala
@@ -9,22 +9,22 @@ import docs.CompileOnlySpec
 
 class DirectiveExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
-  // format: OFF
-
   "example-1" in {
     //#example-1
     val route: Route =
       path("order" / IntNumber) { id =>
-        get {
-          complete {
-            "Received GET request for order " + id
+        concat(
+          get {
+            complete {
+              "Received GET request for order " + id
+            }
+          },
+          put {
+            complete {
+              "Received PUT request for order " + id
+            }
           }
-        } ~
-        put {
-          complete {
-            "Received PUT request for order " + id
-          }
-        }
+        )
       }
     verify(route) // #hide
     //#example-1
@@ -33,16 +33,18 @@ class DirectiveExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "example-2" in {
     //#getOrPut
     def innerRoute(id: Int): Route =
-      get {
-        complete {
-          "Received GET request for order " + id
+      concat(
+        get {
+          complete {
+            "Received GET request for order " + id
+          }
+        },
+        put {
+          complete {
+            "Received PUT request for order " + id
+          }
         }
-      } ~
-      put {
-        complete {
-          "Received PUT request for order " + id
-        }
-      }
+      )
 
     val route: Route = path("order" / IntNumber) { id => innerRoute(id) }
     verify(route) // #hide
@@ -116,16 +118,16 @@ class DirectiveExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "example-8" in {
     //#example-8
     def innerRoute(id: Int): Route =
-      concat(get {
+      get {
         complete {
           "Received GET request for order " + id
         }
-      },
-      put {
-        complete {
-          "Received PUT request for order " + id
+      } ~
+        put {
+          complete {
+            "Received PUT request for order " + id
+          }
         }
-      })
 
     val route: Route = path("order" / IntNumber) { id => innerRoute(id) }
     verify(route) // #hide

--- a/docs/src/test/scala/docs/http/scaladsl/server/FullSpecs2TestKitExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/FullSpecs2TestKitExampleSpec.scala
@@ -4,8 +4,6 @@
 
 package docs.http.scaladsl.server
 
-// format: OFF
-
 //#source-quote
 import org.specs2.mutable.Specification
 import akka.http.scaladsl.model.StatusCodes
@@ -17,14 +15,16 @@ class FullSpecs2TestKitExampleSpec extends Specification with Specs2RouteTest {
 
   val smallRoute =
     get {
-      pathSingleSlash {
-        complete {
-          "Captain on the bridge!"
+      concat(
+        pathSingleSlash {
+          complete {
+            "Captain on the bridge!"
+          }
+        },
+        path("ping") {
+          complete("PONG!")
         }
-      } ~
-      path("ping") {
-        complete("PONG!")
-      }
+      )
     }
 
   "The service" should {

--- a/docs/src/test/scala/docs/http/scaladsl/server/FullTestKitExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/FullTestKitExampleSpec.scala
@@ -4,8 +4,6 @@
 
 package docs.http.scaladsl.server
 
-// format: OFF
-
 //#source-quote
 import org.scalatest.{ Matchers, WordSpec }
 import akka.http.scaladsl.model.StatusCodes
@@ -17,14 +15,16 @@ class FullTestKitExampleSpec extends WordSpec with Matchers with ScalatestRouteT
 
   val smallRoute =
     get {
-      pathSingleSlash {
-        complete {
-          "Captain on the bridge!"
+      concat(
+        pathSingleSlash {
+          complete {
+            "Captain on the bridge!"
+          }
+        },
+        path("ping") {
+          complete("PONG!")
         }
-      } ~
-      path("ping") {
-        complete("PONG!")
-      }
+      )
     }
 
   "The service" should {

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -9,8 +9,6 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.RoutingSpec
 import docs.CompileOnlySpec
 
-// format: OFF
-
 object MyRejectionHandler {
 
   //#custom-handler-example
@@ -25,14 +23,17 @@ object MyRejectionHandler {
   object MyApp extends App {
     implicit def myRejectionHandler =
       RejectionHandler.newBuilder()
-        .handle { case MissingCookieRejection(cookieName) =>
-          complete(HttpResponse(BadRequest, entity = "No cookies, no service!!!"))
+        .handle {
+          case MissingCookieRejection(cookieName) =>
+            complete(HttpResponse(BadRequest, entity = "No cookies, no service!!!"))
         }
-        .handle { case AuthorizationFailedRejection =>
-          complete((Forbidden, "You're out of your depth!"))
+        .handle {
+          case AuthorizationFailedRejection =>
+            complete((Forbidden, "You're out of your depth!"))
         }
-        .handle { case ValidationRejection(msg, _) =>
-          complete((InternalServerError, "That wasn't valid! " + msg))
+        .handle {
+          case ValidationRejection(msg, _) =>
+            complete((InternalServerError, "That wasn't valid! " + msg))
         }
         .handleAll[MethodRejection] { methodRejections =>
           val names = methodRejections.map(_.supported.name)
@@ -71,7 +72,7 @@ object HandleNotFoundWithThePath {
   //#not-found-with-path
 }
 
-class RejectionHandlerExamplesSpec extends RoutingSpec with CompileOnlySpec{
+class RejectionHandlerExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
   "example-1" in {
     //#example-1
@@ -79,14 +80,16 @@ class RejectionHandlerExamplesSpec extends RoutingSpec with CompileOnlySpec{
 
     val route =
       path("order") {
-        get {
-          complete("Received GET")
-        } ~
-        post {
-          decodeRequestWith(Gzip) {
-            complete("Received compressed POST")
+        concat(
+          get {
+            complete("Received GET")
+          },
+          post {
+            decodeRequestWith(Gzip) {
+              complete("Received compressed POST")
+            }
           }
-        }
+        )
       }
     //#example-1
   }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
@@ -435,16 +435,18 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     val route =
       authRejectionsToNothingToSeeHere {
         pathPrefix("auth") {
-          path("never") {
-            authenticateBasic("my-realm", neverAuth) { user =>
-              complete("Welcome to the bat-cave!")
-            }
-          } ~
+          concat(
+            path("never") {
+              authenticateBasic("my-realm", neverAuth) { user =>
+                complete("Welcome to the bat-cave!")
+              }
+            },
             path("always") {
               authenticateBasic("my-realm", alwaysAuth) { user =>
                 complete("Welcome to the secret place!")
               }
             }
+          )
         }
       }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FileAndResourceDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FileAndResourceDirectivesExamplesSpec.scala
@@ -47,9 +47,10 @@ class FileAndResourceDirectivesExamplesSpec extends RoutingSpec with CompileOnly
   "listDirectoryContents-examples" in compileOnlySpec {
     //#listDirectoryContents-examples
     val route =
-      path("tmp") {
-        listDirectoryContents("/tmp")
-      } ~
+      concat(
+        path("tmp") {
+          listDirectoryContents("/tmp")
+        },
         path("custom") {
           // implement your custom renderer here
           val renderer = new DirectoryRenderer {
@@ -57,6 +58,7 @@ class FileAndResourceDirectivesExamplesSpec extends RoutingSpec with CompileOnly
           }
           listDirectoryContents("/tmp")(renderer)
         }
+      )
 
     // tests:
     Get("/logs/example") ~> route ~> check {

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
@@ -31,12 +31,14 @@ class FormFieldDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "formField" in {
     //#formField
     val route =
-      formField('color) { color =>
-        complete(s"The color is '$color'")
-      } ~
+      concat(
+        formField('color) { color =>
+          complete(s"The color is '$color'")
+        },
         formField('id.as[Int]) { id =>
           complete(s"The id is '$id'")
         }
+      )
 
     // tests:
     Post("/", FormData("color" -> "blue")) ~> route ~> check {

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FutureDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FutureDirectivesExamplesSpec.scala
@@ -17,9 +17,7 @@ import akka.http.scaladsl.server.RoutingSpec
 import akka.pattern.CircuitBreaker
 import docs.CompileOnlySpec
 
-// format: OFF
-
-class FutureDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec{
+class FutureDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   object TestException extends Throwable
 
   implicit val myExceptionHandler =
@@ -63,7 +61,8 @@ class FutureDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec{
     }
 
     val resetTimeout = 1.second
-    val breaker = new CircuitBreaker(system.scheduler,
+    val breaker = new CircuitBreaker(
+      system.scheduler,
       maxFailures = 1,
       callTimeout = 5.seconds,
       resetTimeout
@@ -102,16 +101,18 @@ class FutureDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec{
   "onSuccess" in {
     //#onSuccess
     val route =
-      path("success") {
-        onSuccess(Future { "Ok" }) { extraction =>
-          complete(extraction)
+      concat(
+        path("success") {
+          onSuccess(Future { "Ok" }) { extraction =>
+            complete(extraction)
+          }
+        },
+        path("failure") {
+          onSuccess(Future.failed[String](TestException)) { extraction =>
+            complete(extraction)
+          }
         }
-      } ~
-      path("failure") {
-        onSuccess(Future.failed[String](TestException)) { extraction =>
-          complete(extraction)
-        }
-      }
+      )
 
     // tests:
     Get("/success") ~> route ~> check {
@@ -128,16 +129,18 @@ class FutureDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec{
   "completeOrRecoverWith" in {
     //#completeOrRecoverWith
     val route =
-      path("success") {
-        completeOrRecoverWith(Future { "Ok" }) { extraction =>
-          failWith(extraction) // not executed.
+      concat(
+        path("success") {
+          completeOrRecoverWith(Future { "Ok" }) { extraction =>
+            failWith(extraction) // not executed.
+          }
+        },
+        path("failure") {
+          completeOrRecoverWith(Future.failed[String](TestException)) { extraction =>
+            failWith(extraction)
+          }
         }
-      } ~
-      path("failure") {
-        completeOrRecoverWith(Future.failed[String](TestException)) { extraction =>
-          failWith(extraction)
-        }
-      }
+      )
 
     // tests:
     Get("/success") ~> route ~> check {

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/HostDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/HostDirectivesExamplesSpec.scala
@@ -70,12 +70,14 @@ class HostDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "using-regex" in {
     //#using-regex
     val route =
-      host("api|rest".r) { prefix =>
-        complete(s"Extracted prefix: $prefix")
-      } ~
+      concat(
+        host("api|rest".r) { prefix =>
+          complete(s"Extracted prefix: $prefix")
+        },
         host("public.(my|your)company.com".r) { captured =>
           complete(s"You came through $captured company")
         }
+      )
 
     // tests:
     Get() ~> Host("api.company.com") ~> route ~> check {

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/MethodDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/MethodDirectivesExamplesSpec.scala
@@ -107,12 +107,14 @@ class MethodDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "extractMethod-example" in {
     //#extractMethod-example
     val route =
-      get {
-        complete("This is a GET request.")
-      } ~
+      concat(
+        get {
+          complete("This is a GET request.")
+        },
         extractMethod { method =>
           complete(s"This ${method.name} request, clearly is not a GET!")
         }
+      )
 
     // tests:
     Get("/") ~> route ~> check {
@@ -132,12 +134,14 @@ class MethodDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     //#overrideMethodWithParameter-0
     val route =
       overrideMethodWithParameter("method") {
-        get {
-          complete("This looks like a GET request.")
-        } ~
+        concat(
+          get {
+            complete("This looks like a GET request.")
+          },
           post {
             complete("This looks like a POST request.")
           }
+        )
       }
 
     // tests:

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
@@ -52,12 +52,14 @@ class MiscDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "requestEntityEmptyPresent-example" in {
     //#requestEntityEmptyPresent-example
     val route =
-      requestEntityEmpty {
-        complete("request entity empty")
-      } ~
+      concat(
+        requestEntityEmpty {
+          complete("request entity empty")
+        },
         requestEntityPresent {
           complete("request entity present")
         }
+      )
 
     // tests:
     Post("/", "text") ~> Route.seal(route) ~> check {

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/PathDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/PathDirectivesExamplesSpec.scala
@@ -61,20 +61,24 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "path-example" in {
     //#path-example
     val route =
-      path("foo") {
-        complete("/foo")
-      } ~
+      concat(
+        path("foo") {
+          complete("/foo")
+        },
         path("foo" / "bar") {
           complete("/foo/bar")
-        } ~
+        },
         pathPrefix("ball") {
-          pathEnd {
-            complete("/ball")
-          } ~
+          concat(
+            pathEnd {
+              complete("/ball")
+            },
             path(IntNumber) { int =>
               complete(if (int % 2 == 0) "even ball" else "odd ball")
             }
+          )
         }
+      )
 
     // tests:
     Get("/") ~> route ~> check {
@@ -99,12 +103,14 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     //#pathEnd-
     val route =
       pathPrefix("foo") {
-        pathEnd {
-          complete("/foo")
-        } ~
+        concat(
+          pathEnd {
+            complete("/foo")
+          },
           path("bar") {
             complete("/foo/bar")
           }
+        )
       }
 
     // tests:
@@ -126,12 +132,14 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     //#pathEndOrSingleSlash-
     val route =
       pathPrefix("foo") {
-        pathEndOrSingleSlash {
-          complete("/foo")
-        } ~
+        concat(
+          pathEndOrSingleSlash {
+            complete("/foo")
+          },
           path("bar") {
             complete("/foo/bar")
           }
+        )
       }
 
     // tests:
@@ -153,12 +161,14 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     //#pathPrefix-
     val route =
       pathPrefix("ball") {
-        pathEnd {
-          complete("/ball")
-        } ~
+        concat(
+          pathEnd {
+            complete("/ball")
+          },
           path(IntNumber) { int =>
             complete(if (int % 2 == 0) "even ball" else "odd ball")
           }
+        )
       }
 
     // tests:
@@ -180,8 +190,10 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     //#pathPrefixTest-
     val route =
       pathPrefixTest("foo" | "bar") {
-        pathPrefix("foo") { completeWithUnmatchedPath } ~
+        concat(
+          pathPrefix("foo") { completeWithUnmatchedPath },
           pathPrefix("bar") { completeWithUnmatchedPath }
+        )
       }
 
     // tests:
@@ -198,17 +210,21 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "pathSingleSlash-" in {
     //#pathSingleSlash-
     val route =
-      pathSingleSlash {
-        complete("root")
-      } ~
+      concat(
+        pathSingleSlash {
+          complete("root")
+        },
         pathPrefix("ball") {
-          pathSingleSlash {
-            complete("/ball/")
-          } ~
+          concat(
+            pathSingleSlash {
+              complete("/ball/")
+            },
             path(IntNumber) { int =>
               complete(if (int % 2 == 0) "even ball" else "odd ball")
             }
+          )
         }
+      )
 
     // tests:
     Get("/") ~> route ~> check {
@@ -233,12 +249,14 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     //#pathSuffix-
     val route =
       pathPrefix("start") {
-        pathSuffix("end") {
-          completeWithUnmatchedPath
-        } ~
+        concat(
+          pathSuffix("end") {
+            completeWithUnmatchedPath
+          },
           pathSuffix("foo" / "bar" ~ "baz") {
             completeWithUnmatchedPath
           }
+        )
       }
 
     // tests:
@@ -255,10 +273,12 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "pathSuffixTest-" in {
     //#pathSuffixTest-
     val route =
-      pathSuffixTest(Slash) {
-        complete("slashed")
-      } ~
+      concat(
+        pathSuffixTest(Slash) {
+          complete("slashed")
+        },
         complete("unslashed")
+      )
 
     // tests:
     Get("/foo/") ~> route ~> check {
@@ -274,8 +294,10 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     //#rawPathPrefix-
     val route =
       pathPrefix("foo") {
-        rawPathPrefix("bar") { completeWithUnmatchedPath } ~
+        concat(
+          rawPathPrefix("bar") { completeWithUnmatchedPath },
           rawPathPrefix("doo") { completeWithUnmatchedPath }
+        )
       }
 
     // tests:
@@ -315,22 +337,24 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
     val route =
       redirectToTrailingSlashIfMissing(StatusCodes.MovedPermanently) {
-        path("foo"./) {
-          // We require the explicit trailing slash in the path
-          complete("OK")
-        } ~
+        concat(
+          path("foo"./) {
+            // We require the explicit trailing slash in the path
+            complete("OK")
+          },
           path("bad-1") {
             // MISTAKE!
             // Missing `/` in path, causes this path to never match,
             // because it is inside a `redirectToTrailingSlashIfMissing`
             ???
-          } ~
+          },
           path("bad-2/") {
             // MISTAKE!
             // / should be explicit as path element separator and not *in* the path element
             // So it should be: "bad-2" /
             ???
           }
+        )
       }
 
     // tests:
@@ -370,10 +394,11 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
     val route =
       redirectToNoTrailingSlashIfPresent(StatusCodes.MovedPermanently) {
-        path("foo") {
-          // We require to not have a trailing slash in the path
-          complete("OK")
-        } ~
+        concat(
+          path("foo") {
+            // We require to not have a trailing slash in the path
+            complete("OK")
+          },
           path("bad"./) {
             // MISTAKE!
             // Since inside a `redirectToNoTrailingSlashIfPresent` directive
@@ -383,6 +408,7 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
             // It should be `path("bad")` instead.
             ???
           }
+        )
       }
 
     // tests:
@@ -414,14 +440,16 @@ class PathDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "ignoreTrailingSlash" in {
     //#ignoreTrailingSlash
     val route = ignoreTrailingSlash {
-      path("foo") {
-        // Thanks to `ignoreTrailingSlash` it will serve both `/foo` and `/foo/`.
-        complete("OK")
-      } ~
+      concat(
+        path("foo") {
+          // Thanks to `ignoreTrailingSlash` it will serve both `/foo` and `/foo/`.
+          complete("OK")
+        },
         path("bar"./) {
           // Thanks to `ignoreTrailingSlash` it will serve both `/bar` and `/bar/`.
           complete("OK")
         }
+      )
     }
 
     // tests:

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/RouteDirectivesExamplesSpec.scala
@@ -34,28 +34,30 @@ class RouteDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "complete-examples" in {
     //#complete-examples
     val route =
-      path("a") {
-        complete(HttpResponse(entity = "foo"))
-      } ~
+      concat(
+        path("a") {
+          complete(HttpResponse(entity = "foo"))
+        },
         path("b") {
           complete(StatusCodes.OK)
-        } ~
+        },
         path("c") {
           complete(StatusCodes.Created -> "bar")
-        } ~
+        },
         path("d") {
           complete(201 -> "bar")
-        } ~
+        },
         path("e") {
           complete(StatusCodes.Created, List(`Content-Type`(`text/plain(UTF-8)`)), "bar")
-        } ~
+        },
         path("f") {
           complete(201, List(`Content-Type`(`text/plain(UTF-8)`)), "bar")
-        } ~
+        },
         path("g") {
           complete(Future { StatusCodes.Created -> "bar" })
-        } ~
+        },
         (path("h") & complete("baz")) // `&` also works with `complete` as the 2nd argument
+      )
 
     // tests:
     Get("/a") ~> route ~> check {
@@ -105,17 +107,19 @@ class RouteDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "reject-examples" in {
     //#reject-examples
     val route =
-      path("a") {
-        reject // don't handle here, continue on
-      } ~
+      concat(
+        path("a") {
+          reject // don't handle here, continue on
+        },
         path("a") {
           complete("foo")
-        } ~
+        },
         path("b") {
           // trigger a ValidationRejection explicitly
           // rather than through the `validate` directive
           reject(ValidationRejection("Restricted!"))
         }
+      )
 
     // tests:
     Get("/a") ~> route ~> check {
@@ -132,12 +136,14 @@ class RouteDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     //#redirect-examples
     val route =
       pathPrefix("foo") {
-        pathSingleSlash {
-          complete("yes")
-        } ~
+        concat(
+          pathSingleSlash {
+            complete("yes")
+          },
           pathEnd {
             redirect("/foo/", StatusCodes.PermanentRedirect)
           }
+        )
       }
 
     // tests:

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/SchemeDirectivesExamplesSpec.scala
@@ -28,14 +28,16 @@ class SchemeDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     import StatusCodes.MovedPermanently
 
     val route =
-      scheme("http") {
-        extract(_.request.uri) { uri =>
-          redirect(uri.copy(scheme = "https"), MovedPermanently)
-        }
-      } ~
+      concat(
+        scheme("http") {
+          extract(_.request.uri) { uri =>
+            redirect(uri.copy(scheme = "https"), MovedPermanently)
+          }
+        },
         scheme("https") {
           complete(s"Safe and secure!")
         }
+      )
 
     // tests:
     Get("http://www.example.com/hello") ~> route ~> check {


### PR DESCRIPTION
refs: #2537
Modify samples
Modify docs
Restructure docs text to encourage `concat`

This now has the nice side effect that we can remove the `// format: OFF` directives.