### PR TITLE
build: cache modern coursier cache directory in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
     - $HOME/.jabba/jdk
-    - $HOME/.coursier
+    - $HOME/.cache/coursier
 
 script:
   - jabba use "adopt@1.8-0"


### PR DESCRIPTION
As Johan noted in https://github.com/akka/akka-grpc/pull/782#issuecomment-572103694 there is some confusion which directory coursier uses. According to https://get-coursier.io/docs/cache.html#compatibility-with-former-versions
`~/.coursier` is the old directory while `~/.cache/coursier` is the new one. When only the old one is found it will continue to use the old one. It seems just adding the entry here before made it use the old one. But let's use the new one to be safe in the future.