### PR TITLE
Reduce number of stages needed to implement CaptureMaterializationAndTerminationOp

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -470,7 +470,7 @@ private[client] object NewHostConnectionPool {
             response.entity match {
               case _: HttpEntity.Strict => withSlot(_.onResponseReceived(response))
               case e =>
-                val (newEntity, (entitySubscribed, entityComplete, entityKillSwitch)) =
+                val (newEntity, StreamUtils.StreamControl(entitySubscribed, entityComplete, entityKillSwitch)) =
                   StreamUtils.transformEntityStream(response.entity, StreamUtils.CaptureMaterializationAndTerminationOp)
 
                 ongoingResponseEntity = Some(e)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -456,9 +456,9 @@ private[client] object NewHostConnectionPool {
 
             responseIn.cancel()
 
-            // FIXME: or should we use discardEntity which does Sink.ignore?
+            val exception = failure.getOrElse(new IllegalStateException("Connection was closed while response was still in-flight"))
             ongoingResponseEntity.foreach(_.dataBytes.runWith(Sink.cancelled)(subFusingMaterializer))
-            ongoingResponseEntityKillSwitch.foreach(_.abort(new IllegalStateException("Connection was closed while response was still in-flight")))
+            ongoingResponseEntityKillSwitch.foreach(_.abort(exception))
           }
           def isClosed: Boolean = requestOut.isClosed || responseIn.isClosed
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -193,7 +193,8 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
 
         val streamResult = chunks.runWith(Sink.ignore)
         Await.ready(streamResult, 3.seconds)
-        streamResult.value.get.failed.get.getMessage shouldEqual "Connection was closed while response was still in-flight"
+        streamResult.value.get.failed.get.getMessage shouldEqual
+          "Response entity was not subscribed after 1 second. Make sure to read the response entity body or call `discardBytes()` on it. GET /1 Empty -> 200 OK Chunked"
         conn1.expectError()
       }
       "time out when a connection was unused for a long time" in pending


### PR DESCRIPTION
Also report underlying reason for response entity failure when materialization times out.

Follow up to #2630.