### PR TITLE
Fix cancellation race conditions on the client-side

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/2965-introduce-client-stream-cancellation-setting.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/2965-introduce-client-stream-cancellation-setting.excludes
@@ -1,0 +1,14 @@
+# added setting to @DoNotInherit class
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.withStreamCancellationDelay")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ClientConnectionSettings.streamCancellationDelay")
+
+# some cleanup in @DoNotInherit class
+ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.withConnectingTimeout")
+ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.withIdleTimeout")
+ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.withRequestHeaderSizeHint")
+ProblemFilters.exclude[ReversedAbstractMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.withConnectingTimeout")
+ProblemFilters.exclude[ReversedAbstractMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.withIdleTimeout")
+ProblemFilters.exclude[ReversedAbstractMethodProblem]("akka.http.javadsl.settings.ClientConnectionSettings.withRequestHeaderSizeHint")
+
+# changes to internal classes
+ProblemFilters.exclude[Problem]("akka.http.impl.settings.ClientConnectionSettingsImpl.*")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -339,6 +339,16 @@ akka.http {
       # `infinite` by default, or a duration that is the max idle interval after which an keep-alive frame should be sent
       periodic-keep-alive-max-idle = infinite
     }
+
+    # Cancellation in the HTTP streams is delayed by this duration to prevent race conditions between cancellation
+    # and stream completion / failure. In most cases, the value chosen here should make no difference because
+    # HTTP streams are loops where completion and failures should propagate immediately and make the handling of
+    # cancellations redundant.
+    #
+    # In most cases, there should be no reason to change this setting.
+    #
+    # Set to 0 to disable the delay.
+    stream-cancellation-delay = 100 millis
   }
 
   host-connection-pool {

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
@@ -30,6 +30,7 @@ private[akka] final case class ClientConnectionSettingsImpl(
   websocketSettings:          WebSocketSettings,
   socketOptions:              immutable.Seq[SocketOption],
   parserSettings:             ParserSettings,
+  streamCancellationDelay:    FiniteDuration,
   localAddress:               Option[InetSocketAddress],
   transport:                  ClientTransport)
   extends akka.http.scaladsl.settings.ClientConnectionSettings {
@@ -56,6 +57,7 @@ private[akka] object ClientConnectionSettingsImpl extends SettingsCompanionImpl[
       websocketSettings = WebSocketSettingsImpl.client(c.getConfig("websocket")),
       socketOptions = SocketOptionSettings.fromSubConfig(root, c.getConfig("socket-options")),
       parserSettings = ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing")),
+      streamCancellationDelay = c.getFiniteDuration("stream-cancellation-delay"),
       localAddress = None,
       transport = ClientTransport.TCP)
   }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
@@ -36,6 +36,7 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   final def getSocketOptions: java.lang.Iterable[SocketOption] = socketOptions.asJava
   final def getUserAgentHeader: Optional[UserAgent] = OptionConverters.toJava(userAgentHeader)
   final def getLogUnencryptedNetworkBytes: Optional[Int] = OptionConverters.toJava(logUnencryptedNetworkBytes)
+  final def getStreamCancellationDelay: FiniteDuration = streamCancellationDelay
   final def getRequestHeaderSizeHint: Int = requestHeaderSizeHint
   final def getWebsocketSettings: WebSocketSettings = websocketSettings
   final def getWebsocketRandomFactory: Supplier[Random] = new Supplier[Random] {
@@ -47,12 +48,16 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   @ApiMayChange
   def getTransport: ClientTransport = transport.asJava
 
-  // ---
+  // implemented in Scala variant
+
+  def withConnectingTimeout(newValue: FiniteDuration): ClientConnectionSettings
+  def withIdleTimeout(newValue: Duration): ClientConnectionSettings
+  def withRequestHeaderSizeHint(newValue: Int): ClientConnectionSettings
+  def withStreamCancellationDelay(newValue: FiniteDuration): ClientConnectionSettings
+
+  // Java API versions of mutators
 
   def withUserAgentHeader(newValue: Optional[UserAgent]): ClientConnectionSettings = self.copy(userAgentHeader = newValue.asScala.map(_.asScala))
-  def withConnectingTimeout(newValue: FiniteDuration): ClientConnectionSettings = self.copy(connectingTimeout = newValue)
-  def withIdleTimeout(newValue: Duration): ClientConnectionSettings = self.copy(idleTimeout = newValue)
-  def withRequestHeaderSizeHint(newValue: Int): ClientConnectionSettings = self.copy(requestHeaderSizeHint = newValue)
   def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ClientConnectionSettings = self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
   def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ClientConnectionSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
     override def get(): Random = newValue.get()

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
@@ -34,6 +34,7 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   def socketOptions: immutable.Seq[SocketOption]
   def parserSettings: ParserSettings
   def logUnencryptedNetworkBytes: Option[Int]
+  def streamCancellationDelay: FiniteDuration
   def localAddress: Option[InetSocketAddress]
 
   /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
@@ -43,9 +44,10 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   // ---
 
   // overrides for more specific return type
-  override def withConnectingTimeout(newValue: FiniteDuration): ClientConnectionSettings = self.copy(connectingTimeout = newValue)
-  override def withIdleTimeout(newValue: Duration): ClientConnectionSettings = self.copy(idleTimeout = newValue)
-  override def withRequestHeaderSizeHint(newValue: Int): ClientConnectionSettings = self.copy(requestHeaderSizeHint = newValue)
+  def withConnectingTimeout(newValue: FiniteDuration): ClientConnectionSettings = self.copy(connectingTimeout = newValue)
+  def withIdleTimeout(newValue: Duration): ClientConnectionSettings = self.copy(idleTimeout = newValue)
+  def withRequestHeaderSizeHint(newValue: Int): ClientConnectionSettings = self.copy(requestHeaderSizeHint = newValue)
+  def withStreamCancellationDelay(newValue: FiniteDuration): ClientConnectionSettings = self.copy(streamCancellationDelay = newValue)
 
   // overloads for idiomatic Scala use
   def withWebsocketSettings(newValue: WebSocketSettings): ClientConnectionSettings = self.copy(websocketSettings = newValue)


### PR DESCRIPTION
Divide and conquer of the (too) big change in #2678.

Finally fixes #2349, the longest-standing recurrent failure.