### PR TITLE
Merge pull request #2905 from jrudolph/improve-outgoing-request-stream-error

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -96,7 +96,7 @@ private[http] object OutgoingConnectionBlueprint {
 
       val terminationFanout = b.add(Broadcast[HttpResponse](2))
 
-      val logger = b.add(Flow[ByteString].mapError { case t => log.error(t, "Outgoing request stream error"); t }.named("errorLogger"))
+      val logger = b.add(Flow[ByteString].mapError { case t => log.debug(s"Outgoing request stream error {}", t); t }.named("errorLogger"))
       val wrapTls = b.add(Flow[ByteString].map(SendBytes))
 
       val collectSessionBytes = b.add(Flow[SslTlsInbound].collect { case s: SessionBytes => s })


### PR DESCRIPTION
 * now only logged as debug, the reasoning is that the error can be propagated
   to the response side and doesn't need to be logged as prominently
 * added the exception message to the message, the reasoning is that otherwise
   a stack trace will be logged but often only in the next line so it might get
   lost in a simple grep

It's different for response stream errors on the server side: in that case the server is already done with the response and cannot handle any error happening during streaming out the response. There, the best way might actually be to log an error.