### PR TITLE
core: silence noisy pool idle timeout messages

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterface.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterface.scala
@@ -130,7 +130,7 @@ private[http] object PoolInterface {
     }
 
     override protected def onTimer(timerKey: Any): Unit = {
-      log.info(s"Pool shutting down because akka.http.host-connection-pool.idle-timeout triggered after $idleTimeout.")
+      log.debug(s"Pool shutting down because akka.http.host-connection-pool.idle-timeout triggered after $idleTimeout.")
       requestShutdown(ShutdownReason.IdleTimeout)
     }
 
@@ -195,7 +195,7 @@ private[http] object PoolInterface {
     def shutdownIfRequestedAndPossible(): Unit =
       if (shuttingDown) {
         if (remainingRequested == 0) {
-          log.info("Pool is now shutting down as requested.")
+          log.debug("Pool is now shutting down as requested.")
           shutdownPromise.trySuccess(shuttingDownReason.get)
           completeStage()
         } else


### PR DESCRIPTION
Fixes #2728

 * idle timeout messages are now DEBUG level
 * when pool slot is idle, use regular stream completion when pool is shutdown