### PR TITLE
Fix/amend 10.1.10 release notes formatting

### DIFF
--- a/docs/src/main/paradox/release-notes/10.1.x.md
+++ b/docs/src/main/paradox/release-notes/10.1.x.md
@@ -15,13 +15,15 @@ For a full overview you can also see the [10.1.10 milestone](https://github.com/
 * Fix 205 HTTP status not to contain any HTTP entity [#2686](https://github.com/akka/akka-http/pull/2686)
 * Support multiple subprotocols in WebSocket handshake [#2606](https://github.com/akka/akka-http/issues/2606)
 * Add `endsWith` predicate to `Uri.Path` [#2480](https://github.com/akka/akka-http/pull/2480)
-* Handle unrecognized status codes according to spec [#2503](https://github.com/akka/akka-http/pull/2503]
+* Handle unrecognized status codes according to spec [#2503](https://github.com/akka/akka-http/pull/2503)
 * Better error handling on server when response entity stream fails [#2627](https://github.com/akka/akka-http/pull/2627)
 * Force connection closure when pool is stopped [#2631](https://github.com/akka/akka-http/pull/2631)
 * Enable `log-unencrypted-network-bytes` also for websocket client traffic [#2647](https://github.com/akka/akka-http/pull/2647)
 * Add modeled header for Content-Location [#2540](https://github.com/akka/akka-http/pull/2540)
 * Streamed response processing performance improvements [#2645](https://github.com/akka/akka-http/pull/2645)
 * Make custom MediaType and MediaRange.matches case-insensitive [#2126](https://github.com/akka/akka-http/pull/2126)
+* Avoid prematurely closing long-lived requests [#1847](https://github.com/akka/akka-http/issues/1847)
+* Avoid reliance on deprecated ActorPublisher, as this is no longer available in Akka 2.6 [#2617](https://github.com/akka/akka-http/issues/2617)
 
 ##### akka-http
 


### PR DESCRIPTION
Clarify 10.1.10 has a fix to make it work with Akka 2.6