### PR TITLE
Better error handling on server when response entity stream fails

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -179,9 +179,11 @@ private[http] object StreamUtils {
       override def onDownstreamFinish(): Unit = {
         cancelAfter match {
           case finite: FiniteDuration =>
+            log.debug(s"Delaying cancellation for $finite")
             timeout = OptionVal.Some {
               scheduleOnce(finite) {
                 log.debug(s"Stage was canceled after delay of $cancelAfter")
+                timeout = OptionVal.None
                 completeStage()
               }
             }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
@@ -18,6 +18,7 @@ import scala.util.{ Failure, Success }
 import scala.util.matching.Regex
 import akka.util.ByteString
 import akka.actor._
+import akka.http.impl.engine.parsing.ParserOutput.RequestStart
 import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
 
 package object util {
@@ -76,6 +77,9 @@ package object util {
 
   private[http] implicit class RichHttpRequest(val request: HttpRequest) extends AnyVal {
     def debugString: String = s"${request.method.value} ${request.uri.path} ${entityDebugInfo(request.entity)}"
+  }
+  private[http] implicit class RichRequestStart(val request: RequestStart) extends AnyVal {
+    def debugString: String = s"${request.method.value} ${request.uri.path}"
   }
   private[http] implicit class RichHttpResponse(val response: HttpResponse) extends AnyVal {
     def debugString: String = s"${response.status.value} ${entityDebugInfo(response.entity)}"

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -116,6 +116,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def mapParserSettings(f: ParserSettings => ParserSettings): ServerSettings = withParserSettings(f(parserSettings))
   def mapPreviewServerSettings(f: PreviewServerSettings => PreviewServerSettings): ServerSettings = withPreviewServerSettings(f(previewServerSettings))
   def mapWebsocketSettings(f: WebSocketSettings => WebSocketSettings): ServerSettings = withWebsocketSettings(f(websocketSettings))
+  def mapTimeouts(f: ServerSettings.Timeouts => ServerSettings.Timeouts): ServerSettings = withTimeouts(f(timeouts))
 }
 
 object ServerSettings extends SettingsCompanion[ServerSettings] {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -10,7 +10,6 @@ import akka.stream.TLSProtocol._
 
 import scala.concurrent.duration.FiniteDuration
 import akka.actor.ActorSystem
-import akka.event.NoLogging
 import akka.util.ByteString
 import akka.stream._
 import akka.stream.scaladsl._
@@ -37,7 +36,7 @@ abstract class HttpServerTestSetupBase {
     val netIn = TestPublisher.probe[ByteString]()
     val netOut = ByteStringSinkProbe()
 
-    RunnableGraph.fromGraph(GraphDSL.create(modifyServer(HttpServerBluePrint(settings, log = NoLogging, isSecureConnection = false))) { implicit b => server =>
+    RunnableGraph.fromGraph(GraphDSL.create(modifyServer(Http().serverLayer(settings))) { implicit b => server =>
       import GraphDSL.Implicits._
       Source.fromPublisher(netIn) ~> Flow[ByteString].map(SessionBytes(null, _)) ~> server.in2
       server.out1 ~> Flow[SslTlsOutbound].collect { case SendBytes(x) => x }.buffer(1, OverflowStrategy.backpressure) ~> netOut.sink


### PR DESCRIPTION
I.e.

 * when materializing the response entity stream fails: return a 500 response
 * when streaming itself fails: abort the connection 

Refs #848, #894.