### PR TITLE
Update authenticateOAuth2.md

### DIFF
--- a/docs/src/main/paradox/routing-dsl/directives/security-directives/authenticateOAuth2.md
+++ b/docs/src/main/paradox/routing-dsl/directives/security-directives/authenticateOAuth2.md
@@ -14,7 +14,7 @@
 Wraps the inner route with OAuth Bearer Token authentication support using a given @scala[@scaladoc[Authenticator[T]](akka.http.scaladsl.server.Directives#Authenticator[T]=akka.http.scaladsl.server.directives.Credentials=%3EOption[T])]@java[`Authenticator<T>` - function from `Optional<ProvidedCredentials>` to `Optional<T>`].
 
 Provides support for extracting the so-called "*Bearer Token*" from the @apidoc[Authorization] HTTP Header,
-which is used to initiate an OAuth2 authorization.
+which is used to initiate an OAuth2 authorization. The directive also supports extracting the Bearer Token from URI query parameter `access_token`, as described in [RFC 6750](https://tools.ietf.org/html/rfc6750).
 
 @@@ warning
 This directive does not implement the complete OAuth2 protocol, but instead enables implementing it,


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?

## Purpose

It is misleading that the documentation does not mention that the token can be coming from places other than the `Authorization` header, even though these are supported by the existing implementation. There are legitimate use cases where the token should be sent in the URI as a query parameter, for example JavaScript WebSocket API does not support adding the Authorization header to the request, so a query parameter is arguably the next best option.
