### PR TITLE
Improve WS masking performance

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ws/MaskingBench.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ws/MaskingBench.scala
@@ -1,0 +1,15 @@
+package akka.http.impl.engine.ws
+
+import org.openjdk.jmh.annotations.Benchmark
+
+import akka.util.ByteString
+import akka.http.CommonBenchmark
+
+class MaskingBench extends CommonBenchmark {
+  val data = ByteString(new Array[Byte](10000))
+  val mask = 0xfedcba09
+
+  @Benchmark
+  def benchRequestProcessing(): (ByteString, Int) =
+    FrameEventParser.mask(data, mask)
+}

--- a/akka-http-bench-jmh/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
@@ -51,7 +51,7 @@ class LineParserBenchmark {
     val makeSampleFile = Source.single(line)
       .runWith(FileIO.toPath(tempFile))
 
-    Await.result(makeSampleFile, 5 seconds)
+    Await.result(makeSampleFile, 5.seconds)
 
     parserGraph = FileIO
       .fromPath(tempFile, chunkSize)


### PR DESCRIPTION
On top of #2780 

It now masks 4 bytes together and also avoids an extra buffer copy at the end by using `ByteString.fromArrayUnsafe`.

(It cannot fix the 2.13 performance problem because ByteString.toArray is still used)