### PR TITLE
Doc fix for regex paths from Java 

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/JavaRouteTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/JavaRouteTest.java
@@ -145,6 +145,13 @@ public class JavaRouteTest extends JUnitRouteTest {
   }
 
   @Test
+  public void pathCanMatchRegex() {
+    runRoute(route, HttpRequest.GET("/regex_thegroup"))
+        .assertEntity("regex: thegroup");
+  }
+
+
+  @Test
   public void paramIsExtracted() {
     runRoute(route, HttpRequest.GET("/cookies?amount=5"))
       .assertEntity("cookies 5");
@@ -268,6 +275,7 @@ public class JavaRouteTest extends JUnitRouteTest {
     });
   }
 
+  private static Pattern regex = Pattern.compile("regex_(.+)");
 
   public Route getRoute() {
     return concat(
@@ -281,6 +289,9 @@ public class JavaRouteTest extends JUnitRouteTest {
         path(uuidSegment(), id ->
           complete("document " + id)
         )
+      ),
+      path(segment(regex), (group) ->
+          complete("regex: " + group)
       ),
       pathPrefix("people", () ->
         path(name ->

--- a/docs/src/main/paradox/routing-dsl/path-matchers.md
+++ b/docs/src/main/paradox/routing-dsl/path-matchers.md
@@ -158,7 +158,7 @@ PathMatchers.segment(String)
 Note that strings are interpreted as the decoded representation of the path, so if they include a '/' character
 this character will match "%2F" in the encoded raw URI!
 
-PathMatchers.regex
+PathMatchers.segment(java.util.regex.Pattern)
 : You can use a regular expression instance as a path matcher, which matches whatever the regex matches and extracts
 one `String` value. A `PathMatcher` created from a regular expression extracts either the complete match (if the
 regex doesn't contain a capture group) or the capture group (if the regex contains exactly one capture group).


### PR DESCRIPTION
Refs #2749

Also added a test making sure the regex matching is in fact accessible from Java.

