### PR TITLE
Improve JavaUUID path matcher

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -208,6 +208,7 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
     val test = testFor(pathPrefix(JavaUUID) { echoCaptureAndUnmatchedPath })
     "accept [/bdea8652-f26c-40ca-8157-0b96a2a8389d]" inThe test("bdea8652-f26c-40ca-8157-0b96a2a8389d:")
     "accept [/bdea8652-f26c-40ca-8157-0b96a2a8389dyes]" inThe test("bdea8652-f26c-40ca-8157-0b96a2a8389d:yes")
+    "accept [/00000000-0000-0000-0000-000000000000]" inThe test("00000000-0000-0000-0000-000000000000:")
     "reject [/]" inThe test()
     "reject [/abc]" inThe test()
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
@@ -486,10 +486,8 @@ trait PathMatchers {
    * @group pathmatcher
    */
   val JavaUUID: PathMatcher1[UUID] =
-    PathMatcher("""[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}""".r) flatMap { string =>
-      try Some(UUID.fromString(string))
-      catch { case _: IllegalArgumentException => None }
-    }
+    PathMatcher("""[\da-fA-F]{8}-[\da-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][\da-fA-F]{3}-[\da-fA-F]{12}|00000000-0000-0000-0000-000000000000""".r)
+      .map(UUID.fromString)
 
   /**
    * A PathMatcher that always matches, doesn't consume anything and extracts nothing.


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

Improve the JavaUUID path matcher

## Changes

This PR tightens the existing regex and adds the nil uuid, making it accept uuid's as defined in [RFC 4122](https://tools.ietf.org/html/rfc4122). Also avoids a try/catch block.
