### PR TITLE
Roll together 'prior knowledge' and 'negotiated'

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/UseHttp2.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/UseHttp2.scala
@@ -17,5 +17,4 @@ object UseHttp2 {
   def always: UseHttp2 = Always
   def negotiated: UseHttp2 = Negotiated
   def never: UseHttp2 = Never
-  def priorKnowledge: UseHttp2 = PriorKnowledge
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -21,7 +21,7 @@ import akka.http.impl.engine.server._
 import akka.http.impl.engine.ws.WebSocketClientBlueprint
 import akka.http.impl.settings.{ ConnectionPoolSetup, HostConnectionPoolSetup }
 import akka.http.impl.util.StreamUtils
-import akka.http.scaladsl.UseHttp2.{ Always, Never, PriorKnowledge }
+import akka.http.scaladsl.UseHttp2.{ Always, Negotiated, Never }
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.Host
 import akka.http.scaladsl.model.ws.{ Message, WebSocketRequest, WebSocketUpgradeResponse }
@@ -318,11 +318,11 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
     settings:          ServerSettings    = ServerSettings(system),
     parallelism:       Int               = 0,
     log:               LoggingAdapter    = system.log)(implicit fm: Materializer): Future[ServerBinding] = {
-    val http2Enabled = settings.previewServerSettings.enableHttp2 && connectionContext.http2 != Never
-    val http2Encouraged = connectionContext.http2 == Always || connectionContext.http2 == PriorKnowledge
-    if (http2Enabled && (connectionContext.isSecure || http2Encouraged)) {
+    val http2Enabled = settings.previewServerSettings.enableHttp2
+    val http2Forced = connectionContext.http2 == Always
+    if (http2Enabled && connectionContext.http2 != Never) {
       // We do not support HTTP/2 negotiation for insecure connections (h2c), https://github.com/akka/akka-http/issues/1966
-      log.debug("Binding server using HTTP/2{}", if (http2Encouraged) " (forced to be used without TLS)" else "")
+      log.debug("Binding server using HTTP/2{}", if (http2Forced && !connectionContext.isSecure) " (forced to be used without TLS)" else "")
 
       val definitiveSettings =
         if (parallelism > 0) settings.mapHttp2Settings(_.withMaxConcurrentStreams(parallelism))

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/UseHttp2.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/UseHttp2.scala
@@ -14,5 +14,4 @@ object UseHttp2 {
   object Never extends UseHttp2
   object Negotiated extends UseHttp2
   object Always extends UseHttp2
-  object PriorKnowledge extends UseHttp2
 }

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -11,7 +11,7 @@ import akka.http.impl.engine.http2.{ AlpnSwitch, Http2AlpnSupport, Http2Blueprin
 import akka.http.impl.engine.server.MasterServerTerminator
 import akka.http.impl.util.LogByteStringTools.logTLSBidiBySetting
 import akka.http.scaladsl.Http.ServerBinding
-import akka.http.scaladsl.UseHttp2.{ Negotiated, Never, PriorKnowledge, Always }
+import akka.http.scaladsl.UseHttp2.{ Negotiated, Never, Always }
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.TLSProtocol.{ SendBytes, SessionBytes, SslTlsInbound, SslTlsOutbound }
@@ -99,8 +99,6 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
       case _ if connectionContext.isSecure =>
         bindAndHandleAsync(handler, interface, port, connectionContext.asInstanceOf[HttpsConnectionContext], settings, parallelism, log)
       case Negotiated =>
-        throw new NotImplementedError("h2c not supported") // https://github.com/akka/akka-http/issues/1966
-      case PriorKnowledge =>
         bindAndHandleConsiderPriorKnowledge(handler, interface, port, settings, parallelism, log)
       case Always =>
         bindAndHandleWithoutNegotiation(handler, interface, port, settings, parallelism, log)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
@@ -32,7 +32,7 @@ class WithPriorKnowledgeSpec extends AkkaSpec("""
       _ ⇒ Future.successful(HttpResponse(status = StatusCodes.ImATeapot)),
       "127.0.0.1",
       port = 0,
-      HttpConnectionContext(UseHttp2.PriorKnowledge)
+      HttpConnectionContext(UseHttp2.Negotiated)
     ).futureValue
 
     "respond to cleartext HTTP/1.1 requests with cleartext HTTP/1.1" in {

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
@@ -38,8 +38,10 @@ class Http2BindingViaConfigSpec extends AkkaSpec("""
       try {
         val p = TestProbe()
         system.eventStream.subscribe(p.ref, classOf[Logging.Debug])
-
-        binding = Http().bindAndHandleAsync(helloWorldHandler, host, port)
+        binding = Http().bindAndHandleAsync(
+          helloWorldHandler,
+          host, port,
+          new HttpConnectionContext(UseHttp2.Never))
         fishForDebugMessage(p, "binding using plain HTTP")
       } finally if (binding ne null) binding.map(_.unbind())
     }

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -11,7 +11,7 @@ import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.http.scaladsl.UseHttp2.{ Always, PriorKnowledge }
+import akka.http.scaladsl.UseHttp2.{ Always, Negotiated }
 import akka.stream._
 import akka.stream.scaladsl.FileIO
 import com.typesafe.config.Config
@@ -79,7 +79,7 @@ object Http2ServerTest extends App {
         binding1 <- Http().bindAndHandleAsync(asyncHandler, interface = "localhost", port = 9000, ExampleHttpContexts.exampleServerContext)
         binding2 <- Http2().bindAndHandleAsync(asyncHandler, interface = "localhost", port = 9001, ExampleHttpContexts.exampleServerContext)
         binding3 <- Http().bindAndHandleAsync(asyncHandler, interface = "localhost", port = 9002, HttpConnectionContext(http2 = Always))
-        binding4 <- Http().bindAndHandleAsync(asyncHandler, interface = "localhost", port = 9003, HttpConnectionContext(http2 = PriorKnowledge))
+        binding4 <- Http().bindAndHandleAsync(asyncHandler, interface = "localhost", port = 9003, HttpConnectionContext(http2 = Negotiated))
       } yield (binding1, binding2, binding3)
 
     Await.result(bindings, 1.second) // throws if binding fails

--- a/docs/src/test/java/docs/http/javadsl/Http2Test.java
+++ b/docs/src/test/java/docs/http/javadsl/Http2Test.java
@@ -54,7 +54,7 @@ class Http2Test {
     Http.get(system)
       .bindAndHandleAsync(
         asyncHandler,
-        toHost("127.0.0.1", 8080, UseHttp2.priorKnowledge()),
+        toHost("127.0.0.1", 8080, UseHttp2.negotiated()),
         materializer);
     //#bindAndHandleConsiderPriorKnowledge
   }

--- a/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
@@ -27,7 +27,7 @@ import akka.http.scaladsl.UseHttp2.Always
 
 //#bindAndHandleConsiderPriorKnowledge
 import akka.http.scaladsl.HttpConnectionContext
-import akka.http.scaladsl.UseHttp2.PriorKnowledge
+import akka.http.scaladsl.UseHttp2.Negotiated
 
 //#bindAndHandleConsiderPriorKnowledge
 
@@ -61,6 +61,6 @@ object Http2Spec {
     asyncHandler,
     interface = "localhost",
     port = 8080,
-    connectionContext = HttpConnectionContext(http2 = PriorKnowledge))
+    connectionContext = HttpConnectionContext(http2 = Negotiated))
   //#bindAndHandleConsiderPriorKnowledge
 }


### PR DESCRIPTION
Just for discussion, I'm not sure we should do this.
https://github.com/akka/akka-http/pull/2543#discussion_r290340917

I'm hesitant because `Negotiated` is the default, and adding the
`PriorKnowledgeSwitch` might have a performance penalty on top of 'plain'
HTTP/1.

For the same reason I'm not sure we should roll it into `Always`.

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
