### PR TITLE
Add quotes to curl request with parameters

### DIFF
--- a/docs/src/main/paradox/introduction.md
+++ b/docs/src/main/paradox/introduction.md
@@ -185,7 +185,7 @@ Scala
 Java
 :   @@snip [HttpServerActorInteractionExample.java]($test$/java/docs/http/javadsl/HttpServerActorInteractionExample.java) { #actor-interaction }
 
-When you run this server, you can add an auction bid via `curl -X PUT http://localhost:8080/auction?bid=22&user=MartinO` on the terminal; and then you can view the auction status either in a browser, at the url [http://localhost:8080/auction](http://localhost:8080/auction), or, on the terminal, via `curl http://localhost:8080/auction`.
+When you run this server, you can add an auction bid via `curl -X PUT "http://localhost:8080/auction?bid=22&user=MartinO"` on the terminal; and then you can view the auction status either in a browser, at the url [http://localhost:8080/auction](http://localhost:8080/auction), or, on the terminal, via `curl http://localhost:8080/auction`.
 
 More details on how JSON marshalling and unmarshalling works can be found in the @ref[JSON Support section](common/json-support.md).
 


### PR DESCRIPTION
## Purpose

Update the Auction example for the Introduction documentation to include quotes around the curl request.

## References

* References https://github.com/akka/akka-http/issues/2915

## Changes

<!-- Bullets for important changes in this PR -->
* Added quotes around the url in `curl -X PUT http://localhost:8080/auction?bid=22&user=MartinO` (to `curl -X PUT "http://localhost:8080/auction?bid=22&user=MartinO"`
