### PR TITLE
Return 408 RequestTimeout status when `toStrict` times out #2548

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
@@ -182,5 +182,19 @@ class BasicDirectivesSpec extends RoutingSpec {
         }
       } ~> check { responseAs[String] shouldEqual "1" }
     }
+
+    "return 408 Request Timeout status on timeout" in {
+      val neverEndingEntity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, Source.maybe[ByteString])
+      val timeout = 10.milliseconds
+
+      Post("/abc", neverEndingEntity) ~> {
+        extractStrictEntity(timeout) { _ =>
+          complete("content")
+        }
+      } ~> check {
+        entityAs[String] shouldEqual s"Request timed out after $timeout while waiting for entity data"
+        status shouldEqual StatusCodes.RequestTimeout
+      }
+    }
   }
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
@@ -397,14 +397,14 @@ trait BasicDirectives {
     Directive { inner => ctx =>
       import ctx.{ executionContext, materializer }
 
-      ctx.request.entity.toStrict(timeout, maxBytes).flatMap { strictEntity =>
-        val newCtx = ctx.mapRequest(_.copy(entity = strictEntity))
-        inner(())(newCtx)
-      }.recover {
+      ctx.request.entity.toStrict(timeout, maxBytes).recover {
         case _: TimeoutException =>
           throw IllegalRequestException(
             StatusCodes.RequestTimeout,
             ErrorInfo(s"Request timed out after $timeout while waiting for entity data", "Consider increasing the timeout for toStrict"))
+      }.flatMap { strictEntity =>
+        val newCtx = ctx.mapRequest(_.copy(entity = strictEntity))
+        inner(())(newCtx)
       }
     }
 }


### PR DESCRIPTION
## Purpose

Now if extractStrictEntity fails with a timeout it will return 408 Request Timeout status instead of 500 Internal Service Error

## References

https://github.com/akka/akka-http/issues/2548

## Changes

Added TimeoutException handler for toStrict method