### PR TITLE
Update naming for status codes 413, 414, 416 and 505

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
@@ -57,9 +57,27 @@ public final class StatusCodes {
     public static final StatusCode GONE = akka.http.scaladsl.model.StatusCodes.Gone();
     public static final StatusCode LENGTH_REQUIRED = akka.http.scaladsl.model.StatusCodes.LengthRequired();
     public static final StatusCode PRECONDITION_FAILED = akka.http.scaladsl.model.StatusCodes.PreconditionFailed();
+    public static final StatusCode PAYLOAD_TOO_LARGE = akka.http.scaladsl.model.StatusCodes.PayloadTooLarge();
+
+    /**
+     * @deprecated deprecated in favor of Payload Too Large
+     */
+    @Deprecated
     public static final StatusCode REQUEST_ENTITY_TOO_LARGE = akka.http.scaladsl.model.StatusCodes.RequestEntityTooLarge();
+    public static final StatusCode URI_TOO_LONG = akka.http.scaladsl.model.StatusCodes.UriTooLong();
+
+    /**
+     * @deprecated deprecated in favor of Uri Too Long
+     */
+    @Deprecated
     public static final StatusCode REQUEST_URI_TOO_LONG = akka.http.scaladsl.model.StatusCodes.RequestUriTooLong();
     public static final StatusCode UNSUPPORTED_MEDIA_TYPE = akka.http.scaladsl.model.StatusCodes.UnsupportedMediaType();
+    public static final StatusCode RANGE_NOT_SATISFIABLE = akka.http.scaladsl.model.StatusCodes.RangeNotSatisfiable();
+
+    /**
+     * @deprecated deprecated in favor of Range Not Satisfiable
+     */
+    @Deprecated
     public static final StatusCode REQUESTED_RANGE_NOT_SATISFIABLE = akka.http.scaladsl.model.StatusCodes.RequestedRangeNotSatisfiable();
     public static final StatusCode EXPECTATION_FAILED = akka.http.scaladsl.model.StatusCodes.ExpectationFailed();
     public static final StatusCode IM_A_TEAPOT = akka.http.scaladsl.model.StatusCodes.ImATeapot();

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
@@ -107,7 +107,7 @@ public final class StatusCodes {
     public static final StatusCode BAD_GATEWAY = akka.http.scaladsl.model.StatusCodes.BadGateway();
     public static final StatusCode SERVICE_UNAVAILABLE = akka.http.scaladsl.model.StatusCodes.ServiceUnavailable();
     public static final StatusCode GATEWAY_TIMEOUT = akka.http.scaladsl.model.StatusCodes.GatewayTimeout();
-    public static final StatusCode HTTPVERSION_NOT_SUPPORTED = akka.http.scaladsl.model.StatusCodes.HTTPVersionNotSupported();
+    public static final StatusCode HTTPVERSION_NOT_SUPPORTED = akka.http.scaladsl.model.StatusCodes.HttpVersionNotSupported();
     public static final StatusCode VARIANT_ALSO_NEGOTIATES = akka.http.scaladsl.model.StatusCodes.VariantAlsoNegotiates();
     public static final StatusCode INSUFFICIENT_STORAGE = akka.http.scaladsl.model.StatusCodes.InsufficientStorage();
     public static final StatusCode LOOP_DETECTED = akka.http.scaladsl.model.StatusCodes.LoopDetected();

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
@@ -60,14 +60,14 @@ public final class StatusCodes {
     public static final StatusCode PAYLOAD_TOO_LARGE = akka.http.scaladsl.model.StatusCodes.PayloadTooLarge();
 
     /**
-     * @deprecated deprecated in favor of Payload Too Large
+     * @deprecated deprecated in favor of PAYLOAD_TOO_LARGE
      */
     @Deprecated
     public static final StatusCode REQUEST_ENTITY_TOO_LARGE = akka.http.scaladsl.model.StatusCodes.RequestEntityTooLarge();
     public static final StatusCode URI_TOO_LONG = akka.http.scaladsl.model.StatusCodes.UriTooLong();
 
     /**
-     * @deprecated deprecated in favor of Uri Too Long
+     * @deprecated deprecated in favor of URI_TOO_LONG
      */
     @Deprecated
     public static final StatusCode REQUEST_URI_TOO_LONG = akka.http.scaladsl.model.StatusCodes.RequestUriTooLong();
@@ -75,7 +75,7 @@ public final class StatusCodes {
     public static final StatusCode RANGE_NOT_SATISFIABLE = akka.http.scaladsl.model.StatusCodes.RangeNotSatisfiable();
 
     /**
-     * @deprecated deprecated in favor of Range Not Satisfiable
+     * @deprecated deprecated in favor of RANGE_NOT_SATISFIABLE
      */
     @Deprecated
     public static final StatusCode REQUESTED_RANGE_NOT_SATISFIABLE = akka.http.scaladsl.model.StatusCodes.RequestedRangeNotSatisfiable();
@@ -88,7 +88,7 @@ public final class StatusCodes {
     public static final StatusCode FAILED_DEPENDENCY = akka.http.scaladsl.model.StatusCodes.FailedDependency();
 
     /**
-     * @deprecated Non-standard Unordered Collection should not be used, deprecated in favor of Too Early
+     * @deprecated Non-standard Unordered Collection should not be used, deprecated in favor of TOO_EARLY
      */
     @Deprecated
     public static final StatusCode UNORDERED_COLLECTION = akka.http.scaladsl.model.StatusCodes.UnorderedCollection();

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -468,7 +468,7 @@ private[http] object HttpServerBluePrint {
                 case None     => s"Aggregated data length of request entity exceeds the configured limit of $limit bytes"
               }
               val info = ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-              finishWithIllegalRequestError(StatusCodes.RequestEntityTooLarge, info)
+              finishWithIllegalRequestError(StatusCodes.PayloadTooLarge, info)
 
             case IllegalUriException(errorInfo) =>
               finishWithIllegalRequestError(StatusCodes.BadRequest, errorInfo)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
@@ -174,7 +174,9 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val BadGateway                    = reg(e(502)("Bad Gateway", "The server was acting as a gateway or proxy and received an invalid response from the upstream server."))
   val ServiceUnavailable            = reg(e(503)("Service Unavailable", "The server is currently unavailable (because it is overloaded or down for maintenance)."))
   val GatewayTimeout                = reg(e(504)("Gateway Timeout", "The server was acting as a gateway or proxy and did not receive a timely response from the upstream server."))
-  val HTTPVersionNotSupported       = reg(e(505)("HTTP Version Not Supported", "The server does not support the HTTP protocol version used in the request."))
+  val HttpVersionNotSupported       = reg(e(505)("HTTP Version Not Supported", "The server does not support the HTTP protocol version used in the request."))
+  @deprecated("deprecated in favor of Http Version Not Supported", "10.1.11")
+  val HTTPVersionNotSupported       = HttpVersionNotSupported
   val VariantAlsoNegotiates         = reg(e(506)("Variant Also Negotiates", "Transparent content negotiation for the request, results in a circular reference."))
   val InsufficientStorage           = reg(e(507)("Insufficient Storage", "Insufficient storage to complete the request."))
   val LoopDetected                  = reg(e(508)("Loop Detected", "The server detected an infinite loop while processing the request."))

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
@@ -141,10 +141,16 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val Gone                         = reg(c(410)("Gone", "The resource requested is no longer available and will not be available again."))
   val LengthRequired               = reg(c(411)("Length Required", "The request did not specify the length of its content, which is required by the requested resource."))
   val PreconditionFailed           = reg(c(412)("Precondition Failed", "The server does not meet one of the preconditions that the requester put on the request."))
-  val RequestEntityTooLarge        = reg(c(413)("Request Entity Too Large", "The request is larger than the server is willing or able to process."))
-  val RequestUriTooLong            = reg(c(414)("Request-URI Too Long", "The URI provided was too long for the server to process."))
+  val PayloadTooLarge              = reg(c(413)("Payload Too Large", "The request payload is larger than the server is willing or able to process."))
+  @deprecated("deprecated in favor of Payload Too Large", "10.1.11")
+  val RequestEntityTooLarge        = PayloadTooLarge
+  val UriTooLong                   = reg(c(414)("URI Too Long", "The URI provided was too long for the server to process."))
+  @deprecated("deprecated in favor of Uri Too Long", "10.1.11")
+  val RequestUriTooLong            = UriTooLong
   val UnsupportedMediaType         = reg(c(415)("Unsupported Media Type", "The request entity has a media type which the server or resource does not support."))
-  val RequestedRangeNotSatisfiable = reg(c(416)("Requested Range Not Satisfiable", "The client has asked for a portion of the file, but the server cannot supply that portion."))
+  val RangeNotSatisfiable          = reg(c(416)("Range Not Satisfiable", "The client has asked for a portion of the file, but the server cannot supply that portion."))
+  @deprecated("deprecated in favor of Range Not Satisfiable", "10.1.11")
+  val RequestedRangeNotSatisfiable = RangeNotSatisfiable
   val ExpectationFailed            = reg(c(417)("Expectation Failed", "The server cannot meet the requirements of the Expect request-header field."))
   val ImATeapot                    = reg(c(418)("I'm a teapot", "The resulting entity body MAY be short and stout."))
   val EnhanceYourCalm              = reg(c(420)("Enhance Your Calm", "You are being rate-limited.")) // Twitter only
@@ -152,8 +158,6 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val UnprocessableEntity          = reg(c(422)("Unprocessable Entity", "The request was well-formed but was unable to be followed due to semantic errors."))
   val Locked                       = reg(c(423)("Locked", "The resource that is being accessed is locked."))
   val FailedDependency             = reg(c(424)("Failed Dependency", "The request failed due to failure of a previous request."))
-
-
   val TooEarly                     = reg(c(425)("Too Early", "The server is unwilling to risk processing a request that might be replayed.")) // RFC 8470
   @deprecated("Non-standard Unordered Collection should not be used, deprecated in favor of Too Early", "10.1.6")
   val UnorderedCollection          = TooEarly

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
@@ -142,14 +142,14 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val LengthRequired               = reg(c(411)("Length Required", "The request did not specify the length of its content, which is required by the requested resource."))
   val PreconditionFailed           = reg(c(412)("Precondition Failed", "The server does not meet one of the preconditions that the requester put on the request."))
   val PayloadTooLarge              = reg(c(413)("Payload Too Large", "The request payload is larger than the server is willing or able to process."))
-  @deprecated("deprecated in favor of Payload Too Large", "10.1.11")
+  @deprecated("deprecated in favor of PayloadTooLarge", "10.1.11")
   val RequestEntityTooLarge        = PayloadTooLarge
   val UriTooLong                   = reg(c(414)("URI Too Long", "The URI provided was too long for the server to process."))
-  @deprecated("deprecated in favor of Uri Too Long", "10.1.11")
+  @deprecated("deprecated in favor of UriTooLong", "10.1.11")
   val RequestUriTooLong            = UriTooLong
   val UnsupportedMediaType         = reg(c(415)("Unsupported Media Type", "The request entity has a media type which the server or resource does not support."))
   val RangeNotSatisfiable          = reg(c(416)("Range Not Satisfiable", "The client has asked for a portion of the file, but the server cannot supply that portion."))
-  @deprecated("deprecated in favor of Range Not Satisfiable", "10.1.11")
+  @deprecated("deprecated in favor of RangeNotSatisfiable", "10.1.11")
   val RequestedRangeNotSatisfiable = RangeNotSatisfiable
   val ExpectationFailed            = reg(c(417)("Expectation Failed", "The server cannot meet the requirements of the Expect request-header field."))
   val ImATeapot                    = reg(c(418)("I'm a teapot", "The resulting entity body MAY be short and stout."))
@@ -159,7 +159,7 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val Locked                       = reg(c(423)("Locked", "The resource that is being accessed is locked."))
   val FailedDependency             = reg(c(424)("Failed Dependency", "The request failed due to failure of a previous request."))
   val TooEarly                     = reg(c(425)("Too Early", "The server is unwilling to risk processing a request that might be replayed.")) // RFC 8470
-  @deprecated("Non-standard Unordered Collection should not be used, deprecated in favor of Too Early", "10.1.6")
+  @deprecated("Non-standard Unordered Collection should not be used, deprecated in favor of TooEarly", "10.1.6")
   val UnorderedCollection          = TooEarly
   val UpgradeRequired              = reg(c(426)("Upgrade Required", "The client should switch to a different protocol."))
   val PreconditionRequired         = reg(c(428)("Precondition Required", "The server requires the request to be conditional."))
@@ -175,7 +175,7 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val ServiceUnavailable            = reg(e(503)("Service Unavailable", "The server is currently unavailable (because it is overloaded or down for maintenance)."))
   val GatewayTimeout                = reg(e(504)("Gateway Timeout", "The server was acting as a gateway or proxy and did not receive a timely response from the upstream server."))
   val HttpVersionNotSupported       = reg(e(505)("HTTP Version Not Supported", "The server does not support the HTTP protocol version used in the request."))
-  @deprecated("deprecated in favor of Http Version Not Supported", "10.1.11")
+  @deprecated("deprecated in favor of HttpVersionNotSupported", "10.1.11")
   val HTTPVersionNotSupported       = HttpVersionNotSupported
   val VariantAlsoNegotiates         = reg(e(506)("Variant Also Negotiates", "Transparent content negotiation for the request, results in a circular reference."))
   val InsufficientStorage           = reg(e(507)("Insufficient Storage", "Insufficient storage to complete the request."))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -538,7 +538,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
 
       "a too-long URI" in new Test {
         "GET /2345678901234567890123456789012345678901 HTTP/1.1" should parseToError(
-          RequestUriTooLong,
+          UriTooLong,
           ErrorInfo("URI length exceeds the configured limit of 40 characters"))
       }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -545,7 +545,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends FreeSpec
       "HTTP version 1.2" in new Test {
         """GET / HTTP/1.2
           |""" should parseToError(
-          HTTPVersionNotSupported,
+          HttpVersionNotSupported,
           ErrorInfo("The server does not support the HTTP protocol version used in the request."))
       }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -1261,7 +1261,7 @@ class HttpServerSpec extends AkkaSpec(
                 responses.sendError(error.asInstanceOf[Exception])
 
                 expectResponseWithWipedDate(
-                  s"""HTTP/1.1 413 Request Entity Too Large
+                  s"""HTTP/1.1 413 Payload Too Large
                       |Server: akka-http/test
                       |Date: XXXX
                       |Connection: close
@@ -1284,7 +1284,7 @@ class HttpServerSpec extends AkkaSpec(
                 responses.sendError(error.asInstanceOf[Exception])
 
                 expectResponseWithWipedDate(
-                  s"""HTTP/1.1 413 Request Entity Too Large
+                  s"""HTTP/1.1 413 Payload Too Large
                     |Server: akka-http/test
                     |Date: XXXX
                     |Connection: close

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
@@ -88,7 +88,7 @@ public class MiscDirectivesTest extends JUnitRouteTest {
 
     route
       .run(withEntityOfSize(501))
-      .assertStatusCode(StatusCodes.REQUEST_ENTITY_TOO_LARGE);
+      .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE);
 
   }
 

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
@@ -88,7 +88,7 @@ public class RouteDirectivesTest extends JUnitRouteTest {
 
     route
       .run(HttpRequest.create("/limit-5").withEntity("1234567890"))
-      .assertStatusCode(StatusCodes.REQUEST_ENTITY_TOO_LARGE)
+      .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE)
       .assertEntity("EntityStreamSizeException: actual entity size (Some(10)) exceeded content length limit (5 bytes)! " +
               "You can configure this by setting `akka.http.[server|client].parsing.max-content-length` " +
               "or calling `HttpEntity.withSizeLimit` before materializing the dataBytes stream.");

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -62,7 +62,7 @@ class SizeLimitSpec extends WordSpec with Matchers with RequestBuilding with Bef
 
     "not accept entities bigger than configured with akka.http.parsing.max-content-length" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength + 1)))
-        .futureValue.status shouldEqual StatusCodes.RequestEntityTooLarge
+        .futureValue.status shouldEqual StatusCodes.PayloadTooLarge
     }
   }
 
@@ -98,7 +98,7 @@ class SizeLimitSpec extends WordSpec with Matchers with RequestBuilding with Bef
       data.size should be > decodeMaxSize
 
       Http().singleRequest(request)
-        .futureValue.status shouldEqual StatusCodes.RequestEntityTooLarge
+        .futureValue.status shouldEqual StatusCodes.PayloadTooLarge
     }
   }
 
@@ -120,7 +120,7 @@ class SizeLimitSpec extends WordSpec with Matchers with RequestBuilding with Bef
     "reject a small request that decodes into a large chunked entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
       val response = Http().singleRequest(request).futureValue
-      response.status shouldEqual StatusCodes.RequestEntityTooLarge
+      response.status shouldEqual StatusCodes.PayloadTooLarge
     }
   }
 
@@ -142,7 +142,7 @@ class SizeLimitSpec extends WordSpec with Matchers with RequestBuilding with Bef
     "reject a small request that decodes into a large non-chunked streaming entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
       val response = Http().singleRequest(request).futureValue
-      response.status shouldEqual StatusCodes.RequestEntityTooLarge
+      response.status shouldEqual StatusCodes.PayloadTooLarge
     }
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -101,7 +101,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", entityOfSize(501)) ~> Route.seal(route) ~> check {
-        status shouldEqual StatusCodes.RequestEntityTooLarge
+        status shouldEqual StatusCodes.PayloadTooLarge
         entityAs[String] should include("exceeded content length limit")
       }
     }
@@ -119,7 +119,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", formDataOfSize(128)) ~> Route.seal(route) ~> check {
-        status shouldEqual StatusCodes.RequestEntityTooLarge
+        status shouldEqual StatusCodes.PayloadTooLarge
         responseAs[String] shouldEqual "The request content was malformed:\n" +
           "EntityStreamSizeException: actual entity size (Some(134)) " +
           "exceeded content length limit (64 bytes)! " +
@@ -143,7 +143,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", entityOfSize(801)) ~> Route.seal(route) ~> check {
-        status shouldEqual StatusCodes.RequestEntityTooLarge
+        status shouldEqual StatusCodes.PayloadTooLarge
         entityAs[String] should include("exceeded content length limit")
       }
 
@@ -161,7 +161,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", entityOfSize(401)) ~> Route.seal(route2) ~> check {
-        status shouldEqual StatusCodes.RequestEntityTooLarge
+        status shouldEqual StatusCodes.PayloadTooLarge
         entityAs[String] should include("exceeded content length limit")
       }
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -52,9 +52,9 @@ object ExceptionHandler {
         ctx.complete((status, info.format(settings.verboseErrorMessages)))
       }
       case e: EntityStreamSizeException => ctx => {
-        ctx.log.error(e, ErrorMessageTemplate, e, RequestEntityTooLarge)
+        ctx.log.error(e, ErrorMessageTemplate, e, PayloadTooLarge)
         ctx.request.discardEntityBytes(ctx.materializer)
-        ctx.complete((RequestEntityTooLarge, e.getMessage))
+        ctx.complete((PayloadTooLarge, e.getMessage))
       }
       case e: ExceptionWithErrorInfo => ctx => {
         ctx.log.error(e, ErrorMessageTemplate, e.info.formatPretty, InternalServerError)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -190,7 +190,7 @@ object RejectionHandler {
         case MalformedRequestContentRejection(msg, throwable) => {
           val rejectionMessage = "The request content was malformed:\n" + msg
           throwable match {
-            case _: EntityStreamSizeException => rejectRequestEntityAndComplete((RequestEntityTooLarge, rejectionMessage))
+            case _: EntityStreamSizeException => rejectRequestEntityAndComplete((PayloadTooLarge, rejectionMessage))
             case _                            => rejectRequestEntityAndComplete((BadRequest, rejectionMessage))
           }
         }
@@ -225,7 +225,7 @@ object RejectionHandler {
       }
       .handle {
         case TooManyRangesRejection(_) =>
-          rejectRequestEntityAndComplete((RequestedRangeNotSatisfiable, "Request contains too many ranges"))
+          rejectRequestEntityAndComplete((RangeNotSatisfiable, "Request contains too many ranges"))
       }
       .handle {
         case CircuitBreakerOpenRejection(_) =>
@@ -233,7 +233,7 @@ object RejectionHandler {
       }
       .handle {
         case UnsatisfiableRangeRejection(unsatisfiableRanges, actualEntityLength) =>
-          rejectRequestEntityAndComplete((RequestedRangeNotSatisfiable, List(`Content-Range`(ContentRange.Unsatisfiable(actualEntityLength))),
+          rejectRequestEntityAndComplete((RangeNotSatisfiable, List(`Content-Range`(ContentRange.Unsatisfiable(actualEntityLength))),
             unsatisfiableRanges.mkString("None of the following requested Ranges were satisfiable:\n", "\n", "")))
       }
       .handleAll[AuthenticationFailedRejection] { rejections =>

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -89,7 +89,7 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
       .assertStatusCode(StatusCodes.OK);
 
     testRoute(route).run(withEntityOfSize.apply(501))
-      .assertStatusCode(StatusCodes.REQUEST_ENTITY_TOO_LARGE);
+      .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE);
     //#withSizeLimitExample
   }
 
@@ -114,7 +114,7 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
             .assertStatusCode(StatusCodes.OK);
 
     testRoute(route).run(withEntityOfSize.apply(801))
-            .assertStatusCode(StatusCodes.REQUEST_ENTITY_TOO_LARGE);
+            .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE);
     //#withSizeLimitExampleNested
   }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
@@ -129,7 +129,7 @@ class MiscDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     }
 
     Post("/abc", entityOfSize(501)) ~> Route.seal(route) ~> check {
-      status shouldEqual StatusCodes.RequestEntityTooLarge
+      status shouldEqual StatusCodes.PayloadTooLarge
     }
 
     //#withSizeLimit-example
@@ -174,7 +174,7 @@ class MiscDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     }
 
     Post("/abc", entityOfSize(801)) ~> Route.seal(route) ~> check {
-      status shouldEqual StatusCodes.RequestEntityTooLarge
+      status shouldEqual StatusCodes.PayloadTooLarge
     }
     //#withSizeLimit-nested-example
   }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->

For status codes 413, 414 and 416 older names from older RFCs are currently used, I updated them to follow the naming in RFC 7231 and RFC 7233. 
For status code 505 the Scala naming convention was not followed. 
I deprecated the older names.
I decided to leave `OK` (which also doesn't follow the naming convention) as is, because that probably would mean a lot of changes downstream.

