### PR TITLE
build: move </details> to the right place in validation report

### DIFF
--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -446,8 +446,8 @@ object AggregatePRValidation extends AutoPlugin {
             val problem = inc.directCause.map(_.toString).getOrElse(parseIncomplete(inc))
 
             write(s"${showKey(key)} failed because of $problem")
-            write("</details>")
           }
+          write("</details>")
         }
       }
 


### PR DESCRIPTION
Fixes the wrong validation report collapsing observed in https://github.com/akka/akka-http/pull/2753#issuecomment-541599194.