### PR TITLE
Potential fix for idle timeouts in http2

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -23,6 +23,7 @@ import akka.util.ByteString
 import com.typesafe.config.Config
 import javax.net.ssl.SSLEngine
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.Future
 import scala.collection.immutable
 import scala.util.{ Failure, Success }
@@ -60,7 +61,7 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
 
     val masterTerminator = new MasterServerTerminator(log)
 
-    Tcp().bind(interface, effectivePort, settings.backlog, settings.socketOptions, halfClose = false, settings.timeouts.idleTimeout)
+    Tcp().bind(interface, effectivePort, settings.backlog, settings.socketOptions, halfClose = false, Duration.Inf) // we knowingly disable idle-timeout on TCP level, as we handle it explicitly in Akka HTTP itself
       .mapAsyncUnordered(settings.maxConnections) {
         incoming: Tcp.IncomingConnection =>
           try {


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [not needed] Have you updated the documentation?
* [johannes to craft reg test] Have you added tests for any changed functionality?
-->
## Purpose

Fixes idle timeouts for HTTP/2 connections by removing the TCP idle timeout just as for HTTP/1 and instead attaching the timeouts at the HTTP layer.

## References

References [akka-grpc/664](https://github.com/akka/akka-grpc/issues/664) where it was discovered.

## Changes

Idle timeout management for HTTP/2

## Background Context

Because it is near-identical as the HTTP/1 solution
