### PR TITLE
Fix more scalatest 3.1.0 deprecations

### DIFF
--- a/akka-http-caching/src/test/scala/akka/http/caching/ExpiringLfuCacheSpec.scala
+++ b/akka-http-caching/src/test/scala/akka/http/caching/ExpiringLfuCacheSpec.scala
@@ -10,12 +10,14 @@ import java.util.concurrent.CountDownLatch
 import akka.actor.ActorSystem
 import akka.http.caching.scaladsl.CachingSettings
 import akka.testkit.TestKit
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future, Promise }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ExpiringLfuCacheSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+class ExpiringLfuCacheSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   implicit val system: ActorSystem = ActorSystem()
   import system.dispatcher
 

--- a/akka-http-caching/src/test/scala/akka/http/scaladsl/server/directives/CachingDirectivesSpec.scala
+++ b/akka-http-caching/src/test/scala/akka/http/scaladsl/server/directives/CachingDirectivesSpec.scala
@@ -12,9 +12,10 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{ ExceptionHandler, RequestContext }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.model.HttpMethods.GET
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CachingDirectivesSpec extends WordSpec with Matchers with ScalatestRouteTest with CachingDirectives {
+class CachingDirectivesSpec extends AnyWordSpec with Matchers with ScalatestRouteTest with CachingDirectives {
 
   val simpleKeyer: PartialFunction[RequestContext, Uri] = {
     case r: RequestContext if r.request.method == GET => r.request.uri

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -5,8 +5,6 @@
 package akka.http.scaladsl.testkit
 
 import scala.concurrent.duration._
-import org.scalatest.FreeSpec
-import org.scalatest.Matchers
 import akka.testkit._
 import akka.util.Timeout
 import akka.pattern.ask
@@ -19,8 +17,10 @@ import Directives._
 
 import scala.concurrent.Await
 import scala.concurrent.Future
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class ScalatestRouteTestSpec extends FreeSpec with Matchers with ScalatestRouteTest {
+class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRouteTest {
 
   "The ScalatestRouteTest should support" - {
 

--- a/akka-http-tests/src/test/scala/akka/http/javadsl/DirectivesConsistencySpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/javadsl/DirectivesConsistencySpec.scala
@@ -8,11 +8,12 @@ import java.lang.reflect.{ Modifier, Method }
 
 import akka.http.javadsl.server.directives.CorrespondsTo
 import org.scalatest.exceptions.TestPendingException
-import org.scalatest.{ Matchers, WordSpec }
 
 import scala.util.control.NoStackTrace
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DirectivesConsistencySpec extends WordSpec with Matchers {
+class DirectivesConsistencySpec extends AnyWordSpec with Matchers {
 
   val scalaDirectivesClazz = classOf[akka.http.scaladsl.server.Directives]
   val javaDirectivesClazz = classOf[akka.http.javadsl.server.AllDirectives]

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/RouteJavaScalaDslConversionSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/RouteJavaScalaDslConversionSpec.scala
@@ -7,9 +7,9 @@ package akka.http.scaladsl
 import java.util.function.Supplier
 
 import akka.http.javadsl.server.Route
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class RouteJavaScalaDslConversionSpec extends WordSpec {
+class RouteJavaScalaDslConversionSpec extends AnyWordSpec {
 
   "Routes" must {
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
@@ -4,11 +4,12 @@
 
 package akka.http.scaladsl.coding
 
-import org.scalatest.{ BeforeAndAfterAll, Matchers, Suite }
+import org.scalatest.{ BeforeAndAfterAll, Suite }
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import akka.util.ByteString
+import org.scalatest.matchers.should.Matchers
 
 trait CodecSpecSupport extends Matchers with BeforeAndAfterAll { self: Suite =>
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CoderSpec.scala
@@ -14,15 +14,16 @@ import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import java.util.concurrent.ThreadLocalRandom
 import scala.util.control.NoStackTrace
-import org.scalatest.{ Inspectors, WordSpec }
+import org.scalatest.Inspectors
 import akka.util.ByteString
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.http.scaladsl.model.{ HttpEntity, HttpRequest }
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.impl.util._
 import akka.testkit._
+import org.scalatest.wordspec.AnyWordSpec
 
-abstract class CoderSpec extends WordSpec with CodecSpecSupport with Inspectors {
+abstract class CoderSpec extends AnyWordSpec with CodecSpecSupport with Inspectors {
   protected def Coder: Coder with StreamDecoder
   protected def newDecodedInputStream(underlying: InputStream): InputStream
   protected def newEncodedOutputStream(underlying: OutputStream): OutputStream

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/DecoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/DecoderSpec.scala
@@ -8,7 +8,6 @@ import akka.stream.{ Attributes, FlowShape }
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 
 import scala.concurrent.duration._
-import org.scalatest.WordSpec
 import akka.util.ByteString
 import akka.stream.stage._
 import akka.http.scaladsl.model._
@@ -16,8 +15,9 @@ import akka.http.impl.util._
 import akka.testkit._
 import headers._
 import HttpMethods.POST
+import org.scalatest.wordspec.AnyWordSpec
 
-class DecoderSpec extends WordSpec with CodecSpecSupport {
+class DecoderSpec extends AnyWordSpec with CodecSpecSupport {
 
   "A Decoder" should {
     "not transform the message if it doesn't contain a Content-Encoding header" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/EncoderSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/EncoderSpec.scala
@@ -5,15 +5,15 @@
 package akka.http.scaladsl.coding
 
 import akka.util.ByteString
-import org.scalatest.WordSpec
 import akka.http.scaladsl.model._
 import headers._
 import HttpMethods.POST
 import scala.concurrent.duration._
 import akka.http.impl.util._
 import akka.testkit._
+import org.scalatest.wordspec.AnyWordSpec
 
-class EncoderSpec extends WordSpec with CodecSpecSupport {
+class EncoderSpec extends AnyWordSpec with CodecSpecSupport {
 
   "An Encoder" should {
     "not transform the message if messageFilter returns false" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/JsonSupportSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/JsonSupportSpec.scala
@@ -9,7 +9,8 @@ import akka.http.scaladsl.model.{ HttpCharsets, HttpEntity, MediaTypes }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import akka.http.impl.util._
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 case class Employee(fname: String, name: String, age: Int, id: Long, boardMember: Boolean) {
   require(!boardMember || age > 40, "Board members must be older than 40")
@@ -33,7 +34,7 @@ object Employee {
 }
 
 /** Common infrastructure needed for several json support subprojects */
-abstract class JsonSupportSpec extends WordSpec with Matchers with ScalatestRouteTest {
+abstract class JsonSupportSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
   require(getClass.getSimpleName.endsWith("Spec"))
   // assuming that the classname ends with "Spec"
   def name: String = getClass.getSimpleName.dropRight(4)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/xml/ScalaXmlSupportSpec.scala
@@ -12,7 +12,7 @@ import org.xml.sax.SAXParseException
 import scala.xml.NodeSeq
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
-import org.scalatest.{ FreeSpec, Inside, Matchers }
+import org.scalatest.Inside
 import akka.util.ByteString
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.unmarshalling.Unmarshal
@@ -20,8 +20,10 @@ import akka.http.scaladsl.model._
 import akka.testkit._
 import MediaTypes._
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class ScalaXmlSupportSpec extends FreeSpec with Matchers with ScalatestRouteTest with Inside {
+class ScalaXmlSupportSpec extends AnyFreeSpec with Matchers with ScalatestRouteTest with Inside {
   import ScalaXmlSupport._
 
   "NodeSeqMarshaller should" - {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/ContentNegotiationSpec.scala
@@ -9,15 +9,16 @@ import scala.concurrent.duration._
 import akka.http.scaladsl.server.MediaTypeNegotiator
 import akka.http.scaladsl.server.ContentNegotiator.Alternative
 import akka.util.ByteString
-import org.scalatest.{ FreeSpec, Matchers }
 import akka.http.scaladsl.util.FastFuture._
 import akka.http.scaladsl.model._
 import akka.http.impl.util._
 import MediaTypes._
 import HttpCharsets._
 import akka.http.scaladsl.server.util.VarArgsFunction1
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class ContentNegotiationSpec extends FreeSpec with Matchers {
+class ContentNegotiationSpec extends AnyFreeSpec with Matchers {
   "Content Negotiation should work properly for requests with header(s)" - {
     "(without headers)" test { accept =>
       accept(`text/plain` withCharset `UTF-16`) should select(`text/plain` withCharset `UTF-16`)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -17,12 +17,14 @@ import akka.stream.scaladsl.Source
 import akka.testkit.TestKit
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ BeforeAndAfterAll, FreeSpec, Matchers }
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
 import scala.collection.immutable.ListMap
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class MarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with MultipartMarshallers with MarshallingTestUtils {
+class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with MultipartMarshallers with MarshallingTestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
   implicit val materializer = ActorMaterializer()
   import system.dispatcher

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/sse/EventStreamMarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/sse/EventStreamMarshallingSpec.scala
@@ -13,11 +13,12 @@ import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.testkit.RouteTest
 import akka.http.scaladsl.testkit.TestFrameworkInterface.Scalatest
 import akka.stream.scaladsl.{ Sink, Source }
-import org.scalatest.{ Matchers, WordSpec }
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-final class EventStreamMarshallingSpec extends WordSpec with Matchers with RouteTest with Scalatest {
+final class EventStreamMarshallingSpec extends AnyWordSpec with Matchers with RouteTest with Scalatest {
   import Directives._
   import akka.http.scaladsl.marshalling.sse.EventStreamMarshalling._
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -16,14 +16,16 @@ import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.testkit.Utils.assertAllStagesStopped
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String)
-  extends WordSpecLike with Matchers with BeforeAndAfterAll with WithLogCapturing {
+  extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with WithLogCapturing {
 
   val config = ConfigFactory.parseString(s"""
     akka {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
@@ -11,10 +11,12 @@ import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.stream.ActorMaterializer
 import akka.testkit.{ AkkaSpec, SocketUtil, TestKit }
 import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 /** not (yet?) ready for public consuption */
-private[akka] trait IntegrationRoutingSpec extends WordSpecLike with Matchers with BeforeAndAfterAll
+private[akka] trait IntegrationRoutingSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterAll
   with Directives with RequestBuilding
   with ScalaFutures with IntegrationPatience {
   import IntegrationRoutingSpec._

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RoutingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RoutingSpec.scala
@@ -4,9 +4,11 @@
 
 package akka.http.scaladsl.server
 
-import org.scalatest.{ WordSpec, Suite, Matchers }
+import org.scalatest.Suite
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 trait GenericRoutingSpec extends Matchers with Directives with ScalatestRouteTest { this: Suite =>
   val Ok = HttpResponse()
@@ -16,4 +18,4 @@ trait GenericRoutingSpec extends Matchers with Directives with ScalatestRouteTes
   def echoComplete2[T, U]: (T, U) => Route = { (x, y) => complete(s"$x $y") }
 }
 
-abstract class RoutingSpec extends WordSpec with GenericRoutingSpec
+abstract class RoutingSpec extends AnyWordSpec with GenericRoutingSpec

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -20,11 +20,13 @@ import akka.util.ByteString
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{ Millis, Seconds, Span }
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.immutable
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SizeLimitSpec extends WordSpec with Matchers with RequestBuilding with BeforeAndAfterAll with ScalaFutures {
+class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with BeforeAndAfterAll with ScalaFutures {
 
   val maxContentLength = 800
   // Protect network more than memory:

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HostDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HostDirectivesSpec.scala
@@ -6,9 +6,9 @@ package akka.http.scaladsl.server
 package directives
 
 import akka.http.scaladsl.model.headers.Host
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class HostDirectivesSpec extends FreeSpec with GenericRoutingSpec {
+class HostDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec {
   "The 'host' directive" - {
     "in its simple String form should" - {
       "block requests to unmatched hosts" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -5,11 +5,12 @@
 package akka.http.scaladsl.server
 package directives
 
-import org.scalatest.{ FreeSpec, Inside }
+import org.scalatest.Inside
 import akka.http.scaladsl.unmarshalling.Unmarshaller, Unmarshaller._
 import akka.http.scaladsl.model.StatusCodes
+import org.scalatest.freespec.AnyFreeSpec
 
-class ParameterDirectivesSpec extends FreeSpec with GenericRoutingSpec with Inside {
+class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with Inside {
   "when used with 'as[Int]' the parameter directive should" - {
     "extract a parameter value as Int" in {
       Get("/?amount=123") ~> {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -6,7 +6,6 @@ package akka.http.scaladsl.server.directives
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
-import org.scalatest.FreeSpec
 import scala.concurrent.{ Await, Future, Promise }
 import scala.concurrent.duration._
 import akka.testkit.EventFilter
@@ -16,8 +15,9 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.model._
 import headers._
 import StatusCodes._
+import org.scalatest.freespec.AnyFreeSpec
 
-class RouteDirectivesSpec extends FreeSpec with GenericRoutingSpec {
+class RouteDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec {
 
   "The `complete` directive should" - {
     "by chainable with the `&` operator" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/util/TupleOpsSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/util/TupleOpsSpec.scala
@@ -4,9 +4,10 @@
 
 package akka.http.scaladsl.server.util
 
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TupleOpsSpec extends WordSpec with Matchers {
+class TupleOpsSpec extends AnyWordSpec with Matchers {
   import TupleOps._
 
   "The TupleOps" should {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/settings/RoutingSettingsEqualitySpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/settings/RoutingSettingsEqualitySpec.scala
@@ -5,9 +5,10 @@
 package akka.http.scaladsl.settings
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class RoutingSettingsEqualitySpec extends WordSpec with Matchers {
+class RoutingSettingsEqualitySpec extends AnyWordSpec with Matchers {
 
   val config = ConfigFactory.load.resolve
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -7,7 +7,7 @@ package akka.http.scaladsl.unmarshalling
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 import org.scalatest.matchers.Matcher
-import org.scalatest.{ BeforeAndAfterAll, FreeSpec, Matchers }
+import org.scalatest.BeforeAndAfterAll
 import akka.http.scaladsl.testkit.ScalatestUtils
 import akka.util.ByteString
 import akka.actor.ActorSystem
@@ -20,8 +20,10 @@ import akka.http.scaladsl.model.headers._
 import MediaTypes._
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-trait MultipartUnmarshallersSpec extends FreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
+trait MultipartUnmarshallersSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
   implicit val materializer = ActorMaterializer()
   import system.dispatcher

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -7,7 +7,7 @@ package akka.http.scaladsl.unmarshalling
 import java.util.UUID
 
 import akka.http.scaladsl.unmarshalling.Unmarshaller.EitherUnmarshallingException
-import org.scalatest.{ BeforeAndAfterAll, FreeSpec, Matchers }
+import org.scalatest.BeforeAndAfterAll
 import akka.http.scaladsl.testkit.ScalatestUtils
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.MediaType.WithFixedCharset
@@ -18,8 +18,10 @@ import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class UnmarshallingSpec extends FreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
+class UnmarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
   implicit val materializer = ActorMaterializer()
   import system.dispatcher

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/EventStreamUnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/EventStreamUnmarshallingSpec.scala
@@ -13,9 +13,10 @@ import akka.http.scaladsl.model.MediaTypes.`text/event-stream`
 import akka.http.scaladsl.model.sse.ServerSentEvent
 import akka.stream.scaladsl.{ Sink, Source }
 import java.util.{ List => JList }
-import org.scalatest.{ AsyncWordSpec, Matchers }
 import scala.collection.JavaConverters
 import scala.collection.immutable.Seq
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 
 object EventStreamUnmarshallingSpec {
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/LineParserSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/LineParserSpec.scala
@@ -9,7 +9,8 @@ package sse
 
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
-import org.scalatest.{ AsyncWordSpec, Matchers }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 
 final class LineParserSpec extends AsyncWordSpec with Matchers with BaseUnmarshallingSpec {
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
@@ -9,7 +9,8 @@ package sse
 
 import akka.http.scaladsl.model.sse.ServerSentEvent
 import akka.stream.scaladsl.{ Sink, Source }
-import org.scalatest.{ AsyncWordSpec, Matchers }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 
 final class ServerSentEventParserSpec extends AsyncWordSpec with Matchers with BaseUnmarshallingSpec {
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameProbe.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameProbe.scala
@@ -13,9 +13,9 @@ import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.stream.impl.io.ByteStringParser.ByteReader
 import akka.stream.scaladsl.Sink
 import akka.util.ByteString
-import org.scalatest.Matchers
 
 import scala.annotation.tailrec
+import org.scalatest.matchers.should.Matchers
 
 trait Http2FrameProbe {
   def sink: Sink[ByteString, Any]

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/PriorityTreeSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/PriorityTreeSpec.scala
@@ -4,10 +4,11 @@
 
 package akka.http.impl.engine.http2
 
-import org.scalatest.{ Matchers, WordSpec }
 import org.scalatest.matchers.{ MatchResult, Matcher }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class PriorityTreeSpec extends WordSpec with Matchers {
+class PriorityTreeSpec extends AnyWordSpec with Matchers {
   "PriorityTree" should {
     "contain only the root node if empty" in {
       PriorityTree() should printLike(

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ResponseRenderingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ResponseRenderingSpec.scala
@@ -9,11 +9,12 @@ import java.time.format.DateTimeFormatter
 import akka.event.NoLogging
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{ ContentTypes, DateTime, TransferEncodings }
-import org.scalatest.{ Matchers, WordSpec }
 
 import scala.collection.immutable.Seq
 import scala.collection.immutable.VectorBuilder
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 object MyCustomHeader extends ModeledCustomHeaderCompanion[MyCustomHeader] {
   override def name: String = "custom-header"
@@ -24,7 +25,7 @@ class MyCustomHeader(val value: String, val renderInResponses: Boolean) extends 
   override def renderInRequests(): Boolean = false
 }
 
-class ResponseRenderingSpec extends WordSpec with Matchers {
+class ResponseRenderingSpec extends AnyWordSpec with Matchers {
 
   "The response header logic" should {
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithInPendingUntilFixed.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithInPendingUntilFixed.scala
@@ -5,10 +5,10 @@
 package akka.http.impl.engine.http2
 
 import org.scalactic.source
-import org.scalatest.WordSpecLike
+import org.scalatest.wordspec.AnyWordSpecLike
 
 /** Adds `"test" inPendingUntilFixed {...}` which is equivalent to `"test" in pendingUntilFixed({...})` */
-trait WithInPendingUntilFixed extends WordSpecLike {
+trait WithInPendingUntilFixed extends AnyWordSpecLike {
   implicit class InPendingUntilFixed(val str: String) {
     def inPendingUntilFixed(f: => Any /* Assertion */ )(implicit pos: source.Position): Unit =
       str.in(pendingUntilFixed(f))(pos)

--- a/docs/src/test/scala/docs/ApiMayChangeDocCheckerSpec.scala
+++ b/docs/src/test/scala/docs/ApiMayChangeDocCheckerSpec.scala
@@ -10,13 +10,15 @@ import akka.annotation.ApiMayChange
 import org.reflections.Reflections
 import org.reflections.scanners.{ MethodAnnotationsScanner, TypeAnnotationsScanner }
 import org.reflections.util.{ ClasspathHelper, ConfigurationBuilder }
-import org.scalatest.{ Matchers, WordSpec, Assertion }
+import org.scalatest.Assertion
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.io.Source
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ApiMayChangeDocCheckerSpec extends WordSpec with Matchers {
+class ApiMayChangeDocCheckerSpec extends AnyWordSpec with Matchers {
 
   def prettifyName(clazz: Class[_]): String = {
     clazz.getCanonicalName.replaceAll("\\$minus", "-").split("\\$")(0)

--- a/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpAppExampleSpec.scala
@@ -5,9 +5,10 @@
 package docs.http.scaladsl
 
 import docs.CompileOnlySpec
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HttpAppExampleSpec extends WordSpec with Matchers
+class HttpAppExampleSpec extends AnyWordSpec with Matchers
   with CompileOnlySpec {
 
   "minimal-routing-example" in compileOnlySpec {

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -8,9 +8,10 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import docs.CompileOnlySpec
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HttpClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec {
+class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpec {
 
   "manual-entity-consume-example-1" in compileOnlySpec {
     //#manual-entity-consume-example-1

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -11,12 +11,13 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes
 import akka.testkit.TestActors
 import docs.CompileOnlySpec
-import org.scalatest.{ Matchers, WordSpec }
 
 import scala.language.postfixOps
 import scala.concurrent.{ Await, ExecutionContext, Future }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HttpServerExampleSpec extends WordSpec with Matchers
+class HttpServerExampleSpec extends AnyWordSpec with Matchers
   with CompileOnlySpec {
 
   // never actually called

--- a/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
@@ -9,9 +9,10 @@ import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import docs.CompileOnlySpec
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HttpsExamplesSpec extends WordSpec with Matchers with CompileOnlySpec {
+class HttpsExamplesSpec extends AnyWordSpec with Matchers with CompileOnlySpec {
 
   "disable SNI for connection" in compileOnlySpec {
     val unsafeHost = "example.com"

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
@@ -4,9 +4,10 @@
 
 package docs.http.scaladsl
 
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SprayJsonExampleSpec extends WordSpec with Matchers {
+class SprayJsonExampleSpec extends AnyWordSpec with Matchers {
 
   def compileOnlySpec(body: => Unit) = ()
 

--- a/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
@@ -5,9 +5,10 @@
 package docs.http.scaladsl
 
 import docs.CompileOnlySpec
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class WebSocketClientExampleSpec extends WordSpec with Matchers with CompileOnlySpec {
+class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpec {
 
   "singleWebSocket-request-example" in compileOnlySpec {
     //#single-WebSocket-request

--- a/docs/src/test/scala/docs/http/scaladsl/server/BlockingInHttpExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/BlockingInHttpExamplesSpec.scala
@@ -7,11 +7,11 @@ package docs.http.scaladsl.server
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.{ Directives, Route }
 import docs.CompileOnlySpec
-import org.scalatest.WordSpec
 
 import scala.concurrent.Future
+import org.scalatest.wordspec.AnyWordSpec
 
-class BlockingInHttpExamplesSpec extends WordSpec with CompileOnlySpec
+class BlockingInHttpExamplesSpec extends AnyWordSpec with CompileOnlySpec
   with Directives {
 
   compileOnlySpec {

--- a/docs/src/test/scala/docs/http/scaladsl/server/FullTestKitExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/FullTestKitExampleSpec.scala
@@ -5,13 +5,14 @@
 package docs.http.scaladsl.server
 
 //#source-quote
-import org.scalatest.{ Matchers, WordSpec }
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.server._
 import Directives._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class FullTestKitExampleSpec extends WordSpec with Matchers with ScalatestRouteTest {
+class FullTestKitExampleSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
   val smallRoute =
     get {

--- a/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -17,9 +17,10 @@ import com.typesafe.sslconfig.akka.AkkaSSLConfig
 //#imports
 
 import docs.CompileOnlySpec
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-abstract class HttpsServerExampleSpec extends WordSpec with Matchers
+abstract class HttpsServerExampleSpec extends AnyWordSpec with Matchers
   with Directives with CompileOnlySpec {
 
   class HowToObtainSSLConfig {

--- a/docs/src/test/scala/docs/http/scaladsl/server/TestKitFragmentSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/TestKitFragmentSpec.scala
@@ -7,13 +7,14 @@ package docs.http.scaladsl.server
 // format: OFF
 
 //#source-quote
-import org.scalatest.{Matchers, WordSpec}
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.server._
 import Directives._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TestKitFragmentSpec extends WordSpec with Matchers with ScalatestRouteTest {
+class TestKitFragmentSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
 
   val routeFragment =
 //#fragment
@@ -51,7 +52,7 @@ class TestKitFragmentSpec extends WordSpec with Matchers with ScalatestRouteTest
 }
 //#source-quote
 
-class TestKitTimeoutSpec extends WordSpec with ScalatestRouteTest {
+class TestKitTimeoutSpec extends AnyWordSpec with ScalatestRouteTest {
   //#timeout-setting
   import scala.concurrent.duration._
   import akka.http.scaladsl.testkit.RouteTestTimeout

--- a/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
@@ -14,11 +14,12 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Sink }
 import akka.util.ByteString
 import docs.CompileOnlySpec
-import org.scalatest.{ Matchers, WordSpec }
 
 import scala.io.StdIn
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class WebSocketExampleSpec extends WordSpec with Matchers with CompileOnlySpec {
+class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpec {
   "core-example" in compileOnlySpec {
     //#websocket-example-using-core
     import akka.actor.ActorSystem

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
@@ -4,9 +4,9 @@
 
 package docs.http.scaladsl.server.directives
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class JsonStreamingFullExamples extends WordSpec {
+class JsonStreamingFullExamples extends AnyWordSpec {
 
   "compile only spec" in {}
 


### PR DESCRIPTION
Not sure why scalafix missed these when scala-steward applied it in a previous
PR.

Btw. used this diff to run scalafix:

```diff
diff --git a/build.sbt b/build.sbt
index 5eb1f6652e..d200ec87eb 100644
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ inThisBuild(Def.settings(
   Formatting.formatSettings,
   shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
+  scalafixDependencies in ThisBuild += "org.scalatest" %% "autofix" % "3.1.0.0",
+  addCompilerPlugin(scalafixSemanticdb),
 ))
 
 lazy val root = Project(
diff --git a/project/plugins.sbt b/project/plugins.sbt
index 3cc61facb9..e4338e2eff 100644
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,3 +27,5 @@ libraryDependencies += "org.kohsuke" % "github-api" % "1.106"
 
 // used for @unidoc directive
 libraryDependencies += "io.github.lukehutch" % "fast-classpath-scanner" % "3.1.15"
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")
\ No newline at end of file

```