### PR TITLE
Handle test exceptions separately from regular exceptions

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/TestFrameworkInterface.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/TestFrameworkInterface.scala
@@ -4,6 +4,7 @@
 
 package akka.http.scaladsl.testkit
 
+import akka.http.scaladsl.server.ExceptionHandler
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.{ BeforeAndAfterAll, Suite }
 
@@ -13,6 +14,8 @@ trait TestFrameworkInterface {
   def cleanUp()
 
   def failTest(msg: String): Nothing
+
+  def testExceptionHandler: ExceptionHandler
 }
 //#source-quote
 
@@ -27,6 +30,10 @@ object TestFrameworkInterface {
       cleanUp()
       super.afterAll()
     }
+
+    override val testExceptionHandler = ExceptionHandler {
+      case e: org.scalatest.exceptions.TestFailedException => throw e
+    }
   }
 }
 
@@ -38,5 +45,9 @@ object Specs2FrameworkInterface {
     def failTest(msg: String): Nothing = throw new FailureException(Failure(msg))
 
     override def afterAll(): Unit = cleanUp()
+
+    override val testExceptionHandler = ExceptionHandler {
+      case e: org.specs2.execute.FailureException => throw e
+    }
   }
 }

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -14,6 +14,7 @@ import akka.http.scaladsl.model._
 import StatusCodes._
 import HttpMethods._
 import Directives._
+import org.scalatest.exceptions.TestFailedException
 
 import scala.concurrent.Await
 import scala.concurrent.Future
@@ -84,6 +85,28 @@ class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRou
         responseEntity shouldEqual HttpEntity(ContentTypes.`text/plain(UTF-8)`, "abc")
         header("Fancy") shouldEqual Some(pinkHeader)
       }(result)
+    }
+
+    "failing the test inside the route" in {
+
+      val route = get {
+        fail()
+      }
+
+      assertThrows[TestFailedException] {
+        Get() ~> route
+      }
+    }
+
+    "internal server error" in {
+
+      val route = get {
+        throw new RuntimeException("BOOM")
+      }
+
+      Get() ~> route ~> check {
+        status shouldEqual InternalServerError
+      }
     }
   }
 }

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/Specs2RouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/Specs2RouteTestSpec.scala
@@ -73,5 +73,28 @@ class Specs2RouteTestSpec extends Specification with Specs2RouteTest {
         header("Fancy") shouldEqual Some(pinkHeader)
       }(result)
     }
+
+    "failing the test inside the route" in {
+
+      val route = get {
+        failure("BOOM")
+        complete(HttpResponse())
+      }
+
+      {
+        Get() ~> route
+      } must throwA[org.specs2.execute.FailureException]
+    }
+
+    "internal server error" in {
+
+      val route = get {
+        throw new RuntimeException("BOOM")
+      }
+
+      Get() ~> route ~> check {
+        status shouldEqual InternalServerError
+      }
+    }
   }
 }


### PR DESCRIPTION
If we use fail() or an assertion fails inside a route the test won't be
marked as failed. Instead 500 response will be returned. Custom
ExceptionHandler rethrowing TestFailedException fixes this problem.

Refs #2818

