### PR TITLE
Fix compilation in 2.11

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -32,11 +32,10 @@ class GracefulTerminationSpec
     akka.http.server.log-unencrypted-network-bytes = 200
     akka.http.client.log-unencrypted-network-bytes = 200
                                                    """)
-  with Matchers with BeforeAndAfterAll with ScalaFutures
   with Tolerance with Eventually {
   implicit lazy val dispatcher = system.dispatcher
 
-  implicit override val patience = PatienceConfig(5.seconds.dilated, 200.millis)
+  implicit override val patience = PatienceConfig(5.seconds.dilated(system), 200.millis)
 
   "Graceful termination" should {
 


### PR DESCRIPTION
For some reason 2.11.12 cannot pick up the implicit system provided by the
super class at this position.