### PR TITLE
build: use more resilient checking for Scala 2.13 in Mima

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,10 +24,8 @@ object Dependencies {
   lazy val specs2Version = settingKey[String]("The version of Specs2 to use")
   lazy val scalaCheckVersion = settingKey[String]("The version of ScalaCheck to use.")
 
-  val Scala213 = "2.13.1"
-
   val Versions = Seq(
-    crossScalaVersions := Seq("2.12.10", "2.11.12", Scala213), // also update .travis.yml when changing here to avoid confusion
+    crossScalaVersions := Seq("2.12.10", "2.11.12", "2.13.1"), // also update .travis.yml when changing here to avoid confusion
     scalaVersion := crossScalaVersions.value.head,
     scalaCheckVersion := System.getProperty("akka.build.scalaCheckVersion", "1.14.2"),
     scalaTestVersion := "3.0.8",

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -63,7 +63,7 @@ object MiMa extends AutoPlugin {
       )
 
       val versions =
-        if (scalaVersion.value == Dependencies.Scala213) post213Versions
+        if (scalaBinaryVersion.value == "2.13") post213Versions
         else pre213Versions ++ post213Versions
 
       versions.collect { case version if !ignoredModules.get(name.value).exists(_.contains(version)) =>


### PR DESCRIPTION
Fix #2819

The real issue is that nightlies were using `++2.13.0` last night.