### PR TITLE
core: support chunked trailing headers in transformDataBytes

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -510,20 +510,20 @@ object HttpEntity {
       val transformChunks = GraphDSL.create() { implicit builder: GraphDSL.Builder[NotUsed] =>
         import akka.stream.scaladsl.GraphDSL.Implicits._
 
-        val partition = builder.add(Partition[ChunkStreamPart](2, {
+        val partition = builder.add(Partition[HttpEntity.ChunkStreamPart](2, {
           case c: Chunk     => 0
           case c: LastChunk => 1
         }))
-        val concat = builder.add(Concat[ChunkStreamPart](2))
+        val concat = builder.add(Concat[HttpEntity.ChunkStreamPart](2))
 
-        val chunkTransformer: Flow[ChunkStreamPart, ChunkStreamPart, Any] =
-          Flow[ChunkStreamPart]
+        val chunkTransformer: Flow[HttpEntity.ChunkStreamPart, HttpEntity.ChunkStreamPart, Any] =
+          Flow[HttpEntity.ChunkStreamPart]
             .map(_.data)
             .via(transformer)
             .map(b => Chunk(b))
 
-        val trailerBypass: Flow[ChunkStreamPart, ChunkStreamPart, Any] =
-          Flow[ChunkStreamPart]
+        val trailerBypass: Flow[HttpEntity.ChunkStreamPart, HttpEntity.ChunkStreamPart, Any] =
+          Flow[HttpEntity.ChunkStreamPart]
             // make sure to filter out any errors here, otherwise they don't go through the user transformer
             .recover { case NonFatal(ex) => Chunk(ByteString(0), "") }
             .collect { case lc @ LastChunk(_, s) if s.nonEmpty => lc }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -507,6 +507,10 @@ object HttpEntity {
       withSizeLimit(SizeLimit.Disabled)
 
     override def transformDataBytes(transformer: Flow[ByteString, ByteString, Any]): HttpEntity.Chunked = {
+      // This construction allows to keep trailing headers. For that the stream is split into two
+      // tracks. One for the regular chunks and one for the LastChunk. Only the regular chunks are
+      // run through the user-supplied transformer, the LastChunk is just passed on. The tracks are
+      // then concatenated to produce the final stream.
       val transformChunks = GraphDSL.create() { implicit builder: GraphDSL.Builder[NotUsed] =>
         import akka.stream.scaladsl.GraphDSL.Implicits._
 
@@ -526,6 +530,7 @@ object HttpEntity {
           Flow[HttpEntity.ChunkStreamPart]
             // make sure to filter out any errors here, otherwise they don't go through the user transformer
             .recover { case NonFatal(ex) => Chunk(ByteString(0), "") }
+            // only needed to filter the out the result from recover in the line above
             .collect { case lc @ LastChunk(_, s) if s.nonEmpty => lc }
 
         partition ~> chunkTransformer ~> concat

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeoutException
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.http.impl.util.StreamUtils
+import akka.http.impl.util._
 import akka.http.scaladsl.model.HttpEntity._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.ActorMaterializer

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -169,9 +169,9 @@ class HttpEntitySpec extends FreeSpec with MustMatchers with BeforeAndAfterAll {
       "Chunked with LastChunk with trailer header keep header chunk" in {
         val chunkStreamPart = Await.result(Chunked(tpe, source(Chunk(abc), Chunk(fgh), Chunk(ijk), LastChunk("", RawHeader("Foo", "pip apo") :: Nil)))
           .transformDataBytes(duplicateBytesTransformer()).chunks.runWith(Sink.last), awaitAtMost)
-        chunkStreamPart.isLastChunk mustBe(true)
-        chunkStreamPart mustBe a [LastChunk]
-        chunkStreamPart.asInstanceOf[LastChunk].trailer mustEqual(RawHeader("Foo", "pip apo") :: Nil)
+        chunkStreamPart.isLastChunk mustBe (true)
+        chunkStreamPart mustBe a[LastChunk]
+        chunkStreamPart.asInstanceOf[LastChunk].trailer mustEqual (RawHeader("Foo", "pip apo") :: Nil)
       }
     }
     "support toString" - {


### PR DESCRIPTION
## Purpose

To support trailing headers in `akka.http.scaladsl.model.HttpEntity.Chunked#transformDataBytes` to improve compatibility with akka-grpc which is setting trailing header (gRPC status) in `akka.http.scaladsl.model.HttpEntity.Chunked`.

When data of such an entity is about to be processed with `akka.http.scaladsl.model.HttpEntity.Chunked#transformDataBytes`  we get `IllegalArgumentException("Chunked.transformDataBytes not allowed for chunks with metadata") `

## References

References #2218 #45 #1869

## Changes

If the subject of data transormation - `akka.http.scaladsl.model.HttpEntity.chunks` is containing the chunk with trailing headers concatenate it to the chunks which are the result of data transformation with `akka.http.scaladsl.model.HttpEntity.Chunked#transformDataBytes`

## Background Context

I'm instrumenting akka-grpc calls with kamon-akka which performing such http entity transformations, they are not supported at the moment, I would like to fix that
