### PR TITLE
Releasing: minor version links & git

### DIFF
--- a/notes/release-train-issue-template.md
+++ b/notes/release-train-issue-template.md
@@ -2,7 +2,7 @@ Release Train Issue Template for Akka HTTP
 
 (Liberally copied and adopted from Scala itself https://github.com/scala/scala-dev/blob/b11cd2e4a4431de7867db6b39362bea8fa6650e7/notes/releases/template.md)
 
-For every Akka Http release, make a copy of this file named after the release, and expand the variables.
+For every Akka HTTP release, make a copy of this file named after the release, and expand the variables.
 Ideally replacing variables could become a script you can run on your local machine.
 
 Variables to be expanded in this template:
@@ -53,7 +53,22 @@ Wind down PR queue. There has to be enough time after the last (non-trivial) PR 
 - [ ] Check the release on maven central: http://central.maven.org/maven2/com/typesafe/akka/akka-http-core_2.11/
 
 ### When everything is on maven central
-- [ ] Log into gustav.akka.io as akkarepo and update the `current` links on repo.akka.io to point to the latest version with `ln -nsf <latestversion> www/docs/akka-http/current; ln -nsf <latestversion> www/api/akka-http/current; ln -nsf <latestversion> www/japi/akka-http/current`.
+  - [ ] Log into `gustav.akka.io` as `akkarepo`
+    - [ ] update the `10.1` and `current` links on `repo.akka.io` to point to the latest version with (**replace the minor appropriately**)
+         ```
+         ln -nsf $AKKA_HTTP_VER$ www/docs/akka-http/10.1
+         ln -nsf $AKKA_HTTP_VER$ www/api/akka-http/10.1
+         ln -nsf $AKKA_HTTP_VER$ www/japi/akka-http/10.1
+         ln -nsf $AKKA_HTTP_VER$ www/docs/akka-http/current
+         ln -nsf $AKKA_HTTP_VER$ www/api/akka-http/current
+         ln -nsf $AKKA_HTTP_VER$ www/jap/akka-http/current
+         ```
+    - [ ] check changes and commit the new version to the local git repository
+         ```
+         cd ~/www
+         git add docs/akka-http/ api/akka-http/ japi/akka-http/
+         git commit -m "Akka HTTP $AKKA_HTTP_VER$"
+         ```
 
 ### Announcements
 - [ ] Merge draft news item at https://github.com/akka/akka.github.com


### PR DESCRIPTION
## Purpose

Instructions to keep the minor version docs in sync.

## Background Context

I added links for https://doc.akka.io/docs/akka-http/10.1/ and https://doc.akka.io/docs/akka-http/10.0/ today.