### PR TITLE
core: hide `HttpEntity.Strict` body data by default

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -356,26 +356,9 @@ object HttpEntity {
     override def productPrefix = "HttpEntity.Strict"
 
     override def toString = {
-      val dataAsString = contentType match {
-        case _: Binary =>
-          data.toString()
-        case _: WithMissingCharset =>
-          data.toString()
-        case nb: NonBinary =>
-          try {
-            val maxBytes = 4096
-            if (data.length > maxBytes) {
-              val truncatedString = data.take(maxBytes).decodeString(nb.charset.value).dropRight(1)
-              s"$truncatedString ... (${data.length} bytes total)"
-            } else
-              data.decodeString(nb.charset.value)
-          } catch {
-            case NonFatal(e) =>
-              data.toString()
-          }
-      }
+      val dataSizeStr = s"${data.length} bytes total"
 
-      s"$productPrefix($contentType,$dataAsString)"
+      s"$productPrefix($contentType,$dataSizeStr)"
     }
 
     /** Java API */

--- a/akka-http-core/src/test/scala/akka/http/javadsl/JavaInitializationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/JavaInitializationSpec.scala
@@ -31,8 +31,8 @@ class JavaInitializationSpec extends WordSpec with Matchers {
 
   "HttpEntity" should {
     "initializes the right field" in {
-      akka.http.scaladsl.model.HttpEntity.Empty =!= "HttpEntity.Strict(none/none,ByteString())"
-      akka.http.javadsl.model.HttpEntities.EMPTY =!= "HttpEntity.Strict(none/none,ByteString())"
+      akka.http.scaladsl.model.HttpEntity.Empty =!= "HttpEntity.Strict(none/none,0 bytes total)"
+      akka.http.javadsl.model.HttpEntities.EMPTY =!= "HttpEntity.Strict(none/none,0 bytes total)"
     }
   }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -166,18 +166,12 @@ class HttpEntitySpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
       "Strict with binary MediaType" in {
         val binaryType = ContentTypes.`application/octet-stream`
         val entity = Strict(binaryType, abc)
-        entity must renderStrictDataAs(entity.data.toString())
+        entity must renderStrictDataAs("3 bytes total")
       }
-      "Strict with non-binary MediaType and less than 4096 bytes" in {
+      "Strict with non-binary MediaType" in {
         val nonBinaryType = ContentTypes.`application/json`
         val entity = Strict(nonBinaryType, abc)
-        entity must renderStrictDataAs(entity.data.decodeString(nonBinaryType.charset.value))
-      }
-      "Strict with non-binary MediaType and over 4096 bytes" in {
-        val utf8Type = ContentTypes.`text/plain(UTF-8)`
-        val longString = Random.alphanumeric.take(10000).mkString
-        val entity = Strict(utf8Type, ByteString.apply(longString, utf8Type.charset.value))
-        entity must renderStrictDataAs(s"${longString.take(4095)} ... (10000 bytes total)")
+        entity must renderStrictDataAs("3 bytes total")
       }
       "Default" in {
         val entity = Default(tpe, 11, source(abc, de, fgh, ijk))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
@@ -43,7 +43,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1))\n"
+        normalizedDebugMsg shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))\n"
       }
     }
   }
@@ -58,7 +58,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1)))\n"
+        normalizedDebugMsg shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))\n"
       }
     }
   }
@@ -75,8 +75,8 @@ class DebuggingDirectivesSpec extends RoutingSpec {
         response shouldEqual Ok
         normalizedDebugMsg shouldEqual
           """|3: Response for
-             |  Request : HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1))
-             |  Response: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1)))
+             |  Request : HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
+             |  Response: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))
              |""".stripMarginWithNewline("\n")
       }
     }
@@ -95,7 +95,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       Get("/hello") ~> route ~> check {
         handled shouldBe false
         normalizedDebugMsg shouldEqual
-          """Request: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1))
+          """Request: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
             |was rejected with rejections:
             |List(ValidationRejection(The request could not be validated,None))
             |""".stripMargin


### PR DESCRIPTION
## Purpose

Aimed to avoid PII and SPI leakage, partially tackles https://github.com/akka/akka-http/issues/2409

## References

References https://github.com/akka/akka-http/pull/2560
References https://github.com/akka/akka-http/pull/2412
References https://github.com/akka/akka-http/issues/2409#issuecomment-496417344
References https://github.com/akka/akka-http/pull/2412#pullrequestreview-207325113

## Changes

This PR makes `HttpEntity.Strict#toString` method to print just the entity content type and its contents size. Replacing the previous behaviour which included the whole contents (or their beginning if they were excessively long).

## Background Context

https://github.com/akka/akka-http/pull/2560#pullrequestreview-285451541

> avoid including body data from strict entities (not a good idea anyways)