### PR TITLE
[Suggestion] Refactor testConfigSource init codes using option data type

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -36,10 +36,10 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
       .replace('_', '-')
       .filter(_ != '$')
 
-  def testConfigSource: String = ""
+  def testConfigSource: Option[String] = None
   def testConfig: Config = {
     val source = testConfigSource
-    val config = if (source.isEmpty) ConfigFactory.empty() else ConfigFactory.parseString(source)
+    val config = source.fold(ConfigFactory.empty())(ConfigFactory.parseString(_))
     config.withFallback(ConfigFactory.load())
   }
   implicit val system = createActorSystem()


### PR DESCRIPTION
<!--
# Pull Request Checklist

[X] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
[X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
[ ] Have you updated the documentation?
[ ] Have you added tests for any changed functionality?
-->
## Purpose
[Suggestion] I think that `None of Option[String]` is more clear than `""`.

<!-- What does this PR do? -->
## Changes

<!-- Bullets for important changes in this PR -->
`testConfig: String = ""` => `testConfig: Option[String] = None`