### PR TITLE
Prevent extra error log messages when decoded HttpMessage stream fails

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CodingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CodingDirectivesSpec.scala
@@ -115,8 +115,8 @@ class CodingDirectivesSpec extends RoutingSpec with Inside {
       } ~> check { responseAs[String] shouldEqual "Hello" }
     }
     "reject the request content if it has encoding 'gzip' but is corrupt" in {
-      // FIXME this causes both an error and a warning for the same request
-      EventFilter[IllegalRequestException](occurrences = 1).intercept {
+      // make sure there are no extra error logs
+      EventFilter[IllegalRequestException](occurrences = 0).intercept {
         EventFilter.warning(start = "Illegal request", occurrences = 1).intercept {
           Post("/", fromHexDump("000102")) ~> `Content-Encoding`(gzip) ~> {
             decodeRequestWith(Gzip) {
@@ -130,8 +130,8 @@ class CodingDirectivesSpec extends RoutingSpec with Inside {
       }
     }
     "reject truncated gzip request content" in {
-      // FIXME this causes both an error and a warning for the same request
-      EventFilter[IllegalRequestException](occurrences = 1).intercept {
+      // make sure there are no extra error logs
+      EventFilter[IllegalRequestException](occurrences = 0).intercept {
         EventFilter.warning(start = "Illegal request", occurrences = 1).intercept {
           Post("/", helloGzipped.dropRight(2)) ~> `Content-Encoding`(gzip) ~> {
             decodeRequestWith(Gzip) {
@@ -467,8 +467,8 @@ class CodingDirectivesSpec extends RoutingSpec with Inside {
       Post("/", "yes") ~> decodeRequest { echoRequestContent } ~> check { responseAs[String] shouldEqual "yes" }
     }
     "reject the request if it has a `Content-Encoding: deflate` header but the request is encoded with Gzip" in {
-      // FIXME this causes both an error and a warning for the same request
-      EventFilter[IllegalRequestException](occurrences = 1).intercept {
+      // make sure there are no extra error logs
+      EventFilter[IllegalRequestException](occurrences = 0).intercept {
         EventFilter.warning(start = "Illegal request", occurrences = 1).intercept {
           Post("/", helloGzipped) ~> `Content-Encoding`(deflate) ~>
             decodeRequest {

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Decoder.scala
@@ -13,19 +13,15 @@ import headers.HttpEncoding
 import akka.stream.scaladsl.{ Flow, Sink, Source }
 
 import scala.concurrent.Future
-import scala.util.control.NonFatal
 
 trait Decoder {
   def encoding: HttpEncoding
 
   def decodeMessage(message: HttpMessage): message.Self =
     if (message.headers exists Encoder.isContentEncodingHeader)
-      message.transformEntityDataBytes(decoderFlow.recover {
-        case NonFatal(e) =>
-          throw IllegalRequestException(
-            StatusCodes.BadRequest,
-            ErrorInfo("The request's encoding is corrupt", e.getMessage))
-      }).withHeaders(message.headers filterNot Encoder.isContentEncodingHeader)
+      message
+        .transformEntityDataBytes(decoderFlow)
+        .withHeaders(message.headers filterNot Encoder.isContentEncodingHeader)
     else message.self
 
   def decodeData[T](t: T)(implicit mapper: DataMapper[T]): T = mapper.transformDataBytes(t, decoderFlow)


### PR DESCRIPTION
That happened since the error wrapping logic was moved to Decoder (in #2185) and
now also used for the client side where error handling logic might use
`dicardEntityBytes` which only then triggered the error logging by trying
to read the stream again which would send a "Substream Source cannot be
materialized more than once" exception through the stream which would then
tried to be "recovered" but rethrowing in `recover` would trigger that noisy
error log.

Using `mapError` instead and moving the error handling logic back, prevents
the extra logging. The error is still propagated through the stream.