### PR TITLE
core: pull transformDataBytes(newContentLength, transformer) up to HttpEntity

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.9.backwards.excludes/issue-2603-lift-transformDataBytes.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.9.backwards.excludes/issue-2603-lift-transformDataBytes.excludes
@@ -1,0 +1,4 @@
+# Scala 2.11 only problem
+# HttpEntity is sealed, so a compatibility problem would only occur if a Java user would have implemented
+# scaladsl.model.HttpEntity
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpEntity.transformDataBytes")


### PR DESCRIPTION
It can work on any kind of entity and will always return a Universal entity.

Refs #2603.