### PR TITLE
Widen JavaUUID regexp's

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -208,7 +208,9 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
     val test = testFor(pathPrefix(JavaUUID) { echoCaptureAndUnmatchedPath })
     "accept [/bdea8652-f26c-40ca-8157-0b96a2a8389d]" inThe test("bdea8652-f26c-40ca-8157-0b96a2a8389d:")
     "accept [/bdea8652-f26c-40ca-8157-0b96a2a8389dyes]" inThe test("bdea8652-f26c-40ca-8157-0b96a2a8389d:yes")
-    "accept [/00000000-0000-0000-0000-000000000000]" inThe test("00000000-0000-0000-0000-000000000000:")
+    "accept [/00000000-0000-0000-0000-000000000000]" inThe test("00000000-0000-0000-0000-000000000000:") // nil uuid
+    "accept [/733a018b-5f16-4699-0e1a-1d3f6f0d0315]" inThe test("733a018b-5f16-4699-0e1a-1d3f6f0d0315:") // variant 0
+    "accept [/733a018b-5f16-4699-fe1a-1d3f6f0d0315]" inThe test("733a018b-5f16-4699-fe1a-1d3f6f0d0315:") // future variant
     "reject [/]" inThe test()
     "reject [/abc]" inThe test()
   }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -46,6 +46,14 @@ class UnmarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll wi
       val uuid = UUID.randomUUID()
       Unmarshal(uuid.toString).to[UUID] should evaluateTo(uuid)
     }
+    "uuidUnmarshaller should unmarshal variant 0 uuid" in {
+      val uuid = UUID.fromString("733a018b-5f16-4699-0e1a-1d3f6f0d0315")
+      Unmarshal(uuid.toString).to[UUID] should evaluateTo(uuid)
+    }
+    "uuidUnmarshaller should unmarshal future variant uuid" in {
+      val uuid = UUID.fromString("733a018b-5f16-4699-fe1a-1d3f6f0d0315")
+      Unmarshal(uuid.toString).to[UUID] should evaluateTo(uuid)
+    }
     "uuidUnmarshaller should unmarshal nil uuid" in {
       Unmarshal("00000000-0000-0000-0000-000000000000").to[UUID] should evaluateTo(UUID.fromString("00000000-0000-0000-0000-000000000000"))
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/PathMatcher.scala
@@ -486,7 +486,7 @@ trait PathMatchers {
    * @group pathmatcher
    */
   val JavaUUID: PathMatcher1[UUID] =
-    PathMatcher("""[\da-fA-F]{8}-[\da-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][\da-fA-F]{3}-[\da-fA-F]{12}|00000000-0000-0000-0000-000000000000""".r)
+    PathMatcher("""[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}""".r)
       .map(UUID.fromString)
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/PredefinedFromStringUnmarshallers.scala
@@ -47,7 +47,7 @@ trait PredefinedFromStringUnmarshallers {
 
   implicit val uuidFromStringUnmarshaller: Unmarshaller[String, UUID] = {
     val validUuidPattern =
-      "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000".r.pattern
+      """[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}""".r.pattern
 
     Unmarshaller.strict[String, UUID] { string =>
       if (validUuidPattern.matcher(string).matches)


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

Widen JavaUUID regex's (again) to allow for old and future variants of uuid's (described in chapter 4.1.1 of [RFC 4122](https://tools.ietf.org/html/rfc4122).

## References

Following-up after #2569 and #2596. Thanks to @plokhotnyuk for pointing this out in https://github.com/spray/spray-json/pull/313.