### PR TITLE
Disable idle-timeout in Http2

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -25,6 +25,7 @@ import javax.net.ssl.SSLEngine
 
 import scala.concurrent.Future
 import scala.collection.immutable
+import scala.concurrent.duration.Duration
 import scala.util.{ Failure, Success }
 import scala.util.control.NonFatal
 
@@ -60,7 +61,14 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
 
     val masterTerminator = new MasterServerTerminator(log)
 
-    Tcp().bind(interface, effectivePort, settings.backlog, settings.socketOptions, halfClose = false, settings.timeouts.idleTimeout)
+    Tcp().bind(
+      interface,
+      effectivePort,
+      settings.backlog,
+      settings.socketOptions,
+      halfClose = false,
+      idleTimeout = Duration.Inf // we knowingly disable idle-timeout on TCP level, as we handle it explicitly in Akka HTTP itself
+    )
       .mapAsyncUnordered(settings.maxConnections) {
         incoming: Tcp.IncomingConnection =>
           try {


### PR DESCRIPTION
Idle timeout handling logic was moved to http layer in this commit: akka/akka-http@81ae350

idle timeout parameter was disabled in http 1.x https://github.com/akka/akka-http/blob/master/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala#L138

however it wasn't disabled in http2 https://github.com/akka/akka-http/blob/master/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala#L63 which results in duplicate idle timeout logic on diffrent layers http/tcp that doesn't work correctly together. As a result terminated connection doesn't propagate `onDownstreamFinish` and the stream is stopped forever.
