### PR TITLE
Simplify route2HandlerFlow

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -64,6 +64,9 @@ object ParserSettingsImpl extends SettingsCompanionImpl[ParserSettingsImpl]("akk
   private[this] val noCustomStatusCodes: Int => Option[StatusCode] = ConstantFun.scalaAnyToNone
   private[ParserSettingsImpl] val noCustomMediaTypes: (String, String) => Option[MediaType] = ConstantFun.scalaAnyTwoToNone
 
+  def forServer(root: Config): ParserSettingsImpl =
+    fromSubConfig(root, root.getConfig("akka.http.server.parsing"))
+
   def fromSubConfig(root: Config, inner: Config): ParserSettingsImpl = {
     val c = inner.withFallback(root.getConfig(prefix))
     val cacheConfig = c getConfig "header-cache"

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -8,6 +8,7 @@ import java.util
 import java.util.Optional
 import java.util.function.Function
 
+import akka.actor.ActorSystem
 import akka.annotation.DoNotInherit
 import akka.http.impl.settings.ParserSettingsImpl
 import akka.http.impl.util._
@@ -160,4 +161,6 @@ object ParserSettings extends SettingsCompanion[ParserSettings] {
 
   override def apply(config: Config): ParserSettings = ParserSettingsImpl(config)
   override def apply(configOverrides: String): ParserSettings = ParserSettingsImpl(configOverrides)
+
+  def forServer(system: ActorSystem): ParserSettings = ParserSettingsImpl.forServer(system.settings.config)
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -26,7 +26,6 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
 
   private def scalaFlow(system: ActorSystem, materializer: Materializer): Flow[HttpRequest, HttpResponse, NotUsed] = {
     implicit val s: ActorSystem = system
-    implicit val m: Materializer = materializer
     Flow[HttpRequest].map(_.asScala).via(delegate).map(_.asJava)
   }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -54,10 +54,10 @@ object Route {
   /**
    * Turns a `Route` into a server flow.
    *
-   * This conversion is also implicitly available whereever a `Route`` is used through [[RouteResult#routeToFlow]].
+   * This conversion is also implicitly available whereever a `Route` is used through [[RouteResult#routeToFlow]].
    */
   def toFlow(route: Route)(implicit system: ActorSystem): Flow[HttpRequest, HttpResponse, NotUsed] =
-    Flow[HttpRequest].mapAsync(1)(asyncHandler(route, RoutingSettings(system), ParserSettings(system)))
+    Flow[HttpRequest].mapAsync(1)(asyncHandler(route, RoutingSettings(system), ParserSettings.forServer(system)))
 
   /**
    * Turns a `Route` into a server flow.

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -5,13 +5,13 @@
 package akka.http.scaladsl.server
 
 import akka.NotUsed
-import akka.actor.ActorSystem
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.server.directives.BasicDirectives
 import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 import akka.http.scaladsl.util.FastFuture._
 import akka.stream.scaladsl.Flow
-import akka.stream.{ ActorMaterializerHelper, Materializer, SystemMaterializer }
+import akka.stream.{ ActorMaterializerHelper, Materializer }
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 
@@ -76,7 +76,9 @@ object Route {
   def asyncHandler(route: Route, routingSettings: RoutingSettings, parserSettings: ParserSettings)(implicit system: ActorSystem): HttpRequest => Future[HttpResponse] = {
     val routingLog = RoutingLog(system.log)
     val executionContext = system.dispatcher
-    val materializer = SystemMaterializer(system).materializer
+    val materializer = Materializer.matFromSystem(new ClassicActorSystemProvider {
+      override val classicSystem = system
+    })
     // We can seal more efficiently here because we know we can have no inherited settings:
     val sealedRoute = {
       import directives.ExecutionDirectives._

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -97,7 +97,7 @@ object Route {
   /**
    * Turns a `Route` into an async handler function.
    */
-  @deprecated("replaced by asyncHandler without ec or rejection/exception handlers", "10.2.0")
+  @deprecated("Use `asyncHandler` overload without passing ec or rejection/exception handlers. Use directives to specify custom exceptions or rejection handlers", "10.2.0")
   def asyncHandler(route: Route)(implicit
     routingSettings: RoutingSettings,
                                  parserSettings:   ParserSettings,

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -82,7 +82,7 @@ object Route {
     // We can seal more efficiently here because we know we can have no inherited settings:
     val sealedRoute = {
       import directives.ExecutionDirectives._
-      (handleExceptions(ExceptionHandler.seal(ExceptionHandler.default(routingSettings))(routingSettings)) & handleRejections(RejectionHandler.default.seal))
+      (handleExceptions(ExceptionHandler.default(routingSettings)) & handleRejections(RejectionHandler.default))
         .tapply(_ => route)
     }
     request => {

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -38,8 +38,7 @@ object RouteResult {
    * Defined here because `Route` is defined as type `Route = RequestContext => Future[RouteResult]`,
    * which brings this implicit in scope whereever a `Route` is provided though those generic parameters.
    */
-  // FIXME https://github.com/akka/akka-http/issues/2886 or https://github.com/akka/akka/pull/28494
-  implicit def routeToFlow(route: Route)(implicit system: ActorSystem, materializer: Materializer): Flow[HttpRequest, HttpResponse, NotUsed] =
+  implicit def routeToFlow(route: Route)(implicit system: ActorSystem): Flow[HttpRequest, HttpResponse, NotUsed] =
     Route.toFlow(route)
 
   @deprecated("Replaced by routeToFlow", "10.2.0")

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -5,6 +5,7 @@
 package akka.http.scaladsl.server
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.http.javadsl
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
@@ -31,7 +32,18 @@ object RouteResult {
     override def getRejections = rejections.map(r => r: javadsl.server.Rejection).asJava
   }
 
-  implicit def route2HandlerFlow(route: Route)(
+  /**
+   * Turns a `Route` into a server flow.
+   *
+   * Defined here because `Route` is defined as type `Route = RequestContext => Future[RouteResult]`,
+   * which brings this implicit in scope whereever a `Route` is provided though those generic parameters.
+   */
+  // FIXME https://github.com/akka/akka-http/issues/2886 or https://github.com/akka/akka/pull/28494
+  implicit def routeToFlow(route: Route)(implicit system: ActorSystem, materializer: Materializer): Flow[HttpRequest, HttpResponse, NotUsed] =
+    Route.toFlow(route)
+
+  @deprecated("Replaced by routeToFlow", "10.2.0")
+  def route2HandlerFlow(route: Route)(
     implicit
     routingSettings:  RoutingSettings,
     parserSettings:   ParserSettings,
@@ -45,6 +57,6 @@ object RouteResult {
       case e: ExecutionContextExecutor => e
       case _                           => null
     }
-    Route.handlerFlow(route)
+    Route.handlerFlow(route)(routingSettings, parserSettings, materializer, routingLog, ec, rejectionHandler, exceptionHandler)
   }
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -35,8 +35,10 @@ object RouteResult {
   /**
    * Turns a `Route` into a server flow.
    *
-   * Defined here because `Route` is defined as type `Route = RequestContext => Future[RouteResult]`,
-   * which brings this implicit in scope whereever a `Route` is provided though those generic parameters.
+   * This implicit conversion is defined here because `Route` is an alias for
+   * `RequestContext => Future[RouteResult]`, and the fact that `RouteResult`
+   * is in that type means this implicit conversion come into scope whereever
+   * a `Route` is given but a `Flow` is expected.
    */
   implicit def routeToFlow(route: Route)(implicit system: ActorSystem): Flow[HttpRequest, HttpResponse, NotUsed] =
     Route.toFlow(route)

--- a/docs/src/main/paradox/migration-guide/index.md
+++ b/docs/src/main/paradox/migration-guide/index.md
@@ -4,6 +4,7 @@
 
 @@@ index
 
+* [migration-guide-10.2.x](migration-guide-10.2.x.md)
 * [migration-guide-10.1.x](migration-guide-10.1.x.md)
 * [migration-guide-10.0.x](migration-guide-10.0.x.md)
 * [migration-guide-2.4.x-10.0.x](migration-guide-2.4.x-10.0.x.md)

--- a/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
+++ b/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
@@ -1,0 +1,19 @@
+# Migration Guide to and within Akka HTTP 10.2.x
+
+## General Notes
+
+See the general @ref[compatibility guidelines](../compatibility-guidelines.md).
+
+## Akka HTTP 10.1.11 - > 10.2.0
+
+### Providing route settings, exception and rejection handling
+
+Previously, the implicit conversion `route2HandlerFlow` that turns a `Route` into a
+`Flow[HttpRequest, HttpResponse]` allowed implicitly passing in Routing settings,
+Parser settings, custom `Materializer`, `RoutingLog` or `ExecutionContext`, and
+the `RejectionHandler`/`ExceptionHandler` to use.
+
+This has been simplified to use system defaults instead:
+
+* To set Routing or Parser settings, set them in your actor system configuration, e.g. via `application.conf`
+* To apply a custom @apidoc[http.*.RejectionHandler] or @apidoc[ExceptionHandler], use the @ref[handleRejections](../routing-dsl/directives/execution-directives/handleRejections.md) and @ref[handleExceptions](../routing-dsl/directives/execution-directives/handleExceptions.md) directives


### PR DESCRIPTION
Refs #70

~Before merging should be updated not to take a `Materializer` implicit but instead use either #2886 or https://github.com/akka/akka/pull/28494~

~Before merging we need either a release of Akka 2.5.30 (that contains https://github.com/akka/akka/pull/28545) or #2886~

This is ready to go!