### PR TITLE
Uri.Path() should accept raw input with %

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -4,13 +4,13 @@
 
 package akka.http.scaladsl.model
 
-import java.nio.charset.Charset
-import java.net.InetAddress
 import akka.http.impl.util.StringRendering
+import akka.http.scaladsl.model.Uri._
+import akka.parboiled2.UTF8
 import org.scalatest.matchers.{ MatchResult, Matcher }
 import org.scalatest.{ Matchers, WordSpec }
-import akka.parboiled2.UTF8
-import Uri._
+import java.net.InetAddress
+import java.nio.charset.Charset
 
 class UriSpec extends WordSpec with Matchers {
 
@@ -224,6 +224,9 @@ class UriSpec extends WordSpec with Matchers {
       "/%C3%89g%20get%20eti%C3%B0%20gler%20%C3%A1n%20%C3%BEess%20a%C3%B0%20mei%C3%B0a%20mig" should
         roundTripTo(Path / "Ég get etið gler án þess að meiða mig")
       "/%00%E4%00%F6%00%FC" should roundTripTo(Path / "äöü", Charset.forName("UTF-16BE"))
+
+      Path("/example/%12%", encodingMode = EncodingMode.NonEncoded).toString shouldBe "/example/%2512%25"
+      Path("/example/ a", encodingMode = EncodingMode.NonEncoded).toString shouldBe "/example/%20a"
     }
     "support the `startsWith` predicate" in {
       Empty startsWith Empty shouldBe true
@@ -303,6 +306,8 @@ class UriSpec extends WordSpec with Matchers {
       the[IllegalUriException] thrownBy Path("/example/%12%")
       the[IllegalUriException] thrownBy Path("/example/%12%1")
       the[IllegalUriException] thrownBy Path("/example/%12%1V")
+      the[IllegalUriException] thrownBy Path("/example/%12%1V", encodingMode = EncodingMode.Encoded)
+      the[IllegalUriException] thrownBy Path("/example/%12%1V", encodingMode = EncodingMode.Default)
     }
   }
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->

## Purpose

The main purpose of the PR is to make Uri.Path.apply() method non ambiguous regarding accepting % character. 
For instance 
```scala
Path("/example/%12%", encodingMode = EncodingMode.NonEncoded)
```  
accepts raw unencoded string with % characters 
while 
```scala
Path("/example/%12%", encodingMode = EncodingMode.Encoded)
``` 
throws error because it assumes input is already encoded.

to keep backward compatibility 
```scala
Path("/example/%12%")
```  

is the same as 

```scala
Path("/example/%12%", encodingMode = EncodingMode.Deafult)
```  

`EncodingMode.Deafult` means apply method decides whether the input ic encoded or not according to % symbol in input
<!-- What does this PR do? -->

## References
#2577 issue
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #2577

## Changes

<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->