### PR TITLE
[WIP] provide inspectable routes with minimal changes

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/InspectableRouteSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/InspectableRouteSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/InspectableRouteSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/InspectableRouteSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.server
+
+import akka.http.impl.util.AkkaSpecWithMaterializer
+import Directives._
+import DynamicDirective._
+import DirectiveRoute.addByNameNullaryApply
+
+class InspectableRouteSpec extends AkkaSpecWithMaterializer {
+  "Routes" should {
+    "be inspectable" should {
+      "routes from method directives" in {
+        val route = get { post { complete("ok") } }
+        route shouldBe an[InspectableRoute]
+        println(route)
+      }
+      "route alternatives with ~" in {
+        val route = get { complete("ok") } ~ post { complete("ok") }
+        route shouldBe an[InspectableRoute]
+        println(route)
+      }
+      "route alternatives with concat" in {
+        val route =
+          // semantic change here: the whole routing tree is evaluated eagerly because of the alternative
+          // `DirectiveRoute.addByNameNullaryApply` imported above
+          concat(
+            get { complete("ok") },
+            post { complete("ok") }
+          )
+        route shouldBe an[InspectableRoute]
+      }
+      "for routes with extractions" in {
+        val route =
+          // if you use static, it lifts the value into a token, that's the main API change for users
+          parameters("name").static { name: ExtractionToken[String] =>
+            get {
+              // you can only access token values inside of dynamic blocks
+              // it's not possible to inspect inner routes of dynamic blocks
+              dynamic { implicit extractionCtx =>
+                // with an implicit ExtractionContext in scope you can access token values using an implicit conversion
+                complete(s"Hello ${name: String}")
+              }
+            }
+          }
+        route shouldBe an[InspectableRoute]
+        println(route)
+      }
+    }
+  }
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -63,7 +63,7 @@ object SwaggerRoute {
 
   private def apiDescForRoute(route: Route): OpenApi = {
     case class RoutePath(segments: Seq[DirectiveRoute], last: Route) {
-      override def toString: String = segments.map(_.directiveName).mkString(" -> ") + " -> " + last.getClass.toString
+      override def toString: String = segments.map(s => s"${s.directiveName}${s.directiveInfo.fold("")(i => s"($i)")}").mkString(" -> ") + " -> " + last.getClass.toString
     }
     def leaves(route: Route, prefix: Seq[DirectiveRoute]): Seq[RoutePath] = route match {
       case AlternativeRoutes(alternatives) =>

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -62,8 +62,14 @@ object SwaggerRoute {
     complete(apiDescForRoute(forRoute))
 
   private def apiDescForRoute(route: Route): OpenApi = {
+    def formatInfo(info: Any): String = info match {
+      case p: Product =>
+        s"${p.productPrefix}${if (p.productArity > 0) s"(${(0 until p.productArity).map(idx => formatInfo(p.productElement(idx))).mkString(" ,")})}" else ""}"
+      case x => x.toString
+    }
+
     case class RoutePath(segments: Seq[DirectiveRoute], last: Route) {
-      override def toString: String = segments.map(s => s"${s.directiveName}${s.directiveInfo.fold("")(i => s"($i)")}").mkString(" -> ") + " -> " + last.getClass.toString
+      override def toString: String = segments.map(s => s"${s.directiveName}${s.directiveInfo.fold("")(i => s"(${formatInfo(i)})")}").mkString(" -> ") + " -> " + last.getClass.toString
     }
     def leaves(route: Route, prefix: Seq[DirectiveRoute]): Seq[RoutePath] = route match {
       case AlternativeRoutes(alternatives) =>

--- a/akka-http/src/main/mima-filters/10.1.11.backwards.excludes/2966-inspectable-routes.excludes
+++ b/akka-http/src/main/mima-filters/10.1.11.backwards.excludes/2966-inspectable-routes.excludes
@@ -1,9 +1,0 @@
-# New API in @DoNotInherit class
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.RequestContext.tokenValue")
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.RequestContext.addTokenValue")
-
-# Internal API
-ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.server.RequestContextImpl.this")
-
-# FIXME: need to check if that's a real problem
-ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.server.directives.ParameterDirectives#ParamMagnet.apply")

--- a/akka-http/src/main/mima-filters/10.1.11.backwards.excludes/2966-inspectable-routes.excludes
+++ b/akka-http/src/main/mima-filters/10.1.11.backwards.excludes/2966-inspectable-routes.excludes
@@ -1,0 +1,9 @@
+# New API in @DoNotInherit class
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.RequestContext.tokenValue")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.RequestContext.addTokenValue")
+
+# Internal API
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.server.RequestContextImpl.this")
+
+# FIXME: need to check if that's a real problem
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.server.directives.ParameterDirectives#ParamMagnet.apply")

--- a/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/2966-inspectable-routes.excludes
+++ b/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/2966-inspectable-routes.excludes
@@ -1,0 +1,16 @@
+# New API in @DoNotInherit class
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.RequestContext.tokenValue")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.RequestContext.addTokenValue")
+
+# Internal API
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.server.RequestContextImpl.this")
+
+# FIXME: need to check if that's a real problem
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.server.directives.ParameterDirectives#ParamMagnet.apply")
+
+# FIXME: unclear
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.server.PathMatcher.compose")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.server.PathMatcher.andThen")
+
+# Addition to @DoNotExtend
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.server.PathMatchers.Append")

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/InspectableRoute.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/InspectableRoute.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019-2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/InspectableRoute.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/InspectableRoute.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.server
+
+import akka.http.scaladsl.util.FastFuture
+import FastFuture._
+
+import scala.concurrent.Future
+import scala.runtime.ScalaRunTime
+
+sealed trait InspectableRoute extends Route with Product {
+  def name: String
+  def children: Seq[Route]
+
+  // FIXME: only there to help intellij
+  def apply(ctx: RequestContext): Future[RouteResult]
+
+  override def toString(): String = ScalaRunTime._toString(this)
+}
+final case class AlternativeRoutes(alternatives: Seq[Route]) extends InspectableRoute {
+  def name: String = "concat"
+  def children: Seq[Route] = alternatives
+
+  def apply(ctx: RequestContext): Future[RouteResult] = {
+    import ctx.executionContext
+    def tryNext(remaining: List[Route], rejections: Vector[Rejection]): Future[RouteResult] = remaining match {
+      case head :: tail =>
+        head(ctx).fast.flatMap {
+          case x: RouteResult.Complete             => FastFuture.successful(x)
+          case RouteResult.Rejected(newRejections) => tryNext(tail, rejections ++ newRejections)
+        }
+      case Nil => FastFuture.successful(RouteResult.Rejected(rejections))
+    }
+    tryNext(alternatives.toList, Vector.empty)
+  }
+}
+sealed trait DirectiveRoute extends InspectableRoute {
+  def implementation: Route
+  def directiveName: String
+  def child: Route
+
+  def apply(ctx: RequestContext): Future[RouteResult] = implementation(ctx)
+  def children: Seq[Route] = child :: Nil
+  def name: String = s"Directive($directiveName)"
+}
+
+object DirectiveRoute {
+  def wrap(implementation: Route, child: Route, directiveName: String): DirectiveRoute = implementation match {
+    case i: Impl =>
+      i.copy(child = child, directiveName = directiveName)
+    case x => Impl(x, child, directiveName)
+  }
+
+  implicit def addByNameNullaryApply(directive: Directive0): Route => Route =
+    inner => {
+      val impl = directive.tapply(_ => inner)
+      wrap(impl, inner, directive.metaInformation.fold("<unknown>")(_.name))
+    }
+
+  private final case class Impl(
+    implementation: Route,
+    child:          Route,
+    directiveName:  String) extends DirectiveRoute
+}
+
+sealed trait ExtractionToken[+T]
+object ExtractionToken {
+  // syntax sugar
+  implicit def autoExtract[T](token: ExtractionToken[T])(implicit ctx: ExtractionContext): T = ctx.extract(token)
+}
+sealed trait ExtractionContext {
+  def extract[T](token: ExtractionToken[T]): T
+}
+object DynamicDirective {
+  import Directives._
+  def dynamic: Directive1[ExtractionContext] = extractRequestContext.flatMap { ctx =>
+    provide {
+      new ExtractionContext {
+        override def extract[T](token: ExtractionToken[T]): T = ctx.tokenValue(token)
+      }
+    }
+  }
+
+  implicit class AddStatic[T](d: Directive1[T]) {
+    def static: Directive1[ExtractionToken[T]] =
+      Directive { innerCons =>
+        val tok = new ExtractionToken[T] {}
+        val inner = innerCons(Tuple1(tok))
+        val real = d { t => ctx =>
+          inner(ctx.addTokenValue(tok, t))
+        }
+        DirectiveRoute.wrap(real, inner, d.metaInformation.fold("<unknown>")(_.name))
+      }
+  }
+}

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContext.scala
@@ -135,4 +135,7 @@ trait RequestContext {
    * Removes a potentially existing Accept header from the request headers.
    */
   def withAcceptAll: RequestContext
+
+  def tokenValue[T](token: ExtractionToken[T]): T
+  def addTokenValue[T](token: ExtractionToken[T], value: T): RequestContext
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
@@ -84,7 +84,7 @@ trait MethodDirectives {
     extractMethod.flatMap[Unit] {
       case `httpMethod` => pass
       case _            => reject(MethodRejection(httpMethod))
-    } & cancelRejections(classOf[MethodRejection])
+    } & cancelRejections(classOf[MethodRejection]) named s"method($httpMethod)"
   //#method
 
   /**
@@ -114,12 +114,12 @@ object MethodDirectives extends MethodDirectives {
     BasicDirectives.extract(_.request.method)
 
   // format: OFF
-  private val _delete : Directive0 = method(DELETE)
-  private val _get    : Directive0 = method(GET)
-  private val _head   : Directive0 = method(HEAD)
-  private val _options: Directive0 = method(OPTIONS)
-  private val _patch  : Directive0 = method(PATCH)
-  private val _post   : Directive0 = method(POST)
-  private val _put    : Directive0 = method(PUT)
+  private val _delete : Directive0 = method(DELETE) named "delete"
+  private val _get    : Directive0 = method(GET) named "get"
+  private val _head   : Directive0 = method(HEAD) named "head"
+  private val _options: Directive0 = method(OPTIONS) named "options"
+  private val _patch  : Directive0 = method(PATCH) named "patch"
+  private val _post   : Directive0 = method(POST) named "post"
+  private val _put    : Directive0 = method(PUT) named "put"
   // format: ON
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -74,10 +74,10 @@ object ParameterDirectives extends ParameterDirectives {
     def apply(): Out
   }
   object ParamMagnet {
-    implicit def apply[T](value: T)(implicit pdef: ParamDef[T]): ParamMagnet { type Out = pdef.Out } =
+    implicit def apply[T, O](value: T)(implicit pdef: ParamDef[T] { type Out = Directive[O] }): ParamMagnet { type Out = pdef.Out } =
       new ParamMagnet {
         type Out = pdef.Out
-        def apply() = pdef(value)
+        def apply() = pdef(value) named "parameters"
       }
   }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
@@ -29,7 +29,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    *
    * @group path
    */
-  def path[L](pm: PathMatcher[L]): Directive[L] = pathPrefix(pm ~ PathEnd).named(s"path($pm)")
+  def path[L](pm: PathMatcher[L]): Directive[L] = pathPrefix(pm ~ PathEnd).named(s"path")
 
   /**
    * Applies the given [[PathMatcher]] to a prefix of the remaining unmatched path after consuming a leading slash.
@@ -38,7 +38,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    *
    * @group path
    */
-  def pathPrefix[L](pm: PathMatcher[L]): Directive[L] = rawPathPrefix(Slash ~ pm).named(s"pathPrefix($pm)")
+  def pathPrefix[L](pm: PathMatcher[L]): Directive[L] = rawPathPrefix(Slash ~ pm).named(s"pathPrefix")
 
   /**
    * Applies the given matcher directly to a prefix of the unmatched path of the
@@ -54,7 +54,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
       case Matched(rest, values) => tprovide(values) & mapRequestContext(_ withUnmatchedPath rest)
       case Unmatched             => reject
     }
-  }
+  }.info(pm)
 
   /**
    * Checks whether the unmatchedPath of the [[RequestContext]] has a prefix matched by the

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
@@ -29,7 +29,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    *
    * @group path
    */
-  def path[L](pm: PathMatcher[L]): Directive[L] = pathPrefix(pm ~ PathEnd)
+  def path[L](pm: PathMatcher[L]): Directive[L] = pathPrefix(pm ~ PathEnd).named(s"path($pm)")
 
   /**
    * Applies the given [[PathMatcher]] to a prefix of the remaining unmatched path after consuming a leading slash.
@@ -38,7 +38,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    *
    * @group path
    */
-  def pathPrefix[L](pm: PathMatcher[L]): Directive[L] = rawPathPrefix(Slash ~ pm)
+  def pathPrefix[L](pm: PathMatcher[L]): Directive[L] = rawPathPrefix(Slash ~ pm).named(s"pathPrefix($pm)")
 
   /**
    * Applies the given matcher directly to a prefix of the unmatched path of the
@@ -119,7 +119,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
    *
    * @group path
    */
-  def pathEnd: Directive0 = rawPathPrefix(PathEnd)
+  def pathEnd: Directive0 = rawPathPrefix(PathEnd).named("pathEnd")
 
   /**
    * Only passes on the request to its inner route if the request path has been matched


### PR DESCRIPTION
Refs #201, #2956

In a previous try, I tried to create a full AST of possible route structures. However, I don't think that's necessary. What we should strive for is

 * a generic structure that is good enough to provide information for debugging and introspection purposes
 * only minimal API changes to help with migration
 * an incremental way of adding metadata to existing directives without having to create a complete fork of the API