### PR TITLE
Ignore FormFieldDirective incompatibility in 2.13

### DIFF
--- a/akka-http-compatibility-tests/src/test/scala/akka/http/scaladsl/server/directives/CompatFormFieldSpec.scala
+++ b/akka-http-compatibility-tests/src/test/scala/akka/http/scaladsl/server/directives/CompatFormFieldSpec.scala
@@ -5,13 +5,14 @@
 package akka.http.scaladsl.server
 package directives
 
+import akka.http.ccompat.pre213
+import akka.http.ccompat.since213
 import akka.http.scaladsl.model.FormData
 import akka.http.scaladsl.server.RoutingSpec
 
 class CompatFormFieldSpec extends RoutingSpec {
-
-  "FormFieldDirectives" should {
-    "be compatible" should {
+  def test(): Unit =
+    if (!scala.util.Properties.versionNumberString.startsWith("2.13")) {
       "for one parameter" in {
         val req = Post("/", FormData("num" -> "12"))
         req ~> CompatFormField.oneParameter(echoComplete) ~> check {
@@ -31,6 +32,12 @@ class CompatFormFieldSpec extends RoutingSpec {
           responseAs[String] shouldEqual "Aloisia 12"
         }
       }
+    } else
+      "ignore incompatiblity in 2.13" in succeed
+
+  "FormFieldDirectives" should {
+    "be compatible" should {
+      test()
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -365,7 +365,10 @@ lazy val compatibilityTests = Project("akka-http-compatibility-tests", file("akk
   .enablePlugins(NoPublish)
   .disablePlugins(BintrayPlugin, MimaPlugin)
   .settings(
-    libraryDependencies += "com.typesafe.akka" %% "akka-http" % "10.1.8" % "provided", // TODO, should we make that latest?
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-stream" % AkkaDependency.akkaVersion,
+      "com.typesafe.akka" %% "akka-http" % "10.1.8" % "provided", // TODO, should we make that latest?
+    ),
     (dependencyClasspath in Test) := {
       // HACK: We'd like to use `dependsOn(http % "test->compile")` to upgrade the explicit dependency above to the
       //       current version but that fails. So, this is a manual `dependsOn` which works as expected.


### PR DESCRIPTION
And add missing dependency on akka-stream to make it compile with Scala 2.11

Refs #2612 