### PR TITLE
core: identify Content-Type `charset` parameter even if not lower case

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonActions.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonActions.scala
@@ -8,6 +8,8 @@ import akka.annotation.InternalApi
 import akka.http.impl.util._
 import akka.http.scaladsl.model._
 
+import scala.annotation.tailrec
+
 /** INTERNAL API */
 @InternalApi
 private[parser] trait CommonActions {
@@ -57,4 +59,21 @@ private[parser] trait CommonActions {
     HttpCharsets
       .getForKeyCaseInsensitive(name)
       .getOrElse(HttpCharset.custom(name))
+
+  /**
+   * Returns true if both strings only contain ASCII characters and each character matches case insensitively.
+   */
+  def equalsAsciiCaseInsensitive(str1: String, str2: String): Boolean = {
+    @tailrec def stringEquals(at: Int, length: Int): Boolean =
+      if (at < length) {
+        val char1 = str1.charAt(at)
+        val char2 = str2.charAt(at)
+
+        (char1 | char2) < 0x80 &&
+          Character.toLowerCase(char1) == Character.toLowerCase(char2) &&
+          stringEquals(at + 1, length)
+      } else true
+
+    str1.length == str2.length && stringEquals(0, str1.length)
+  }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
@@ -9,6 +9,7 @@ import scala.collection.immutable.TreeMap
 
 import akka.parboiled2.Parser
 import akka.http.scaladsl.model._
+import akka.http.impl.util._
 
 private[parser] trait ContentTypeHeader { this: Parser with CommonRules with CommonActions =>
 
@@ -33,7 +34,7 @@ private[parser] trait ContentTypeHeader { this: Parser with CommonRules with Com
           case x: MediaType.WithOpenCharset if charset.isEmpty   => ContentType.WithMissingCharset(x)
         }
 
-      case Seq(("charset", value), tail @ _*) =>
+      case Seq((key, value), tail @ _*) if key.toRootLowerCase == "charset" =>
         contentType(main, sub, tail, Some(getCharset(value)), builder)
 
       case Seq(kvp, tail @ _*) =>

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
@@ -9,7 +9,6 @@ import scala.collection.immutable.TreeMap
 
 import akka.parboiled2.Parser
 import akka.http.scaladsl.model._
-import akka.http.impl.util._
 
 private[parser] trait ContentTypeHeader { this: Parser with CommonRules with CommonActions =>
 
@@ -34,7 +33,7 @@ private[parser] trait ContentTypeHeader { this: Parser with CommonRules with Com
           case x: MediaType.WithOpenCharset if charset.isEmpty   => ContentType.WithMissingCharset(x)
         }
 
-      case Seq((key, value), tail @ _*) if key.toRootLowerCase == "charset" =>
+      case Seq((key, value), tail @ _*) if equalsAsciiCaseInsensitive(key, "charset") =>
         contentType(main, sub, tail, Some(getCharset(value)), builder)
 
       case Seq(kvp, tail @ _*) =>

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -224,6 +224,8 @@ class HttpHeaderSpec extends AnyFreeSpec with Matchers {
         `Content-Type`(`application/json`)
       "Content-Type: text/plain; charset=utf8" =!=
         `Content-Type`(ContentType(`text/plain`, `UTF-8`)).renderedTo("text/plain; charset=UTF-8")
+      "Content-Type: text/plain; Charset=utf8" =!=
+        `Content-Type`(ContentType(`text/plain`, `UTF-8`)).renderedTo("text/plain; charset=UTF-8")
       "Content-Type: text/plain" =!=
         `Content-Type`(ContentType.WithMissingCharset(MediaTypes.`text/plain`)).renderedTo("text/plain")
       "Content-Type: text/xml2; version=3; charset=windows-1252" =!=


### PR DESCRIPTION
Fixes #2910 