### PR TITLE
There's a typo in the introduction.md

### DIFF
--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -19,7 +19,7 @@ akka.http {
     server-header = akka-http/${akka.http.version}
 
     # "PREVIEW" features that are not yet fully production ready.
-    # These flags can can change or be removed between patch releases.
+    # These flags can change or be removed between patch releases.
     preview {
       # ONLY WORKS WITH `bindAndHandleAsync` (currently)
       #

--- a/docs/src/main/paradox/introduction.md
+++ b/docs/src/main/paradox/introduction.md
@@ -84,7 +84,7 @@ project](https://github.com/akka/akka-http-java-seed.g8)].
 ## Routing DSL for HTTP servers
 
 The high-level, routing API of Akka HTTP provides a DSL to describe HTTP "routes" and how they should be handled.
-Each route is composed of one or more level of `Directive` s that narrows down to handling one specific type of
+Each route is composed of one or more level of `Directives` that narrows down to handling one specific type of
 request.
 
 For example one route might start with matching the `path` of the request, only matching if it is "/hello", then


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

in the src/main/paradox/introduction.md line 87 
> The high-level, routing API of Akka HTTP provides a DSL to describe HTTP "routes" and how they should be handled. Each route is composed of one or more level of `Directive` s that narrows down to handling one specific type of request.

the Directives wrote wrong.
I'm glad to fix it :)
