### PR TITLE
Support for request/response message attributes

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/AttributeKey.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/AttributeKey.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.javadsl.model;
 
 import akka.annotation.DoNotInherit;

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/AttributeKey.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/AttributeKey.java
@@ -1,0 +1,10 @@
+package akka.http.javadsl.model;
+
+import akka.annotation.DoNotInherit;
+
+@DoNotInherit
+public interface AttributeKey<T> {
+    static <U> AttributeKey<U> newInstance() {
+        return new akka.http.scaladsl.model.AttributeKey<U>();
+    }
+}

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/AttributeKey.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/AttributeKey.java
@@ -7,8 +7,8 @@ package akka.http.javadsl.model;
 import akka.annotation.DoNotInherit;
 
 @DoNotInherit
-public interface AttributeKey<T> {
-    static <U> AttributeKey<U> newInstance() {
-        return new akka.http.scaladsl.model.AttributeKey<U>();
+public abstract class AttributeKey<T> {
+    public static <U> AttributeKey<U> create(String name, Class<U> clazz) {
+        return new akka.http.scaladsl.model.AttributeKey<U>(name, clazz);
     }
 }

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -140,6 +140,11 @@ public interface HttpMessage {
         Self removeHeader(String headerName);
 
         /**
+         * Returns a copy of this message with the attribute with this key (if any) removed.
+         */
+        Self removeAttribute(AttributeKey<?> key);
+
+        /**
          * Returns a copy of this message with a new entity.
          */
         Self withEntity(String string);

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -66,6 +66,12 @@ public interface HttpMessage {
     <T extends HttpHeader> Iterable<T> getHeaders(Class<T> headerClass);
 
     /**
+     * Try to find the attribute for the given key and return
+     * Optional.of(attribute), otherwise this method returns an empty Optional.
+     */
+    <T> Optional<T> getAttribute(AttributeKey<T> key);
+
+    /**
      * The entity of this message.
      */
     ResponseEntity entity();
@@ -120,6 +126,8 @@ public interface HttpMessage {
          * Returns a copy of this message with new headers.
          */
         Self withHeaders(Iterable<HttpHeader> headers);
+
+        <T> Self addAttribute(AttributeKey<T> key, T value);
 
         /**
          * Returns a copy of this message with the given http credential header added to the list of headers.

--- a/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/1500-attributes.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/1500-attributes.excludes
@@ -1,0 +1,5 @@
+# Adding methods to a class or interface marked DoNotInherit is OK
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.withAttributes")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.attributes")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage.getAttribute")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage#MessageTransformations.addAttribute")

--- a/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/1500-attributes.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/1500-attributes.excludes
@@ -3,3 +3,4 @@ ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.H
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.HttpMessage.attributes")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage.getAttribute")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage#MessageTransformations.addAttribute")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.HttpMessage#MessageTransformations.removeAttribute")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -266,7 +266,7 @@ private[http] object HttpServerBluePrint {
           val access = new TimeoutAccessImpl(request, initialTimeout, requestEnd, callback,
             interpreter.materializer, log)
           openTimeouts = openTimeouts.enqueue(access)
-          push(requestOut, request.copy(headers = `Timeout-Access`(access) +: request.headers, entity = entity))
+          push(requestOut, request.addHeader(`Timeout-Access`(access)).withEntity(entity))
         }
         override def onUpstreamFinish() = complete(requestOut)
         override def onUpstreamFailure(ex: Throwable) = fail(requestOut, ex)

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
@@ -212,6 +212,9 @@ private[http] object JavaMapping {
   implicit object InetSocketAddress extends Identity[java.net.InetSocketAddress]
   implicit object ByteString extends Identity[akka.util.ByteString]
 
+  implicit val AttributeKey = new Inherited[jm.AttributeKey[_], sm.AttributeKey[_]]
+  implicit def attributeKey[T]: Inherited[jm.AttributeKey[T], sm.AttributeKey[T]] =
+    AttributeKey.asInstanceOf[Inherited[jm.AttributeKey[T], sm.AttributeKey[T]]]
   implicit object ContentType extends Inherited[jm.ContentType, sm.ContentType]
   implicit object ContentTypeBinary extends Inherited[jm.ContentType.Binary, sm.ContentType.Binary]
   implicit object ContentTypeNonBinary extends Inherited[jm.ContentType.NonBinary, sm.ContentType.NonBinary]

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKey.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKey.scala
@@ -1,0 +1,8 @@
+package akka.http.scaladsl.model
+
+import akka.http.javadsl.{ model => jm }
+
+class AttributeKey[T] extends jm.AttributeKey[T]
+object AttributeKey {
+  def apply[T](): AttributeKey[T] = new AttributeKey[T]()
+}

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKey.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKey.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.scaladsl.model
 
 import akka.http.javadsl.{ model => jm }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKey.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKey.scala
@@ -6,7 +6,11 @@ package akka.http.scaladsl.model
 
 import akka.http.javadsl.{ model => jm }
 
-class AttributeKey[T] extends jm.AttributeKey[T]
+import scala.reflect.ClassTag
+
+case class AttributeKey[T](name: String, private val clazz: Class[_]) extends jm.AttributeKey[T]
+
 object AttributeKey {
-  def apply[T](): AttributeKey[T] = new AttributeKey[T]()
+  def apply[T: ClassTag](name: String): AttributeKey[T] =
+    new AttributeKey[T](name, implicitly[ClassTag[T]].runtimeClass)
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -540,7 +540,7 @@ final class HttpResponse(
     headers:    immutable.Seq[HttpHeader] = headers,
     entity:     ResponseEntity            = entity,
     protocol:   HttpProtocol              = protocol,
-    attributes: Map[AttributeKey[_], _] = attributes
+    attributes: Map[AttributeKey[_], _]   = attributes
   ) = new HttpResponse(status, headers, attributes, entity, protocol)
 
   @deprecated("use the method that includes an attributes parameter instead", "10.2.0")

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -370,7 +370,7 @@ final class HttpRequest(
     entity:   RequestEntity,
     protocol: HttpProtocol) = new HttpRequest(method, uri, headers, attributes, entity, protocol)
 
-  def copy(
+  private[model] def copy(
     method:     HttpMethod                  = method,
     uri:        Uri                         = uri,
     headers:    immutable.Seq[HttpHeader]   = headers,
@@ -530,7 +530,7 @@ final class HttpResponse(
 
   /* Manual Case Class things, to ease bin-compat */
 
-  def copy(
+  private[model] def copy(
     status:     StatusCode                  = status,
     headers:    immutable.Seq[HttpHeader]   = headers,
     entity:     ResponseEntity              = entity,

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -170,6 +170,8 @@ sealed trait HttpMessage extends jm.HttpMessage {
     mapHeaders(_.filterNot(_.is(lowerHeaderName)))
   }
 
+  def removeAttribute(key: jm.AttributeKey[_]): Self = mapAttributes(_ - key.asInstanceOf[AttributeKey[Any]])
+
   def withEntity(string: String): Self = withEntity(HttpEntity(string))
   def withEntity(bytes: Array[Byte]): Self = withEntity(HttpEntity(bytes))
   def withEntity(bytes: ByteString): Self = withEntity(HttpEntity(bytes))

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -302,8 +302,8 @@ final class HttpRequest(
   override def isRequest = true
   override def isResponse = false
 
-  @deprecated("for backwards compatibility", "10.2.0")
-  def this(method: HttpMethod, uri: Uri, headers: immutable.Seq[HttpHeader], entity: RequestEntity, protocol: HttpProtocol) =
+  @deprecated("use the constructor that includes an attributes parameter instead", "10.2.0")
+  private[model] def this(method: HttpMethod, uri: Uri, headers: immutable.Seq[HttpHeader], entity: RequestEntity, protocol: HttpProtocol) =
     this(method, uri, headers, Map.empty, entity, protocol)
 
   /**
@@ -360,8 +360,8 @@ final class HttpRequest(
 
   /* Manual Case Class things, to easen bin-compat */
 
-  @deprecated("Kept for binary compatibility", "10.2.0")
-  def copy(
+  @deprecated("use the method that includes an attributes parameter instead", "10.2.0")
+  private[model] def copy(
     method:   HttpMethod,
     uri:      Uri,
     headers:  immutable.Seq[HttpHeader],
@@ -387,10 +387,11 @@ final class HttpRequest(
   }
 
   override def equals(obj: scala.Any): Boolean = obj match {
-    case HttpRequest(_method, _uri, _headers, _entity, _protocol) =>
+    case request @ HttpRequest(_method, _uri, _headers, _entity, _protocol) =>
       method == _method &&
         uri == _uri &&
         headers == _headers &&
+        attributes == request.attributes &&
         entity == _entity &&
         protocol == _protocol
     case _ => false
@@ -500,8 +501,8 @@ final class HttpResponse(
   override def isRequest = false
   override def isResponse = true
 
-  @deprecated("for backwards compatibility", "10.2.0")
-  def this(status: StatusCode, headers: immutable.Seq[HttpHeader], entity: ResponseEntity, protocol: HttpProtocol) =
+  @deprecated("use the constructor that includes an attributes parameter instead", "10.2.0")
+  private[model] def this(status: StatusCode, headers: immutable.Seq[HttpHeader], entity: ResponseEntity, protocol: HttpProtocol) =
     this(status, headers, Map.empty, entity, protocol)
 
   override def withHeaders(headers: immutable.Seq[HttpHeader]): HttpResponse =
@@ -535,17 +536,18 @@ final class HttpResponse(
     attributes: Map[AttributeKey[Any], Any] = attributes
   ) = new HttpResponse(status, headers, attributes, entity, protocol)
 
-  @deprecated("kept for binary compatibility", "10.2.0")
-  def copy(
+  @deprecated("use the method that includes an attributes parameter instead", "10.2.0")
+  private[model] def copy(
     status:   StatusCode,
     headers:  immutable.Seq[HttpHeader],
     entity:   ResponseEntity,
     protocol: HttpProtocol) = new HttpResponse(status, headers, attributes, entity, protocol)
 
   override def equals(obj: scala.Any): Boolean = obj match {
-    case HttpResponse(_status, _headers, _entity, _protocol) =>
+    case response @ HttpResponse(_status, _headers, _entity, _protocol) =>
       status == _status &&
         headers == _headers &&
+        attributes == response.attributes &&
         entity == _entity &&
         protocol == _protocol
     case _ => false

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/HttpMessageTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/HttpMessageTest.java
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.javadsl.model;
 
 import akka.http.scaladsl.model.AttributeKey$;

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/HttpMessageTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/HttpMessageTest.java
@@ -6,8 +6,10 @@ package akka.http.javadsl.model;
 
 import akka.http.scaladsl.model.AttributeKey$;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
 import org.scalatestplus.junit.JUnitSuite;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class HttpMessageTest extends JUnitSuite {
     @Test
@@ -36,5 +38,9 @@ public class HttpMessageTest extends JUnitSuite {
         assertEquals(otherString, request.getAttribute(otherStringKey).get());
         assertEquals(integer, request.getAttribute(intKey).get());
         assertEquals(otherInteger, request.getAttribute(otherIntKey).get());
+
+        HttpRequest smaller = request.removeAttribute(intKey);
+        assertEquals(otherString, smaller.getAttribute(otherStringKey).get());
+        assertFalse(smaller.getAttribute(intKey).isPresent());
     }
 }

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/HttpMessageTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/HttpMessageTest.java
@@ -1,0 +1,28 @@
+package akka.http.javadsl.model;
+
+import akka.http.scaladsl.model.AttributeKey$;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.scalatestplus.junit.JUnitSuite;
+
+public class HttpMessageTest extends JUnitSuite {
+    @Test
+    public void testRetrieveAttributeByKey() {
+        AttributeKey<String> oneStringKey = AttributeKey.newInstance();
+        AttributeKey<String> otherStringKey = AttributeKey.newInstance();
+        AttributeKey<Integer> intKey = AttributeKey$.MODULE$.apply();
+
+        String oneStringAttribute = "A string attribute!";
+        String otherStringAttribute = "Another";
+        Integer intAttribute = 42;
+
+        HttpRequest request = HttpRequest.create()
+                .addAttribute(oneStringKey, oneStringAttribute)
+                .addAttribute(otherStringKey, otherStringAttribute)
+                .addAttribute(intKey, intAttribute);
+
+        assertEquals(oneStringAttribute, request.getAttribute(oneStringKey).get());
+        assertEquals(otherStringAttribute, request.getAttribute(otherStringKey).get());
+        assertEquals(intAttribute, request.getAttribute(intKey).get());
+    }
+}

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/HttpMessageTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/HttpMessageTest.java
@@ -12,21 +12,29 @@ import org.scalatestplus.junit.JUnitSuite;
 public class HttpMessageTest extends JUnitSuite {
     @Test
     public void testRetrieveAttributeByKey() {
-        AttributeKey<String> oneStringKey = AttributeKey.newInstance();
-        AttributeKey<String> otherStringKey = AttributeKey.newInstance();
-        AttributeKey<Integer> intKey = AttributeKey$.MODULE$.apply();
+        AttributeKey<String> oneStringKey = AttributeKey.create("one", String.class);
+        // keys with the same type but different names should be considered different
+        AttributeKey<String> otherStringKey = AttributeKey.create("other", String.class);
 
-        String oneStringAttribute = "A string attribute!";
-        String otherStringAttribute = "Another";
-        Integer intAttribute = 42;
+        // it should be possible to use 'Scala attribute keys' in the Java API's
+        AttributeKey<Integer> intKey = AttributeKey$.MODULE$.apply("int", Integer.class);
+        // keys with the same name but different types should be considered different
+        AttributeKey<Integer> otherIntKey = AttributeKey.create("other", Integer.class);
+
+        String oneString = "A string attribute!";
+        String otherString = "Another";
+        Integer integer = 42;
+        Integer otherInteger = 37;
 
         HttpRequest request = HttpRequest.create()
-                .addAttribute(oneStringKey, oneStringAttribute)
-                .addAttribute(otherStringKey, otherStringAttribute)
-                .addAttribute(intKey, intAttribute);
+                .addAttribute(oneStringKey, oneString)
+                .addAttribute(otherStringKey, otherString)
+                .addAttribute(intKey, integer)
+                .addAttribute(otherIntKey, otherInteger);
 
-        assertEquals(oneStringAttribute, request.getAttribute(oneStringKey).get());
-        assertEquals(otherStringAttribute, request.getAttribute(otherStringKey).get());
-        assertEquals(intAttribute, request.getAttribute(intKey).get());
+        assertEquals(oneString, request.getAttribute(oneStringKey).get());
+        assertEquals(otherString, request.getAttribute(otherStringKey).get());
+        assertEquals(integer, request.getAttribute(intKey).get());
+        assertEquals(otherInteger, request.getAttribute(otherIntKey).get());
     }
 }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -618,7 +618,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
     class StrictEqualHttpRequest(val req: HttpRequest) {
       override def equals(other: scala.Any): Boolean = other match {
         case other: StrictEqualHttpRequest =>
-          this.req.copy(entity = HttpEntity.Empty) == other.req.copy(entity = HttpEntity.Empty) &&
+          this.req.withEntity(HttpEntity.Empty) == other.req.withEntity(HttpEntity.Empty) &&
             this.req.entity.toStrict(awaitAtMost).awaitResult(awaitAtMost) ==
             other.req.entity.toStrict(awaitAtMost).awaitResult(awaitAtMost)
       }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -294,7 +294,7 @@ abstract class ResponseParserSpec(mode: String, newLine: String) extends AnyFree
       override def equals(other: scala.Any): Boolean = other match {
         case other: StrictEqualHttpResponse =>
 
-          this.resp.copy(entity = HttpEntity.Empty) == other.resp.copy(entity = HttpEntity.Empty) &&
+          this.resp.withEntity(HttpEntity.Empty) == other.resp.withEntity(HttpEntity.Empty) &&
             Await.result(this.resp.entity.toStrict(awaitAtMost), awaitAtMost) ==
             Await.result(other.resp.entity.toStrict(awaitAtMost), awaitAtMost)
       }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
@@ -8,6 +8,7 @@ import akka.util.ByteString
 import headers._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import akka.http.javadsl.{ model => jm }
 
 class HttpMessageSpec extends AnyWordSpec with Matchers {
 
@@ -71,6 +72,24 @@ class HttpMessageSpec extends AnyWordSpec with Matchers {
       val hostHeader = Host("akka.io")
       val request = HttpRequest().withHeaders(oneCookieHeader, anotherCookieHeader, hostHeader)
       request.headers[`Set-Cookie`] should ===(Seq(oneCookieHeader, anotherCookieHeader))
+    }
+    "retrieve an attribute by key" in {
+      val oneStringKey = AttributeKey[String]()
+      val otherStringKey = AttributeKey[String]()
+      val intKey = jm.AttributeKey.newInstance[Int]()
+
+      val oneStringAttribute = "A string attribute!"
+      val otherStringAttribute = "Another"
+      val intAttribute = 42
+
+      val request = HttpRequest()
+        .addAttribute(oneStringKey, oneStringAttribute)
+        .addAttribute(otherStringKey, otherStringAttribute)
+        .addAttribute(intKey, intAttribute)
+
+      request.attribute(oneStringKey) should be(Some(oneStringAttribute))
+      request.attribute(otherStringKey) should be(Some(otherStringAttribute))
+      request.attribute(intKey) should be(Some(intAttribute))
     }
   }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
@@ -97,6 +97,10 @@ class HttpMessageSpec extends AnyWordSpec with Matchers {
       request.attribute(otherStringKey) should be(Some(otherString))
       request.attribute(intKey) should be(Some(int))
       request.attribute(otherIntKey) should be(Some(otherInt))
+
+      val smaller = request.removeAttribute(intKey)
+      smaller.attribute(otherStringKey) should be(Some(otherString))
+      smaller.attribute(intKey) should be(None)
     }
   }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
@@ -74,22 +74,29 @@ class HttpMessageSpec extends AnyWordSpec with Matchers {
       request.headers[`Set-Cookie`] should ===(Seq(oneCookieHeader, anotherCookieHeader))
     }
     "retrieve an attribute by key" in {
-      val oneStringKey = AttributeKey[String]()
-      val otherStringKey = AttributeKey[String]()
-      val intKey = jm.AttributeKey.newInstance[Int]()
+      val oneStringKey = AttributeKey[String]("one")
+      // keys with the same type but different names should be different
+      val otherStringKey = AttributeKey[String]("other")
+      // it should be possible to use 'Java attribute keys' in the Scala API's
+      val intKey = jm.AttributeKey.create("int", classOf[Int])
+      // keys with the same name but different types should be different
+      val otherIntKey = AttributeKey[Int]("other")
 
-      val oneStringAttribute = "A string attribute!"
-      val otherStringAttribute = "Another"
-      val intAttribute = 42
+      val oneString = "A string attribute!"
+      val otherString = "Another"
+      val int = 42
+      val otherInt = 37
 
       val request = HttpRequest()
-        .addAttribute(oneStringKey, oneStringAttribute)
-        .addAttribute(otherStringKey, otherStringAttribute)
-        .addAttribute(intKey, intAttribute)
+        .addAttribute(oneStringKey, oneString)
+        .addAttribute(otherStringKey, otherString)
+        .addAttribute(intKey, int)
+        .addAttribute(otherIntKey, otherInt)
 
-      request.attribute(oneStringKey) should be(Some(oneStringAttribute))
-      request.attribute(otherStringKey) should be(Some(otherStringAttribute))
-      request.attribute(intKey) should be(Some(intAttribute))
+      request.attribute(oneStringKey) should be(Some(oneString))
+      request.attribute(otherStringKey) should be(Some(otherString))
+      request.attribute(intKey) should be(Some(int))
+      request.attribute(otherIntKey) should be(Some(otherInt))
     }
   }
 

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
@@ -36,7 +36,7 @@ trait RouteTestResultComponent {
       }
     }
 
-    def response: HttpResponse = rawResponse.copy(entity = entity)
+    def response: HttpResponse = rawResponse.withEntity(entity)
 
     /** Returns a "fresh" entity with a "fresh" unconsumed byte- or chunk stream (if not strict) */
     def entity: ResponseEntity = entityRecreator()

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RejectionSpec.scala
@@ -30,7 +30,7 @@ class RejectionSpec extends RoutingSpec {
         .mapRejectionResponse {
           case res @ HttpResponse(_, _, ent: HttpEntity.Strict, _) =>
             val message = ent.data.utf8String.replaceAll("\"", """\"""")
-            res.copy(entity = HttpEntity(ContentTypes.`application/json`, s"""{"rejection": "$message"}"""))
+            res.withEntity(HttpEntity(ContentTypes.`application/json`, s"""{"rejection": "$message"}"""))
 
           case x => x // pass through all other types of responses
         }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -492,7 +492,7 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
     "reject path traversal attempts" in {
       def _listDirectoryContents(directory: String) = listDirectoryContents(new File(testRoot, directory).getCanonicalPath)
       def route(uri: String) =
-        mapRequestContext(_.withUnmatchedPath(Path("/" + uri)).mapRequest(_.copy(uri = "/" + uri))) {
+        mapRequestContext(_.withUnmatchedPath(Path("/" + uri)).mapRequest(_.withUri("/" + uri))) {
           _listDirectoryContents("someDir/sub")
         }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
@@ -403,7 +403,7 @@ trait BasicDirectives {
             StatusCodes.RequestTimeout,
             ErrorInfo(s"Request timed out after $timeout while waiting for entity data", "Consider increasing the timeout for toStrict"))
       }.flatMap { strictEntity =>
-        val newCtx = ctx.mapRequest(_.copy(entity = strictEntity))
+        val newCtx = ctx.mapRequest(_.withEntity(strictEntity))
         inner(())(newCtx)
       }
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
@@ -102,7 +102,7 @@ trait MethodDirectives {
     parameter(paramName?) flatMap {
       case Some(method) =>
         getForKey(method.toUpperCase) match {
-          case Some(m) => mapRequest(_.copy(method = m))
+          case Some(m) => mapRequest(_.withMethod(m))
           case _       => complete(StatusCodes.NotImplemented)
         }
       case None => pass

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -1192,10 +1192,10 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
     }
     def decodeHeadersToResponse(bytes: ByteString): HttpResponse =
       decodeHeaders(bytes).foldLeft(HttpResponse())((old, header) => header match {
-        case (":status", value)                             => old.copy(status = value.toInt)
-        case ("content-length", value) if value.toLong == 0 => old.copy(entity = HttpEntity.Empty)
-        case ("content-length", value)                      => old.copy(entity = HttpEntity.Default(old.entity.contentType, value.toLong, Source.empty))
-        case ("content-type", value)                        => old.copy(entity = old.entity.withContentType(ContentType.parse(value).right.get))
+        case (":status", value)                             => old.withStatus(value.toInt)
+        case ("content-length", value) if value.toLong == 0 => old.withEntity(HttpEntity.Empty)
+        case ("content-length", value)                      => old.withEntity(HttpEntity.Default(old.entity.contentType, value.toLong, Source.empty))
+        case ("content-type", value)                        => old.withEntity(old.entity.withContentType(ContentType.parse(value).right.get))
         case (name, value)                                  => old.addHeader(RawHeader(name, value)) // FIXME: decode to modeled headers
       })
   }

--- a/docs/src/main/paradox/common/http-model.md
+++ b/docs/src/main/paradox/common/http-model.md
@@ -356,6 +356,18 @@ Implement @apidoc[ModeledCustomHeader] and @java[@javadoc[ModeledCustomHeaderFac
 able to use the convenience methods that allow parsing the custom user-defined header from @apidoc[HttpHeader].
 @@@
 
+## Attributes
+
+Sometimes it can be useful to keep track of some information associated with a request without
+explicitly closing over it. Such information can be attached to a request or response though
+message attributes:
+
+Scala
+:   @@snip [ModelSpec.scala]($test$/scala/docs/http/scaladsl/ModelSpec.scala) { #attributes }
+
+Java
+:   @@snip [ModelDocTest.java]($test$/java/docs/http/javadsl/ModelDocTest.java) { #attributes }
+
 ## Parsing / Rendering
 
 Parsing and rendering of HTTP data structures is heavily optimized and for most types there's currently no public API

--- a/docs/src/main/paradox/common/http-model.md
+++ b/docs/src/main/paradox/common/http-model.md
@@ -368,6 +368,8 @@ Scala
 Java
 :   @@snip [ModelDocTest.java]($test$/java/docs/http/javadsl/ModelDocTest.java) { #attributes }
 
+Message attributes are only to be used within in your application, they are not present on the wire.
+
 ## Parsing / Rendering
 
 Parsing and rendering of HTTP data structures is heavily optimized and for most types there's currently no public API

--- a/docs/src/test/java/docs/http/javadsl/ModelDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/ModelDocTest.java
@@ -6,6 +6,7 @@ package docs.http.javadsl;
 
 import akka.util.ByteString;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 //#import-model
 import akka.http.javadsl.model.*;
@@ -88,6 +89,39 @@ public class ModelDocTest {
             return Optional.empty();
     }
     //#headers
+
+    static
+    //#attributes
+    class User {
+        final String name;
+        public User(String name) {
+            this.name = name;
+        }
+
+        public static final AttributeKey<User> attributeKey = AttributeKey.create("user", User.class);
+    }
+
+    public HttpRequest determineUser(HttpRequest request) {
+        User user = //... somehow determine the user for this request
+        //#attributes
+        new User("joe");
+        //#attributes
+
+        // Add the attribute
+        return request.addAttribute(User.attributeKey, user);
+    }
+    //#attributes
+
+  @Test
+  public void testAttributes() {
+    HttpRequest requestWithAttribute = determineUser(HttpRequest.create());
+    //#attributes
+
+    // Retrieve the attribute
+    Optional<User> user = requestWithAttribute.getAttribute(User.attributeKey);
+    //#attributes
+    assertEquals("joe", user.get().name);
+  }
 
   @Test
   public void syntheticHeaderS3() {

--- a/docs/src/test/scala/docs/http/scaladsl/ModelSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/ModelSpec.scala
@@ -89,6 +89,33 @@ class ModelSpec extends AkkaSpec {
     credentialsOfRequest(HttpRequest(headers = List(Authorization(GenericHttpCredentials("Other", Map.empty[String, String]))))) should be(None)
   }
 
+  "deal with attributes" in {
+    //#attributes
+    case class User(name: String)
+    object User {
+      val attributeKey = AttributeKey[User]("user")
+    }
+
+    def determineUser(req: HttpRequest): HttpRequest = {
+      val user = // ... somehow determine the user for this request
+        //#attributes
+        User("joe")
+      //#attributes
+
+      // Add the attribute
+      req.addAttribute(User.attributeKey, user)
+    }
+    //#attributes
+
+    val requestWithAttribute = determineUser(HttpRequest())
+    //#attributes
+
+    // Retrieve the attribute
+    val user: Option[User] = requestWithAttribute.attribute(User.attributeKey)
+    //#attributes
+    user should be(Some(User("joe")))
+  }
+
   "Synthetic-header-s3" in {
     //#synthetic-header-s3
     import akka.http.scaladsl.model.headers.`Raw-Request-URI`

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -108,7 +108,7 @@ class RejectionHandlerExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
             // we copy the response in order to keep all headers and status code, wrapping the message as hand rolled JSON
             // you could the entity using your favourite marshalling library (e.g. spray json or anything else)
-            res.copy(entity = HttpEntity(ContentTypes.`application/json`, s"""{"rejection": "$message"}"""))
+            res.withEntity(HttpEntity(ContentTypes.`application/json`, s"""{"rejection": "$message"}"""))
 
           case x => x // pass through all other types of responses
         }
@@ -142,7 +142,7 @@ class RejectionHandlerExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
             // we copy the response in order to keep all headers and status code, wrapping the message as hand rolled JSON
             // you could the entity using your favourite marshalling library (e.g. spray json or anything else)
-            res.copy(entity = HttpEntity(ContentTypes.`application/json`, s"""{"rejection": "$message"}"""))
+            res.withEntity(HttpEntity(ContentTypes.`application/json`, s"""{"rejection": "$message"}"""))
 
           case x => x // pass through all other types of responses
         }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
@@ -242,7 +242,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "0mapResponse" in {
     //#mapResponse0
     def overwriteResultStatus(response: HttpResponse): HttpResponse =
-      response.copy(status = StatusCodes.BadGateway)
+      response.withStatus(StatusCodes.BadGateway)
     val route = mapResponse(overwriteResultStatus)(complete("abc"))
 
     // tests:
@@ -265,7 +265,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
           case code if code.isSuccess => response
           case code =>
             log.warning("Dropping response entity since response status code was: {}", code)
-            response.copy(entity = NullJsonEntity)
+            response.withEntity(NullJsonEntity)
         }
 
       /** Wrapper for all of our JSON API routes */
@@ -301,7 +301,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     val makeEverythingOk = mapRouteResult {
       case Complete(response) =>
         // "Everything is OK!"
-        Complete(response.copy(status = 200))
+        Complete(response.withStatus(200))
       case r => r
     }
 
@@ -498,7 +498,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   }
   "0mapRequest" in {
     //#mapRequest0
-    def transformToPostRequest(req: HttpRequest): HttpRequest = req.copy(method = HttpMethods.POST)
+    def transformToPostRequest(req: HttpRequest): HttpRequest = req.withMethod(HttpMethods.POST)
     val route =
       mapRequest(transformToPostRequest) {
         extractRequest { req =>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,7 +23,7 @@ addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.4.0")
 
 // used in ValidatePullRequest to check github PR comments whether to build all subprojects
-libraryDependencies += "org.kohsuke" % "github-api" % "1.103"
+libraryDependencies += "org.kohsuke" % "github-api" % "1.106"
 
 // used for @unidoc directive
 libraryDependencies += "io.github.lukehutch" % "fast-classpath-scanner" % "3.1.15"


### PR DESCRIPTION
In this draft, attributes are identified by AttributeKey instance. Explicitly
naming the keys doesn't seem necessary, as they are 'internal' and never
serialized.

Refs #1500, contrast with #2872

If we decide to go with this approach we should also add directives to extract
attributes by key.