### PR TITLE
Close outgoing HTTP/2 streams earlier

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -42,7 +42,7 @@ private[http2] trait Http2Multiplexer {
  */
 @InternalApi
 private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with StageLogging =>
-  def createMultiplexer(outlet: GenericOutlet[FrameEvent], prioritizer: StreamPrioritizer): Http2Multiplexer =
+  def createMultiplexer(outlet: GenericOutlet[FrameEvent], prioritizer: StreamPrioritizer, http2StreamHandling: Http2StreamHandling): Http2Multiplexer =
     new Http2Multiplexer with OutHandler with StateTimingSupport with LogSupport { self =>
       outlet.setHandler(this)
 
@@ -112,6 +112,7 @@ private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with Stage
           trailer = None
           maybeInlet.foreach(_.cancel())
           self.closeStream(this)
+          http2StreamHandling.handleOutgoingEnded(streamId)
 
           if (maybeInlet.isDefined) {
             maybeInlet = None

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -25,8 +25,6 @@ import FrameEvent._
  *
  * This stage contains all control logic for handling frames and (de)muxing data to/from substreams.
  *
- * (This is not a final documentation, more like a brain-dump of how it could work.)
- *
  * The BidiStage consumes and produces FrameEvents from the network. It will output one Http2SubStream
  * for incoming frames per substream and likewise accepts a single Http2SubStream per substream with
  * outgoing frames.
@@ -88,7 +86,7 @@ private[http2] class Http2ServerDemux(http2Settings: Http2ServerSettings) extend
 
       override protected def logSource: Class[_] = classOf[Http2ServerDemux]
 
-      val multiplexer = createMultiplexer(frameOut, StreamPrioritizer.first())
+      val multiplexer = createMultiplexer(frameOut, StreamPrioritizer.first(), this)
 
       override def preStart(): Unit = {
         pull(frameIn)

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -86,7 +86,7 @@ private[http2] class Http2ServerDemux(http2Settings: Http2ServerSettings) extend
 
       override protected def logSource: Class[_] = classOf[Http2ServerDemux]
 
-      val multiplexer = createMultiplexer(frameOut, StreamPrioritizer.first(), this)
+      val multiplexer = createMultiplexer(frameOut, StreamPrioritizer.first())
 
       override def preStart(): Unit = {
         pull(frameIn)

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -67,6 +67,9 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
     multiplexer.pushControlFrame(RstStreamFrame(streamId, errorCode))
   }
 
+  /**
+   * https://http2.github.io/http2-spec/#StreamStates
+   */
   sealed abstract class IncomingStreamState { _: Product =>
     def handle(event: StreamFrameEvent): IncomingStreamState
     def handleOutgoingEnded(): IncomingStreamState
@@ -97,7 +100,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
     }
 
     override def handleOutgoingEnded(): IncomingStreamState = {
-      log.error("handleOutgoingEnded called prematurely")
+      log.error("handleOutgoingEnded called prematurely. This indicates a bug in Akka HTTP, please report it to the issue tracker.")
       Idle
     }
 
@@ -148,7 +151,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
   }
   case class HalfClosedLocal(buffer: IncomingStreamBuffer) extends ReceivingData(Closed) {
     override def handleOutgoingEnded(): IncomingStreamState = {
-      log.error("handleOutgoingEnded called twice")
+      log.error("handleOutgoingEnded called twice. This indicates a bug in Akka HTTP, please report it to the issue tracker.")
       this
     }
   }
@@ -172,7 +175,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
         receivedUnexpectedFrame(event)
     }
     override def handleOutgoingEnded(): IncomingStreamState = {
-      log.error("handleOutgoingEnded called twice")
+      log.error("handleOutgoingEnded called twice. This indicates a bug in Akka HTTP, please report it to the issue tracker.")
       this
     }
   }

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -16,7 +16,15 @@ import scala.collection.immutable
 
 import FrameEvent._
 
-/** INTERNAL API */
+/**
+ * INTERNAL API
+ *
+ * Handles the 'incoming' side of HTTP/2 streams.
+ * Accepts `FrameEvent`s from the network side and emits `ByteHttp2SubStream`s for streams
+ * to be handled by the Akka HTTP layer.
+ *
+ * Mixed into the Http2ServerDemux graph logic.
+ */
 @InternalApi
 private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLogging =>
   // required API from demux
@@ -47,6 +55,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
   def handleStreamEvent(e: StreamFrameEvent): Unit = {
     updateState(e.streamId, streamFor(e.streamId).handle(e))
   }
+  // Called by the outgoing stream multiplexer when that side of the stream is ended.
   def handleOutgoingEnded(streamId: Int): Unit = {
     updateState(streamId, streamFor(streamId).handleOutgoingEnded())
   }


### PR DESCRIPTION
Before they would be closed when the connection closes, which caused
unnecessary memory use for long-lived HTTP/2 connections with many streams
(as is common with gRPC).

Refs #2551