### PR TITLE
build: make sure to lift all akka dependencies to source when test-against-akka-master is used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,7 +149,7 @@ lazy val httpCore = project("akka-http-core")
   .addAkkaModuleDependency("akka-stream", "provided")
   .addAkkaModuleDependency("akka-stream-testkit", "test")
   .addAkkaModuleDependency(
-    "akka-stream",
+    "akka-stream-testkit",
     "test",
     shouldUseSourceDependency = true,
     uri("git://github.com/akka/akka.git#master"),


### PR DESCRIPTION
Fixes #2747. Might obsolete #2754.