### PR TITLE
Accept RST on an already-half-closed HTTP/2 stream

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/util/WithLogCapturing.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/WithLogCapturing.scala
@@ -10,19 +10,22 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.event.Logging._
 import akka.testkit.{ EventFilter, TestEventListener }
+
 import org.scalatest.{ Outcome, SuiteMixin, TestSuite }
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Mixin this trait to a test to make log lines appear only when the test failed.
  */
-trait WithLogCapturing extends SuiteMixin { this: TestSuite =>
+trait WithLogCapturing extends SuiteMixin with Matchers with Eventually { this: TestSuite =>
   implicit def system: ActorSystem
 
-  abstract override def withFixture(test: NoArgTest): Outcome = {
-    // When filtering just collects events into this var (yeah, it's a hack to do that in a filter).
-    // We assume that the filter will always ever be used from a single actor, so a regular var should be fine.
-    var events: List[LogEvent] = Nil
+  // When filtering just collects events into this var (yeah, it's a hack to do that in a filter).
+  var events: List[LogEvent] = null
 
+  abstract override def withFixture(test: NoArgTest): Outcome = {
+    events = Nil
     object LogEventCollector extends EventFilter(Int.MaxValue) {
       override protected def matches(event: Logging.LogEvent): Boolean = {
         events ::= event
@@ -35,17 +38,26 @@ trait WithLogCapturing extends SuiteMixin { this: TestSuite =>
       myLogger.debug(s"Logging started for test [${test.name}]")
       val r = test()
       myLogger.debug(s"Logging finished for test [${test.name}]")
+      eventually { events.map(_.message) should contain(s"Logging finished for test [${test.name}]") }
       r
     }
 
     if (!(res.isSucceeded || res.isPending)) {
       println(s"--> [${Console.BLUE}${test.name}${Console.RESET}] Start of log messages of test that [$res]")
       val logger = new StdOutLogger {}
-      withPrefixedOut("| ") { events.reverse.foreach(logger.print) }
+      withPrefixedOut("| ") {
+        events.reverse.foreach(logger.print)
+      }
       println(s"<-- [${Console.BLUE}${test.name}${Console.RESET}] End of log messages of test that [$res]")
     }
-
     res
+  }
+
+  def expectNoWarningsOrErrors(): Unit = {
+    events should not be (null)
+    events.find(e => e.level == WarningLevel || e.level == ErrorLevel) should be(empty)
+    Thread.sleep(1000)
+    events.find(e => e.level == WarningLevel || e.level == ErrorLevel) should be(empty)
   }
 
   /** Adds a prefix to every line printed out during execution of the thunk. */

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CodingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CodingDirectivesSpec.scala
@@ -26,10 +26,6 @@ import scala.concurrent.duration._
 
 class CodingDirectivesSpec extends RoutingSpec with Inside {
 
-  override def testConfigSource = """
-    akka.loggers = ["akka.testkit.TestEventListener"]
-  """
-
   implicit val routeTestTimeout = RouteTestTimeout(3.seconds.dilated)
 
   val echoRequestContent: Route = { ctx => ctx.complete(ctx.request.entity.dataBytes.utf8String) }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -30,9 +30,8 @@ class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Ins
   val testRoot = new File("akka-http-tests/src/test/resources")
   require(testRoot.exists(), s"testRoot was not found at ${testRoot.getAbsolutePath}")
 
-  override def testConfigSource = """
+  override def testConfigSource = super.testConfigSource ++ """
     akka.http.routing.range-coalescing-threshold = 1
-    akka.loggers = ["akka.testkit.TestEventListener"]
   """
 
   def writeAllText(text: String, file: File): Unit =

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -16,10 +16,6 @@ import akka.http.scaladsl.server.util.VarArgsFunction1
 
 class MiscDirectivesSpec extends RoutingSpec {
 
-  override def testConfigSource = """
-    akka.loggers = ["akka.testkit.TestEventListener"]
-  """
-
   "the extractClientIP directive" should {
     "extract from a X-Forwarded-For header" in {
       Get() ~> addHeaders(`X-Forwarded-For`(remoteAddress("2.3.4.5")), RawHeader("x-real-ip", "1.2.3.4")) ~> {

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -27,7 +27,6 @@ import scala.util.Random
  */
 object Http2ServerTest extends App {
   val testConf: Config = ConfigFactory.parseString("""
-    akka.loglevel = INFO
     akka.log-dead-letters = off
     akka.stream.materializer.debug.fuzzing-mode = off
     akka.actor.serialize-creators = off

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FileUploadDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FileUploadDirectivesExamplesSpec.scala
@@ -20,7 +20,9 @@ import scala.concurrent.duration._
 
 class FileUploadDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
-  override def testConfigSource = "akka.actor.default-mailbox.mailbox-type = \"akka.dispatch.UnboundedMailbox\""
+  override def testConfigSource = super.testConfigSource ++ """
+    akka.actor.default-mailbox.mailbox-type = "akka.dispatch.UnboundedMailbox"
+  """
 
   // test touches disk, so give it some time
   implicit val routeTimeout = RouteTestTimeout(3.seconds.dilated)


### PR DESCRIPTION
Refs #2957

When grpccurl is used on a Akka gRPC server that does not support server
reflection, we send a 404, and grpcurl sends a RST with error code
PROTOCOL_ERROR.

We definitely didn't handle the RST correctly in that scenario. This PR
fixes handling the RST.

Separate from this PR, we should also investigate why grpcurl is sending
a PROTOCOL_ERROR: this indicates a HTTP/2 protocol-level error, while us
sending a 404 is an application-level error. It might be that grpcurl is
just incorrectly sending a PROTOCOL_ERROR here, or that we're in fact doing
something else wrong that triggers it.

The test is not very nice, but I don't see another way.