### PR TITLE
Fix project-info links to API docs

### DIFF
--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -1,7 +1,7 @@
 project-info {
   version: "current"
-  scaladoc: "https://doc.akka.io/api/akka-http/"${project-info.version}"/akka/http/scaladsl"
-  javadoc: "https://doc.akka.io/japi/akka-http/"${project-info.version}
+  scaladoc: "https://doc.akka.io/api/akka-http/current/akka/http/scaladsl"
+  javadoc: "https://doc.akka.io/japi/akka-http/current"
   shared-info {
     jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
     // snapshots: { }


### PR DESCRIPTION
project-info.jar does not work (https://github.com/lightbend/sbt-paradox-project-info/issues/15),
but linking to `current` is probably better for SEO reasons anyway.