### PR TITLE
 http2: backpressure incoming frames when too many outgoing control frames are buffered

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.9.backwards.excludes/pr-2706-add-http2-setting-outgoing-control-frame-buffer-size.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.9.backwards.excludes/pr-2706-add-http2-setting-outgoing-control-frame-buffer-size.excludes
@@ -1,0 +1,8 @@
+# Addition to @DoNotInherit classes
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.Http2ServerSettings.getOutgoingControlFrameBufferSize")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.Http2ServerSettings.withOutgoingControlFrameBufferSize")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings.outgoingControlFrameBufferSize")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings.withOutgoingControlFrameBufferSize")
+
+# changes to internal classes
+ProblemFilters.exclude[Problem]("akka.http.scaladsl.settings.Http2ServerSettings#Http2ServerSettingsImpl.*")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -220,6 +220,22 @@ akka.http {
       # be increased for high bandwidth-delay-product connections.
       incoming-stream-level-buffer-size = 512kB
 
+      # The maximum number of outgoing control frames to buffer when the peer does not read from its TCP connection before
+      # backpressuring incoming frames.
+      #
+      # On a healthy HTTP/2 connection this setting should have little effect because control frames are given priority over
+      # data frames and should not be buffered for a long time.
+      #
+      # The limit is necessary to prevent a malicious peer to solicit buffering of outgoing control frames (e.g. by sending PINGs)
+      # without ever reading frames ultimately leading to an out of memory situation. With the limit in place, the implementation
+      # stops reading incoming frames when the number of outgoing control frames has reached the given amount. This way an attacker
+      # isn't able to communicate any further without first freeing space in the TCP window, draining the buffered control frames.
+      #
+      # See CVE-2019-9512 for an example of such an attack.
+      #
+      # Note that only control frames are affected because data frames, in contrast, are covered by the HTTP/2 flow control.
+      outgoing-control-frame-buffer-size = 1024
+
       # Enable verbose debug logging for all ingoing and outgoing frames
       log-frames = false
     }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
@@ -22,6 +22,9 @@ trait Http2ServerSettings { self: scaladsl.settings.Http2ServerSettings =>
   def getMaxConcurrentStreams: Int = maxConcurrentStreams
   def withMaxConcurrentStreams(newValue: Int): Http2ServerSettings
 
+  def getOutgoingControlFrameBufferSize: Int = outgoingControlFrameBufferSize
+  def withOutgoingControlFrameBufferSize(newValue: Int): Http2ServerSettings
+
   def logFrames: Boolean
   def withLogFrames(shouldLog: Boolean): Http2ServerSettings
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
@@ -32,6 +32,9 @@ trait Http2ServerSettings extends javadsl.settings.Http2ServerSettings { self: H
   def maxConcurrentStreams: Int
   override def withMaxConcurrentStreams(newValue: Int): Http2ServerSettings = copy(maxConcurrentStreams = newValue)
 
+  def outgoingControlFrameBufferSize: Int
+  override def withOutgoingControlFrameBufferSize(newValue: Int): Http2ServerSettings = copy(outgoingControlFrameBufferSize = newValue)
+
   def logFrames: Boolean
   override def withLogFrames(shouldLog: Boolean): Http2ServerSettings = copy(logFrames = shouldLog)
 
@@ -52,12 +55,14 @@ object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
     requestEntityChunkSize:            Int,
     incomingConnectionLevelBufferSize: Int,
     incomingStreamLevelBufferSize:     Int,
+    outgoingControlFrameBufferSize:    Int,
     logFrames:                         Boolean,
     internalSettings:                  Option[Http2InternalServerSettings])
     extends Http2ServerSettings {
     require(requestEntityChunkSize > 0, "request-entity-chunk-size must be > 0")
     require(incomingConnectionLevelBufferSize > 0, "incoming-connection-level-buffer-size must be > 0")
     require(incomingStreamLevelBufferSize > 0, "incoming-stream-level-buffer-size must be > 0")
+    require(outgoingControlFrameBufferSize > 0, "outgoing-control-frame-buffer-size must be > 0")
   }
 
   private[http] object Http2ServerSettingsImpl extends akka.http.impl.util.SettingsCompanionImpl[Http2ServerSettingsImpl]("akka.http.server.http2") {
@@ -66,6 +71,7 @@ object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
       requestEntityChunkSize = c.getIntBytes("request-entity-chunk-size"),
       incomingConnectionLevelBufferSize = c.getIntBytes("incoming-connection-level-buffer-size"),
       incomingStreamLevelBufferSize = c.getIntBytes("incoming-stream-level-buffer-size"),
+      outgoingControlFrameBufferSize = c.getIntBytes("outgoing-control-frame-buffer-size"),
       logFrames = c.getBoolean("log-frames"),
       None // no possibility to configure internal settings with config
     )


### PR DESCRIPTION
Fixes CVE-2019-9512, CVE-2019-9514, CVE-2019-9515.