### PR TITLE
Add detail to onBadProtocol

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/2877-better-LogByteStringTools-printByteString.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/2877-better-LogByteStringTools-printByteString.excludes
@@ -1,0 +1,2 @@
+# Internals
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.util.LogByteStringTools.printByteString")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -48,7 +48,7 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
   protected def headerParser: HttpHeaderParser
   protected def isResponseParser: Boolean
   /** invoked if the specified protocol is unknown */
-  protected def onBadProtocol(): Nothing
+  protected def onBadProtocol(input: ByteString): Nothing
   protected def parseMessage(input: ByteString, offset: Int): HttpMessageParser.StateResult
   protected def parseEntity(headers: List[HttpHeader], protocol: HttpProtocol, input: ByteString, bodyStart: Int,
                             clh: Option[`Content-Length`], cth: Option[`Content-Type`], isChunked: Boolean,
@@ -120,10 +120,10 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
       protocol = c(7) match {
         case '0' => `HTTP/1.0`
         case '1' => `HTTP/1.1`
-        case _   => onBadProtocol()
+        case _   => onBadProtocol(input.drop(cursor))
       }
       cursor + 8
-    } else onBadProtocol()
+    } else onBadProtocol(input.drop(cursor))
   }
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
@@ -82,7 +82,7 @@ private[http] final class HttpRequestParser(
           parseHeaderLines(input, cursor + 2)
         else if (byteChar(input, cursor) == '\n')
           parseHeaderLines(input, cursor + 1)
-        else onBadProtocol()
+        else onBadProtocol(input.drop(cursor))
       } else
         // Without HTTP pipelining it's likely that buffer is exhausted after reading one message,
         // so we check above explicitly if we are done and stop work here without running into NotEnoughDataException
@@ -167,7 +167,7 @@ private[http] final class HttpRequestParser(
       uriEnd + 1
     }
 
-    override def onBadProtocol(): Nothing = throw new ParsingException(HttpVersionNotSupported)
+    override def onBadProtocol(input: ByteString): Nothing = throw new ParsingException(HttpVersionNotSupported, "")
 
     // http://tools.ietf.org/html/rfc7230#section-3.3
     override def parseEntity(headers: List[HttpHeader], protocol: HttpProtocol, input: ByteString, bodyStart: Int,

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/package.scala
@@ -62,10 +62,12 @@ package parsing {
   private[parsing] class ParsingException(
     val status: StatusCode,
     val info:   ErrorInfo) extends RuntimeException(info.formatPretty) {
-    def this(status: StatusCode, summary: String = "") =
+    def this(status: StatusCode, summary: String) =
       this(status, ErrorInfo(if (summary.isEmpty) status.defaultMessage else summary))
     def this(summary: String) =
       this(StatusCodes.BadRequest, ErrorInfo(summary))
+    def this(summary: String, detail: String) =
+      this(StatusCodes.BadRequest, ErrorInfo(summary, detail))
   }
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/util/LogByteStringTools.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/LogByteStringTools.scala
@@ -62,26 +62,24 @@ private[akka] object LogByteStringTools {
       case SessionBytes(session, bytes) => "SessionBytes " + printByteString(bytes, maxBytes)
     }).addAttributes(LogFailuresOnDebugAttributes)
 
-  def printByteString(bytes: ByteString, maxBytes: Int = MaxBytesPrinted): String = {
-    val indent = " "
-
+  def printByteString(bytes: ByteString, maxBytes: Int = MaxBytesPrinted, addPrefix: Boolean = true, indent: String = " "): String = {
     def formatBytes(bs: ByteString): Iterator[String] = {
       def asHex(b: Byte): String = b formatted "%02X"
 
       def formatLine(bs: ByteString): String = {
         val hex = bs.map(asHex).mkString(" ")
         val ascii = bs.map(asASCII).mkString
-        f"$indent%s  $hex%-48s | $ascii"
+        f"$indent%s$hex%-48s | $ascii"
       }
       def formatBytes(bs: ByteString): String =
         bs.grouped(16).map(formatLine).mkString("\n")
 
       val prefix = s"${indent}ByteString(${bs.size} bytes)"
 
-      if (bs.size <= maxBytes * 2) Iterator(prefix + "\n", formatBytes(bs))
+      if (bs.size <= maxBytes * 2) Iterator(if (addPrefix) prefix + "\n" else "", formatBytes(bs))
       else
         Iterator(
-          s"$prefix first + last $maxBytes:\n",
+          if (addPrefix) s"$prefix first + last $maxBytes:\n" else "",
           formatBytes(bs.take(maxBytes)),
           s"\n$indent                    ... [${bs.size - (maxBytes * 2)} bytes omitted] ...\n",
           formatBytes(bs.takeRight(maxBytes)))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -540,7 +540,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
 
         responsesSub.request(1)
         val error @ IllegalResponseException(info) = responses.expectError()
-        info.summary shouldEqual "The server-side HTTP version is not supported"
+        info.formatPretty shouldEqual "The server-side protocol or HTTP version is not supported: start of response: [48 54 54 50 2F 31 2E 32 20 32 30 30 20 4F 4B 0D  | HTTP/1.2 200 OK.]"
         netOut.expectError(error)
         requestsSub.expectCancellation()
         netInSub.expectCancellation()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -298,8 +298,8 @@ abstract class ResponseParserSpec(mode: String, newLine: String) extends AkkaSpe
 
     "reject a response with" should {
       "HTTP version 1.2" in new Test {
-        Seq(s"HTTP/1.2 200 OK${newLine}") should generalMultiParseTo(Left(MessageStartError(
-          400: StatusCode, ErrorInfo("The server-side HTTP version is not supported"))))
+        Seq("HTTP/1.2 200 OK") should generalMultiParseTo(Left(MessageStartError(
+          400: StatusCode, ErrorInfo("The server-side protocol or HTTP version is not supported", "start of response: [48 54 54 50 2F 31 2E 32 20 32 30 30 20 4F 4B     | HTTP/1.2 200 OK]"))))
       }
 
       "an illegal status code" in new Test {


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you updated the documentation?
* [X] Have you added tests for any changed functionality?
-->
## Purpose

This PR adds detail to `onBadProtocol` error messages to better help diagnose when this error is thrown

## Changes

- This PR simply allows the `detail: String` as well as the original `summary: String` to be passed into the `ErrorInfo` class.
- Note that one side effect of this change is I had to remove default parameters from `ParsingException` due to conflicts with overloaded definitions (you cannot have default parameters with overloaded functions)

## Background Context

`ErrorInfo` already contains a `detail: String` field designed to provide extra information about the issue, this PR simply uses that field to provide more details about the error when `onBadProtocol` is called.
