### PR TITLE
Always target java 8 bootclasspath

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,21 +31,6 @@ inThisBuild(Def.settings(
   //  test in assembly := {},
   licenses := Seq("Apache-2.0" -> url("https://opensource.org/licenses/Apache-2.0")),
   description := "Akka Http: Modern, fast, asynchronous, streaming-first HTTP server and client.",
-  scalacOptions ++= Seq(
-    "-deprecation",
-    "-encoding", "UTF-8", // yes, this is 2 args
-    "-target:jvm-1.8",
-    "-unchecked",
-    "-Xlint",
-    // "-Yno-adapted-args", //akka-http heavily depends on adapted args and => Unit implicits break otherwise
-    "-Ywarn-dead-code"
-    // "-Xfuture" // breaks => Unit implicits
-  ),
-  javacOptions ++= Seq(
-    "-encoding", "UTF-8",
-    "-source", "1.8",
-  ),
-  javacOptions in (Compile, compile) ++= Seq("-target", "1.8"), // sbt #1785, avoids passing to javadoc
   testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v"),
   Dependencies.Versions,
   Formatting.formatSettings,
@@ -149,7 +134,7 @@ lazy val parsing = project("akka-parsing")
   .addAkkaModuleDependency("akka-actor", "provided")
   .settings(Dependencies.parsing)
   .settings(
-    scalacOptions := scalacOptions.value.filterNot(Set("-Xfatal-warnings", "-Xlint", "-Ywarn-dead-code").contains), // disable warnings for parboiled code
+    scalacOptions --= Seq("-Xfatal-warnings", "-Xlint", "-Ywarn-dead-code"), // disable warnings for parboiled code
     scalacOptions += "-language:_",
     unmanagedSourceDirectories in ScalariformKeys.format in Test := (unmanagedSourceDirectories in Test).value
   )

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka
+
+import sbt._
+import Keys._
+
+object Common extends AutoPlugin {
+  override def trigger: PluginTrigger = allRequirements
+  override lazy val projectSettings = Seq(
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-encoding", "UTF-8", // yes, this is 2 args
+      "-target:jvm-1.8",
+      "-unchecked",
+      "-Xlint",
+      // "-Yno-adapted-args", //akka-http heavily depends on adapted args and => Unit implicits break otherwise
+      "-Ywarn-dead-code"
+      // "-Xfuture" // breaks => Unit implicits
+    ),
+    // '-release' parameter is restricted to 'Compile, compile' scope because
+    // otherwise `sbt akka-http-xml/compile:doc` fails with it on Scala 2.12.9
+    scalacOptions in (Compile, compile) ++= {
+      if (scalaMinorVersion.value >= 12 && !sys.props("java.version").startsWith("1.") /* i.e. Java version >= 9 */)
+        Seq("-release", "8")
+      else
+        Nil
+    },
+    javacOptions ++= Seq(
+      "-encoding", "UTF-8",
+    ),
+    javacOptions ++= {
+      if (!sys.props("java.version").startsWith("1.") /* i.e. Java version >= 9 */)
+        Seq("--release", "8")
+      else
+        Seq("-source", "1.8")
+    },
+    // restrict to 'compile' scope because otherwise it is also passed to
+    // javadoc and -target is not valid there.
+    // https://github.com/sbt/sbt/issues/1785
+    javacOptions in (Compile, compile) ++= {
+      if (!sys.props("java.version").startsWith("1.") /* i.e. Java version >= 9 */)
+        Nil
+      else
+        Seq("-target", "1.8")
+    },
+  )
+
+  def scalaMinorVersion: Def.Initialize[Long] = Def.setting { CrossVersion.partialVersion(scalaVersion.value).get._2 }
+
+}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -22,31 +22,26 @@ object Common extends AutoPlugin {
     ),
     // '-release' parameter is restricted to 'Compile, compile' scope because
     // otherwise `sbt akka-http-xml/compile:doc` fails with it on Scala 2.12.9
-    scalacOptions in (Compile, compile) ++= {
-      if (scalaMinorVersion.value >= 12 && !sys.props("java.version").startsWith("1.") /* i.e. Java version >= 9 */)
-        Seq("-release", "8")
-      else
-        Nil
-    },
-    javacOptions ++= Seq(
-      "-encoding", "UTF-8",
-    ),
-    javacOptions ++= {
-      if (!sys.props("java.version").startsWith("1.") /* i.e. Java version >= 9 */)
-        Seq("--release", "8")
-      else
-        Seq("-source", "1.8")
-    },
+    scalacOptions in (Compile, compile) ++=
+      onlyAfterScala212(onlyAfterJdk8("-release", "8")).value,
+    javacOptions ++=
+      Seq("-encoding", "UTF-8") ++ onlyOnJdk8("-source", "1.8") ++ onlyAfterJdk8("--release", "8"),
     // restrict to 'compile' scope because otherwise it is also passed to
     // javadoc and -target is not valid there.
     // https://github.com/sbt/sbt/issues/1785
-    javacOptions in (Compile, compile) ++= {
-      if (!sys.props("java.version").startsWith("1.") /* i.e. Java version >= 9 */)
-        Nil
-      else
-        Seq("-target", "1.8")
-    },
+    javacOptions in (Compile, compile) ++=
+      // From jdk9 onwards this is covered by the '-release' flag above
+      onlyOnJdk8("-target", "1.8"),
   )
+
+  val specificationVersion: String = sys.props("java.specification.version")
+  def isJdk8: Boolean =
+    VersionNumber(specificationVersion).matchesSemVer(SemanticSelector(s"=1.8"))
+  def onlyOnJdk8[T](values: T*): Seq[T] = if (isJdk8) values else Seq.empty[T]
+  def onlyAfterJdk8[T](values: T*): Seq[T] = if (isJdk8) Seq.empty[T] else values
+  def onlyAfterScala212[T](values: Seq[T]): Def.Initialize[Seq[T]] = Def.setting {
+    if (scalaMinorVersion.value >= 12) values else Seq.empty[T]
+  }
 
   def scalaMinorVersion: Def.Initialize[Long] = Def.setting { CrossVersion.partialVersion(scalaVersion.value).get._2 }
 


### PR DESCRIPTION
Refs #2673

Tested with javap (`javap -p -c akka-http-core/target/scala-2.12/classes/akka/http/impl/engine/parsing/HttpHeaderParser\$.class | grep clear` should be `Method java/nio/ByteBuffer.clear:()Ljava/nio/Buffer;` and not `Method java/nio/ByteBuffer.clear:()Ljava/nio/ByteBuffer`).

Also tested with cinnamon, also looks good.