### PR TITLE
Improve validation in uuid unmarshaller

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -46,6 +46,9 @@ class UnmarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll wi
       val uuid = UUID.randomUUID()
       Unmarshal(uuid.toString).to[UUID] should evaluateTo(uuid)
     }
+    "uuidUnmarshaller should unmarshal nil uuid" in {
+      Unmarshal("00000000-0000-0000-0000-000000000000").to[UUID] should evaluateTo(UUID.fromString("00000000-0000-0000-0000-000000000000"))
+    }
   }
 
   "The GenericUnmarshallers" - {

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
@@ -45,14 +45,17 @@ trait PredefinedFromStringUnmarshallers {
       }
     }
 
-  implicit val uuidFromStringUnmarshaller: Unmarshaller[String, UUID] =
-    Unmarshaller.strict { string =>
-      try UUID.fromString(string)
-      catch {
-        case e: IllegalArgumentException =>
-          throw new IllegalArgumentException(s"'$string' is not a valid UUID value", e)
-      }
+  implicit val uuidFromStringUnmarshaller: Unmarshaller[String, UUID] = {
+    val validUuidPattern =
+      "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000".r.pattern
+
+    Unmarshaller.strict[String, UUID] { string =>
+      if (validUuidPattern.matcher(string).matches)
+        UUID.fromString(string)
+      else
+        throw new IllegalArgumentException(s"'$string' is not a valid UUID value")
     }
+  }
 
   implicit def CsvSeq[T](implicit unmarshaller: Unmarshaller[String, T]): Unmarshaller[String, immutable.Seq[T]] =
     Unmarshaller.strict[String, immutable.Seq[String]] { string =>


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

Improve the validation in the uuid unmarshaller.

## References

Follows #2505 which introduced the unmarshaller.

## Changes

Uses a regex that accepts uuid's as defined in [RFC 4122](https://tools.ietf.org/html/rfc4122). A special case is added for the nil uuid. Also avoids a try/catch block.

## Background Context

The validation in `UUID.fromString`-method in java 8 is pretty poor and accepts a lot of invalid uuid strings, java 9 improves on it somewhat but is still far too accepting.