### PR TITLE
First draft of message attributes

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -49,13 +49,13 @@ public interface HttpMessage {
 
     /**
      * Try to find the first header with the given name (case-insensitive) and return
-     * Some(header), otherwise this method returns None.
+     * Optional.of(header), otherwise this method returns an empty Optional.
      */
     Optional<HttpHeader> getHeader(String headerName);
 
     /**
      * Try to find the first header of the given class and return
-     * Some(header), otherwise this method returns None.
+     * Optional.of(header), otherwise this method returns an empty Optional.
      */
     <T extends HttpHeader> Optional<T> getHeader(Class<T> headerClass);
 
@@ -64,6 +64,22 @@ public interface HttpMessage {
      * of this message.
      */
     <T extends HttpHeader> Iterable<T> getHeaders(Class<T> headerClass);
+
+    /**
+     * An iterable containing the attributes for this message.
+     */
+    Iterable<Object> getAttributes();
+
+    /**
+     * Try to find the first attribute of the given class and return
+     * Optional.of(attribute), otherwise this method returns an empty Optional
+     */
+    <T> Optional<T> getAttribute(Class<T> attributeClass);
+
+    /**
+     * An iterable containing all attributes of the given class of this message
+     */
+     <T> Iterable<T> getAttributes(Class<T> attributeClass);
 
     /**
      * The entity of this message.

--- a/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/issue-1500-attributes.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/issue-1500-attributes.excludes
@@ -1,0 +1,12 @@
+# Adding a method to an interface marked DoNotInherit is OK
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage.getAttributes")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage.getAttribute")
+
+# Adding a method to a sealed trait is safe
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.attributes")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.withAttributes")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.mapAttributes")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.addAttribute")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.getAttributes")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.getAttribute")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.getAttributes")

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
@@ -71,6 +71,14 @@ class HttpMessageSpec extends WordSpec with Matchers {
       val request = HttpRequest().withHeaders(oneCookieHeader, anotherCookieHeader, hostHeader)
       request.headers[`Set-Cookie`] should ===(Seq(oneCookieHeader, anotherCookieHeader))
     }
+    "retrieve all attributes of a given class when calling attributes[...]" in {
+      val oneStringAttribute: String = "A string attribute!"
+      val anotherStringAttribute: String = "And another"
+      val intAttribute: Integer = 42
+      val request = HttpRequest().withAttributes(oneStringAttribute, anotherStringAttribute, intAttribute)
+      println(request.attributes)
+      request.attributes[String] should ===(Seq(oneStringAttribute, anotherStringAttribute))
+    }
   }
 
 }


### PR DESCRIPTION
Refs  #1500

This approach follows the Play API (https://www.playframework.com/documentation/2.8.x/Highlights26)
in that you can add attributes of any user type. Otherwise it follows the
existing conventions from Akka HTTP Headers, so you can have multiple
attributes of the same type. If you want to distinguish different attributes of
the same type, like you could in Play with different keys, you would have to
introduce a wrapper type (either holding the key or creating a separate wrapper
for each key).

The main downside of this approach is that it increases the memory usage of a
message with one field.