### PR TITLE
Streamed response processing performance improvements

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.9.backwards.excludes/response-rendering-performance-improvements.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.9.backwards.excludes/response-rendering-performance-improvements.excludes
@@ -1,0 +1,2 @@
+# Changes to internal classes
+ProblemFilters.exclude[Problem]("akka.http.impl.engine.rendering.*")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -82,9 +82,8 @@ private[http] class HttpResponseRendererFactory(
                 push(out, outElement)
                 if (close) completeStage()
               case HeadersAndStreamedEntity(headerData, outStream) =>
-                try {
-                  transfer(headerData, outStream)
-                } catch {
+                try transfer(headerData, outStream)
+                catch {
                   case NonFatal(e) =>
                     transferring = false
                     log.error(e, s"Rendering of response failed because response entity stream materialization failed with '${e.getMessage}'. Sending out 500 response instead.")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
@@ -70,7 +70,7 @@ private[rendering] object RenderSupport {
                         skipEntity: Boolean = false): Source[ByteString, Any] = {
     val messageStart = Source.single(header)
     val messageBytes =
-      if (!skipEntity) (messageStart ++ entityBytes).mapMaterializedValue(_ => ())
+      if (!skipEntity) messageStart ++ entityBytes
       else CancelSecond(messageStart, entityBytes)
     messageBytes
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
@@ -66,15 +66,6 @@ private[rendering] object RenderSupport {
       r ~~ headers.`Content-Type` ~~ ct ~~ CrLf
   }
 
-  def renderByteStrings(header: ByteString, entityBytes: => Source[ByteString, Any],
-                        skipEntity: Boolean = false): Source[ByteString, Any] = {
-    val messageStart = Source.single(header)
-    val messageBytes =
-      if (!skipEntity) messageStart ++ entityBytes
-      else CancelSecond(messageStart, entityBytes)
-    messageBytes
-  }
-
   object ChunkTransformer {
     val flow = Flow.fromGraph(new ChunkTransformer).named("renderChunks")
   }


### PR DESCRIPTION
Culprits were `Future.failed` and `Source.concat`. This improved speed for streamed responses from ~20x slower to only ~10x slower than strict responses (which is still a lot).