### PR TITLE
http: fix default rejection message for unsupported content type (#2804)

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -261,9 +261,13 @@ object RejectionHandler {
           supported.map(_.value).mkString("\n")))
       }
       .handleAll[UnsupportedRequestContentTypeRejection] { rejections =>
+        val unsupported = rejections.find(_.contentType.isDefined).flatMap(_.contentType).fold("")(" [" + _ + "]")
         val supported = rejections.flatMap(_.supported).mkString(" or ")
-        val unsupportedContentType = rejections.find(_.contentType.isDefined).map(_.contentType)
-        rejectRequestEntityAndComplete((UnsupportedMediaType, s"The request's Content-Type [$unsupportedContentType] is not supported. Expected:\n" + supported))
+        val expected =
+          if (supported.isEmpty) ""
+          else " Expected:\n" + supported
+
+        rejectRequestEntityAndComplete((UnsupportedMediaType, s"The request's Content-Type$unsupported is not supported.$expected"))
       }
       .handleAll[UnsupportedRequestEncodingRejection] { rejections =>
         val supported = rejections.map(_.supported.value).mkString(" or ")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

This PR fixes a message which the default rejection handler produces for `UnsupportedRequestContentTypeRejection`. With this PR the message looks something like
```
The request's Content-Type [image/bmp] is not supported. Expected:
image/jpeg or image/png
```
if the corresponding rejection has the `contentType` option defined or
```
The request's Content-Type is not supported. Expected:
image/jpeg or image/png
```
if the `contentType` option is set to `None`.
In case if `UnsupportedRequestContentTypeRejection` doesn't provide supported content type ranges,
the rejection message will look like:
```
The request's Content-Type [image/bmp] is not supported.
```

## References

References #2804

## Changes

* The default `RejectionHandler`'s error message for `UnsupportedRequestContentTypeRejection` is changed.
