### PR TITLE
When route2HandlerFlow calls handlerFlow, executionContext is always null.

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -17,7 +17,7 @@ import akka.http.scaladsl.settings.ServerSettings
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{ Await, ExecutionContext, Future, Promise, blocking }
+import scala.concurrent.{ Await, ExecutionContext, ExecutionContextExecutor, Future, Promise, blocking }
 import scala.io.StdIn
 import scala.util.{ Failure, Success, Try }
 
@@ -87,7 +87,7 @@ abstract class HttpApp extends Directives {
     implicit val theSystem = system.getOrElse(ActorSystem(Logging.simpleName(this).replaceAll("\\$", "")))
     systemReference.set(theSystem)
     implicit val materializer = ActorMaterializer()
-    implicit val executionContext = theSystem.dispatcher
+    implicit val executionContext: ExecutionContextExecutor = theSystem.dispatcher
 
     val bindingFuture = Http().bindAndHandle(
       handler = routes,

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -79,7 +79,7 @@ object Route {
     val effectiveEC = if (executionContext ne null) executionContext else materializer.executionContext
 
     {
-      implicit val executionContext = effectiveEC // overrides parameter
+      implicit val executionContext: ExecutionContextExecutor = effectiveEC // overrides parameter
       val effectiveParserSettings = if (parserSettings ne null) parserSettings else ParserSettings(ActorMaterializerHelper.downcast(materializer).system)
       val sealedRoute = seal(route)
       request =>

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -4,15 +4,16 @@
 
 package akka.http.scaladsl.server
 
-import scala.collection.immutable
-import scala.concurrent.ExecutionContext
 import akka.NotUsed
-import akka.http.scaladsl.settings.{ RoutingSettings, ParserSettings }
+import akka.http.javadsl
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
-import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
-import akka.http.javadsl
+
 import scala.collection.JavaConverters._
+import scala.collection.immutable
+import scala.concurrent.ExecutionContextExecutor
 
 /**
  * The result of handling a request.
@@ -36,9 +37,9 @@ object RouteResult {
     parserSettings:   ParserSettings,
     materializer:     Materializer,
     routingLog:       RoutingLog,
-    executionContext: ExecutionContext = null,
-    rejectionHandler: RejectionHandler = RejectionHandler.default,
-    exceptionHandler: ExceptionHandler = null
+    executionContext: ExecutionContextExecutor = null,
+    rejectionHandler: RejectionHandler         = RejectionHandler.default,
+    exceptionHandler: ExceptionHandler         = null
   ): Flow[HttpRequest, HttpResponse, NotUsed] =
     Route.handlerFlow(route)
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -13,7 +13,7 @@ import akka.stream.scaladsl.Flow
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
 
 /**
  * The result of handling a request.
@@ -37,9 +37,14 @@ object RouteResult {
     parserSettings:   ParserSettings,
     materializer:     Materializer,
     routingLog:       RoutingLog,
-    executionContext: ExecutionContextExecutor = null,
-    rejectionHandler: RejectionHandler         = RejectionHandler.default,
-    exceptionHandler: ExceptionHandler         = null
-  ): Flow[HttpRequest, HttpResponse, NotUsed] =
+    executionContext: ExecutionContext = null,
+    rejectionHandler: RejectionHandler = RejectionHandler.default,
+    exceptionHandler: ExceptionHandler = null
+  ): Flow[HttpRequest, HttpResponse, NotUsed] = {
+    implicit val ec: ExecutionContextExecutor = executionContext match {
+      case e: ExecutionContextExecutor => e
+      case _                           => null
+    }
     Route.handlerFlow(route)
+  }
 }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

ExecutionContextExecutor is a subclass of ExecutionContext.

```scala
handlerFlow(implicit executionContext: ExecutionContextExecutor)
```
can not find `route2HandlerFlow`s `executionContext: ExecutionContext`

e.g
```scala
implicit val strAny: AnyRef = "str"
def foo (implicit str: String = null) = str
foo// null
```

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
