### PR TITLE
Plaintext connection to https endpoint hangs on jdk11: reproducer

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -1005,12 +1005,11 @@ Host: example.com
       val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
       val request = HttpRequest(uri = s"http://$hostname:$port", headers = headers.Connection("close") :: Nil)
 
-      val serverConnectionContext = ExampleHttpContexts.exampleServerContext
-
-      val routes: Flow[HttpRequest, HttpResponse, Any] = Flow[HttpRequest].map { _ => ??? }
       val serverBinding =
         Http()
-          .bindAndHandle(routes, hostname, port, connectionContext = serverConnectionContext)
+          .newServerAt(hostname, port)
+          .enableHttps(ExampleHttpContexts.exampleServerContext)
+          .bind(_ => ???)
           .futureValue
 
       val failure = Http()
@@ -1020,7 +1019,8 @@ Host: example.com
 
       failure.getMessage should include("Connection reset by peer")
 
-      serverBinding.unbind()
+      serverBinding.unbind().futureValue
+      Http().shutdownAllConnectionPools()
     }
 
   }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -1017,7 +1017,10 @@ Host: example.com
         .failed
         .futureValue
 
-      failure.getMessage should include("Connection reset by peer")
+      if (failure.getMessage.contains("Connection reset by peer"))
+        fail("It seems #1219 was fixed, please update the test accordingly")
+      else
+        pending
 
       serverBinding.unbind().futureValue
       Http().shutdownAllConnectionPools()


### PR DESCRIPTION
Refs #2614

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
