### PR TITLE
Add scala-steward config to exclude akka

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,6 @@
+updates.ignore = [
+  { groupId = "com.typesafe.akka", artifactId = "akka-actor" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-stream" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-testkit" },
+  { groupId = "com.typesafe.akka", artifactId = "akka-stream-testkit" },
+]


### PR DESCRIPTION
So that if we enable it it won't send PR's to upgrade Akka