### PR TITLE
Reduced some scalac warnings.

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -465,7 +465,7 @@ private[http] object HttpHeaderParser {
     if (settings.illegalHeaderWarnings)
       info => logParsingError(info withSummaryPrepended "Illegal header", log, settings.errorLoggingVerbosity, settings.ignoreIllegalHeaderFor)
     else
-      (_: ErrorInfo) => _ // Does exactly what the label says - nothing
+      (_: ErrorInfo) => () // Does exactly what the label says - nothing
 
   def unprimed(settings: HttpHeaderParser.Settings, log: LoggingAdapter, warnOnIllegalHeader: ErrorInfo => Unit) =
     new HttpHeaderParser(settings, log, warnOnIllegalHeader)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -213,6 +213,7 @@ object HttpMessage {
     protocol match {
       case HttpProtocols.`HTTP/1.1` => connectionHeader.isDefined && connectionHeader.get.hasClose
       case HttpProtocols.`HTTP/1.0` => connectionHeader.isEmpty || !connectionHeader.get.hasKeepAlive
+      case _                        => throw new UnsupportedOperationException(protocol.value + " is unsupported.")
     }
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -213,7 +213,7 @@ object HttpMessage {
     protocol match {
       case HttpProtocols.`HTTP/1.1` => connectionHeader.isDefined && connectionHeader.get.hasClose
       case HttpProtocols.`HTTP/1.0` => connectionHeader.isEmpty || !connectionHeader.get.hasKeepAlive
-      case _                        => throw new UnsupportedOperationException(protocol.value + " is unsupported.")
+      case _                        => throw new UnsupportedOperationException(s"HttpMessage does not support ${protocol.value}.")
     }
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -358,7 +358,10 @@ object Multipart {
     /** INTERNAL API */
     @InternalApi
     private[akka] def createStrict(fields: Map[String, akka.http.javadsl.model.HttpEntity.Strict]): Multipart.FormData.Strict = Multipart.FormData.Strict {
-      fields.iterator.map { case (name, entity: akka.http.scaladsl.model.HttpEntity.Strict) => Multipart.FormData.BodyPart.Strict(name, entity) }.to(scala.collection.immutable.IndexedSeq)
+      fields.iterator.map {
+        case (name, entity: akka.http.scaladsl.model.HttpEntity.Strict) => Multipart.FormData.BodyPart.Strict(name, entity)
+        case _ => throw new UnsupportedOperationException("must strict")
+      }.to(scala.collection.immutable.IndexedSeq)
     }
     /** INTERNAL API */
     @InternalApi

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -360,7 +360,7 @@ object Multipart {
     private[akka] def createStrict(fields: Map[String, akka.http.javadsl.model.HttpEntity.Strict]): Multipart.FormData.Strict = Multipart.FormData.Strict {
       fields.iterator.map {
         case (name, entity: akka.http.scaladsl.model.HttpEntity.Strict) => Multipart.FormData.BodyPart.Strict(name, entity)
-        case _ => throw new UnsupportedOperationException("must strict")
+        case _ => throw new IllegalStateException("Entity is expected to be strict.")
       }.to(scala.collection.immutable.IndexedSeq)
     }
     /** INTERNAL API */

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/DebuggingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/DebuggingDirectives.scala
@@ -34,7 +34,7 @@ abstract class DebuggingDirectives extends CookieDirectives {
    * @param level One of the log levels defined in akka.event.Logging
    */
   def logRequest(marker: String, level: LogLevel, inner: Supplier[Route]): Route = RouteAdapter {
-    D.logRequest(marker, level) { inner.get.delegate }
+    D.logRequest(marker -> level) { inner.get.delegate }
   }
 
   /**
@@ -57,7 +57,7 @@ abstract class DebuggingDirectives extends CookieDirectives {
    * @param level One of the log levels defined in akka.event.Logging
    */
   def logResult(marker: String, level: LogLevel, inner: Supplier[Route]): Route = RouteAdapter {
-    D.logResult(marker, level) { inner.get.delegate }
+    D.logResult(marker -> level) { inner.get.delegate }
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/DebuggingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/DebuggingDirectives.scala
@@ -34,7 +34,7 @@ abstract class DebuggingDirectives extends CookieDirectives {
    * @param level One of the log levels defined in akka.event.Logging
    */
   def logRequest(marker: String, level: LogLevel, inner: Supplier[Route]): Route = RouteAdapter {
-    D.logRequest(marker -> level) { inner.get.delegate }
+    D.logRequest((marker, level)) { inner.get.delegate }
   }
 
   /**
@@ -57,7 +57,7 @@ abstract class DebuggingDirectives extends CookieDirectives {
    * @param level One of the log levels defined in akka.event.Logging
    */
   def logResult(marker: String, level: LogLevel, inner: Supplier[Route]): Route = RouteAdapter {
-    D.logResult(marker -> level) { inner.get.delegate }
+    D.logResult((marker, level)) { inner.get.delegate }
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/StrictForm.scala
@@ -65,9 +65,9 @@ object StrictForm {
           fsu(value.entity.data.decodeString(charsetName))
       })
 
-    @implicitNotFound(msg =
-      s"In order to unmarshal a `StrictForm.Field` to type `$${T}` you need to supply a " +
-        s"`FromStringUnmarshaller[$${T}]` and/or a `FromEntityUnmarshaller[$${T}]`")
+    @implicitNotFound(
+      "In order to unmarshal a `StrictForm.Field` to type `${T}` you need to supply a " +
+        "`FromStringUnmarshaller[${T}]` and/or a `FromEntityUnmarshaller[${T}]`")
     sealed trait FieldUnmarshaller[T] {
       def unmarshalString(value: String)(implicit ec: ExecutionContext, mat: Materializer): Future[T]
       def unmarshalPart(value: Multipart.FormData.BodyPart.Strict)(implicit ec: ExecutionContext, mat: Materializer): Future[T]

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -314,7 +314,7 @@ object Credentials {
         new Credentials.Provided(token) {
           def verify(secret: String, hasher: String => String): Boolean = secret secure_== hasher(token)
         }
-      case Some(GenericHttpCredentials(scheme, token, params)) =>
+      case Some(_: HttpCredentials) =>
         throw new UnsupportedOperationException("cannot verify generic HTTP credentials")
       case None => Credentials.Missing
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -314,8 +314,8 @@ object Credentials {
         new Credentials.Provided(token) {
           def verify(secret: String, hasher: String => String): Boolean = secret secure_== hasher(token)
         }
-      case Some(_: HttpCredentials) =>
-        throw new UnsupportedOperationException("cannot verify generic HTTP credentials")
+      case Some(c) =>
+        throw new UnsupportedOperationException(s"Credentials does not support $c.")
       case None => Credentials.Missing
     }
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -315,7 +315,7 @@ object Credentials {
           def verify(secret: String, hasher: String => String): Boolean = secret secure_== hasher(token)
         }
       case Some(c) =>
-        throw new UnsupportedOperationException(s"Credentials does not support $c.")
+        throw new UnsupportedOperationException(s"Credentials does not support scheme '${c.scheme}'.")
       case None => Credentials.Missing
     }
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/TimeoutDirectives.scala
@@ -82,7 +82,7 @@ trait TimeoutDirectives {
           }
         case _ => ctx.log.warning("withRequestTimeout was used in route however no request-timeout is set!")
       }
-      inner()(ctx)
+      inner(())(ctx)
     }
 
   /**
@@ -100,7 +100,7 @@ trait TimeoutDirectives {
         case Some(t) => t.timeoutAccess.updateHandler(handler)
         case _       => ctx.log.warning("withRequestTimeoutResponse was used in route however no request-timeout is set!")
       }
-      inner()(ctx)
+      inner(())(ctx)
     }
 
 }

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -140,7 +140,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
         maybeFinishStream(h.endStream)
 
       case _: ContinuationFrame | _: HeadersFrame | _: PriorityFrame | _: PushPromiseFrame | _: UnknownFrameEvent | _: WindowUpdateFrame =>
-        throw new UnsupportedOperationException(event.frameTypeName + " is unsupported.")
+        throw new UnsupportedOperationException(s"${this.getClass.getName} does not support ${event.frameTypeName}.")
     }
 
     protected def maybeFinishStream(endStream: Boolean): IncomingStreamState =

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -139,8 +139,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
 
         maybeFinishStream(h.endStream)
 
-      case _: ContinuationFrame | _: HeadersFrame | _: PriorityFrame | _: PushPromiseFrame | _: UnknownFrameEvent | _: WindowUpdateFrame =>
-        throw new UnsupportedOperationException(s"${this.getClass.getName} does not support ${event.frameTypeName}.")
+      case _ => throw new IllegalStateException(s"Unexpected frame type ${event.frameTypeName} in state ${this.getClass.getName}.")
     }
 
     protected def maybeFinishStream(endStream: Boolean): IncomingStreamState =

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -138,6 +138,9 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
         } else pushGOAWAY(Http2Protocol.ErrorCode.PROTOCOL_ERROR, "Got unexpected mid-stream HEADERS frame")
 
         maybeFinishStream(h.endStream)
+
+      case _: ContinuationFrame | _: HeadersFrame | _: PriorityFrame | _: PushPromiseFrame | _: UnknownFrameEvent | _: WindowUpdateFrame =>
+        throw new UnsupportedOperationException(event.frameTypeName + " is unsupported.")
     }
 
     protected def maybeFinishStream(endStream: Boolean): IncomingStreamState =

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
@@ -19,7 +19,7 @@ import FrameEvent._
 /** INTERNAL API */
 @InternalApi
 private[http2] object FrameRenderer {
-  implicit val byteOrder = ByteOrder.BIG_ENDIAN
+  implicit val byteOrder: ByteOrder = ByteOrder.BIG_ENDIAN
 
   def render(frame: FrameEvent): ByteString =
     frame match {
@@ -139,6 +139,8 @@ private[http2] object FrameRenderer {
           streamId,
           renderPriorityInfo(frame)
         )
+      case _: ParsedHeadersFrame | _: UnknownFrameEvent =>
+        throw new UnsupportedOperationException(frame.frameTypeName + "is unsupported")
     }
 
   def renderFrame(tpe: FrameType, flags: ByteFlag, streamId: Int, payload: ByteString): ByteString = {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
@@ -139,8 +139,7 @@ private[http2] object FrameRenderer {
           streamId,
           renderPriorityInfo(frame)
         )
-      case _: ParsedHeadersFrame | _: UnknownFrameEvent =>
-        throw new UnsupportedOperationException(frame.frameTypeName + "is unsupported")
+      case _ => throw new IllegalStateException(s"Unexpected frame type ${frame.frameTypeName}.")
     }
 
   def renderFrame(tpe: FrameType, flags: ByteFlag, streamId: Int, payload: ByteString): ByteString = {

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -7,12 +7,12 @@ package akka.http.scaladsl
 import akka.actor.{ ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
 import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
-import akka.http.impl.engine.http2.{ ProtocolSwitch, Http2AlpnSupport, Http2Blueprint, Http2Protocol }
+import akka.http.impl.engine.http2.{ ProtocolSwitch, Http2AlpnSupport, Http2Blueprint }
 import akka.http.impl.engine.server.MasterServerTerminator
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.TLSProtocol.{ SessionBytes, SslTlsInbound, SslTlsOutbound }
+import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
 import akka.stream.scaladsl.{ BidiFlow, Flow, Keep, Sink, TLS, TLSPlacebo, Tcp }
 import akka.stream.{ IgnoreComplete, Materializer }
 import akka.util.ByteString

--- a/akka-parsing/src/main/scala/akka/parboiled2/CharPredicate.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/CharPredicate.scala
@@ -41,8 +41,8 @@ sealed abstract class CharPredicate extends (Char => Boolean) {
 
   def ++(char: Char): CharPredicate = this ++ (char :: Nil)
   def --(char: Char): CharPredicate = this -- (char :: Nil)
-  def ++(chars: String): CharPredicate = this ++ chars.toCharArray
-  def --(chars: String): CharPredicate = this -- chars.toCharArray
+  def ++(chars: String): CharPredicate = this ++ chars.toIndexedSeq
+  def --(chars: String): CharPredicate = this -- chars.toIndexedSeq
 
   def intersect(that: CharPredicate): CharPredicate
 
@@ -124,7 +124,7 @@ object CharPredicate {
   object ApplyMagnet {
     implicit def fromPredicate(predicate: Char => Boolean): ApplyMagnet = new ApplyMagnet(from(predicate))
     implicit def fromChar(c: Char): ApplyMagnet = fromChars(c :: Nil)
-    implicit def fromCharArray(array: Array[Char]): ApplyMagnet = fromChars(array)
+    implicit def fromCharArray(array: Array[Char]): ApplyMagnet = fromChars(array.toIndexedSeq)
     implicit def fromString(chars: String): ApplyMagnet = fromChars(chars)
     implicit def fromChars(chars: Seq[Char]): ApplyMagnet =
       chars match {
@@ -244,7 +244,7 @@ object CharPredicate {
 
     def ++(that: CharPredicate): CharPredicate = that match {
       case Empty         => this
-      case x: ArrayBased => this ++ x.chars
+      case x: ArrayBased => this ++ x.chars.toIndexedSeq
       case _             => this or that
     }
 
@@ -254,7 +254,7 @@ object CharPredicate {
 
     def --(that: CharPredicate): CharPredicate = that match {
       case Empty         => this
-      case x: ArrayBased => this -- x.chars
+      case x: ArrayBased => this -- x.chars.toIndexedSeq
       case _             => this andNot that
     }
 

--- a/akka-parsing/src/main/scala/akka/parboiled2/ErrorFormatter.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/ErrorFormatter.scala
@@ -187,7 +187,7 @@ class ErrorFormatter(
    */
   def formatTraces(error: ParseError): String = {
     import error._
-    traces.map(formatTrace(_, position.index)).mkString(traces.size + " rule" + (if (traces.size != 1) "s" else "") +
+    traces.map(formatTrace(_, position.index)).mkString(s"${traces.size} rule" + (if (traces.size != 1) "s" else "") +
       " mismatched at error location:\n  ", "\n  ", "\n")
   }
 
@@ -238,7 +238,7 @@ class ErrorFormatter(
       case Capture             => "capture"
       case Cut                 => "cut"
       case FirstOf             => "|"
-      case x: IgnoreCaseString => '"' + escape(x.string) + '"'
+      case x: IgnoreCaseString => s""""${escape(x.string)}""""
       case x: MapMatch         => x.map.toString()
       case x: Named            => x.name
       case OneOrMore           => "+"
@@ -248,7 +248,7 @@ class ErrorFormatter(
       case Run                 => "<run>"
       case RunSubParser        => "runSubParser"
       case Sequence            => "~"
-      case x: StringMatch      => '"' + escape(x.string) + '"'
+      case x: StringMatch      => s""""${escape(x.string)}""""
       case x: Times            => "times"
       case ZeroOrMore          => "*"
     }
@@ -260,7 +260,7 @@ class ErrorFormatter(
     import CharUtils.escape
     terminal match {
       case ANY                                       => "ANY"
-      case AnyOf(s)                                  => '[' + escape(s) + ']'
+      case AnyOf(s)                                  => s"[${escape(s)}]"
       case CharMatch(c)                              => "'" + escape(c) + '\''
       case CharPredicateMatch(_)                     => "<CharPredicate>"
       case CharRange(from, to)                       => s"'${escape(from)}'-'${escape(to)}'"


### PR DESCRIPTION
- match may not be exhaustive.
- Unused import.
- Invalid implicitNotFound message.
- Adapting argument list.
- method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated.
- Adding a number and a String is deprecated.