### PR TITLE
http2: fix receiving HEADERS with more than one CONTINUATION frame

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -83,7 +83,10 @@ private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEven
           if (endHeaders) {
             parseAndEmit(streamId, endStream, receivedData ++ payload, priorityInfo)
             become(Idle)
-          } else receivedData ++= payload
+          } else {
+            receivedData ++= payload
+            pull(eventsIn)
+          }
         case x => protocolError(s"While waiting for CONTINUATION frame on stream $streamId received unexpected frame $x")
       }
     }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -134,15 +134,17 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
           expectedResponseHeaderBlock = HPackSpecExamples.C63ThirdResponseWithHuffman
         )
       }
-      "GET request in one HEADERS and one CONTINUATION frame" in new TestSetup with RequestResponseProbes {
+      "GET request in one HEADERS and two CONTINUATION frames" in new TestSetup with RequestResponseProbes {
         val headerBlock = HPackSpecExamples.C41FirstRequestWithHuffman
         val fragment1 = headerBlock.take(8) // must be grouped by octets
-        val fragment2 = headerBlock.drop(8)
+        val fragment2 = headerBlock.drop(8).take(8)
+        val fragment3 = headerBlock.drop(16)
 
         sendHEADERS(1, endStream = true, endHeaders = false, fragment1)
         requestIn.ensureSubscription()
         requestIn.expectNoMessage(remainingOrDefault)
-        sendCONTINUATION(1, endHeaders = true, fragment2)
+        sendCONTINUATION(1, endHeaders = false, fragment2)
+        sendCONTINUATION(1, endHeaders = true, fragment3)
 
         val request = expectRequestRaw()
 


### PR DESCRIPTION
I guess no one has noticed so far because it only shows starting from HEADER blocks with more than 2 * frame size.