### PR TITLE
Disallow entity for 205 status code

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
@@ -113,7 +113,7 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val Accepted                    = reg(s(202)("Accepted", "The request has been accepted for processing, but the processing has not been completed."))
   val NonAuthoritativeInformation = reg(s(203)("Non-Authoritative Information", "The server successfully processed the request, but is returning information that may be from another source."))
   val NoContent                   = reg(s(204)("No Content", "The server successfully processed the request and is not returning any content.", allowsEntity = false))
-  val ResetContent                = reg(s(205)("Reset Content", "The server successfully processed the request, but is not returning any content."))
+  val ResetContent                = reg(s(205)("Reset Content", "The server successfully processed the request, but is not returning any content.", allowsEntity = false))
   val PartialContent              = reg(s(206)("Partial Content", "The server is delivering only part of the resource due to a range header sent by the client."))
   val MultiStatus                 = reg(s(207)("Multi-Status", "The message body that follows is an XML message and can contain a number of separate response codes, depending on how many sub-requests were made."))
   val AlreadyReported             = reg(s(208)("Already Reported", "The members of a DAV binding have already been enumerated in a previous reply to this request, and are not being included again."))

--- a/docs/src/main/paradox/release-notes/10.1.x.md
+++ b/docs/src/main/paradox/release-notes/10.1.x.md
@@ -1,5 +1,13 @@
 # 10.1.x Release Notes
 
+## 10.1.10
+
+### Changes since 10.1.9
+
+##### akka-http
+
+* Fix 205 HTTP status not to contain any HTTP entity [#2686](https://github.com/akka/akka-http/pull/2686)
+
 ## 10.1.9
 
 10.1.9 is the tenth release in the 10.1.x series of Akka HTTP. See the [announcement](https://akka.io/blog/news/2019/07/17/akka-http-10.1.9-released.html) and the full list of changes below.

--- a/docs/src/main/paradox/release-notes/10.1.x.md
+++ b/docs/src/main/paradox/release-notes/10.1.x.md
@@ -2,6 +2,10 @@
 
 ## 10.1.10
 
+### Migration notes
+
+[RFC 7231](https://tools.ietf.org/html/rfc7231#section-6.3.6) dictates an HTTP response with status code 205 ('Reset Content') is not allowed to have an entity body. Since [#2686](https://github.com/akka/akka-http/pull/2686) we enforce this restriction, so if you (incorrectly) produced such responses you will have to either remove the entity body or select a different status code.
+
 ### Changes since 10.1.9
 
 ##### akka-http


### PR DESCRIPTION
## Purpose

Disallow entity for 205 status code as response with this status code [should contain empty content](https://tools.ietf.org/html/rfc7231#section-6.3.6).

## References

References #2685

## Changes

- Now you cannot pass HTTP entity to response with 205 status code

## Background Context

Set `allowsEntity` as `false` would be the simplest way of following RFC spec.
