### PR TITLE
Update authorizeAsync.md

### DIFF
--- a/docs/src/main/paradox/routing-dsl/directives/security-directives/authorizeAsync.md
+++ b/docs/src/main/paradox/routing-dsl/directives/security-directives/authorizeAsync.md
@@ -16,9 +16,10 @@ The user-defined authorization check can either be supplied as a @scala[`=> Futu
 just from information out of the lexical scope, or as a function @scala[`RequestContext => Future[Boolean]`]@java[`Function<RequestContext,CompletionStage<Boolean>>`] which can also
 take information from the request itself into account.
 
-If the check returns `true` or the @scala[`Future`]@java[`CompletionStage`] is failed the request is passed on to the inner route unchanged,
-otherwise an @apidoc[AuthorizationFailedRejection] is created, triggering a `403 Forbidden` response by default
-(the same as in the case of an @apidoc[AuthenticationFailedRejection]).
+If the check returns `true`, the request is passed on to the inner route unchanged; if it
+returns `false` or the @scala[`Future`]@java[`CompletionStage`] is failed,
+an @apidoc[AuthorizationFailedRejection] is created, triggering a `403 Forbidden` response
+by default (the same as in the case of an @apidoc[AuthenticationFailedRejection]).
 
 In a common use-case you would check if a user (e.g. supplied by any of the `authenticate*` family of directives,
 e.g. @ref[authenticateBasic](authenticateBasic.md)) is allowed to access the inner routes, e.g. by checking if the user has the needed permissions.


### PR DESCRIPTION
The documentation got it wrong, as is evident from the source code (and common sense):

```scala
  /**
   * Asynchronous version of [[authorize]].
   * If the [[Future]] fails or is completed with `false`
   * authorization fails and the route is rejected with an [[AuthorizationFailedRejection]].
   *
   * @group security
   */
  def authorizeAsync(check: RequestContext => Future[Boolean]): Directive0 =
    extract(check).flatMap[Unit] { fa =>
      onComplete(fa).flatMap {
        case Success(true) => pass
        case _             => reject(AuthorizationFailedRejection)
      }
    }
```

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
