### PR TITLE
docs: disable unsupported `-doc-canonical-base-url` for Scala 2.11

### DIFF
--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -52,7 +52,10 @@ object Scaladoc extends AutoPlugin {
     })
 
   def scaladocOptions(scalaBinaryVersion: String, ver: String, base: File, plugins: Seq[File]): List[String] = {
-    val urlString = GitHub.url(ver) + "/€{FILE_PATH_EXT}#L€{FILE_LINE}"
+    val urlString = GitHub.url(ver) +
+                    // supported from Scala 2.12.9
+                    (if (scalaBinaryVersion != "2.11") "€{FILE_PATH_EXT}#L€{FILE_LINE}" else "€{FILE_PATH}.scala")
+
     val opts = List(
       "-implicits",
       "-groups",

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -33,6 +33,7 @@ object Scaladoc extends AutoPlugin {
     inTask(doc)(Seq(
       scalacOptions in Compile ++=
         scaladocOptions(
+          scalaBinaryVersion.value,
           version.value,
           (baseDirectory in ThisBuild).value,
           libraryDependencies.value
@@ -50,7 +51,7 @@ object Scaladoc extends AutoPlugin {
       docs
     })
 
-  def scaladocOptions(ver: String, base: File, plugins: Seq[File]): List[String] = {
+  def scaladocOptions(scalaBinaryVersion: String, ver: String, base: File, plugins: Seq[File]): List[String] = {
     val urlString = GitHub.url(ver) + "/€{FILE_PATH_EXT}#L€{FILE_LINE}"
     val opts = List(
       "-implicits",
@@ -59,10 +60,10 @@ object Scaladoc extends AutoPlugin {
       "-sourcepath", base.getAbsolutePath,
       "-doc-title", "Akka HTTP",
       "-doc-version", ver,
-      "-doc-canonical-base-url", "https://doc.akka.io/api/akka-http/current/",
       // Workaround https://issues.scala-lang.org/browse/SI-10028
       "-skip-packages", "akka.pattern:org.specs2",
     ) ++
+      (if (scalaBinaryVersion != "2.11") List("-doc-canonical-base-url", "https://doc.akka.io/api/akka-http/current/") else Nil) ++
       plugins.map(plugin => "-Xplugin:" + plugin)
     CliOptions.scaladocDiagramsEnabled.ifTrue("-diagrams").toList ::: opts
   }


### PR DESCRIPTION
Follow up to #2662.