### PR TITLE
core: allow client setting overrides for target hosts in config

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/host-overrides.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/host-overrides.backwards.excludes
@@ -1,0 +1,7 @@
+# #996 Host overrides
+# ConnectionPoolSettingsImpl is private[akka]
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.this")
+# ConnectionPoolSettings should not be overridden
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.hostOverrides")

--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/host-overrides.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/host-overrides.backwards.excludes
@@ -3,5 +3,6 @@
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.apply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.copy")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.unapply")
 # ConnectionPoolSettings should not be overridden
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.hostOverrides")

--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/host-overrides.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/host-overrides.backwards.excludes
@@ -6,3 +6,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.Conn
 ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.unapply")
 # ConnectionPoolSettings should not be overridden
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.hostOverrides")
+# Can be abstract since this class is not for user extension
+ProblemFilters.exclude[ReversedAbstractMethodProblem]("akka.http.javadsl.settings.ConnectionPoolSettings.with*")
+ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.javadsl.settings.ConnectionPoolSettings.with*")

--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/host-overrides.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/host-overrides.backwards.excludes
@@ -6,6 +6,7 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.Conn
 ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.unapply")
 # ConnectionPoolSettings should not be overridden
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.hostOverrides")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ConnectionPoolSettings.with*")
 # Can be abstract since this class is not for user extension
 ProblemFilters.exclude[ReversedAbstractMethodProblem]("akka.http.javadsl.settings.ConnectionPoolSettings.with*")
 ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.javadsl.settings.ConnectionPoolSettings.with*")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -490,7 +490,8 @@ akka.http {
     #   }
     #]
     #
-    # When multiple overrides match, the first matching override is selected.
+    # wildcards are allowed in the patterns, but should not overlap, because in that case it is
+    # not defined which set of overrides will take precedence.
     per-host-override = []
 
   }

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -489,6 +489,8 @@ akka.http {
     #   "*.example.com" = { # allow `*` to apply overrides for all subdomains, including `example.com`
     #   }
     #]
+    #
+    # When multiple overrides match, the first matching override is selected.
     per-host-override = []
 
   }

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -478,6 +478,19 @@ akka.http {
     client = {
       # no overrides by default, see `akka.http.client` for default values
     }
+
+    # Add client specific overrides to host-connection-pool. Allows exact and prefixed urls
+    # eg:
+    # per-host-override = [
+    #   "akka.io" = { # can use same things as in global `host-connection-pool` section
+    #     max-connections = 10
+    #   },
+
+    #   "*.example.com" = { # allow `*` to apply overrides for all subdomains, including `example.com`
+    #   }
+    #]
+    per-host-override = []
+
   }
 
   # Modify to tweak default parsing settings.

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -479,23 +479,39 @@ akka.http {
       # no overrides by default, see `akka.http.client` for default values
     }
 
-    # Add client specific overrides to host-connection-pool. Allows exact and prefixed urls
-    # eg:
+    # Allows overriding settings per host. The setting must be a list in which each entry
+    # is an object with a `host-pattern` entry that specifies for which hosts the overrides
+    # should take effect. All other entries have the same syntax as entries in the 
+    # `host-connection-pool` section.
+    #
+    # The `host-pattern` can have these forms:
+    #  * `regex:<pattern>`: the host name is matched against the regular expression pattern
+    #  * `glob:<glob-pattern>` or just `<glob-pattern>`: the host is matched against the given
+    #    pattern. In the pattern the wildcard `*` stands for zero or more characters and `?`
+    #    for any single character
+    #
+    # In both cases, a pattern that matches `*.` at the beginning, i.e. every subdomain,
+    # is expanded to also cover the domain itself (without the leading dot).
+    #
+    # If patterns from multiple entries in the list are matched, only settings from the
+    # first entry found are applied.
+    #
+    # Example:
+    #
     # per-host-override = [
     # {
-    #   host-pattern = "akka.io"
-    #   #can use same things as in global `host-connection-pool` section
+    #   host-pattern = "doc.akka.io"
+    #   # Use the same entries as in the `host-connection-pool` section
     #   max-connections = 10
     # },
     # {
-    #   # allows `*` as a wildcard to apply overrides for all subdomains, including `example.com`
-    #   host-pattern = "*.example.com"
+    #   # `*.akka.io` matches all subdomains like `repo.akka.io` but also `akka.io` itself.
+    #   # `doc.akka.io` is already covered by a previous entry, so these settings here
+    #   # will not apply to `doc.akka.io`.
+    #   host-pattern = "*.akka.io"
     #   max-connections = 11
     # }
     # ]
-    #
-    # wildcards are allowed in the patterns. When wildcards overlap, the first matching set of overrides
-    # is selected.
     per-host-override = []
 
   }

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -482,16 +482,20 @@ akka.http {
     # Add client specific overrides to host-connection-pool. Allows exact and prefixed urls
     # eg:
     # per-host-override = [
+    # {
     #   "akka.io" = { # can use same things as in global `host-connection-pool` section
     #     max-connections = 10
-    #   },
-
-    #   "*.example.com" = { # allow `*` to apply overrides for all subdomains, including `example.com`
     #   }
-    #]
+    # },
+    # {
+    #   {
+    #     "*.example.com" = { # allow `*` to apply overrides for all subdomains, including `example.com`
+    #   }
+    # }
+    # ]
     #
-    # wildcards are allowed in the patterns, but should not overlap, because in that case it is
-    # not defined which set of overrides will take precedence.
+    # wildcards are allowed in the patterns. When wildcards overlap, the first matching set of overrides
+    # is selected.
     per-host-override = []
 
   }

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -483,14 +483,14 @@ akka.http {
     # eg:
     # per-host-override = [
     # {
-    #   "akka.io" = { # can use same things as in global `host-connection-pool` section
-    #     max-connections = 10
-    #   }
+    #   host-pattern = "akka.io"
+    #   #can use same things as in global `host-connection-pool` section
+    #   max-connections = 10
     # },
     # {
-    #   {
-    #     "*.example.com" = { # allow `*` to apply overrides for all subdomains, including `example.com`
-    #   }
+    #   # allows `*` as a wildcard to apply overrides for all subdomains, including `example.com`
+    #   host-pattern = "*.example.com"
+    #   max-connections = 11
     # }
     # ]
     #

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -28,8 +28,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   idleTimeout:                       Duration,
   connectionSettings:                ClientConnectionSettings,
   responseEntitySubscriptionTimeout: Duration,
-  hostOverrides:                     immutable.Seq[(Regex, ConnectionPoolSettings)],
-  hostOverrideImpl:                  HostOverride)
+  hostOverrides:                     immutable.Seq[(Regex, ConnectionPoolSettings)])
   extends ConnectionPoolSettings {
 
   require(maxConnections > 0, "max-connections must be > 0")
@@ -73,7 +72,6 @@ private[akka] final case class ConnectionPoolSettingsImpl(
     maxConnectionBackoff:              FiniteDuration                                   = maxConnectionBackoff,
     idleTimeout:                       Duration                                         = idleTimeout,
     connectionSettings:                ClientConnectionSettings                         = connectionSettings,
-    poolImplementation:                PoolImplementation                               = poolImplementation,
     responseEntitySubscriptionTimeout: Duration                                         = responseEntitySubscriptionTimeout): ConnectionPoolSettings =
     copy(
       maxConnections,
@@ -86,7 +84,6 @@ private[akka] final case class ConnectionPoolSettingsImpl(
       maxConnectionBackoff,
       idleTimeout,
       connectionSettings,
-      poolImplementation,
       responseEntitySubscriptionTimeout,
       hostOverrides = hostOverrides.map { case (k, v) => k -> mapHostOverrides(v) })
 
@@ -134,9 +131,8 @@ private[akka] object ConnectionPoolSettingsImpl extends SettingsCompanionImpl[Co
       c.getFiniteDuration("max-connection-backoff"),
       c.getPotentiallyInfiniteDuration("idle-timeout"),
       ClientConnectionSettingsImpl.fromSubConfig(root, c.getConfig("client")),
-      c.getPotentiallyInfiniteDuration("response-entity-subscription-timeout"),
-      List.empty,
-      NoOpHostOverride
+      c getPotentiallyInfiniteDuration "response-entity-subscription-timeout",
+      List.empty
     )
   }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -44,6 +44,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
     minConnections == 0 || (baseConnectionBackoff.toMillis > 0 && maxConnectionBackoff.toMillis > 10),
     "If min-connections > 0, you need to set a base-connection-backoff must be > 0 and max-connection-backoff must be > 10 millis " +
       "to avoid client pools excessively trying to open up new connections.")
+  require(hostOverrides.isEmpty || hostOverrides.forall(_._2.hostOverrides.isEmpty), "host-overrides should not be nested")
 
   override def productPrefix = "ConnectionPoolSettings"
 
@@ -93,6 +94,23 @@ private[akka] final case class ConnectionPoolSettingsImpl(
 @InternalApi
 private[akka] object ConnectionPoolSettingsImpl extends SettingsCompanionImpl[ConnectionPoolSettingsImpl]("akka.http.host-connection-pool") {
 
+  def fromSubConfig(root: Config, c: Config): ConnectionPoolSettingsImpl = {
+    new ConnectionPoolSettingsImpl(
+      c.getInt("max-connections"),
+      c.getInt("min-connections"),
+      c.getInt("max-retries"),
+      c.getInt("max-open-requests"),
+      c.getInt("pipelining-limit"),
+      c.getPotentiallyInfiniteDuration("max-connection-lifetime"),
+      c.getFiniteDuration("base-connection-backoff"),
+      c.getFiniteDuration("max-connection-backoff"),
+      c.getPotentiallyInfiniteDuration("idle-timeout"),
+      ClientConnectionSettingsImpl.fromSubConfig(root, c.getConfig("client")),
+      c getPotentiallyInfiniteDuration "response-entity-subscription-timeout",
+      List.empty
+    )
+  }
+
   private[akka] def hostRegex(pattern: String): Regex = {
     val regexPattern = if (pattern.startsWith("regex:")) {
       pattern.stripPrefix("regex:")
@@ -117,23 +135,6 @@ private[akka] object ConnectionPoolSettingsImpl extends SettingsCompanionImpl[Co
 
     p.r
 
-  }
-
-  def fromSubConfig(root: Config, c: Config): ConnectionPoolSettingsImpl = {
-    new ConnectionPoolSettingsImpl(
-      c.getInt("max-connections"),
-      c.getInt("min-connections"),
-      c.getInt("max-retries"),
-      c.getInt("max-open-requests"),
-      c.getInt("pipelining-limit"),
-      c.getPotentiallyInfiniteDuration("max-connection-lifetime"),
-      c.getFiniteDuration("base-connection-backoff"),
-      c.getFiniteDuration("max-connection-backoff"),
-      c.getPotentiallyInfiniteDuration("idle-timeout"),
-      ClientConnectionSettingsImpl.fromSubConfig(root, c.getConfig("client")),
-      c getPotentiallyInfiniteDuration "response-entity-subscription-timeout",
-      List.empty
-    )
   }
 
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -59,6 +59,37 @@ private[akka] final case class ConnectionPoolSettingsImpl(
 
     s"Perhaps try $below or $above."
   }
+
+  /** INTERNAL API */
+  private[http] def copyDeep(
+    mapHostOverrides:                  ConnectionPoolSettings => ConnectionPoolSettings,
+    maxConnections:                    Int                                              = maxConnections,
+    minConnections:                    Int                                              = minConnections,
+    maxRetries:                        Int                                              = maxRetries,
+    maxOpenRequests:                   Int                                              = maxOpenRequests,
+    pipeliningLimit:                   Int                                              = pipeliningLimit,
+    maxConnectionLifetime:             Duration                                         = maxConnectionLifetime,
+    baseConnectionBackoff:             FiniteDuration                                   = baseConnectionBackoff,
+    maxConnectionBackoff:              FiniteDuration                                   = maxConnectionBackoff,
+    idleTimeout:                       Duration                                         = idleTimeout,
+    connectionSettings:                ClientConnectionSettings                         = connectionSettings,
+    poolImplementation:                PoolImplementation                               = poolImplementation,
+    responseEntitySubscriptionTimeout: Duration                                         = responseEntitySubscriptionTimeout): ConnectionPoolSettings =
+    copy(
+      maxConnections,
+      minConnections,
+      maxRetries,
+      maxOpenRequests,
+      pipeliningLimit,
+      maxConnectionLifetime,
+      baseConnectionBackoff,
+      maxConnectionBackoff,
+      idleTimeout,
+      connectionSettings,
+      poolImplementation,
+      responseEntitySubscriptionTimeout,
+      hostOverrides = hostOverrides.map { case (k, v) => k -> mapHostOverrides(v) })
+
 }
 
 /** INTERNAL API */

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -6,11 +6,13 @@ package akka.http.impl.settings
 
 import akka.annotation.InternalApi
 import akka.http.impl.util._
-import akka.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
+import akka.http.scaladsl.settings._
 import com.typesafe.config.Config
 
+import scala.collection.immutable
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.FiniteDuration
+import scala.util.matching.Regex
 
 /** INTERNAL API */
 @InternalApi
@@ -25,7 +27,9 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   maxConnectionBackoff:              FiniteDuration,
   idleTimeout:                       Duration,
   connectionSettings:                ClientConnectionSettings,
-  responseEntitySubscriptionTimeout: Duration)
+  responseEntitySubscriptionTimeout: Duration,
+  hostOverrides:                     immutable.Seq[(Regex, ConnectionPoolSettings)],
+  hostOverrideImpl:                  HostOverride)
   extends ConnectionPoolSettings {
 
   require(maxConnections > 0, "max-connections must be > 0")
@@ -45,7 +49,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   override def productPrefix = "ConnectionPoolSettings"
 
   def withUpdatedConnectionSettings(f: ClientConnectionSettings => ClientConnectionSettings): ConnectionPoolSettingsImpl =
-    copy(connectionSettings = f(connectionSettings))
+    copy(connectionSettings = f(connectionSettings), hostOverrides = hostOverrides.map { case (k, v) => k -> v.withUpdatedConnectionSettings(f) })
 
   private def suggestPowerOfTwo(around: Int): String = {
     val firstBit = 31 - Integer.numberOfLeadingZeros(around)
@@ -60,6 +64,33 @@ private[akka] final case class ConnectionPoolSettingsImpl(
 /** INTERNAL API */
 @InternalApi
 private[akka] object ConnectionPoolSettingsImpl extends SettingsCompanionImpl[ConnectionPoolSettingsImpl]("akka.http.host-connection-pool") {
+
+  private[akka] def hostRegex(pattern: String): Regex = {
+    val regexPattern = if (pattern.startsWith("regex:")) {
+      pattern.stripPrefix("regex:")
+    } else {
+      pattern.stripPrefix("glob:").map {
+        case '*'   => ".*"
+        case '?'   => "."
+        case '.'   => "\\."
+        case other => other.toString
+      }.mkString
+    }
+
+    // If the pattern starts with a wildcard, we want to match subdomains, as well as the raw domain
+    // so *.example.com should match www.example.com as well as example.com. So we replacing any leading
+    // (.*\.) pattern to allow for the beginning of the string, as well as an arbitrary subdomain. But it
+    // won't match something like thisexample.com
+    val p = if (regexPattern.startsWith(".*\\.")) {
+      s"(^|.*\\.)${regexPattern.drop(4)}"
+    } else {
+      regexPattern
+    }
+
+    p.r
+
+  }
+
   def fromSubConfig(root: Config, c: Config): ConnectionPoolSettingsImpl = {
     new ConnectionPoolSettingsImpl(
       c.getInt("max-connections"),
@@ -72,7 +103,10 @@ private[akka] object ConnectionPoolSettingsImpl extends SettingsCompanionImpl[Co
       c.getFiniteDuration("max-connection-backoff"),
       c.getPotentiallyInfiniteDuration("idle-timeout"),
       ClientConnectionSettingsImpl.fromSubConfig(root, c.getConfig("client")),
-      c.getPotentiallyInfiniteDuration("response-entity-subscription-timeout")
+      c.getPotentiallyInfiniteDuration("response-entity-subscription-timeout"),
+      List.empty,
+      NoOpHostOverride
     )
   }
+
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -49,7 +49,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
 
   def withMaxConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxConnections(n), maxConnections = n)
   def withMinConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMinConnections(n), minConnections = n)
-  def withMaxRetries(n: Int): ConnectionPoolSettings
+  def withMaxRetries(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxRetries(n), maxRetries = n)
   def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxOpenRequests(newValue), maxOpenRequests = newValue)
   /** Client-side pipelining is not currently supported, see https://github.com/akka/akka-http/issues/32 */
   def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withPipeliningLimit(newValue), pipeliningLimit = newValue)

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -49,7 +49,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
 
   def withMaxConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxConnections(n), maxConnections = n)
   def withMinConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMinConnections(n), minConnections = n)
-  def withMaxRetries(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxRetries(n), maxRetries = n)
+  def withMaxRetries(n: Int): ConnectionPoolSettings
   def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxOpenRequests(newValue), maxOpenRequests = newValue)
   /** Client-side pipelining is not currently supported, see https://github.com/akka/akka-http/issues/32 */
   def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withPipeliningLimit(newValue), pipeliningLimit = newValue)

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -47,20 +47,20 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   @ApiMayChange
   def appendHostOverride(hostPattern: String, settings: ConnectionPoolSettings): ConnectionPoolSettings = self.copy(hostOverrides = hostOverrides :+ (ConnectionPoolSettingsImpl.hostRegex(hostPattern) -> settings.asScala))
 
-  def withMaxConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxConnections(n), maxConnections = n)
-  def withMinConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMinConnections(n), minConnections = n)
-  def withMaxRetries(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxRetries(n), maxRetries = n)
-  def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxOpenRequests(newValue), maxOpenRequests = newValue)
+  def withMaxConnections(n: Int): ConnectionPoolSettings
+  def withMinConnections(n: Int): ConnectionPoolSettings
+  def withMaxRetries(n: Int): ConnectionPoolSettings
+  def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings
   /** Client-side pipelining is not currently supported, see https://github.com/akka/akka-http/issues/32 */
-  def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withPipeliningLimit(newValue), pipeliningLimit = newValue)
-  def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withBaseConnectionBackoff(newValue), baseConnectionBackoff = newValue)
-  def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionBackoff(newValue), maxConnectionBackoff = newValue)
-  def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withIdleTimeout(newValue), idleTimeout = newValue)
-  def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionLifetime(newValue), maxConnectionLifetime = newValue)
+  def withPipeliningLimit(newValue: Int): ConnectionPoolSettings
+  def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings
+  def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings
+  def withIdleTimeout(newValue: Duration): ConnectionPoolSettings
+  def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copyDeep(_.withConnectionSettings(newValue.asScala), connectionSettings = newValue.asScala)
 
   @ApiMayChange
-  def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withResponseEntitySubscriptionTimeout(newValue), responseEntitySubscriptionTimeout = newValue)
+  def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings
 
   def withTransport(newValue: ClientTransport): ConnectionPoolSettings = withUpdatedConnectionSettings(_.withTransport(newValue.asScala))
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -4,14 +4,18 @@
 
 package akka.http.javadsl.settings
 
+import java.time.{ Duration => JDuration }
+
+import com.typesafe.config.Config
+
+import scala.concurrent.duration.{ Duration, FiniteDuration }
+
 import akka.actor.ActorSystem
 import akka.annotation.{ ApiMayChange, DoNotInherit }
 import akka.http.impl.settings.ConnectionPoolSettingsImpl
 import akka.http.impl.util.JavaMapping.Implicits._
 import akka.http.javadsl.ClientTransport
-import com.typesafe.config.Config
-
-import scala.concurrent.duration.{ Duration, FiniteDuration }
+import akka.util.JavaDurationConverters._
 
 /**
  * Public API but not intended for subclassing
@@ -23,6 +27,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def getMaxRetries: Int = maxRetries
   def getMaxOpenRequests: Int = maxOpenRequests
   def getPipeliningLimit: Int = pipeliningLimit
+  def getMaxConnectionLifetime: JDuration = maxConnectionLifetime.asJava
   def getBaseConnectionBackoff: FiniteDuration = baseConnectionBackoff
   def getMaxConnectionBackoff: FiniteDuration = maxConnectionBackoff
   def getIdleTimeout: Duration = idleTimeout
@@ -42,20 +47,20 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   @ApiMayChange
   def appendHostOverride(hostPattern: String, settings: ConnectionPoolSettings): ConnectionPoolSettings = self.copy(hostOverrides = hostOverrides :+ (ConnectionPoolSettingsImpl.hostRegex(hostPattern) -> settings.asScala))
 
-  def withMaxConnections(n: Int): ConnectionPoolSettings = self.copy(maxConnections = n, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxConnections(n) })
-  def withMinConnections(n: Int): ConnectionPoolSettings = self.copy(minConnections = n, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMinConnections(n) })
-  def withMaxRetries(n: Int): ConnectionPoolSettings = self.copy(maxRetries = n, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxRetries(n) })
-  def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copy(maxOpenRequests = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxOpenRequests(newValue) })
+  def withMaxConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxConnections(n), maxConnections = n)
+  def withMinConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMinConnections(n), minConnections = n)
+  def withMaxRetries(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxRetries(n), maxRetries = n)
+  def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxOpenRequests(newValue), maxOpenRequests = newValue)
   /** Client-side pipelining is not currently supported, see https://github.com/akka/akka-http/issues/32 */
-  def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withPipeliningLimit(newValue) })
-  def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(baseConnectionBackoff = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withBaseConnectionBackoff(newValue) })
-  def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(maxConnectionBackoff = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxConnectionBackoff(newValue) })
-  def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withIdleTimeout(newValue) })
-  def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copy(maxConnectionLifetime = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxConnectionLifetime(newValue) })
-  def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withConnectionSettings(newValue).asScala })
+  def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withPipeliningLimit(newValue), pipeliningLimit = newValue)
+  def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withBaseConnectionBackoff(newValue), baseConnectionBackoff = newValue)
+  def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionBackoff(newValue), maxConnectionBackoff = newValue)
+  def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withIdleTimeout(newValue), idleTimeout = newValue)
+  def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionLifetime(newValue), maxConnectionLifetime = newValue)
+  def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copyDeep(_.withConnectionSettings(newValue.asScala), connectionSettings = newValue.asScala)
 
   @ApiMayChange
-  def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(responseEntitySubscriptionTimeout = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withResponseEntitySubscriptionTimeout(newValue) })
+  def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withResponseEntitySubscriptionTimeout(newValue), responseEntitySubscriptionTimeout = newValue)
 
   def withTransport(newValue: ClientTransport): ConnectionPoolSettings = withUpdatedConnectionSettings(_.withTransport(newValue.asScala))
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -33,20 +33,29 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
 
   // ---
 
-  def withMaxConnections(n: Int): ConnectionPoolSettings = self.copy(maxConnections = n)
-  def withMinConnections(n: Int): ConnectionPoolSettings = self.copy(minConnections = n)
-  def withMaxRetries(n: Int): ConnectionPoolSettings = self.copy(maxRetries = n)
-  def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copy(maxOpenRequests = newValue)
-  /** Client-side pipelining is not currently supported, see https://github.com/akka/akka-http/issues/32 */
-  def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue)
-  def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(baseConnectionBackoff = newValue)
-  def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(maxConnectionBackoff = newValue)
-  def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue)
-  def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copy(maxConnectionLifetime = newValue)
-  def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala)
+  @ApiMayChange
+  def withHostOverrides(hostOverrides: java.util.List[(String, ConnectionPoolSettings)]): ConnectionPoolSettings = {
+    import scala.collection.JavaConverters._
+    self.copy(hostOverrides = hostOverrides.asScala.toList.map { case (h, s) => ConnectionPoolSettingsImpl.hostRegex(h) -> s.asScala })
+  }
 
   @ApiMayChange
-  def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(responseEntitySubscriptionTimeout = newValue)
+  def appendHostOverride(hostPattern: String, settings: ConnectionPoolSettings): ConnectionPoolSettings = self.copy(hostOverrides = hostOverrides :+ (ConnectionPoolSettingsImpl.hostRegex(hostPattern) -> settings.asScala))
+
+  def withMaxConnections(n: Int): ConnectionPoolSettings = self.copy(maxConnections = n, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxConnections(n) })
+  def withMinConnections(n: Int): ConnectionPoolSettings = self.copy(minConnections = n, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMinConnections(n) })
+  def withMaxRetries(n: Int): ConnectionPoolSettings = self.copy(maxRetries = n, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxRetries(n) })
+  def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copy(maxOpenRequests = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxOpenRequests(newValue) })
+  /** Client-side pipelining is not currently supported, see https://github.com/akka/akka-http/issues/32 */
+  def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withPipeliningLimit(newValue) })
+  def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(baseConnectionBackoff = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withBaseConnectionBackoff(newValue) })
+  def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(maxConnectionBackoff = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxConnectionBackoff(newValue) })
+  def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withIdleTimeout(newValue) })
+  def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copy(maxConnectionLifetime = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxConnectionLifetime(newValue) })
+  def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withConnectionSettings(newValue).asScala })
+
+  @ApiMayChange
+  def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(responseEntitySubscriptionTimeout = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withResponseEntitySubscriptionTimeout(newValue) })
 
   def withTransport(newValue: ClientTransport): ConnectionPoolSettings = withUpdatedConnectionSettings(_.withTransport(newValue.asScala))
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -82,7 +82,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
   override val sslConfig = AkkaSSLConfig(system)
   validateAndWarnAboutLooseSettings()
 
-  private[this] val defaultConnectionPoolSettings = ConnectionPoolSettings.withOverrides(system)
+  private[this] val defaultConnectionPoolSettings = ConnectionPoolSettings(system)
 
   // configured default HttpsContext for the client-side
   // SYNCHRONIZED ACCESS ONLY!

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -91,7 +91,7 @@ object ConnectionPoolSettings extends SettingsCompanion[ConnectionPoolSettings] 
   /**
    * Builds a ConnectionPoolSettings that has the host specific overrides populated from config
    *
-   * This is the ONLY place that a connection pool object can be created that has the abililty to be configured per
+   * This is the ONLY place that a connection pool object can be created that has the ability to be configured per
    * host, and it's ONLY used by `HttpExt.defaultConnectionPoolSettings`. The intent is NOT to let users define or use
    * this, or even for akka internally to use this. Think of this more like a placeholder for the
    * `defaultConnectionPoolSettings` provided in the HttpExt.singleRequest and other client methods instead of breaking

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -64,7 +64,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   override def withMinConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMinConnections(n), minConnections = n)
   override def withMaxRetries(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxRetries(n), maxRetries = n)
   override def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxOpenRequests(newValue), maxOpenRequests = newValue)
-  override def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withBaseConnectionBackoff(newValue))
+  override def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withBaseConnectionBackoff(newValue), baseConnectionBackoff = newValue)
   override def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionBackoff(newValue), maxConnectionBackoff = newValue)
   override def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withPipeliningLimit(newValue), pipeliningLimit = newValue)
   override def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withIdleTimeout(newValue), idleTimeout = newValue)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -60,19 +60,19 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   @ApiMayChange
   def appendHostOverride(hostPattern: String, settings: ConnectionPoolSettings): ConnectionPoolSettings = self.copy(hostOverrides = hostOverrides :+ (ConnectionPoolSettingsImpl.hostRegex(hostPattern) -> settings))
 
-  override def withMaxConnections(n: Int): ConnectionPoolSettings = self.copy(maxConnections = n, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxConnections(n) })
-  override def withMinConnections(n: Int): ConnectionPoolSettings = self.copy(minConnections = n, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMinConnections(n) })
-  override def withMaxRetries(n: Int): ConnectionPoolSettings = self.copy(maxRetries = n, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxRetries(n) })
-  override def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copy(maxOpenRequests = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxOpenRequests(newValue) })
-  override def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(baseConnectionBackoff = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withBaseConnectionBackoff(newValue) })
-  override def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(maxConnectionBackoff = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxConnectionBackoff(newValue) })
-  override def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copy(pipeliningLimit = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withPipeliningLimit(newValue) })
-  override def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withIdleTimeout(newValue) })
-  override def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copy(maxConnectionLifetime = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withMaxConnectionLifetime(newValue) })
-  def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withConnectionSettings(newValue) })
+  override def withMaxConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxConnections(n), maxConnections = n)
+  override def withMinConnections(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMinConnections(n), minConnections = n)
+  override def withMaxRetries(n: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxRetries(n), maxRetries = n)
+  override def withMaxOpenRequests(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withMaxOpenRequests(newValue), maxOpenRequests = newValue)
+  override def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withBaseConnectionBackoff(newValue))
+  override def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionBackoff(newValue), maxConnectionBackoff = newValue)
+  override def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withPipeliningLimit(newValue), pipeliningLimit = newValue)
+  override def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withIdleTimeout(newValue), idleTimeout = newValue)
+  override def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionLifetime(newValue), maxConnectionLifetime = newValue)
+  def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copyDeep(_.withConnectionSettings(newValue), connectionSettings = newValue)
 
   @ApiMayChange
-  override def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(responseEntitySubscriptionTimeout = newValue, hostOverrides = hostOverrides.map { case (k, v) => k -> v.withResponseEntitySubscriptionTimeout(newValue) })
+  override def withResponseEntitySubscriptionTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withResponseEntitySubscriptionTimeout(newValue), responseEntitySubscriptionTimeout = newValue)
 
   /**
    * Since 10.1.0, the transport is configured in [[ClientConnectionSettings]]. This method is a shortcut for

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -89,13 +89,13 @@ object ConnectionPoolSettings extends SettingsCompanion[ConnectionPoolSettings] 
   override def apply(config: Config) = ConnectionPoolSettingsImpl(config)
 
   /**
-   * Builds a ConnectionPoolSettings that has the host specific overrides populated from config
+   * Builds `ConnectionPoolSettings` that have the host specific overrides populated from config
    *
    * This is the ONLY place that a connection pool object can be created that has the ability to be configured per
    * host, and it's ONLY used by `HttpExt.defaultConnectionPoolSettings`. The intent is NOT to let users define or use
    * this, or even for akka internally to use this. Think of this more like a placeholder for the
-   * `defaultConnectionPoolSettings` provided in the HttpExt.singleRequest and other client methods instead of breaking
-   * binary compatibility by making those calls take an `Option[_]`or using `null`
+   * `defaultConnectionPoolSettings` provided in the `HttpExt.singleRequest` and other client methods instead of breaking
+   * binary compatibility by making those calls take an `Option[_]` or using `null`
    *
    */
   @ApiMayChange
@@ -104,13 +104,13 @@ object ConnectionPoolSettings extends SettingsCompanion[ConnectionPoolSettings] 
   }
 
   /**
-   * Builds a ConnectionPoolSettings that has the host specific overrides populated from config
+   * Builds `ConnectionPoolSettings` that have the host specific overrides populated from config
    *
    * This is the ONLY place that a connection pool object can be created that has the abililty to be configured per
    * host, and it's ONLY used by `HttpExt.defaultConnectionPoolSettings`. The intent is NOT to let users define or use
    * this, or even for akka internally to use this. Think of this more like a placeholder for the
-   * `defaultConnectionPoolSettings` provided in the HttpExt.singleRequest and other client methods instead of breaking
-   * binary compatibility by making those calls take an `Option[_]`or using `null`
+   * `defaultConnectionPoolSettings` provided in the `HttpExt.singleRequest` and other client methods instead of breaking
+   * binary compatibility by making those calls take an `Option[_]` or using `null`
    *
    */
   @ApiMayChange

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -86,13 +86,9 @@ object ConnectionPoolSettings extends SettingsCompanion[ConnectionPoolSettings] 
   override def apply(config: Config): ConnectionPoolSettingsImpl = {
     import scala.collection.JavaConverters._
 
-    val hostOverrides = config.getConfigList("akka.http.host-connection-pool.per-host-override").asScala.toList.flatMap { cfg =>
-      val entries = cfg.root.entrySet().asScala
-      require(entries.size < 2, "Please specify each per-host-override in its own object. This is needed to preserve the order.")
-      entries.map { entry =>
-        ConnectionPoolSettingsImpl.hostRegex(entry.getKey) ->
-          ConnectionPoolSettingsImpl(entry.getValue.atPath("akka.http.host-connection-pool").withFallback(config))
-      }
+    val hostOverrides = config.getConfigList("akka.http.host-connection-pool.per-host-override").asScala.toList.map { cfg =>
+      ConnectionPoolSettingsImpl.hostRegex(cfg.getString("host-pattern")) ->
+        ConnectionPoolSettingsImpl(cfg.atPath("akka.http.host-connection-pool").withFallback(config))
     }
 
     ConnectionPoolSettingsImpl(config).copy(hostOverrides = hostOverrides)

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -55,7 +55,7 @@ class GracefulTerminationSpec
       // immediately trying a new connection should cause `Connection refused` since we unbind immediately:
       val r3 = makeRequest(ensureNewConnection = true)
       val ex = intercept[StreamTcpException] {
-        Await.result(r3, 5.seconds)
+        Await.result(r3, 2.seconds)
       }
       ex.getMessage should include("Connection refused")
     }
@@ -201,7 +201,7 @@ class GracefulTerminationSpec
   }
 
   private def ensureConnectionIsClosed(r: Future[HttpResponse]): Assertion =
-    (the[StreamTcpException] thrownBy Await.result(r, 6.second)).getMessage should endWith("Connection refused")
+    (the[StreamTcpException] thrownBy Await.result(r, 1.second)).getMessage should endWith("Connection refused")
 
   class TestSetup(overrideResponse: Option[HttpResponse] = None) {
     val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -55,7 +55,7 @@ class GracefulTerminationSpec
       // immediately trying a new connection should cause `Connection refused` since we unbind immediately:
       val r3 = makeRequest(ensureNewConnection = true)
       val ex = intercept[StreamTcpException] {
-        Await.result(r3, 2.seconds)
+        Await.result(r3, 5.seconds)
       }
       ex.getMessage should include("Connection refused")
     }
@@ -201,7 +201,7 @@ class GracefulTerminationSpec
   }
 
   private def ensureConnectionIsClosed(r: Future[HttpResponse]): Assertion =
-    (the[StreamTcpException] thrownBy Await.result(r, 1.second)).getMessage should endWith("Connection refused")
+    (the[StreamTcpException] thrownBy Await.result(r, 6.second)).getMessage should endWith("Connection refused")
 
   class TestSetup(overrideResponse: Option[HttpResponse] = None) {
     val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -9,6 +9,7 @@ import scala.util.Success
 import scala.util.Try
 import akka.testkit.AkkaSpec
 import akka.http.scaladsl.model.headers.`User-Agent`
+import com.typesafe.config.ConfigFactory
 
 class ConnectionPoolSettingsSpec extends AkkaSpec {
   "ConnectionPoolSettings" should {
@@ -39,6 +40,123 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
       expectError("akka.http.host-connection-pool.max-open-requests = 100") should include("Perhaps try 64 or 128")
       expectError("akka.http.host-connection-pool.max-open-requests = 1000") should include("Perhaps try 512 or 1024")
     }
+
+    "allow per host overrides" in {
+
+      val settingsString =
+        """
+          |akka.http.host-connection-pool {
+          |  max-connections = 7
+          |
+          |  per-host-override : [
+          |    {
+          |      "akka.io" : { # can use same things as in global `host-connection-pool` section
+          |        max-connections = 47
+          |      }
+          |    },
+          |
+          |   {
+          |     "*.example.com" : { # allow `*` to apply overrides for all subdomains
+          |       max-connections = 34
+          |     }
+          |   },
+          |
+          |   {
+          |     "glob:*example2.com" : {
+          |       max-connections = 39
+          |     }
+          |   },
+          |
+          |   {
+          |     "regex:((w{3})?\\.)?scala-lang\\.(com|org)" : {
+          |       max-connections = 36
+          |     }
+          |   }
+          |  ]
+          |}
+        """.stripMargin
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("akka.io").maxConnections shouldEqual 47
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("test.akka.io").maxConnections shouldEqual 7
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("example.com").maxConnections shouldEqual 34
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.example.com").maxConnections shouldEqual 34
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("example2.com").maxConnections shouldEqual 39
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.example2.com").maxConnections shouldEqual 39
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.someexample2.com").maxConnections shouldEqual 39
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("test.example.com").maxConnections shouldEqual 34
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("lightbend.com").maxConnections shouldEqual 7
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.scala-lang.org").maxConnections shouldEqual 36
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("scala-lang.org").maxConnections shouldEqual 36
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("ww.scala-lang.org").maxConnections shouldEqual 7
+
+      ConnectionPoolSettings.withOverrides(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("scala-lang.com").maxConnections shouldEqual 36
+
+      // Make sure calls to .apply instead of .forDefault don't get overridden by config
+      ConnectionPoolSettings(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("akka.io").maxConnections shouldEqual 7
+
+    }
+
+    "disregard per host overrides when not created via forDefault method" in {
+      val settingsString =
+        """
+          |akka.http.host-connection-pool {
+          |  max-connections = 7
+          |
+          |  per-host-override : [
+          |    {
+          |      "akka.io" = { # can use same things as in global `host-connection-pool` section
+          |        max-connections = 47
+          |      }
+          |    }
+          |  ]
+          |}
+        """.stripMargin
+
+      ConnectionPoolSettings(
+        ConfigFactory.parseString(settingsString)
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("akka.io").maxConnections shouldEqual 7
+
+    }
+
     def expectError(configString: String): String = Try(config(configString)) match {
       case Failure(cause) => cause.getMessage
       case Success(_)     => fail("Expected a failure when max-open-requests is not a power of 2")

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -76,59 +76,25 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
           |}
         """.stripMargin
 
-      ConnectionPoolSettings.withOverrides(
+      val settings = ConnectionPoolSettings.withOverrides(
         ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("akka.io").maxConnections shouldEqual 47
+          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader)))
 
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("test.akka.io").maxConnections shouldEqual 7
+      settings.forHost("akka.io").maxConnections shouldEqual 47
+      settings.forHost("test.akka.io").maxConnections shouldEqual 7
+      settings.forHost("example.com").maxConnections shouldEqual 34
+      settings.forHost("www.example.com").maxConnections shouldEqual 34
+      settings.forHost("example2.com").maxConnections shouldEqual 39
+      settings.forHost("www.example2.com").maxConnections shouldEqual 39
+      settings.forHost("www.someexample2.com").maxConnections shouldEqual 39
+      settings.forHost("test.example.com").maxConnections shouldEqual 34
+      settings.forHost("lightbend.com").maxConnections shouldEqual 7
+      settings.forHost("www.scala-lang.org").maxConnections shouldEqual 36
+      settings.forHost("scala-lang.org").maxConnections shouldEqual 36
+      settings.forHost("ww.scala-lang.org").maxConnections shouldEqual 7
+      settings.forHost("scala-lang.com").maxConnections shouldEqual 36
 
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("example.com").maxConnections shouldEqual 34
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.example.com").maxConnections shouldEqual 34
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("example2.com").maxConnections shouldEqual 39
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.example2.com").maxConnections shouldEqual 39
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.someexample2.com").maxConnections shouldEqual 39
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("test.example.com").maxConnections shouldEqual 34
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("lightbend.com").maxConnections shouldEqual 7
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("www.scala-lang.org").maxConnections shouldEqual 36
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("scala-lang.org").maxConnections shouldEqual 36
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("ww.scala-lang.org").maxConnections shouldEqual 7
-
-      ConnectionPoolSettings.withOverrides(
-        ConfigFactory.parseString(settingsString)
-          .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("scala-lang.com").maxConnections shouldEqual 36
-
-      // Make sure calls to .apply instead of .forDefault don't get overridden by config
+      // Make sure calls to .apply instead of .withOverrides don't get overridden by config
       ConnectionPoolSettings(
         ConfigFactory.parseString(settingsString)
           .withFallback(ConfigFactory.defaultReference(getClass.getClassLoader))).forHost("akka.io").maxConnections shouldEqual 7

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -50,27 +50,22 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
           |
           |  per-host-override : [
           |    {
-          |      "akka.io" : { # can use same things as in global `host-connection-pool` section
-          |        max-connections = 47
-          |      }
+          |      host-pattern = "akka.io"
+          |      # can use same things as in global `host-connection-pool` section
+          |      max-connections = 47
           |    },
-          |
           |   {
-          |     "*.example.com" : { # allow `*` to apply overrides for all subdomains
-          |       max-connections = 34
-          |     }
+          |     host-pattern = "*.example.com"
+          |     # allow `*` to apply overrides for all subdomains
+          |     max-connections = 34
           |   },
-          |
           |   {
-          |     "glob:*example2.com" : {
-          |       max-connections = 39
-          |     }
+          |     host-pattern = "glob:*example2.com"
+          |     max-connections = 39
           |   },
-          |
           |   {
-          |     "regex:((w{3})?\\.)?scala-lang\\.(com|org)" : {
-          |       max-connections = 36
-          |     }
+          |     host-pattern = "regex:((w{3})?\\.)?scala-lang\\.(com|org)"
+          |     max-connections = 36
           |   }
           |  ]
           |}
@@ -103,9 +98,9 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
           |
           |  per-host-override = [
           |    {
-          |      "akka.io" : { # can use same things as in global `host-connection-pool` section
-          |        max-connections = 47
-          |      }
+          |      host-pattern = "akka.io"
+          |      # can use same things as in global `host-connection-pool` section
+          |      max-connections = 47
           |    }
           |  ]
           |}
@@ -129,15 +124,15 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
           |
           |  per-host-override = [
           |    {
-          |      "akka.io" : { # can use same things as in global `host-connection-pool` section
-          |        max-connections = 27
-          |      }
+          |      host-pattern = "akka.io"
+          |      # can use same things as in global `host-connection-pool` section
+          |      max-connections = 27
           |    },
           |    {
-          |      "*.io" : { # can use same things as in global `host-connection-pool` section
-          |        min-connections = 22
-          |        max-connections = 47
-          |      }
+          |      host-pattern = "*.io"
+          |      # can use same things as in global `host-connection-pool` section
+          |      min-connections = 22
+          |      max-connections = 47
           |    }
           |  ]
           |}
@@ -154,30 +149,6 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
       settings.forHost("other.io").minConnections shouldEqual 22
       settings.forHost("akka.com").minConnections shouldEqual 2
       settings.minConnections shouldEqual 2
-    }
-
-    "throw an error when combining multiple keys in one config object" in {
-      val settingsString =
-        """
-          |akka.http.host-connection-pool {
-          |  max-connections = 7
-          |
-          |  per-host-override = [
-          |    {
-          |      "akka.io" : { # can use same things as in global `host-connection-pool` section
-          |        max-connections = 27
-          |      }
-          |      "*.io" : { # can use same things as in global `host-connection-pool` section
-          |        max-connections = 47
-          |      }
-          |    }
-          |  ]
-          |}
-        """.stripMargin
-
-      an[IllegalArgumentException] should be thrownBy {
-        ConnectionPoolSettings(ConfigFactory.parseString(settingsString).withFallback(ConfigFactory.defaultReference(getClass.getClassLoader)))
-      }
     }
 
     def expectError(configString: String): String = Try(config(configString)) match {

--- a/docs/src/main/paradox/compatibility-guidelines.md
+++ b/docs/src/main/paradox/compatibility-guidelines.md
@@ -64,10 +64,14 @@ Scala
     akka.http.scaladsl.settings.PoolImplementation
     akka.http.scaladsl.settings.ClientConnectionSettings#transport
     akka.http.scaladsl.settings.ClientConnectionSettings#withTransport
+    akka.http.scaladsl.settings.ConnectionPoolSettings#appendHostOverride
     akka.http.scaladsl.settings.ConnectionPoolSettings#poolImplementation
     akka.http.scaladsl.settings.ConnectionPoolSettings#responseEntitySubscriptionTimeout
+    akka.http.scaladsl.settings.ConnectionPoolSettings#withHostOverrides
+    akka.http.scaladsl.settings.ConnectionPoolSettings#withOverrides
     akka.http.scaladsl.settings.ConnectionPoolSettings#withPoolImplementation
     akka.http.scaladsl.settings.ConnectionPoolSettings#withResponseEntitySubscriptionTimeout
+    akka.http.scaladsl.settings.HostOverride
     akka.http.scaladsl.settings.Http2ServerSettings
     akka.http.scaladsl.settings.PreviewServerSettings
     akka.http.scaladsl.settings.ServerSentEventSettings
@@ -81,8 +85,10 @@ Java
     akka.http.javadsl.ClientTransport
     akka.http.javadsl.settings.ClientConnectionSettings#getTransport
     akka.http.javadsl.settings.ClientConnectionSettings#withTransport
+    akka.http.javadsl.settings.ConnectionPoolSettings#appendHostOverride
     akka.http.javadsl.settings.ConnectionPoolSettings#getPoolImplementation
     akka.http.javadsl.settings.ConnectionPoolSettings#getResponseEntitySubscriptionTimeout
+    akka.http.javadsl.settings.ConnectionPoolSettings#withHostOverrides
     akka.http.javadsl.settings.ConnectionPoolSettings#withPoolImplementation
     akka.http.javadsl.settings.ConnectionPoolSettings#withResponseEntitySubscriptionTimeout
     akka.http.javadsl.settings.PoolImplementation


### PR DESCRIPTION
Rebased version of #1926

Refs #996

The default connection pool object can lookup host overrides for a
particular host, but client supplied connection pools will not be
overridden