### PR TITLE
core: fix LowLevelOutgoingConnectionSpec which has subtly different behavior in Akka 2.5 and 2.6

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -461,7 +461,10 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
         info.summary shouldEqual "HTTP message had declared Content-Length 8 but entity data stream amounts to 2 bytes less"
         netInSub.sendComplete()
         responsesSub.request(1)
-        responses.expectError().getMessage shouldBe "The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests"
+        responses.expectError().getMessage should (
+          equal("HTTP message had declared Content-Length 8 but entity data stream amounts to 2 bytes less") or // with Akka 2.6
+          equal("The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests") // with Akka 2.5
+        )
       }
 
       "catch the request entity stream being longer than the Content-Length" in new TestSetup {
@@ -487,7 +490,10 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpec("akka.loggers = []\n akka.
         info.summary shouldEqual "HTTP message had declared Content-Length 8 but entity data stream amounts to more bytes"
         netInSub.sendComplete()
         responsesSub.request(1)
-        responses.expectError().getMessage shouldBe "The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests"
+        responses.expectError().getMessage should (
+          equal("HTTP message had declared Content-Length 8 but entity data stream amounts to more bytes") or // with Akka 2.6
+          equal("The http server closed the connection unexpectedly before delivering responses for 1 outstanding requests") // with Akka 2.5
+        )
       }
 
       "catch illegal response starts" in new TestSetup {


### PR DESCRIPTION
Fixes #2762.