### PR TITLE
build: add command line flag that allows running akka-http-core tests against akka master branch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -148,6 +148,13 @@ lazy val httpCore = project("akka-http-core")
   .dependsOn(parsing)
   .addAkkaModuleDependency("akka-stream", "provided")
   .addAkkaModuleDependency("akka-stream-testkit", "test")
+  .addAkkaModuleDependency(
+    "akka-stream",
+    "test",
+    shouldUseSourceDependency = true,
+    uri("git://github.com/akka/akka.git#master"),
+    onlyIf = System.getProperty("akka.http.test-against-akka-master", "false") == "true"
+  )
   .settings(Dependencies.httpCore)
   .settings(VersionGenerator.versionSettings)
   .settings(scalaMacroSupport)

--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -43,22 +43,29 @@ object AkkaDependency {
 
   implicit class RichProject(project: Project) {
     /** Adds either a source or a binary dependency, depending on whether the above settings are set */
-    def addAkkaModuleDependency(module: String, config: String = ""): Project =
-      if (shouldUseSourceDependency) {
-        val moduleRef = ProjectRef(akkaRepository, module)
-        val withConfig: ClasspathDependency =
-          if (config == "") moduleRef
-          else moduleRef % config
+    def addAkkaModuleDependency(module: String,
+                                config: String = "",
+                                shouldUseSourceDependency: Boolean = AkkaDependency.shouldUseSourceDependency,
+                                akkaRepository: URI = AkkaDependency.akkaRepository,
+                                onlyIf: Boolean = true): Project =
+      if (onlyIf) {
+        if (shouldUseSourceDependency) {
+          val moduleRef = ProjectRef(akkaRepository, module)
+          val withConfig: ClasspathDependency =
+            if (config == "") moduleRef
+            else moduleRef % config
 
-        project.dependsOn(withConfig)
-      } else {
-        project.settings(libraryDependencies += {
-          val dep = "com.typesafe.akka" %% module % akkaVersion
-          val withConfig =
-            if (config == "") dep
-            else dep % config
-          withConfig
-        })
+          project.dependsOn(withConfig)
+        } else {
+          project.settings(libraryDependencies += {
+            val dep = "com.typesafe.akka" %% module % akkaVersion
+            val withConfig =
+              if (config == "") dep
+              else dep % config
+            withConfig
+          })
+        }
       }
+      else project // return unchanged
   }
 }


### PR DESCRIPTION
The idea is to add another build step in nightlies that exercises those tests, so we'll catch binary incompatibilities (i.e. ones we might otherwise miss because they are fixed by recompiling against akka master) like #2651 early on.

Currently, only akka-http-core tests would be included in those tests but just that would already add a lot of coverage to that case.