### PR TITLE
CVE-2019-14439: bump jackson-databind to 2.9.9.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -339,7 +339,7 @@ lazy val docs = project("docs")
         case akka.Doc.BinVer(_) => ""
         case _                  => "cross CrossVersion.full"
       }),
-      "jackson.version" -> Dependencies.jacksonVersion,
+      "jackson.version" -> Dependencies.jacksonXmlVersion,
       "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/${AkkaDependency.akkaVersion}/%s",
       "extref.akka25-docs.base_url" -> s"https://doc.akka.io/docs/akka/2.5/%s",
       "javadoc.akka.http.base_url" -> {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,8 @@ import scala.language.implicitConversions
 object Dependencies {
   import DependencyHelpers._
 
-  val jacksonVersion = "2.9.9"
+  val jacksonDatabindVersion = "2.9.9.3"
+  val jacksonXmlVersion = "2.9.9"
   val junitVersion = "4.12"
   val h2specVersion = "1.5.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
@@ -46,7 +47,7 @@ object Dependencies {
     val sprayJson   = "io.spray"                     %% "spray-json"                   % "1.3.5"       // ApacheV2
 
     // For akka-http-jackson support
-    val jackson     = "com.fasterxml.jackson.core"    % "jackson-databind"             % jacksonVersion // ApacheV2
+    val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind"            % jacksonDatabindVersion // ApacheV2
 
     // For akka-http-testkit-java
     val junit       = "junit"                         % "junit"                        % junitVersion  // Common Public License 1.0
@@ -60,7 +61,7 @@ object Dependencies {
     object Docs {
       val sprayJson   = Compile.sprayJson                                                                    % "test"
       val gson        = "com.google.code.gson"             % "gson"                    % "2.8.5"             % "test"
-      val jacksonXml  = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml"  % jacksonVersion      % "test" // ApacheV2
+      val jacksonXml  = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml"  % jacksonXmlVersion   % "test" // ApacheV2
       val reflections = "org.reflections"                  % "reflections"             % "0.9.11"            % "test" // WTFPL
     }
 
@@ -123,7 +124,7 @@ object Dependencies {
     libraryDependencies += Test.scalatest.value
   )
 
-  lazy val httpJackson = l ++= Seq(jackson)
+  lazy val httpJackson = l ++= Seq(jacksonDatabind)
 
   lazy val docs = l ++= Seq(Docs.sprayJson, Docs.gson, Docs.jacksonXml, Docs.reflections)
 }


### PR DESCRIPTION
PR https://github.com/akka/akka-http/pull/2671 bumps the `jackson-databind` version to 2.9.9. However, this version is susceptible to CVE-2019-14439 (original issue: https://github.com/FasterXML/jackson-databind/issues/2389). While the vulnerability might not be directly exploitable from Akka HTTP, it might still pose a problem for projects pulling it in as a transitive dependency.

This PR bumps `jackson-databind` further, to its latest stable version, 2.9.9.3.

FYI, there are three more CVE's of this kind present in all versions of `jackson-databind`, including this one - they will be fixed in the forthcoming 2.10.0 release:

https://github.com/FasterXML/jackson-databind/issues/2410
https://github.com/FasterXML/jackson-databind/issues/2420
https://github.com/FasterXML/jackson-databind/issues/2421