### PR TITLE
fix: akka-stream-testkit version

### DIFF
--- a/docs/src/main/paradox/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/routing-dsl/testkit.md
@@ -9,7 +9,7 @@ route logic easy and convenient. This "route test DSL" is made available with th
 To use Akka HTTP TestKit, add the module to your project:
 
 @@dependency [sbt,Gradle,Maven] {
-  group="com.typesafe.akka" artifact="akka-stream-testkit_$scala.binary.version$" version="2.5.23"
+  group="com.typesafe.akka" artifact="akka-stream-testkit_$scala.binary.version$" version="$akka.version$"
   group2="com.typesafe.akka" artifact2="akka-http-testkit_$scala.binary.version$" version2="$project.version$"
 }
 

--- a/docs/src/main/paradox/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/routing-dsl/testkit.md
@@ -9,7 +9,7 @@ route logic easy and convenient. This "route test DSL" is made available with th
 To use Akka HTTP TestKit, add the module to your project:
 
 @@dependency [sbt,Gradle,Maven] {
-  group="com.typesafe.akka" artifact="akka-stream-testkit_$scala.binary.version$" version="2.5.19"
+  group="com.typesafe.akka" artifact="akka-stream-testkit_$scala.binary.version$" version="2.5.23"
   group2="com.typesafe.akka" artifact2="akka-http-testkit_$scala.binary.version$" version2="$project.version$"
 }
 


### PR DESCRIPTION
The old one (19) results in:
sbt.librarymanagement.ResolveException: unresolved dependency: com.typesafe.akka#akka-stream-testkit_2.13;2.5.19: not found

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #xxxx

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
