### PR TITLE
Support multiple subprotocols in Websocket handshake for client side

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/WebSocketRequest.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/WebSocketRequest.scala
@@ -14,7 +14,7 @@ import akka.http.scaladsl.model.{ HttpHeader, Uri }
  * Represents a WebSocket request.
  * @param uri The target URI to connect to.
  * @param extraHeaders Extra headers to add to the WebSocket request.
- * @param subprotocol A WebSocket subprotocol if required.
+ * @param subprotocol WebSocket subprotocols (comma separated) if required.
  */
 final case class WebSocketRequest(
   uri:          Uri,
@@ -23,4 +23,14 @@ final case class WebSocketRequest(
 object WebSocketRequest {
   implicit def fromTargetUri(uri: Uri): WebSocketRequest = WebSocketRequest(uri)
   implicit def fromTargetUriString(uriString: String): WebSocketRequest = WebSocketRequest(uriString)
+
+  def apply(
+    uri:          Uri,
+    extraHeaders: immutable.Seq[HttpHeader],
+    subprotocols: immutable.Seq[String]): WebSocketRequest =
+    WebSocketRequest(
+      uri,
+      extraHeaders,
+      if (subprotocols.nonEmpty) Some(subprotocols.mkString(",")) else None
+    )
 }


### PR DESCRIPTION
Currently passing multiple websockets subprotocols in `Sec-WebSocket-Protocol` header is not supported (see https://github.com/akka/akka-http/issues/2606). This PR makes it possible to do so, passing them separated by comma in `subprotocol: Option[String]` field of the [`WebSocketRequest`](https://github.com/akka/akka-http/blob/master/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/WebSocketRequest.scala#L22) model. This corresponds to the `Sec-WebSocket-Protocol` header definition in [RFC 6455](https://tools.ietf.org/html/rfc6455#section-11.3.4)

A better solution would be to change the `WebSocketRequest` model to accept a `subprotocols: Seq[String]` field, but that would break compatibility with current client code. If it, nevertheless, makes sense to do this change, please let us know - we are happy to submit a corresponding PR.

References https://github.com/akka/akka-http/issues/2606