### PR TITLE
docs: add warning on usage on extractClientIP

### DIFF
--- a/docs/src/main/paradox/routing-dsl/directives/misc-directives/extractClientIP.md
+++ b/docs/src/main/paradox/routing-dsl/directives/misc-directives/extractClientIP.md
@@ -15,6 +15,10 @@ Provides the value of `X-Forwarded-For`, `Remote-Address`, or `X-Real-IP` header
 The akka-http server engine adds the `Remote-Address` header to every request automatically if the respective
 setting `akka.http.server.remote-address-header` is set to `on`. Per default it is set to `off`.
 
+@@@ warning
+Clients can send any values in these headers. When the value is an invalid IP address, then this extractor will return `RemoteAddress.Unknown`. If the client is not a tructed upstream, the IP address can be malicious and by pass your security rules.
+@@@
+
 ## Example
 
 Scala

--- a/docs/src/main/paradox/routing-dsl/directives/misc-directives/extractClientIP.md
+++ b/docs/src/main/paradox/routing-dsl/directives/misc-directives/extractClientIP.md
@@ -10,13 +10,13 @@
 
 ## Description
 
-Provides the value of `X-Forwarded-For`, `Remote-Address`, or `X-Real-IP` headers as an instance of `RemoteAddress`.
+Provides the value of `X-Forwarded-For`, `Remote-Address`, or `X-Real-IP` headers as an instance of `RemoteAddress`. When the value is an invalid IP address in the header first seen, then this extractor will return `RemoteAddress.Unknown`.
 
 The akka-http server engine adds the `Remote-Address` header to every request automatically if the respective
 setting `akka.http.server.remote-address-header` is set to `on`. Per default it is set to `off`.
 
 @@@ warning
-Clients can send any values in these headers. When the value is an invalid IP address, then this extractor will return `RemoteAddress.Unknown`. If the client is not a trusted upstream, the IP address can be malicious and by pass your security rules.
+Clients can send any values in these headers. If the client is not a trusted upstream, the IP address can be malicious and by pass your security rules.
 @@@
 
 ## Example

--- a/docs/src/main/paradox/routing-dsl/directives/misc-directives/extractClientIP.md
+++ b/docs/src/main/paradox/routing-dsl/directives/misc-directives/extractClientIP.md
@@ -16,7 +16,7 @@ The akka-http server engine adds the `Remote-Address` header to every request au
 setting `akka.http.server.remote-address-header` is set to `on`. Per default it is set to `off`.
 
 @@@ warning
-Clients can send any values in these headers. When the value is an invalid IP address, then this extractor will return `RemoteAddress.Unknown`. If the client is not a tructed upstream, the IP address can be malicious and by pass your security rules.
+Clients can send any values in these headers. When the value is an invalid IP address, then this extractor will return `RemoteAddress.Unknown`. If the client is not a trusted upstream, the IP address can be malicious and by pass your security rules.
 @@@
 
 ## Example


### PR DESCRIPTION
update the document as this can be a common error developers may make.
