### PR TITLE
build: disable coursier when `akka.http.test-against-akka-master` is enabled

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,9 @@ inThisBuild(Def.settings(
   Formatting.formatSettings,
   shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
+  // with coursier the dependency resolution with this extra setting breaks leading to missing akka dependencies
+  // in the provided classpath
+  useCoursier := System.getProperty("akka.http.test-against-akka-master", "false") != "true",
 ))
 
 lazy val root = Project(


### PR DESCRIPTION
It seems coursier isn't able to correctly determine the dependencies when
internal and external dependencies with the same coordinates are mixed in
different configurations.

Since we will drop support for 2.5 on master, let's only add this workaround for the release-10.1 (still need to setup nightlies for that).

Fixes #2909.