### PR TITLE
Temporary fix for Typed doc sample code

### DIFF
--- a/docs/src/main/paradox/routing-dsl/index.md
+++ b/docs/src/main/paradox/routing-dsl/index.md
@@ -103,6 +103,8 @@ Scala
 :  @@snip [HttpServerWithTypedSpec.scala]($test$/scala-2.12+/docs/http/scaladsl/HttpServerWithTypedSpec.scala) { #akka-typed-bootstrap }
 
 
+Note that the `akka.actor.typed.ActorSystem` is converted with `toClassic`, which comes from
+`import akka.actor.typed.scaladsl.adapter._`. If you are using Akka 2.5.x this conversion method is named `toUntyped`.
 
 ## Dynamic Routing Example
 

--- a/docs/src/test/scala-2.12+/docs/http/scaladsl/HttpServerWithTypedSpec.scala
+++ b/docs/src/test/scala-2.12+/docs/http/scaladsl/HttpServerWithTypedSpec.scala
@@ -146,6 +146,8 @@ class HttpServerWithTypedSpec extends WordSpec with Matchers with CompileOnlySpe
     }
     //#akka-typed-route
 
+
+    /* FIXME currently not compiled because toUntyped in Akka 2.5 was renamed to toClassic in Akka 2.6
     //#akka-typed-bootstrap
     import akka.{ actor, Done }
     import akka.actor.typed.scaladsl.adapter._
@@ -159,7 +161,7 @@ class HttpServerWithTypedSpec extends WordSpec with Matchers with CompileOnlySpe
     val system = ActorSystem[Done](Behaviors.setup[Done] { ctx =>
       // http doesn't know about akka typed so create untyped system/materializer
       implicit val untypedSystem: actor.ActorSystem = ctx.system.toUntyped
-      implicit val materializer: ActorMaterializer = ActorMaterializer()(ctx.system.toUntyped)
+      implicit val materializer: ActorMaterializer = ActorMaterializer()(ctx.system.toClassic)
       implicit val ec: ExecutionContextExecutor = ctx.system.executionContext
 
       val buildJobRepository = ctx.spawn(BuildJobRepository(), "BuildJobRepositoryActor")
@@ -183,5 +185,6 @@ class HttpServerWithTypedSpec extends WordSpec with Matchers with CompileOnlySpe
     }, "BuildJobsServer")
 
     //#akka-typed-bootstrap
+    */
   }
 }

--- a/docs/src/test/scala-2.12+/docs/http/scaladsl/HttpServerWithTypedSpec.scala
+++ b/docs/src/test/scala-2.12+/docs/http/scaladsl/HttpServerWithTypedSpec.scala
@@ -146,7 +146,6 @@ class HttpServerWithTypedSpec extends WordSpec with Matchers with CompileOnlySpe
     }
     //#akka-typed-route
 
-
     /* FIXME currently not compiled because toUntyped in Akka 2.5 was renamed to toClassic in Akka 2.6
     //#akka-typed-bootstrap
     import akka.{ actor, Done }


### PR DESCRIPTION
Quick fix to fix the build against akka master.

Maybe we should backport some of the toClassic methods to release-2.5 branch since it's causing these kind of problems?