### PR TITLE
Force connection closure when pool is stopped

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -564,7 +564,7 @@ private[client] object NewHostConnectionPool {
         }
         override def postStop(): Unit = {
           slots.foreach(_.shutdown())
-          log.warning(s"Pool stopped")
+          log.debug(s"Pool stopped")
         }
 
         private def willClose(response: HttpResponse): Boolean =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -191,12 +191,12 @@ private[pool] object SlotState {
   private[pool] case object OutOfEmbargo extends UnconnectedState
   private[pool] case object Unconnected extends UnconnectedState
 
-  private[pool] abstract class ShouldCloseConnectionState(val closeRegularly: Boolean) extends SlotState {
+  private[pool] abstract class ShouldCloseConnectionState(val failure: Option[Throwable]) extends SlotState {
     override def isIdle: Boolean = false
     override def isConnected: Boolean = false
   }
-  private[pool] case object ToBeClosed extends ShouldCloseConnectionState(closeRegularly = true)
-  private[pool] case class Failed(cause: Throwable) extends ShouldCloseConnectionState(closeRegularly = false)
+  private[pool] case object ToBeClosed extends ShouldCloseConnectionState(None)
+  private[pool] case class Failed(cause: Throwable) extends ShouldCloseConnectionState(Some(cause))
 
   private[pool] case object Idle extends ConnectedState with IdleState {
     override def onNewRequest(ctx: SlotContext, requestContext: RequestContext): SlotState =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -5,6 +5,7 @@
 package akka.http.impl.engine.client.pool
 
 import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.TimeoutException
 
 import akka.annotation.InternalApi
 import akka.http.impl.engine.client.PoolFlow.RequestContext
@@ -144,7 +145,7 @@ private[pool] object SlotState {
       if (ongoingRequest.canBeRetried) { // push directly because it will be buffered internally
         ctx.dispatchResponseResult(ongoingRequest, Failure(cause))
         if (waitingForEndOfRequestEntity) WaitingForEndOfRequestEntity
-        else Unconnected
+        else Failed(cause)
       } else
         WaitingForResponseDispatch(ongoingRequest, Failure(cause), waitingForEndOfRequestEntity)
     }
@@ -190,12 +191,19 @@ private[pool] object SlotState {
   private[pool] case object OutOfEmbargo extends UnconnectedState
   private[pool] case object Unconnected extends UnconnectedState
 
+  private[pool] abstract class ShouldCloseConnectionState(val closeRegularly: Boolean) extends SlotState {
+    override def isIdle: Boolean = false
+    override def isConnected: Boolean = false
+  }
+  private[pool] case object ToBeClosed extends ShouldCloseConnectionState(closeRegularly = true)
+  private[pool] case class Failed(cause: Throwable) extends ShouldCloseConnectionState(closeRegularly = false)
+
   private[pool] case object Idle extends ConnectedState with IdleState {
     override def onNewRequest(ctx: SlotContext, requestContext: RequestContext): SlotState =
       PushingRequestToConnection(requestContext)
 
-    override def onConnectionCompleted(ctx: SlotContext): SlotState = Unconnected
-    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = Unconnected
+    override def onConnectionCompleted(ctx: SlotContext): SlotState = ToBeClosed
+    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = ToBeClosed
   }
   private[pool] final case class Connecting(ongoingRequest: RequestContext) extends ConnectedState with BusyState {
     val waitingForEndOfRequestEntity = false
@@ -231,7 +239,7 @@ private[pool] object SlotState {
 
     private def onConnectionFailure(ctx: SlotContext, signal: String, cause: Throwable): SlotState = {
       ctx.debug("Connection was closed by [{}] while preconnecting because of [{}].", signal, cause.getMessage)
-      Unconnected
+      Failed(cause)
     }
   }
   final case class PushingRequestToConnection(ongoingRequest: RequestContext) extends ConnectedState with BusyState {
@@ -271,7 +279,7 @@ private[pool] object SlotState {
 
       result match {
         case Success(res)   => WaitingForResponseEntitySubscription(ongoingRequest, res, ctx.settings.responseEntitySubscriptionTimeout, waitingForEndOfRequestEntity)
-        case Failure(cause) => Unconnected
+        case Failure(cause) => Failed(cause)
       }
     }
   }
@@ -280,7 +288,7 @@ private[pool] object SlotState {
     override def onResponseEntityFailed(ctx: SlotContext, cause: Throwable): SlotState = {
       ctx.debug(s"Response entity for request [{}] failed with [{}]", ongoingRequest.request.debugString, cause.getMessage)
       // response must have already been dispatched, so don't try to dispatch a response
-      Unconnected
+      Failed(cause)
     }
 
     // ignore since we already accepted the request
@@ -302,10 +310,11 @@ private[pool] object SlotState {
       WaitingForEndOfResponseEntity(ongoingRequest, ongoingResponse, waitingForEndOfRequestEntity)
 
     override def onTimeout(ctx: SlotContext): SlotState = {
-      ctx.warning(
+      val msg =
         s"Response entity was not subscribed after $stateTimeout. Make sure to read the response entity body or call `discardBytes()` on it. " +
-          s"${ongoingRequest.request.debugString} -> ${ongoingResponse.debugString}")
-      Unconnected
+          s"${ongoingRequest.request.debugString} -> ${ongoingResponse.debugString}"
+      ctx.warning(msg) // FIXME: should still warn here?
+      Failed(new TimeoutException(msg))
     }
 
   }
@@ -318,7 +327,7 @@ private[pool] object SlotState {
       if (waitingForEndOfRequestEntity)
         WaitingForEndOfRequestEntity
       else if (ctx.willCloseAfter(ongoingResponse) || ctx.isConnectionClosed)
-        Unconnected
+        ToBeClosed // when would ctx.isConnectionClose be true? what that mean that the connection has already failed before? do we need that state at all?
       else
         Idle
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -32,6 +32,7 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 import scala.util.Failure
+import scala.util.Try
 
 /**
  * Tests the host connection pool infrastructure.
@@ -83,7 +84,14 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
 
   def testSet(poolImplementation: PoolImplementation, clientServerImplementation: ClientServerImplementation) =
     s"$poolImplementation on $clientServerImplementation" should {
-      "complete a simple request/response cycle with a strict request and response" in new SetupWithServerProbes {
+      implicit class EnhancedIn(name: String) {
+        def inWithShutdown(body: => TestSetup): Unit = name in {
+          val res = body
+          Try(res.shutdown())
+        }
+      }
+
+      "complete a simple request/response cycle with a strict request and response" inWithShutdown new SetupWithServerProbes {
         pushRequest(HttpRequest(uri = "/simple"))
 
         val conn1 = expectNextConnection()
@@ -91,7 +99,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         conn1.pushResponse(HttpResponse(entity = req.uri.path.toString))
         expectResponseEntityAsString() shouldEqual "/simple"
       }
-      "complete a simple request/response cycle with a chunked request and response" in new SetupWithServerProbes {
+      "complete a simple request/response cycle with a chunked request and response" inWithShutdown new SetupWithServerProbes {
         val reqBody = Source("Hello" :: " World" :: Nil map ByteString.apply)
         pushRequest(HttpRequest(uri = "/simple", entity = HttpEntity.Chunked.fromData(ContentTypes.`application/octet-stream`, reqBody)))
 
@@ -109,7 +117,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         resBodyIn.request(1) // FIXME: should we support eager completion here? (reason is substreamHandler in PrepareResponse)
         resBodyIn.expectComplete()
       }
-      "complete a request/response cycle with a chunked request and response with dependent entity bytes" in new SetupWithServerProbes {
+      "complete a request/response cycle with a chunked request and response with dependent entity bytes" inWithShutdown new SetupWithServerProbes {
         val reqBody = Source("Hello" :: " World" :: Nil map ByteString.apply)
         pushRequest(HttpRequest(uri = "/simple", entity = HttpEntity.Chunked.fromData(ContentTypes.`application/octet-stream`, reqBody)))
 
@@ -128,7 +136,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         resBodyIn.request(1) // FIXME: should we support eager completion here? (reason is substreamHandler in PrepareResponse)
         resBodyIn.expectComplete()
       }
-      "open up to max-connections when enough requests are pending" in new SetupWithServerProbes(_.withMaxConnections(2)) {
+      "open up to max-connections when enough requests are pending" inWithShutdown new SetupWithServerProbes(_.withMaxConnections(2)) {
         pushRequest(HttpRequest(uri = "/1"))
         val conn1 = expectNextConnection()
         conn1.expectRequestToPath("/1")
@@ -143,7 +151,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         conn1.expectRequestToPath("/3")
       }
       "only buffer a reasonable number of extra requests" in pending
-      "only send next request when last response entity was read completely" in new SetupWithServerProbes() {
+      "only send next request when last response entity was read completely" inWithShutdown new SetupWithServerProbes() {
         pushRequest(HttpRequest(uri = "/chunked-1"))
         pushRequest(HttpRequest(uri = "/2"))
         val conn1 = expectNextConnection()
@@ -165,7 +173,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
 
         conn1.expectRequestToPath("/2")
       }
-      "time out quickly when response entity stream is not subscribed fast enough" in new SetupWithServerProbes {
+      "time out quickly when response entity stream is not subscribed fast enough" inWithShutdown new SetupWithServerProbes {
         pendingIn(targetImpl = LegacyPoolImplementation) // not implemented in legacy
         pendingIn(targetTrans = PassThrough) // infra seems to be missing something
 
@@ -189,7 +197,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
       "time out when a connection was unused for a long time" in pending
       "time out and reconnect when a request is not handled in time" in pending
       "time out when connection cannot be established" in pending
-      "fail a request if the request entity fails" in new SetupWithServerProbes {
+      "fail a request if the request entity fails" inWithShutdown new SetupWithServerProbes {
         val reqBytesOut = pushChunkedRequest(numRetries = 0)
 
         val conn1 = expectNextConnection()
@@ -208,7 +216,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         //        of properly threading through the context field from request to response
         // responseOut.expectError() // actually, only the response should be failed
       }
-      "fail a request if the connection stream fails while waiting for request entity bytes" in new SetupWithServerProbes {
+      "fail a request if the connection stream fails while waiting for request entity bytes" inWithShutdown new SetupWithServerProbes {
         val reqBytesOut = pushChunkedRequest(HttpRequest(method = HttpMethods.POST), numRetries = 0)
 
         val conn1 = expectNextConnection()
@@ -224,7 +232,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         // reqBytesOut.expectCancellation()
         expectResponseError()
       }
-      "fail a request if the connection stream fails while waiting for a response" in new SetupWithServerProbes {
+      "fail a request if the connection stream fails while waiting for a response" inWithShutdown new SetupWithServerProbes {
         pushRequest(HttpRequest(method = HttpMethods.POST), numRetries = 0)
         val conn1 = expectNextConnection()
         conn1.expectRequest()
@@ -232,7 +240,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         conn1.failConnection(new RuntimeException("solar wind prevented transmission"))
         expectResponseError()
       }
-      "fail a request if the connection stream fails while waiting for response entity bytes" in new SetupWithServerProbes {
+      "fail a request if the connection stream fails while waiting for response entity bytes" inWithShutdown new SetupWithServerProbes {
         pushRequest(HttpRequest(method = HttpMethods.POST), numRetries = 0)
         val conn1 = expectNextConnection()
         conn1.expectRequest()
@@ -247,7 +255,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
 
         // client already received response, no need to report error another time
       }
-      "fail a request if the response entity stream fails during processing" in new SetupWithServerProbes {
+      "fail a request if the response entity stream fails during processing" inWithShutdown new SetupWithServerProbes {
         pushRequest(HttpRequest(method = HttpMethods.POST), numRetries = 0)
         val conn1 = expectNextConnection()
         conn1.expectRequest()
@@ -262,7 +270,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
 
         // client already received response, no need to report error another time
       }
-      "create a new connection when previous one was closed regularly between requests" in new SetupWithServerProbes {
+      "create a new connection when previous one was closed regularly between requests" inWithShutdown new SetupWithServerProbes {
         pendingIn(targetImpl = LegacyPoolImplementation) // flaky test, no reason to debug old client pool issues for now
         pushRequest(HttpRequest(uri = "/simple"))
 
@@ -278,7 +286,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         conn2.pushResponse(HttpResponse(entity = "response"))
         expectResponseEntityAsString() shouldEqual "response"
       }
-      "create a new connection when previous one was closed regularly between requests without sending a `Connection: close` header first" in new SetupWithServerProbes {
+      "create a new connection when previous one was closed regularly between requests without sending a `Connection: close` header first" inWithShutdown new SetupWithServerProbes {
         pendingIn(targetImpl = LegacyPoolImplementation) // flaky test, no reason to debug old client pool issues for now
         pushRequest(HttpRequest(uri = "/simple"))
 
@@ -300,7 +308,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         conn2.pushResponse(HttpResponse(entity = "response"))
         expectResponseEntityAsString() shouldEqual "response"
       }
-      "create a new connection when previous one failed between requests" in new SetupWithServerProbes {
+      "create a new connection when previous one failed between requests" inWithShutdown new SetupWithServerProbes {
         pendingIn(targetImpl = LegacyPoolImplementation) // flaky test, no reason to debug old client pool issues for now
         pushRequest(HttpRequest(uri = "/simple"))
 
@@ -317,7 +325,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         expectResponseEntityAsString() shouldEqual "response"
       }
       "support 100-continue" in pending
-      "without any connections establish the number of configured min-connections" in new SetupWithServerProbes(_.withMaxConnections(2).withMinConnections(1)) {
+      "without any connections establish the number of configured min-connections" inWithShutdown new SetupWithServerProbes(_.withMaxConnections(2).withMinConnections(1)) {
         // expect a new connection immediately
         val conn1 = expectNextConnection()
 
@@ -325,7 +333,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         pushRequest(HttpRequest(uri = "/simple"))
         conn1.expectRequest()
       }
-      "re-establish min-connections when number of open connections falls below threshold" in new SetupWithServerProbes(_.withMaxConnections(2).withMinConnections(1)) {
+      "re-establish min-connections when number of open connections falls below threshold" inWithShutdown new SetupWithServerProbes(_.withMaxConnections(2).withMinConnections(1)) {
         pendingIn(targetImpl = LegacyPoolImplementation) // has failed a few times but I didn't check why exactly
 
         // expect a new connection immediately
@@ -340,7 +348,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
 
         expectNextConnection()
       }
-      "not buffer an unreasonable number of outgoing responses" in new SetupWithServerProbes(_.withMaxConnections(1).withMinConnections(1)) {
+      "not buffer an unreasonable number of outgoing responses" inWithShutdown new SetupWithServerProbes(_.withMaxConnections(1).withMinConnections(1)) {
         val conn1 = expectNextConnection()
 
         def oneCycle(): Unit = {
@@ -354,7 +362,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
           a[Throwable] should be thrownBy oneCycle()
         }
       }
-      "dispatch multiple failures on different slots when request entity fails" in new SetupWithServerProbes(_.withMaxConnections(3)) {
+      "dispatch multiple failures on different slots when request entity fails" inWithShutdown new SetupWithServerProbes(_.withMaxConnections(3)) {
         val req1 = pushChunkedRequest(numRetries = 0)
         val conn1 = expectNextConnection()
         conn1.expectChunkedRequestBytesAsProbe()
@@ -392,7 +400,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
       "provide access to basic metrics as the materialized value" in pending
       "ignore the pipelining setting (for now)" in pending
       "work correctly in the presence of `Connection: close` headers" in pending
-      "if connecting attempt fails, backup the next connection attempts" in {
+      "if connecting attempt fails, backup the next connection attempts" inWithShutdown {
         @volatile var shouldFail = true
         val connectionCounter = new AtomicInteger()
 
@@ -496,6 +504,11 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
 
         def expectResponseError(): Throwable =
           responseOut.requestNext().response.failed.get
+
+        def shutdown(): Unit = {
+          requestIn.sendError(new RuntimeException("TestSetup.shutdown"))
+          responseOut.expectError()
+        }
       }
 
       class SetupWithServerProbes(changeSettings: ConnectionPoolSettings => ConnectionPoolSettings = identity) extends TestSetup {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
@@ -56,7 +56,7 @@ class SlotStateSpec extends AkkaSpec {
       state should be(Idle)
 
       state = state.onConnectionCompleted(context)
-      state should be(Unconnected)
+      state should be(ToBeClosed)
     }
 
     "allow postponing completing the request until just after the response was received" in {


### PR DESCRIPTION
Otherwise, those connections might hang around for a while when a request is ongoing and the client flow isn't expecting or reacting to completion or cancellation.