### PR TITLE
build: rename `akka.build.version` env var not to clash with the one in the akka build

### DIFF
--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -17,7 +17,7 @@ object AkkaDependency {
   // Updated only when needed, https://github.com/akka/akka/issues/26985
   val defaultAkkaVersion = "2.5.23"
   val akkaVersion =
-    System.getProperty("akka.build.version", defaultAkkaVersion) match {
+    System.getProperty("akka.http.build.akka.version", defaultAkkaVersion) match {
       case "default" => defaultAkkaVersion
       case x => x
     }


### PR DESCRIPTION
Follow up to #2758, obsoletes #2754.