### PR TITLE
= only catch NonFatal Exceptions

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
@@ -6,7 +6,7 @@ package akka.http.impl.engine.parsing
 
 import scala.annotation.tailrec
 import scala.concurrent.Promise
-import scala.util.control.NoStackTrace
+import scala.util.control.{ NoStackTrace, NonFatal }
 import akka.http.scaladsl.settings.ParserSettings
 import akka.http.impl.model.parser.CharacterClasses
 import akka.util.ByteString
@@ -79,7 +79,7 @@ private[http] class HttpResponseParser(protected val settings: ParserSettings, p
               val reason = asciiString(input, reasonStartIdx, reasonEndIdx)
               StatusCodes.custom(code, reason)
             } catch {
-              case _: Exception => badStatusCodeSpecific(code)
+              case NonFatal(_) => badStatusCodeSpecific(code)
             }
           }
         }


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

 I spotted this while reviewing some code https://github.com/akka/akka-http/pull/2503/files/fa1e4241b004a2c92d0513a1a9a55ab00b811f0c#diff-934eaac30edce2e74265c0760314da50 

No longer catch exceptions that are fatal to the JVM. 

<!-- What does this PR do? -->

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References  https://github.com/akka/akka-http/pull/2503/files/fa1e4241b004a2c92d0513a1a9a55ab00b811f0c#diff-934eaac30edce2e74265c0760314da50 
