### PR TITLE
docs: fix broken links for bootstrap a new sbt project

### DIFF
--- a/docs/src/main/paradox/introduction.md
+++ b/docs/src/main/paradox/introduction.md
@@ -69,19 +69,19 @@ configured using the [Giter8](http://www.foundweekends.org/giter8/) template:
 
 @@@ div { .group-scala }
 ```sh
-sbt -Dsbt.version=0.13.15 new https://github.com/akka/akka-http-scala-seed.g8
+sbt -Dsbt.version=0.13.15 new https://github.com/akka/akka-http-quickstart-scala.g8
 ```
 @@@
 @@@ div { .group-java }
 ```sh
-sbt -Dsbt.version=0.13.15 new https://github.com/akka/akka-http-java-seed.g8
+sbt -Dsbt.version=0.13.15 new https://github.com/akka/akka-http-quickstart-java.g8
 ```
 From there on the prepared project can be built using Gradle or Maven.
 @@@
 
 More instructions can be found on the @scala[[template
-project](https://github.com/akka/akka-http-scala-seed.g8)]@java[[template
-project](https://github.com/akka/akka-http-java-seed.g8)].
+project](https://github.com/akka/akka-http-quickstart-scala.g8)]@java[[template
+project](https://github.com/akka/akka-http-quickstart-java.g8)].
 
 ## Routing DSL for HTTP servers
 

--- a/notes/release-train-issue-template.md
+++ b/notes/release-train-issue-template.md
@@ -48,7 +48,7 @@ Wind down PR queue. There has to be enough time after the last (non-trivial) PR 
 - [ ] Go to the Maven Central tab and sync with Sonatype
 - [ ] Log in to Sonatype to Close the staging repository (optional, should happen automatically if selected in Bintray)
 - [ ] Notify Telemetry / Play team to check against staged artifacts
-- [ ] Run a test against the staging repository to make sure the release went well, for example by using https://github.com/akka/akka-http-scala-seed.g8 and adding the sonatype staging repo with `resolvers += "Staging Repo" at "https://oss.sonatype.org/content/repositories/comtypesafe-xxx"`
+- [ ] Run a test against the staging repository to make sure the release went well, for example by using https://github.com/akka/akka-http-quickstart-scala.g8 and adding the sonatype staging repo with `resolvers += "Staging Repo" at "https://oss.sonatype.org/content/repositories/comtypesafe-xxx"`
 - [ ] Release the staging repository to Maven Central.
 - [ ] Checkout the newly created tag and run `sbt -Dakka.genjavadoc.enabled=true ++2.12.8 "deployRsync akkarepo@gustav.akka.io"` to deploy API and reference documentation.
 


### PR DESCRIPTION
## Purpose

Follow the instruction in the [Introduction page](https://doc.akka.io/docs/akka-http/current/introduction.html#using-akka-http) to bootstrap a new project, there will be get a **template not found** message:

```
$ sbt new https://github.com/akka/akka-http-scala-seed.g8
[info] Loading settings for project global-plugins from idea.sbt ...
[info] Loading global plugins from /Users/xxx/.sbt/1.0/plugins
[info] Set current project to akka (in build file:/Users/xxx/)
[info] Set current project to akka (in build file:/Users/xxx)
Template not found for: new https://github.com/akka/akka-http-scala-seed.g8
```
