### PR TITLE
Require Akka 2.6

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HeaderParserBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HeaderParserBenchmark.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
-class HeaderParserBenchmark {
+final class HeaderParserBenchmark {
   implicit val system: ActorSystem = ActorSystem("header-parser-benchmark")
 
   @Param(Array("no", "yes"))

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
@@ -10,7 +10,6 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.headers
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.TLSPlacebo
@@ -24,7 +23,6 @@ class ServerProcessingBenchmark extends CommonBenchmark {
 
   var httpFlow: Flow[ByteString, ByteString, Any] = _
   implicit var system: ActorSystem = _
-  implicit var mat: ActorMaterializer = _
 
   @Benchmark
   @OperationsPerInvocation(10000)
@@ -48,7 +46,6 @@ class ServerProcessingBenchmark extends CommonBenchmark {
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
-    mat = ActorMaterializer()
     httpFlow =
       Flow[HttpRequest].map(_ => response) join
         (HttpServerBluePrint(ServerSettings(system), NoLogging, false) atop

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark2.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark2.scala
@@ -13,7 +13,6 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.headers
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
@@ -41,7 +40,6 @@ class ServerProcessingBenchmark2 extends CommonBenchmark {
   var httpFlow: Flow[ByteString, ByteString, Any] = _
 
   implicit var system: ActorSystem = _
-  implicit var mat: ActorMaterializer = _
 
   @Benchmark
   @OperationsPerInvocation(1)
@@ -69,7 +67,6 @@ class ServerProcessingBenchmark2 extends CommonBenchmark {
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
-    mat = ActorMaterializer()
 
     val byteChunk = ByteString(new Array[Byte](bytesPerChunk.toInt))
     val streamedBytes = Source.repeat(byteChunk).take(numChunks.toInt) // 1MB of data

--- a/akka-http-bench-jmh/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.TimeUnit
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ FileIO, Keep, RunnableGraph, Sink, Source }
 import akka.util.ByteString
 import org.openjdk.jmh.annotations._
@@ -19,7 +18,6 @@ import scala.concurrent.duration._
 @BenchmarkMode(Array(Mode.AverageTime))
 class LineParserBenchmark {
   implicit val system: ActorSystem = ActorSystem("line-parser-benchmark")
-  implicit val mat: ActorMaterializer = ActorMaterializer()
 
   // @formatter:off
   @Param(Array(

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/Http2Shadow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/Http2Shadow.scala
@@ -11,7 +11,7 @@ import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.ConnectionContext
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.{ ActorMaterializerHelper, Materializer }
+import akka.stream.Materializer
 
 import scala.concurrent.Future
 
@@ -38,10 +38,8 @@ private[akka] object Http2Shadow {
     parallelism: Int,
     log:         LoggingAdapter)(implicit fm: Materializer): Future[ServerBinding] = {
 
-    val mat = ActorMaterializerHelper.downcast(fm)
-
     try {
-      val system = mat.system.asInstanceOf[ExtendedActorSystem]
+      val system = fm.system.asInstanceOf[ExtendedActorSystem]
       val extensionIdClazz = system.dynamicAccess.getClassFor[ShadowHttp2]("akka.http.scaladsl.Http2").get
 
       val extensionInstance: ShadowHttp2Ext = extensionIdClazz.getMethod("get", Array(classOf[ActorSystem]): _*)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
@@ -168,7 +168,7 @@ private final class HttpsProxyGraphStage(
         }
       }
 
-      override def onDownstreamFinish(): Unit = cancel(sslIn)
+      override def onDownstreamFinish(cause: Throwable): Unit = cancel(sslIn, cause)
 
     })
 
@@ -177,7 +177,7 @@ private final class HttpsProxyGraphStage(
         pull(bytesIn)
       }
 
-      override def onDownstreamFinish(): Unit = cancel(bytesIn)
+      override def onDownstreamFinish(cause: Throwable): Unit = cancel(bytesIn, cause)
 
     })
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -198,7 +198,7 @@ private[http] object OutgoingConnectionBlueprint {
         if (!entitySubstreamStarted) pull(responseOutputIn)
       }
 
-      override def onDownstreamFinish(): Unit = {
+      override def onDownstreamFinish(cause: Throwable): Unit = {
         // if downstream cancels while streaming entity,
         // make sure we also cancel the entity source, but
         // after being done with streaming the entity

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterface.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterface.scala
@@ -15,7 +15,6 @@ import akka.http.impl.util._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.settings.PoolImplementation
-import akka.stream.ActorMaterializer
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet
@@ -59,7 +58,7 @@ private[http] object PoolInterface {
     import gateway.hcps
     import hcps._
     import setup.{ connectionContext, settings }
-    implicit val system = fm.asInstanceOf[ActorMaterializer].system
+    implicit val system = fm.system
     val log: LoggingAdapter = Logging(system, gateway)(GatewayLogSource)
 
     log.debug("Creating pool.")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolSlot.scala
@@ -105,7 +105,7 @@ private object PoolSlot {
           } else pull(slotCommandIn)
         }
 
-        override def onDownstreamFinish(): Unit = connectionFlowSource.complete()
+        override def onDownstreamFinish(cause: Throwable): Unit = connectionFlowSource.complete()
       }
 
       // SinkInlet is connected to the connectionFlow's outlet, an upstream

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -522,7 +522,7 @@ private[client] object NewHostConnectionPool {
 
           def onPull(): Unit = () // emitRequests makes sure not to push too early
 
-          override def onDownstreamFinish(): Unit =
+          override def onDownstreamFinish(cause: Throwable): Unit =
             withSlot(_.debug("Connection cancelled"))
 
           /** Helper that makes sure requestOut is pulled before pushing */
@@ -537,7 +537,7 @@ private[client] object NewHostConnectionPool {
                   requestOut.setHandler(connection)
                 }
 
-                override def onDownstreamFinish(): Unit = connection.onDownstreamFinish()
+                override def onDownstreamFinish(cause: Throwable): Unit = connection.onDownstreamFinish(cause)
               })
         }
         def openConnection(slot: Slot): SlotConnection = {
@@ -585,9 +585,9 @@ private[client] object NewHostConnectionPool {
           log.debug("Pool upstream failed with {}", ex)
           super.onUpstreamFailure(ex)
         }
-        override def onDownstreamFinish(): Unit = {
+        override def onDownstreamFinish(cause: Throwable): Unit = {
           log.debug("Pool downstream cancelled")
-          super.onDownstreamFinish()
+          super.onDownstreamFinish(cause)
         }
         override def postStop(): Unit = {
           slots.foreach(_.shutdown())

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -121,7 +121,7 @@ private[http] class HttpRequestRendererFactory(
       val stream = ctx.sendEntityTrigger match {
         case None => headerPart ++ body
         case Some(future) =>
-          val barrier = Source.fromFuture(future).drop(1).asInstanceOf[Source[ByteString, Any]]
+          val barrier = Source.future(future).drop(1).asInstanceOf[Source[ByteString, Any]]
           (headerPart ++ barrier ++ body).recoverWithRetries(-1, { case HttpResponseParser.OneHundredContinueError => Source.empty })
       }
       RequestRenderingOutput.Streamed(stream)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -125,9 +125,9 @@ private[http] class HttpResponseRendererFactory(
             override def onPull(): Unit =
               if (!headersSent) sendHeaders()
               else sinkIn.pull()
-            override def onDownstreamFinish(): Unit = {
+            override def onDownstreamFinish(cause: Throwable): Unit = {
               completeStage()
-              sinkIn.cancel()
+              sinkIn.cancel(cause)
             }
           })
 

--- a/akka-http-core/src/main/scala/akka/http/impl/util/One2OneBidiFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/One2OneBidiFlow.scala
@@ -78,7 +78,7 @@ private[http] object One2OneBidiFlow {
         override def onPull(): Unit =
           if (insideWrappedFlow < maxPending || maxPending == -1) pull(in)
           else pullSuppressed = true
-        override def onDownstreamFinish(): Unit = cancel(in)
+        override def onDownstreamFinish(cause: Throwable): Unit = cancel(in, cause)
       })
 
       setHandler(fromWrapped, new InHandler {
@@ -101,7 +101,7 @@ private[http] object One2OneBidiFlow {
 
       setHandler(out, new OutHandler {
         override def onPull(): Unit = pull(fromWrapped)
-        override def onDownstreamFinish(): Unit = cancel(fromWrapped)
+        override def onDownstreamFinish(cause: Throwable): Unit = cancel(fromWrapped, cause)
       })
     }
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StageLoggingWithOverride.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StageLoggingWithOverride.scala
@@ -10,8 +10,6 @@ package akka.http.impl.util
 import akka.annotation.InternalApi
 import akka.stream.stage.GraphStageLogic
 import akka.event.LoggingAdapter
-import akka.stream.ActorMaterializer
-import akka.event.NoLogging
 
 // TODO Try to reconcile with what Akka provides in StageLogging.
 // We thought this could be removed when https://github.com/akka/akka/issues/18793 had been implemented
@@ -34,10 +32,7 @@ private[akka] trait StageLoggingWithOverride { self: GraphStageLogic =>
         _log =
           logOverride match {
             case DefaultNoLogging =>
-              materializer match {
-                case a: ActorMaterializer => akka.event.Logging(a.system, logSource)
-                case _                    => NoLogging
-              }
+              akka.event.Logging(materializer.system, logSource)
             case x => x
           }
       case _ =>

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -205,7 +205,7 @@ private[http] object StreamUtils {
 
       var timeout: OptionVal[Cancellable] = OptionVal.None
 
-      override def onDownstreamFinish(): Unit = {
+      override def onDownstreamFinish(cause: Throwable): Unit = {
         cancelAfter match {
           case finite: FiniteDuration =>
             log.debug(s"Delaying cancellation for $finite")

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -183,7 +183,7 @@ private[http] object StreamUtils {
   object OneTimeValve {
     def apply(): OneTimeValve = new OneTimeValve {
       val promise = Promise[Unit]()
-      val _source = Source.fromFuture(promise.future).drop(1) // we are only interested in the completion event
+      val _source = Source.future(promise.future).drop(1) // we are only interested in the completion event
 
       def source[T]: Source[T, NotUsed] = _source.asInstanceOf[Source[T, NotUsed]] // safe, because source won't generate any elements
       def open(): Unit = promise.success(())

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -389,7 +389,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
   // ** CLIENT ** //
 
   private[this] val poolMasterActorRef = system.systemActorOf(PoolMasterActor.props, "pool-master")
-  private[this] val systemMaterializer = ActorMaterializer()
+  private[this] val systemMaterializer = SystemMaterializer(system).materializer
 
   /**
    * Creates a [[akka.stream.scaladsl.Flow]] representing a prospective HTTP client connection to the given endpoint.

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -75,7 +75,7 @@ sealed trait HttpEntity extends jm.HttpEntity {
    */
   def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[HttpEntity.Strict] = {
     import akka.http.impl.util._
-    val config = fm.asInstanceOf[ActorMaterializer].system.settings.config
+    val config = fm.system.settings.config
     toStrict(timeout, config.getPossiblyInfiniteBytes("akka.http.parsing.max-to-strict-bytes"))
   }
 

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/EntityDiscardingTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/EntityDiscardingTest.java
@@ -7,7 +7,8 @@ package akka.http.javadsl.model;
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.japi.function.Procedure;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.SystemMaterializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
@@ -24,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class EntityDiscardingTest extends JUnitSuite {
 
   private ActorSystem sys = ActorSystem.create("test");
-  private ActorMaterializer mat = ActorMaterializer.create(sys);
+  private Materializer mat = SystemMaterializer.get(sys).materializer();
   private Iterable<ByteString> testData = Arrays.asList(ByteString.fromString("abc"), ByteString.fromString("def"));
 
   @Test

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
@@ -8,14 +8,15 @@ import akka.http.impl.util.AkkaSpecWithMaterializer
 import javax.net.ssl.SSLContext
 import akka.http.scaladsl.{ ConnectionContext, Http }
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
-import akka.stream.ActorMaterializer
+import akka.stream.SystemMaterializer
 import akka.stream.scaladsl.{ Flow, Sink, Source }
 import akka.stream.testkit.{ TestPublisher, TestSubscriber, Utils }
 import akka.http.scaladsl.model.headers
 import akka.testkit.SocketUtil
 
 class ClientCancellationSpec extends AkkaSpecWithMaterializer {
-  val noncheckedMaterializer = ActorMaterializer()
+  // TODO document why this explicit materializer is needed here?
+  val noncheckedMaterializer = SystemMaterializer(system).materializer
 
   "Http client connections" must {
     val address = SocketUtil.temporaryServerAddress()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -178,7 +178,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         pendingIn(targetImpl = LegacyPoolImplementation) // not implemented in legacy
         pendingIn(targetTrans = PassThrough) // infra seems to be missing something
 
-        // FIXME: set subscription timeout to value relating to below `expectNoMsg`
+        // FIXME: set subscription timeout to value relating to below `expectNoMessage`
 
         pushRequest(HttpRequest(uri = "/1"))
         val conn1 = expectNextConnection()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -697,7 +697,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
             super.onUpstreamFailure(ex)
           }
 
-          override def onDownstreamFinish(): Unit = failStage(new RuntimeException("was cancelled"))
+          override def onDownstreamFinish(cause: Throwable): Unit = failStage(new RuntimeException("was cancelled", cause))
         }
         setHandlers(reqIn, reqOut, new MonitorMessage(reqIn, reqOut))
         setHandlers(resIn, resOut, new MonitorMessage(resIn, resOut))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/PrepareResponseSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/PrepareResponseSpec.scala
@@ -9,7 +9,7 @@ import akka.http.impl.engine.parsing.ParserOutput
 import akka.http.impl.engine.parsing.ParserOutput.{ StrictEntityCreator, EntityStreamError, EntityChunk, StreamedEntityCreator }
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ParserSettings
-import akka.stream.{ ActorMaterializer, Attributes }
+import akka.stream.Attributes
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.testkit.{ TestSubscriber, TestPublisher }
 import akka.util.ByteString
@@ -46,8 +46,6 @@ class PrepareResponseSpec extends AkkaSpec {
   "The PrepareRequest stage" should {
 
     "not lose demand that comes in while streaming entity" in {
-      implicit val mat = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]
 
@@ -91,8 +89,6 @@ class PrepareResponseSpec extends AkkaSpec {
     }
 
     "not lose demand that comes in while handling strict entity" in {
-      implicit val mat = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]
 
@@ -127,8 +123,6 @@ class PrepareResponseSpec extends AkkaSpec {
     "complete entity stream then complete stage when downstream cancels" in {
       // to make it possible to cancel a big file download for example
       // without downloading the entire response first
-      implicit val mat = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]
 
@@ -168,8 +162,6 @@ class PrepareResponseSpec extends AkkaSpec {
     }
 
     "complete stage when downstream cancels before end of strict request has arrived" in {
-      implicit val mat = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]
 
@@ -196,8 +188,6 @@ class PrepareResponseSpec extends AkkaSpec {
     }
 
     "cancel entire stage when the entity stream is canceled" in {
-      implicit val mat = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
@@ -11,10 +11,9 @@ import akka.http.impl.engine.parsing.{ HttpHeaderParser, HttpResponseParser, Par
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ParserSettings
 import akka.stream.TLSProtocol.SessionBytes
-import akka.stream.javadsl.RunnableGraph
-import akka.stream.scaladsl.{ GraphDSL, Sink, Source }
+import akka.stream.scaladsl.{ GraphDSL, RunnableGraph, Sink, Source }
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
-import akka.stream.{ ActorMaterializer, Attributes, ClosedShape }
+import akka.stream.{ Attributes, ClosedShape }
 import akka.testkit.AkkaSpec
 import akka.util.ByteString
 
@@ -25,8 +24,6 @@ class ResponseParsingMergeSpec extends AkkaSpec {
   "The ResponseParsingMerge stage" should {
 
     "not lose entity truncation errors on upstream finish" in {
-      implicit val mat = ActorMaterializer()
-
       val inBypassProbe = TestPublisher.manualProbe[OutgoingConnectionBlueprint.BypassData]()
       val inSessionBytesProbe = TestPublisher.manualProbe[SessionBytes]()
       val responseProbe = TestSubscriber.manualProbe[List[ParserOutput.ResponseOutput]]
@@ -47,7 +44,7 @@ class ResponseParsingMergeSpec extends AkkaSpec {
 
           ClosedShape
         }.withAttributes(Attributes.inputBuffer(1, 8))
-      ).run(mat)
+      ).run()
 
       val inSessionBytesSub = inSessionBytesProbe.expectSubscription()
       val inBypassSub = inBypassProbe.expectSubscription()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -11,7 +11,6 @@ import scala.concurrent.duration._
 import com.typesafe.config.{ Config, ConfigFactory }
 import akka.util.ByteString
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.stream.TLSProtocol._
 import org.scalatest.matchers.Matcher
@@ -46,7 +45,6 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
   import system.dispatcher
 
   val BOLT = HttpMethod.custom("BOLT", safe = false, idempotent = true, requestEntityAcceptance = Expected)
-  implicit val materializer = ActorMaterializer()
 
   s"The request parsing logic should (mode: $mode)" - {
     "properly parse a request" - {
@@ -671,7 +669,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
         }
         .concatSubstreams
         .flatMapConcat { x =>
-          Source.fromFuture {
+          Source.future {
             x match {
               case Right(request) => compactEntity(request.entity).fast.map(x => Right(request.withEntity(x)))
               case Left(error)    => FastFuture.successful(Left(error))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -17,7 +17,7 @@ import org.scalatest.matchers.Matcher
 import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.stream.scaladsl._
-import akka.stream.{ ActorMaterializer, Attributes, FlowShape, Inlet, Outlet }
+import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
 import akka.http.scaladsl.util.FastFuture._
 import akka.http.impl.util._
 import akka.http.scaladsl.model._
@@ -42,7 +42,6 @@ abstract class ResponseParserSpec(mode: String, newLine: String) extends AnyFree
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
 
-  implicit val materializer = ActorMaterializer()
   val ServerOnTheMove = StatusCodes.custom(331, "Server on the move")
   val TotallyUnrecognized = StatusCodes.custom(456, "Totally unrecognized")
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
@@ -18,7 +18,6 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.impl.util._
 import akka.stream.scaladsl._
-import akka.stream.ActorMaterializer
 import HttpEntity._
 import HttpMethods._
 import akka.testkit._
@@ -31,8 +30,6 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
     akka.loglevel = WARNING""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
-
-  implicit val materializer = ActorMaterializer()
 
   "The request preparation logic should" - {
     "properly render an unchunked" - {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -17,7 +17,6 @@ import akka.http.scaladsl.model.headers._
 import akka.http.impl.util._
 import akka.util.ByteString
 import akka.stream.scaladsl._
-import akka.stream.ActorMaterializer
 import HttpEntity._
 import akka.http.impl.engine.rendering.ResponseRenderingContext.CloseRequested
 import akka.testkit._
@@ -31,7 +30,6 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
 
   val ServerOnTheMove = StatusCodes.custom(330, "Server on the move")
-  implicit val materializer = ActorMaterializer()
 
   "The response preparation logic should properly render" - {
     "a response with no body," - {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
@@ -8,7 +8,6 @@ import akka.http.scaladsl.model.HttpEntity.Chunked
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.{ ContentType, HttpRequest, HttpResponse }
 import akka.http.scaladsl.model.MediaTypes._
-import akka.stream.{ ActorMaterializer, Materializer }
 import akka.stream.testkit.Utils.{ TE, _ }
 import akka.testkit._
 import org.scalatest.Inside
@@ -22,13 +21,11 @@ class HttpServerBug21008Spec extends AkkaSpec(
    akka.loggers = ["akka.testkit.TestEventListener", "akka.event.Logging$DefaultLogger"]
    akka.http.server.request-timeout = infinite
    akka.test.filter-leeway=1s""") with Inside { spec =>
-  implicit val materializer = ActorMaterializer()
 
   "The HttpServer" should {
 
     "not cause internal graph failures when consuming a `100 Continue` entity triggers a failure" in assertAllStagesStopped(new HttpServerTestSetupBase {
       override implicit def system = HttpServerBug21008Spec.this.system
-      override implicit def materializer: Materializer = HttpServerBug21008Spec.this.materializer
 
       send("""POST / HTTP/1.1
              |Host: example.com

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -18,7 +18,6 @@ import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.scaladsl._
 import akka.stream.testkit.Utils.assertAllStagesStopped
 import akka.stream.testkit._
-import akka.stream.ActorMaterializer
 import akka.stream.Attributes
 import akka.stream.Outlet
 import akka.stream.SourceShape
@@ -40,7 +39,6 @@ class HttpServerSpec extends AkkaSpec(
      akka.http.server.request-timeout = infinite
      akka.scheduler.implementation = "akka.testkit.ExplicitlyTriggeredScheduler"
   """) with Inside with WithLogCapturing { spec =>
-  implicit val materializer = ActorMaterializer()
 
   "The server implementation" should {
     "deliver an empty request as soon as all headers are received" in assertAllStagesStopped(new TestSetup {
@@ -1461,7 +1459,6 @@ class HttpServerSpec extends AkkaSpec(
   }
   class TestSetup(maxContentLength: Int = -1) extends HttpServerTestSetupBase {
     implicit def system = spec.system
-    implicit def materializer = spec.materializer
     val scheduler = spec.system.scheduler.asInstanceOf[ExplicitlyTriggeredScheduler]
 
     override def settings = {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -21,7 +21,6 @@ import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 
 abstract class HttpServerTestSetupBase {
   implicit def system: ActorSystem
-  implicit def materializer: Materializer
 
   val requests = TestSubscriber.probe[HttpRequest]
   val responses = TestPublisher.probe[HttpResponse]()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/PrepareRequestsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/PrepareRequestsSpec.scala
@@ -9,7 +9,7 @@ import akka.http.impl.engine.parsing.ParserOutput.{ StrictEntityCreator, EntityS
 import akka.http.impl.engine.server.HttpServerBluePrint.PrepareRequests
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.{ Attributes, ActorMaterializer }
+import akka.stream.Attributes
 import akka.stream.scaladsl.{ Sink, Source, Flow }
 import akka.stream.testkit.{ TestSubscriber, TestPublisher }
 import akka.testkit._
@@ -53,7 +53,6 @@ class PrepareRequestsSpec extends AkkaSpec {
   "The PrepareRequest stage" should {
 
     "not fail when there is demand from both streamed entity consumption and regular flow" in {
-      implicit val materializer = ActorMaterializer()
       // covers bug #19623 where a reply before the streamed
       // body has been consumed causes pull/push twice
       val inProbe = TestPublisher.manualProbe[ParserOutput.RequestOutput]()
@@ -113,8 +112,6 @@ class PrepareRequestsSpec extends AkkaSpec {
     }
 
     "not complete running entity stream when upstream cancels" in {
-      implicit val materializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.RequestOutput]()
       val upstreamProbe = TestSubscriber.manualProbe[HttpRequest]()
 
@@ -164,8 +161,6 @@ class PrepareRequestsSpec extends AkkaSpec {
 
     "complete stage if chunked stream is completed without reaching end of chunks" in {
       // a bit unsure about this, but to document the assumption
-      implicit val materializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.RequestOutput]()
       val upstreamProbe = TestSubscriber.manualProbe[HttpRequest]()
 
@@ -205,8 +200,6 @@ class PrepareRequestsSpec extends AkkaSpec {
     }
 
     "cancel the stage when the entity stream is canceled" in {
-      implicit val materializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.RequestOutput]()
       val upstreamProbe = TestSubscriber.manualProbe[HttpRequest]()
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
@@ -53,7 +53,7 @@ private[http] object ByteStringSinkProbe {
       }
       def expectNoBytes(): Unit = {
         ensureRequested()
-        probe.expectNoMsg()
+        probe.expectNoMessage()
       }
       def expectNoBytes(timeout: FiniteDuration): Unit = {
         ensureRequested()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/EchoTestClientApp.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/EchoTestClientApp.scala
@@ -6,12 +6,12 @@ package akka.http.impl.engine.ws
 
 import akka.NotUsed
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.ws.{ TextMessage, BinaryMessage, Message }
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.util.ByteString
 
@@ -23,8 +23,7 @@ import scala.util.{ Failure, Success }
  */
 object EchoTestClientApp extends App {
   implicit val system = ActorSystem()
-  import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   def delayedCompletion(delay: FiniteDuration): Source[Nothing, NotUsed] =
     Source.single(1)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSClientAutobahnTest.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSClientAutobahnTest.scala
@@ -6,11 +6,10 @@ package akka.http.impl.engine.ws
 
 import akka.Done
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success, Try }
 import spray.json._
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri
@@ -18,8 +17,7 @@ import akka.http.scaladsl.model.ws._
 
 object WSClientAutobahnTest extends App {
   implicit val system = ActorSystem()
-  import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   val Agent = "akka-http"
   val Parallelism = 4

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSServerAutobahnTest.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSServerAutobahnTest.scala
@@ -13,14 +13,12 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.ws.{ Message, UpgradeToWebSocket }
 import akka.http.scaladsl.model._
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 
 import scala.io.StdIn
 
 object WSServerAutobahnTest extends App {
   implicit val system = ActorSystem("WSServerTest")
-  implicit val fm = ActorMaterializer()
 
   val host = System.getProperty("akka.ws-host", "127.0.0.1")
   val port = System.getProperty("akka.ws-port", "9001").toInt

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
@@ -29,8 +29,6 @@ import scala.util.{ Failure, Success }
 class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.fuzzing-mode=off")
   with Eventually {
 
-  implicit val materializer = ActorMaterializer()
-
   "A WebSocket server" must {
 
     "not reset the connection when no data are flowing" in Utils.assertAllStagesStopped {

--- a/akka-http-core/src/test/scala/akka/http/impl/util/AkkaSpecWithMaterializer.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/AkkaSpecWithMaterializer.scala
@@ -8,6 +8,8 @@ import akka.stream.ActorMaterializer
 import akka.testkit.AkkaSpec
 import akka.testkit.EventFilter
 
+// TODO #2886 check that the SystemMaterializer is shut down before the rest of the system,
+// if so this helper is no longer necessary.
 abstract class AkkaSpecWithMaterializer(s: String)
   extends AkkaSpec(s +
     """

--- a/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
@@ -7,7 +7,6 @@ package akka.http.impl.util
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.NotUsed
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.stream.testkit.Utils._
 import akka.stream.testkit._
@@ -18,8 +17,6 @@ import akka.testkit._
 import org.scalatest.concurrent.Eventually
 
 class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
-  implicit val materializer = ActorMaterializer()
-
   "A One2OneBidiFlow" must {
 
     def test(flow: Flow[Int, Int, NotUsed]) =

--- a/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.http.impl.util
 
-import akka.stream.{ ActorMaterializer, Attributes }
+import akka.stream.Attributes
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
 import akka.testkit._
@@ -15,7 +15,6 @@ import scala.concurrent.duration._
 import scala.util.Failure
 
 class StreamUtilsSpec extends AkkaSpec with ScalaFutures {
-  implicit val materializer = ActorMaterializer()
 
   "captureTermination" should {
     "signal completion" when {

--- a/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
@@ -17,7 +17,7 @@ import akka.actor.ActorSystem
 import akka.event.NoLogging
 import akka.http.javadsl.model._
 import akka.japi.Function
-import akka.stream.ActorMaterializer
+import akka.stream.SystemMaterializer
 import akka.stream.javadsl.{ Flow, Keep, Sink, Source }
 import akka.stream.testkit.TestSubscriber
 import akka.testkit.TestKit
@@ -46,7 +46,7 @@ class HttpExtensionApiSpec extends AnyWordSpec with Matchers with BeforeAndAfter
 
     ActorSystem(getClass.getSimpleName, testConf)
   }
-  implicit val materializer = ActorMaterializer()
+  val materializer = SystemMaterializer.get(system).materializer
 
   val http = Http.get(system)
   val connectionContext = ConnectionContext.noEncryption()

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
@@ -11,8 +11,8 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.scalatest.{ BeforeAndAfterAll, Inside }
-import akka.stream.ActorMaterializer
 import akka.actor.ActorSystem
+import akka.stream.SystemMaterializer
 import akka.stream.javadsl.Source
 import akka.testkit._
 
@@ -26,7 +26,7 @@ class MultipartsSpec extends AnyWordSpec with Matchers with Inside with BeforeAn
   akka.event-handlers = ["akka.testkit.TestEventListener"]
   akka.loglevel = WARNING""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
-  implicit val materializer = ActorMaterializer()
+  val materializer = SystemMaterializer.get(system).materializer
   override def afterAll() = TestKit.shutdownActorSystem(system)
 
   "Multiparts.createFormDataFromParts" should {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -414,7 +414,7 @@ class ClientServerSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll 
             override def postStop(): Unit = stageCounter.decrementAndGet()
             override def onPush(): Unit = push(out, HttpResponse(entity = stageCounter.get().toString))
             override def onPull(): Unit = pull(in)
-            override def onDownstreamFinish(): Unit = cancelCounter.incrementAndGet()
+            override def onDownstreamFinish(cause: Throwable): Unit = cancelCounter.incrementAndGet()
 
             setHandlers(in, out, this)
           }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
@@ -7,7 +7,6 @@ package akka.http.scaladsl
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.HttpMethods._
-import akka.stream.ActorMaterializer
 import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.duration._
 import scala.concurrent.Await
@@ -25,7 +24,6 @@ class ClientSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     akka.log-dead-letters = OFF
     akka.http.server.request-timeout = infinite""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
-  implicit val materializer = ActorMaterializer()
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
@@ -11,7 +11,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.util.{ Failure, Success }
 import akka.actor.{ ActorSystem, UnhandledMessage }
-import akka.stream.{ ActorMaterializer, IOResult }
+import akka.stream.IOResult
 import akka.stream.scaladsl.{ FileIO, Sink, Source }
 import akka.http.scaladsl.model._
 import akka.http.impl.util._
@@ -26,7 +26,6 @@ object TestClient extends App {
     akka.log-dead-letters = off
     akka.io.tcp.trace-logging = off""")
   implicit val system = ActorSystem("ServerTest", testConf)
-  implicit val fm = ActorMaterializer()
   import system.dispatcher
 
   installEventStreamLoggerFor[UnhandledMessage]
@@ -81,8 +80,6 @@ object TestClient extends App {
     akka.log-dead-letters = off
     akka.io.tcp.trace-logging = off""")
     implicit val system = ActorSystem("ServerTest", testConf)
-    implicit val fm = ActorMaterializer()
-    import system.dispatcher
 
     try {
       val done = Future.traverse(urls.zipWithIndex) {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
@@ -11,7 +11,6 @@ import scala.concurrent.Await
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ws._
-import akka.stream._
 import akka.stream.scaladsl.{ Flow, Source }
 import com.typesafe.config.{ Config, ConfigFactory }
 import HttpMethods._
@@ -29,11 +28,6 @@ object TestServer extends App {
     """)
   implicit val system = ActorSystem("ServerTest", testConf)
 
-  val settings = ActorMaterializerSettings(system)
-    .withFuzzing(false)
-    //    .withSyncProcessingLimit(Int.MaxValue)
-    .withInputBuffer(128, 128)
-  implicit val fm = ActorMaterializer(settings)
   try {
     val binding = Http().bindAndHandleSync({
       case req @ HttpRequest(GET, Uri.Path("/"), _, _, _) if req.header[UpgradeToWebSocket].isDefined =>

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl._
-import akka.stream.{ OverflowStrategy, ActorMaterializer }
+import akka.stream.OverflowStrategy
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
@@ -27,7 +27,6 @@ class TightRequestTimeoutSpec extends AnyWordSpec with Matchers with BeforeAndAf
     akka.http.server.request-timeout = 10ms""")
 
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
-  implicit val materializer = ActorMaterializer()
   implicit val patience = PatienceConfig(3.seconds.dilated)
 
   override def afterAll() = TestKit.shutdownActorSystem(system)

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
@@ -6,7 +6,6 @@ package akka.http.scaladsl.model
 
 import akka.Done
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.testkit._
 import scala.concurrent.duration._
@@ -15,8 +14,6 @@ import akka.util.ByteString
 import scala.concurrent.{ Await, Promise }
 
 class EntityDiscardingSpec extends AkkaSpec {
-
-  implicit val mat = ActorMaterializer()
 
   val testData = Vector.tabulate(200)(i => ByteString(s"row-$i"))
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -11,7 +11,6 @@ import akka.actor.ActorSystem
 import akka.http.impl.util._
 import akka.http.scaladsl.model.HttpEntity._
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.testkit._
 import akka.util.ByteString
@@ -36,7 +35,6 @@ class HttpEntitySpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   akka.loglevel = WARNING""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
 
-  implicit val materializer = ActorMaterializer()
   override def afterAll() = TestKit.shutdownActorSystem(system)
 
   val awaitAtMost = 3.seconds.dilated
@@ -96,7 +94,7 @@ class HttpEntitySpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
       "Infinite data stream" in {
         val neverCompleted = Promise[ByteString]()
         intercept[TimeoutException] {
-          Await.result(Default(tpe, 42, Source.fromFuture(neverCompleted.future)).toStrict(100.millis), awaitAtMost)
+          Await.result(Default(tpe, 42, Source.future(neverCompleted.future)).toStrict(100.millis), awaitAtMost)
         }.getMessage must be("HttpEntity.toStrict timed out after 100 milliseconds while still waiting for outstanding data")
       }
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/MultipartSpec.scala
@@ -9,7 +9,6 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.scalatest.{ BeforeAndAfterAll, Inside }
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
 import akka.actor.ActorSystem
@@ -24,7 +23,6 @@ class MultipartSpec extends AnyWordSpec with Matchers with Inside with BeforeAnd
   akka.event-handlers = ["akka.testkit.TestEventListener"]
   akka.loglevel = WARNING""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
-  implicit val materializer = ActorMaterializer()
   override def afterAll() = TestKit.shutdownActorSystem(system)
 
   "Multipart.General" should {

--- a/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
@@ -13,7 +13,6 @@ import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.http.ccompat._
 import akka.http.scaladsl.model._
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.testkit._
 import headers._
@@ -45,8 +44,6 @@ class HttpModelIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndA
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
-
-  implicit val materializer = ActorMaterializer()
 
   "External HTTP libraries" should {
 

--- a/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -4,11 +4,12 @@
 
 package akka.http.scaladsl.marshallers.sprayjson
 
+import scala.concurrent.ExecutionContext
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.MessageEntity
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream.ActorMaterializer
 import akka.util.ByteString
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
@@ -23,8 +24,7 @@ class SprayJsonSupportSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
   implicit val exampleFormat = jsonFormat1(Example.apply)
   implicit val sys = ActorSystem("SprayJsonSupportSpec")
-  implicit val mat = ActorMaterializer()
-  import sys.dispatcher
+  implicit val ec: ExecutionContext = sys.dispatcher
 
   val TestString = "Contains all UTF-8 characters: 2-byte: £, 3-byte: ﾖ, 4-byte: 😁, 4-byte as a literal surrogate pair: \uD83D\uDE01"
 

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.settings.RoutingSettings
 import akka.http.scaladsl.unmarshalling._
 import akka.http.scaladsl.util.FastFuture._
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.Materializer
 import akka.testkit.TestKit
 import akka.util.ConstantFun
 import com.typesafe.config.{ Config, ConfigFactory }
@@ -44,7 +44,6 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
   }
   implicit val system = createActorSystem()
   implicit def executor = system.dispatcher
-  implicit val materializer = ActorMaterializer()
 
   def cleanUp(): Unit = TestKit.shutdownActorSystem(system)
 

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSProbe.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSProbe.scala
@@ -128,7 +128,7 @@ object WSProbe {
         case _ => throw new AssertionError(s"""Expected BinaryMessage("$bytes") but got TextMessage""")
       }
 
-      def expectNoMessage(): Unit = subscriber.expectNoMsg()
+      def expectNoMessage(): Unit = subscriber.expectNoMessage()
       def expectNoMessage(max: FiniteDuration): Unit = subscriber.expectNoMessage(max)
 
       def expectCompletion(): Unit = subscriber.expectComplete()

--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -13,7 +13,6 @@ import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
 import akka.http.scaladsl.server.{ Directives, Route }
 import akka.http.scaladsl.Http
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.testkit.{ ImplicitSender, LongRunningTest, SocketUtil }
 import akka.util.{ ByteString, Timeout }
@@ -22,7 +21,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.exceptions.TestPendingException
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Promise }
+import scala.concurrent.{ Await, ExecutionContext, Promise }
 import scala.util.Try
 
 object AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeConfig {
@@ -168,8 +167,7 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
 
   if (enableSpec) {
     "Akka HTTP" must {
-      implicit val dispatcher = system.dispatcher
-      implicit val mat = ActorMaterializer()
+      implicit val ec: ExecutionContext = system.dispatcher
 
       "start Akka HTTP" taggedAs LongRunningTest in {
         enterBarrier("startup")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -8,7 +8,6 @@ import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.MediaType.WithFixedCharset
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives
-import akka.stream.ActorMaterializer
 import akka.testkit._
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
@@ -16,8 +15,6 @@ import scala.concurrent.duration._
 
 class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
   with Directives with RequestBuilding {
-
-  implicit val mat = ActorMaterializer()
 
   "Http" should {
     "find media types in a set if they differ in casing" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
@@ -9,14 +9,11 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.settings.ConnectionPoolSettings
-import akka.stream.ActorMaterializer
 import akka.testkit.{ AkkaSpec, SocketUtil }
 import org.scalatest.concurrent.ScalaFutures
 
 class CustomStatusCodesSpec extends AkkaSpec with ScalaFutures
   with Directives with RequestBuilding {
-
-  implicit val mat = ActorMaterializer()
 
   "Http" should {
     "allow registering custom status code" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
@@ -4,15 +4,15 @@
 
 package akka.http.scaladsl
 
-import akka.stream.ActorMaterializer
+import scala.concurrent.ExecutionContext
+
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model._
 import akka.testkit.AkkaSpec
 
 class FormDataSpec extends AkkaSpec {
-  implicit val materializer = ActorMaterializer()
-  import system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   val formData = FormData(Map("surname" -> "Smith", "age" -> "42"))
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/TestSingleRequest.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/TestSingleRequest.scala
@@ -8,7 +8,6 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.util.ByteString
 import com.typesafe.config.{ ConfigFactory, Config }
 import akka.actor.ActorSystem
-import akka.stream._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.io.StdIn
@@ -20,7 +19,6 @@ object TestSingleRequest extends App {
     akka.stream.materializer.debug.fuzzing-mode = off
     """)
   implicit val system = ActorSystem("ServerTest", testConf)
-  implicit val materializer = ActorMaterializer()
   import system.dispatcher
 
   val url = StdIn.readLine("url? ")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
@@ -6,7 +6,6 @@ package akka.http.scaladsl.coding
 
 import org.scalatest.{ BeforeAndAfterAll, Suite }
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.matchers.should.Matchers
@@ -71,7 +70,6 @@ voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita ka
 est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy e""".replace("\r\n", "\n")
 
   implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = ActorMaterializer()
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -12,7 +12,6 @@ import akka.http.scaladsl.model.MediaTypes._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.MarshallingTestUtils
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -26,7 +25,6 @@ import org.scalatest.matchers.should.Matchers
 
 class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with MultipartMarshallers with MarshallingTestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = ActorMaterializer()
   import system.dispatcher
 
   override val testConfig = ConfigFactory.load()

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
@@ -8,9 +8,10 @@ import akka.actor._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
 import akka.stream.scaladsl.{ Flow, Sink, Source }
-import akka.stream.{ ActorMaterializer, OverflowStrategy }
+import akka.stream.OverflowStrategy
 import com.typesafe.config.{ Config, ConfigFactory }
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.io.StdIn
 import scala.util.{ Failure, Success, Try }
@@ -28,8 +29,7 @@ object ConnectionTestApp {
     """)
 
   implicit val system = ActorSystem("ConnectionTest", testConf)
-  import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   val clientFlow = Http().superPool[Int]()
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -11,7 +11,7 @@ import akka.event.Logging
 import akka.http.impl.util.WithLogCapturing
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.testkit.Utils.assertAllStagesStopped
 import akka.testkit.TestKit
@@ -38,7 +38,7 @@ abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String
       http.host-connection-pool.base-connection-backoff = 0 ms
     }""").withFallback(ConfigFactory.load())
   implicit val system = ActorSystem("DontLeakActorsOnFailingConnectionSpecs-" + poolImplementation, config)
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer = Materializer(system)
 
   val log = Logging(system, getClass)
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
@@ -8,7 +8,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
-import akka.stream.ActorMaterializer
 import akka.testkit.{ AkkaSpec, SocketUtil, TestKit }
 import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatest.BeforeAndAfterAll
@@ -22,7 +21,6 @@ private[akka] trait IntegrationRoutingSpec extends AnyWordSpecLike with Matchers
   import IntegrationRoutingSpec._
 
   implicit val system = ActorSystem(AkkaSpec.getCallerName(getClass))
-  implicit val mat = ActorMaterializer()
   import system.dispatcher
 
   override protected def afterAll() = TestKit.shutdownActorSystem(system)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -13,7 +13,6 @@ import akka.http.scaladsl.model.HttpEntity.Chunk
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{ HttpEncoding, HttpEncodings, `Content-Encoding` }
 import akka.http.scaladsl.server.Directives._
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Source }
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -41,7 +40,6 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
     """)
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
-  implicit val materializer = ActorMaterializer()
   val random = new scala.util.Random(42)
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(5, Millis))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
@@ -9,7 +9,7 @@ import java.net.InetSocketAddress
 import akka.actor.{ ActorSystem, ActorSystemImpl }
 import akka.event.Logging
 import akka.stream.scaladsl._
-import akka.stream.{ ActorAttributes, ActorMaterializer }
+import akka.stream.ActorAttributes
 import akka.util.ByteString
 import com.typesafe.config.{ Config, ConfigFactory }
 import scala.io.StdIn
@@ -21,7 +21,6 @@ object TcpLeakApp extends App {
     akka.log-dead-letters = on
     akka.io.tcp.trace-logging = on""")
   implicit val system = ActorSystem("ServerTest", testConf)
-  implicit val fm = ActorMaterializer()
 
   import system.dispatcher
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -10,11 +10,11 @@ import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.directives.Credentials
 import com.typesafe.config.{ Config, ConfigFactory }
 import akka.actor.ActorSystem
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.common.EntityStreamingSupport
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.io.StdIn
 
@@ -26,8 +26,7 @@ object TestServer extends App {
     """)
 
   implicit val system = ActorSystem("ServerTest", testConf)
-  import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   import spray.json.DefaultJsonProtocol._
   import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -5,13 +5,12 @@
 package akka.http.scaladsl.unmarshalling
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{ Await, ExecutionContext, Future }
 import org.scalatest.matchers.Matcher
 import org.scalatest.BeforeAndAfterAll
 import akka.http.scaladsl.testkit.ScalatestUtils
 import akka.util.ByteString
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.util.FastFuture._
@@ -25,8 +24,7 @@ import org.scalatest.matchers.should.Matchers
 
 trait MultipartUnmarshallersSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = ActorMaterializer()
-  import system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   def lineFeed: String
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -11,20 +11,18 @@ import org.scalatest.BeforeAndAfterAll
 import akka.http.scaladsl.testkit.ScalatestUtils
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.MediaType.WithFixedCharset
-import akka.stream.ActorMaterializer
 import akka.http.scaladsl.model._
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class UnmarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = ActorMaterializer()
-  import system.dispatcher
 
   override val testConfig = ConfigFactory.load()
 
@@ -99,6 +97,8 @@ class UnmarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll
   }
 
   "Unmarshaller.forContentTypes" - {
+    implicit val ec: ExecutionContext = system.dispatcher
+
     "should handle media ranges of types with missing charset by assuming UTF-8 charset when matching" in {
       val um = Unmarshaller.stringUnmarshaller.forContentTypes(MediaTypes.`text/plain`)
       Await.result(um(HttpEntity(MediaTypes.`text/plain`.withMissingCharset, "Hêllö".getBytes("utf-8"))), 1.second.dilated) should ===("Hêllö")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/BaseUnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/BaseUnmarshallingSpec.scala
@@ -8,7 +8,6 @@ package unmarshalling
 package sse
 
 import akka.actor.ActorSystem
-import akka.stream.{ ActorMaterializer, Materializer }
 import org.scalatest.{ BeforeAndAfterAll, Suite }
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
@@ -17,9 +16,6 @@ trait BaseUnmarshallingSpec extends BeforeAndAfterAll { this: Suite =>
 
   protected implicit val system: ActorSystem =
     ActorSystem()
-
-  protected implicit val mat: Materializer =
-    ActorMaterializer()
 
   override protected def afterAll() = {
     Await.ready(system.terminate(), 42.seconds)

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
@@ -211,8 +211,7 @@ abstract class BasicDirectives {
     D.extractMaterializer { m => inner.apply(m).delegate })
 
   /**
-   * Extracts the [[akka.actor.ActorSystem]] if the available Materializer is an [[akka.stream.ActorMaterializer]].
-   * Otherwise throws an exception as it won't be able to extract the system from arbitrary materializers.
+   * Extracts the [[akka.actor.ActorSystem]]
    */
   def extractActorSystem(inner: JFunction[ActorSystem, Route]): Route = RouteAdapter(
     D.extractActorSystem { system => inner.apply(system).delegate })

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -12,7 +12,6 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
-import akka.stream.ActorMaterializer
 import akka.http.scaladsl.settings.ServerSettings
 import com.typesafe.config.ConfigFactory
 
@@ -86,7 +85,6 @@ abstract class HttpApp extends Directives {
   def startServer(host: String, port: Int, settings: ServerSettings, system: Option[ActorSystem]): Unit = {
     implicit val theSystem = system.getOrElse(ActorSystem(Logging.simpleName(this).replaceAll("\\$", "")))
     systemReference.set(theSystem)
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext: ExecutionContextExecutor = theSystem.dispatcher
 
     val bindingFuture = Http().bindAndHandle(

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.util.FastFuture._
-import akka.stream.{ ActorMaterializerHelper, Materializer }
+import akka.stream.Materializer
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 
@@ -33,7 +33,7 @@ private[http] class RequestContextImpl(
     this(request, request.uri.path, ec, materializer, log, settings, parserSettings)
 
   def this(request: HttpRequest, log: LoggingAdapter, settings: RoutingSettings)(implicit ec: ExecutionContextExecutor, materializer: Materializer) =
-    this(request, request.uri.path, ec, materializer, log, settings, ParserSettings(ActorMaterializerHelper.downcast(materializer).system))
+    this(request, request.uri.path, ec, materializer, log, settings, ParserSettings(materializer.system))
 
   def reconfigure(executionContext: ExecutionContextExecutor, materializer: Materializer, log: LoggingAdapter, settings: RoutingSettings): RequestContext =
     copy(executionContext = executionContext, materializer = materializer, log = log, routingSettings = settings)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.server.directives.BasicDirectives
 import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 import akka.http.scaladsl.util.FastFuture._
 import akka.stream.scaladsl.Flow
-import akka.stream.{ ActorMaterializerHelper, Materializer }
+import akka.stream.Materializer
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 
@@ -80,7 +80,7 @@ object Route {
 
     {
       implicit val executionContext: ExecutionContextExecutor = effectiveEC // overrides parameter
-      val effectiveParserSettings = if (parserSettings ne null) parserSettings else ParserSettings(ActorMaterializerHelper.downcast(materializer).system)
+      val effectiveParserSettings = if (parserSettings ne null) parserSettings else ParserSettings(materializer.system)
       val sealedRoute = seal(route)
       request =>
         sealedRoute(new RequestContextImpl(request, routingLog.requestLog(request), routingSettings, effectiveParserSettings)).fast

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
@@ -17,7 +17,7 @@ import scala.collection.immutable
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.Uri.Path
 import akka.util.ConstantFun.scalaIdentityFunction
-import akka.stream.{ ActorMaterializerHelper, Materializer }
+import akka.stream.Materializer
 import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 import akka.http.scaladsl.server.util.Tuple
 import akka.http.scaladsl.util.FastFuture
@@ -254,13 +254,12 @@ trait BasicDirectives {
   def extractMaterializer: Directive1[Materializer] = BasicDirectives._extractMaterializer
 
   /**
-   * Extracts the [[akka.actor.ActorSystem]] if the available Materializer is an [[akka.stream.ActorMaterializer]].
-   * Otherwise throws an exception as it won't be able to extract the system from arbitrary materializers.
+   * Extracts the [[akka.actor.ActorSystem]]
    *
    * @group basic
    */
   def extractActorSystem: Directive1[ActorSystem] = extract { ctx =>
-    ActorMaterializerHelper.downcast(ctx.materializer).system
+    ctx.materializer.system
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
@@ -14,7 +14,6 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ParserSettings
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.http.scaladsl.util.FastFuture
-import akka.stream.ActorMaterializerHelper
 import akka.stream.scaladsl._
 
 import scala.collection.immutable
@@ -74,7 +73,7 @@ trait MultipartUnmarshallers {
               FastFuture.failed(new RuntimeException("Content-Type with a multipart media type must have a 'boundary' parameter"))
             case Some(boundary) =>
               import BodyPartParser._
-              val effectiveParserSettings = Option(parserSettings).getOrElse(ParserSettings(ActorMaterializerHelper.downcast(mat).system))
+              val effectiveParserSettings = Option(parserSettings).getOrElse(ParserSettings(mat.system))
               val parser = new BodyPartParser(defaultContentType, boundary, log, effectiveParserSettings)
 
               entity match {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -208,7 +208,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
     outlet.setHandler(this)
 
     def onPull(): Unit = dispatchNextChunk()
-    override def onDownstreamFinish(): Unit = {
+    override def onDownstreamFinish(cause: Throwable): Unit = {
       multiplexer.pushControlFrame(RstStreamFrame(streamId, ErrorCode.CANCEL))
       incomingStreams -= streamId
     }

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
@@ -119,9 +119,9 @@ private[http] object ProtocolSwitch {
 
             val outHandler = new OutHandler {
               override def onPull(): Unit = in.pull()
-              override def onDownstreamFinish(): Unit = {
-                in.cancel()
-                super.onDownstreamFinish()
+              override def onDownstreamFinish(cause: Throwable): Unit = {
+                in.cancel(cause)
+                super.onDownstreamFinish(cause)
               }
             }
             in.setHandler(handler)

--- a/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
@@ -11,10 +11,10 @@ import akka.http.impl.util.{ ExampleHttpContexts, WithLogCapturing }
 import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.Http2
-import akka.stream.ActorMaterializer
 import akka.testkit._
 import org.scalatest.concurrent.ScalaFutures
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.sys.process._
 
@@ -33,8 +33,7 @@ class H2SpecIntegrationSpec extends AkkaSpec(
      }
   """) with Directives with ScalaFutures with WithLogCapturing {
 
-  import system.dispatcher
-  implicit val mat = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   override def expectedTestDuration = 5.minutes // because slow jenkins, generally finishes below 1 or 2 minutes
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ProtocolSwitchSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ProtocolSwitchSpec.scala
@@ -8,7 +8,6 @@ import scala.concurrent.Promise
 
 import akka.Done
 import akka.NotUsed
-import akka.stream.ActorMaterializer
 import akka.stream.OverflowStrategy
 import akka.stream.QueueOfferResult.Enqueued
 import akka.stream.TLSProtocol._
@@ -24,7 +23,6 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.time.{ Span, Seconds, Milliseconds }
 
 class ProtocolSwitchSpec extends AkkaSpec {
-  implicit val mat = ActorMaterializer()
 
   override implicit val patience: PatienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(50, Milliseconds))
 

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
@@ -7,7 +7,6 @@ package akka.http.scaladsl
 import akka.event.Logging
 import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model._
-import akka.stream._
 import akka.testkit.{ AkkaSpec, TestProbe, SocketUtil }
 
 import scala.concurrent.Future
@@ -20,7 +19,6 @@ class Http2BindingViaConfigSpec extends AkkaSpec("""
     akka.loglevel = DEBUG
     akka.log-dead-letters = off
   """) {
-  implicit val mat = ActorMaterializer()
   import system.dispatcher
 
   val (host, port) = SocketUtil.temporaryServerHostnameAndPort()

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -11,12 +11,12 @@ import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream._
 import akka.stream.scaladsl.FileIO
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.io.StdIn
@@ -37,13 +37,7 @@ object Http2ServerTest extends App {
     akka.http.server.preview.enable-http2 = true
                                                    """)
   implicit val system = ActorSystem("ServerTest", testConf)
-  import system.dispatcher
-
-  val settings = ActorMaterializerSettings(system)
-    .withFuzzing(false)
-    //    .withSyncProcessingLimit(Int.MaxValue)
-    .withInputBuffer(128, 128)
-  implicit val fm = ActorMaterializer(settings)
+  implicit val ec: ExecutionContext = system.dispatcher
 
   def slowDown[T](millis: Int): T => Future[T] = { t =>
     akka.pattern.after(millis.millis, system.scheduler)(Future.successful(t))

--- a/docs/src/main/paradox/routing-dsl/directives/basic-directives/extractActorSystem.md
+++ b/docs/src/main/paradox/routing-dsl/directives/basic-directives/extractActorSystem.md
@@ -13,10 +13,6 @@
 Extracts the @apidoc[akka.actor.ActorSystem] from the @apidoc[RequestContext], which can be useful when the external API
 in your route needs one.
 
-@@@ warning
-This is only supported when the available Materializer is an ActorMaterializer.
-@@@
-
 ## Example
 
 Scala

--- a/docs/src/main/paradox/routing-dsl/index.md
+++ b/docs/src/main/paradox/routing-dsl/index.md
@@ -105,7 +105,7 @@ Scala
 
 
 Note that the `akka.actor.typed.ActorSystem` is converted with `toClassic`, which comes from
-`import akka.actor.typed.scaladsl.adapter._`. If you are using an earlier version than Akka 2.5.26 this conversion method is named `toUntyped`.
+`import akka.actor.typed.scaladsl.adapter._`.
 
 ## Dynamic Routing Example
 

--- a/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
@@ -15,7 +15,7 @@ import akka.http.javadsl.server.Route;
 import akka.http.javadsl.unmarshalling.Unmarshaller;
 import akka.http.javadsl.testkit.JUnitRouteTest;
 import akka.http.javadsl.testkit.TestRouteResult;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.util.ByteString;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -51,7 +51,7 @@ public class RangeDirectivesExamplesTest extends JUnitRouteTest {
                 akka.http.javadsl.model.ContentRange.create(0, 2, 8);
         final akka.http.javadsl.model.ContentRange bytes678Range =
                 akka.http.javadsl.model.ContentRange.create(6, 7, 8);
-        final ActorMaterializer materializer = systemResource().materializer();
+        final Materializer materializer = systemResource().materializer();
 
         testRoute(route).run(HttpRequest.GET("/")
                 .addHeader(Range.create(RangeUnits.BYTES, ByteRange.createSlice(3, 4))))

--- a/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
@@ -6,7 +6,6 @@ package docs.http.scaladsl
 
 import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
-import akka.stream.ActorMaterializer
 
 //#bindAndHandleSecure
 import scala.concurrent.Future
@@ -33,7 +32,6 @@ object Http2Spec {
   val asyncHandler: HttpRequest => Future[HttpResponse] = _ => Future.successful(HttpResponse(status = StatusCodes.ImATeapot))
   val httpsServerContext: HttpsConnectionContext = ExampleHttpContexts.exampleServerContext
   implicit val system: ActorSystem = ActorSystem()
-  implicit val materializer: Materializer = ActorMaterializer()
 
   //#bindAndHandleSecure
   Http().bindAndHandleAsync(

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientDecodingExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientDecodingExampleSpec.scala
@@ -6,6 +6,7 @@ package docs.http.scaladsl
 
 import docs.CompileOnlySpec
 import org.scalatest.concurrent.ScalaFutures
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import akka.testkit.AkkaSpec
 
@@ -16,13 +17,11 @@ class HttpClientDecodingExampleSpec extends AkkaSpec with CompileOnlySpec with S
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.coding.{ Gzip, Deflate, NoCoding }
     import akka.http.scaladsl.model._, headers.HttpEncodings
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.Future
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
-    import system.dispatcher
+    implicit val ec: ExecutionContext = system.dispatcher
 
     val http = Http()
 

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -23,13 +23,10 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
 
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.{ FileIO, Framing }
     import akka.util.ByteString
 
     implicit val system = ActorSystem()
-    implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     val response: HttpResponse = ???
 
@@ -50,12 +47,10 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
 
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.util.ByteString
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     case class ExamplePerson(name: String)
     def parse(line: ByteString): ExamplePerson = ???
@@ -78,20 +73,17 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
 
   "manual-entity-consume-example-3" in compileOnlySpec {
     //#manual-entity-consume-example-3
-    import scala.concurrent.duration._
     import scala.concurrent.Future
 
     import akka.NotUsed
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.util.ByteString
     import akka.stream.scaladsl.{ Flow, Sink, Source }
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     case class ExamplePerson(name: String)
 
@@ -132,11 +124,9 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model.HttpMessage.DiscardedEntity
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     val response1: HttpResponse = ??? // obtained from an HTTP call (see examples below)
 
@@ -151,12 +141,10 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.Done
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.Sink
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     //#manual-entity-discard-example-2
     val response1: HttpResponse = ??? // obtained from an HTTP call (see examples below)
@@ -171,7 +159,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
 
     import scala.concurrent.Future
@@ -180,7 +167,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     object WebClient {
       def main(args: Array[String]): Unit = {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         implicit val executionContext = system.dispatcher
 
         val connectionFlow: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] =
@@ -223,14 +209,12 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
 
     import akka.stream.{ OverflowStrategy, QueueOfferResult }
 
     implicit val system = ActorSystem()
     import system.dispatcher // to get an implicit ExecutionContext into scope
-    implicit val materializer = ActorMaterializer()
 
     val QueueSize = 10
 
@@ -271,7 +255,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
 
     import akka.http.scaladsl.model.Multipart.FormData
@@ -279,7 +262,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
 
     implicit val system = ActorSystem()
     import system.dispatcher // to get an implicit ExecutionContext into scope
-    implicit val materializer = ActorMaterializer()
 
     case class FileToUpload(name: String, location: Path)
 
@@ -333,7 +315,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.Future
     import scala.util.{ Failure, Success }
@@ -341,7 +322,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     object Client {
       def main(args: Array[String]): Unit = {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -377,7 +357,7 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     Post("https://userservice.example/users", "data")
     //#create-post-request
 
-    implicit val materializer: ActorMaterializer = null
+    implicit val system: ActorSystem = null
     val response: HttpResponse = null
     //#unmarshal-response-body
     import akka.http.scaladsl.unmarshalling.Unmarshal
@@ -396,7 +376,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.{ Actor, ActorLogging }
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
     import akka.util.ByteString
 
     class Myself extends Actor
@@ -405,9 +384,8 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
       import akka.pattern.pipe
       import context.dispatcher
 
-      final implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(context.system))
-
-      val http = Http(context.system)
+      implicit val system = context.system
+      val http = Http(system)
 
       override def preStart() = {
         http.singleRequest(HttpRequest(uri = "http://akka.io"))
@@ -433,11 +411,9 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import java.net.InetSocketAddress
 
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.{ ClientTransport, Http }
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val proxyHost = "localhost"
     val proxyPort = 8888
@@ -455,11 +431,9 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import java.net.InetSocketAddress
 
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.{ ClientTransport, Http }
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val proxyHost = "localhost"
     val proxyPort = 8888
@@ -485,7 +459,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.headers.`Set-Cookie`
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.ExecutionContextExecutor
     import scala.concurrent.Future
@@ -493,7 +466,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     object Client {
       def main(args: Array[String]): Unit = {
         implicit val system: ActorSystem = ActorSystem()
-        implicit val materializer: ActorMaterializer = ActorMaterializer()
         implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
         val responseFuture: Future[HttpResponse] = Http().singleRequest(HttpRequest(uri = "http://akka.io"))

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -27,11 +27,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     //#binding-example
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     val serverSource: Source[Http.IncomingConnection, Future[Http.ServerBinding]] =
@@ -50,14 +48,12 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.Http.ServerBinding
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.Future
 
     object WebServer {
       def main(args: Array[String]) {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future foreach in the end
         implicit val executionContext = system.dispatcher
 
@@ -89,12 +85,10 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.Http.ServerBinding
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.Future
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future foreach in the end
     implicit val executionContext = system.dispatcher
 
@@ -121,11 +115,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.actor.ActorRef
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.Flow
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     import Http._
@@ -151,11 +143,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.Flow
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     val (host, port) = ("localhost", 8080)
@@ -188,11 +178,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.HttpMethods._
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.Sink
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     val serverSource = Http().bind(interface = "localhost", port = 8080)
@@ -231,14 +219,12 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.HttpMethods._
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import scala.io.StdIn
 
     object WebServer {
 
       def main(args: Array[String]) {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future map/flatmap in the end
         implicit val executionContext = system.dispatcher
 
@@ -277,13 +263,11 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import scala.io.StdIn
 
     object WebServer {
       def main(args: Array[String]) {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -320,14 +304,12 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import scala.io.StdIn
 
     object WebServer {
       def main(args: Array[String]) {
 
         implicit val system = ActorSystem("my-system")
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -359,7 +341,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
     import akka.pattern.ask
-    import akka.stream.ActorMaterializer
     import akka.util.Timeout
 
     // types used by the API routes
@@ -376,7 +357,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     implicit val orderSeqM: ToResponseMarshaller[Seq[Order]] = ???
     implicit val timeout: Timeout = ??? // for actor asks
     implicit val ec: ExecutionContext = ???
-    implicit val mat: ActorMaterializer = ???
     implicit val sys: ActorSystem = ???
 
     // backend entry points
@@ -471,7 +451,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.{ HttpEntity, ContentTypes }
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import scala.util.Random
     import scala.io.StdIn
 
@@ -480,7 +459,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
       def main(args: Array[String]) {
 
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -521,7 +499,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
     import akka.pattern.ask
-    import akka.stream.ActorMaterializer
     import akka.util.Timeout
     import spray.json.DefaultJsonProtocol._
     import scala.concurrent.Future
@@ -551,7 +528,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
 
       def main(args: Array[String]) {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -594,11 +570,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-    import akka.stream.ActorMaterializer
     import spray.json.DefaultJsonProtocol._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future flatMap/onComplete in the end
     implicit val executionContext = system.dispatcher
 
@@ -624,11 +598,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.stream.scaladsl.FileIO
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import java.io.File
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future flatMap/onComplete in the end
     implicit val executionContext = system.dispatcher
 
@@ -652,11 +624,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     //#discard-discardEntityBytes
     import akka.actor.ActorSystem
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.model.HttpRequest
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future flatMap/onComplete in the end
     implicit val executionContext = system.dispatcher
 
@@ -682,10 +652,8 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.stream.scaladsl.Sink
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.model.headers.Connection
-    import akka.stream.ActorMaterializer
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future flatMap/onComplete in the end
     implicit val executionContext = system.dispatcher
 
@@ -713,12 +681,10 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.Route
-    import akka.stream.ActorMaterializer
     import spray.json.DefaultJsonProtocol._
     import spray.json._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#dynamic-routing-example
     case class MockDefinition(path: String, requests: Seq[JsValue], responses: Seq[JsValue])
@@ -761,12 +727,10 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.Route
-    import akka.stream.ActorMaterializer
     import scala.concurrent.duration._
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     val routes = get {
       complete("Hello world!")

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerWithTypedSample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerWithTypedSample.scala
@@ -142,16 +142,12 @@ object HttpServerWithTypedSample {
   }
   //#akka-typed-route
 
-  /* there are still differences making this impossible to compile both for 2.5 and 2.6 at the same time
-     without passing implicits explicitly and making the sample somewhat weird. This is however verified
-     against 2.6.0-RC1 with those implicits noted removed.
-
   //#akka-typed-bootstrap
   import akka.actor.typed.PostStop
   import akka.actor.typed.scaladsl.adapter._
-  import akka.stream.ActorMaterializer
   import akka.http.scaladsl.Http.ServerBinding
   import akka.http.scaladsl.Http
+  import akka.stream.Materializer
 
   import scala.concurrent.ExecutionContextExecutor
   import scala.util.{ Success, Failure }
@@ -168,9 +164,8 @@ object HttpServerWithTypedSample {
       implicit val system = ctx.system
       // http doesn't know about akka typed so provide untyped system
       implicit val untypedSystem: akka.actor.ActorSystem = ctx.system.toClassic
-      // implicit materializer only required in Akka 2.5
-      // in 2.6 having an implicit classic or typed ActorSystem in scope is enough
-      implicit val materializer: ActorMaterializer = ActorMaterializer()(ctx.system.toClassic)
+      // FIXME #2893 should not be needed
+      implicit val materializer = Materializer(system)
       implicit val ec: ExecutionContextExecutor = ctx.system.executionContext
 
       val buildJobRepository = ctx.spawn(JobRepository(), "JobRepository")
@@ -223,6 +218,4 @@ object HttpServerWithTypedSample {
       ActorSystem(Server("localhost", 8080), "BuildJobsServer")
   }
   //#akka-typed-bootstrap
-
-  */
 }

--- a/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
@@ -6,7 +6,6 @@ package docs.http.scaladsl
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import docs.CompileOnlySpec
 import org.scalatest.matchers.should.Matchers
@@ -18,7 +17,6 @@ class HttpsExamplesSpec extends AnyWordSpec with Matchers with CompileOnlySpec {
     val unsafeHost = "example.com"
     //#disable-sni-connection
     implicit val system = ActorSystem()
-    implicit val mat = ActorMaterializer()
 
     // WARNING: disabling SNI is a very bad idea, please don't unless you have a very good reason to.
     val badSslConfig = AkkaSSLConfig().mapSettings(s => s.withLoose(s.loose.withDisableSNI(true)))

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
@@ -53,7 +53,6 @@ class SprayJsonExampleSpec extends AnyWordSpec with Matchers {
     //#second-spray-json-example
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.Done
     import akka.http.scaladsl.server.Route
     import akka.http.scaladsl.server.Directives._
@@ -71,7 +70,6 @@ class SprayJsonExampleSpec extends AnyWordSpec with Matchers {
 
       // needed to run the route
       implicit val system = ActorSystem()
-      implicit val materializer = ActorMaterializer()
       // needed for the future map/flatmap in the end and future in fetchItem and saveOrder
       implicit val executionContext = system.dispatcher
 

--- a/docs/src/test/scala/docs/http/scaladsl/UnmarshalSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/UnmarshalSpec.scala
@@ -4,7 +4,6 @@
 
 package docs.http.scaladsl
 
-import akka.stream.{ Materializer, ActorMaterializer }
 import akka.testkit.AkkaSpec
 
 class UnmarshalSpec extends AkkaSpec {
@@ -13,7 +12,6 @@ class UnmarshalSpec extends AkkaSpec {
     //#use-unmarshal
     import akka.http.scaladsl.unmarshalling.Unmarshal
     import system.dispatcher // Optional ExecutionContext (default from Materializer)
-    implicit val materializer: Materializer = ActorMaterializer()
 
     import scala.concurrent.Await
     import scala.concurrent.duration._
@@ -30,7 +28,6 @@ class UnmarshalSpec extends AkkaSpec {
 
   "use unmarshal without execution context" in {
     import akka.http.scaladsl.unmarshalling.Unmarshal
-    implicit val materializer: Materializer = ActorMaterializer()
 
     import scala.concurrent.Await
     import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
@@ -15,7 +15,6 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     import akka.actor.ActorSystem
     import akka.{ Done, NotUsed }
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model._
     import akka.http.scaladsl.model.ws._
@@ -25,7 +24,6 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     object SingleWebSocketRequest {
       def main(args: Array[String]) = {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         import system.dispatcher
 
         // print each incoming strict text message
@@ -72,12 +70,10 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     import akka.actor.ActorSystem
     import akka.NotUsed
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model.ws._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#half-closed-WebSocket-closing-example
 
@@ -98,14 +94,12 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
   "half-closed-WebSocket-working-example" in compileOnlySpec {
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model.ws._
 
     import scala.concurrent.Promise
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#half-closed-WebSocket-working-example
 
@@ -129,14 +123,12 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
   "half-closed-WebSocket-finite-working-example" in compileOnlySpec {
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model.ws._
 
     import scala.concurrent.Promise
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#half-closed-WebSocket-finite-working-example
 
@@ -161,13 +153,11 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     import akka.actor.ActorSystem
     import akka.NotUsed
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model.headers.{ Authorization, BasicHttpCredentials }
     import akka.http.scaladsl.model.ws._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     import collection.immutable.Seq
 
     val flow: Flow[Message, Message, NotUsed] =
@@ -191,7 +181,6 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     import akka.actor.ActorSystem
     import akka.Done
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model._
     import akka.http.scaladsl.model.ws._
@@ -201,7 +190,6 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     object WebSocketClientFlow {
       def main(args: Array[String]) = {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         import system.dispatcher
 
         // Future[Done] is the materialized value of Sink.foreach,
@@ -252,14 +240,12 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
 
     import akka.actor.ActorSystem
     import akka.NotUsed
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.{ ClientTransport, Http }
     import akka.http.scaladsl.settings.ClientConnectionSettings
     import akka.http.scaladsl.model.ws._
     import akka.stream.scaladsl._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val flow: Flow[Message, Message, NotUsed] =
       Flow.fromSinkAndSource(
@@ -281,14 +267,12 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
 
     import akka.actor.ActorSystem
     import akka.NotUsed
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.{ ClientTransport, Http }
     import akka.http.scaladsl.settings.ClientConnectionSettings
     import akka.http.scaladsl.model.ws._
     import akka.stream.scaladsl._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val flow: Flow[Message, Message, NotUsed] =
       Flow.fromSinkAndSource(

--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -19,7 +19,6 @@ object MyExplicitExceptionHandler {
   import StatusCodes._
   import akka.http.scaladsl.server._
   import Directives._
-  import akka.stream.ActorMaterializer
 
   val myExceptionHandler = ExceptionHandler {
     case _: ArithmeticException =>
@@ -32,7 +31,6 @@ object MyExplicitExceptionHandler {
   object MyApp extends App {
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val route: Route =
       handleExceptions(myExceptionHandler) {
@@ -55,7 +53,6 @@ object MyImplicitExceptionHandler {
   import StatusCodes._
   import akka.http.scaladsl.server._
   import Directives._
-  import akka.stream.ActorMaterializer
 
   implicit def myExceptionHandler: ExceptionHandler =
     ExceptionHandler {
@@ -69,7 +66,6 @@ object MyImplicitExceptionHandler {
   object MyApp extends App {
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val route: Route =
     // ... some route structure
@@ -118,7 +114,6 @@ object RespondWithHeaderExceptionHandlerExample {
   import akka.http.scaladsl.server._
   import Directives._
   import akka.http.scaladsl.Http
-  import akka.stream.ActorMaterializer
   import RespondWithHeaderExceptionHandler.route
 
 
@@ -153,7 +148,6 @@ object RespondWithHeaderExceptionHandlerExample {
 
   object MyApp extends App {
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     Http().bindAndHandle(route, "localhost", 8080)
   }

--- a/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -12,7 +12,6 @@ import javax.net.ssl.{ SSLContext, TrustManagerFactory, KeyManagerFactory }
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.{ Route, Directives }
 import akka.http.scaladsl.{ ConnectionContext, HttpsConnectionContext, Http }
-import akka.stream.ActorMaterializer
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 //#imports
 
@@ -33,7 +32,6 @@ abstract class HttpsServerExampleSpec extends AnyWordSpec with Matchers
   "low level api" in compileOnlySpec {
     //#low-level-default
     implicit val system = ActorSystem()
-    implicit val mat = ActorMaterializer()
     implicit val dispatcher = system.dispatcher
 
     // Manual HTTPS configuration

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -13,7 +13,6 @@ object MyRejectionHandler {
 
   //#custom-handler-example
   import akka.actor.ActorSystem
-  import akka.stream.ActorMaterializer
   import akka.http.scaladsl.Http
   import akka.http.scaladsl.model._
   import akka.http.scaladsl.server._
@@ -43,7 +42,6 @@ object MyRejectionHandler {
         .result()
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val route: Route =
       // ... some route structure

--- a/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
@@ -10,7 +10,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.ws.{ BinaryMessage, Message, WebSocketRequest }
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Sink }
 import akka.util.ByteString
 import docs.CompileOnlySpec
@@ -23,7 +22,6 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
   "core-example" in compileOnlySpec {
     //#websocket-example-using-core
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.{ Source, Flow }
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.ws.UpgradeToWebSocket
@@ -32,7 +30,6 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
     import akka.http.scaladsl.model.HttpMethods._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#websocket-handler
     // The Greeter WebSocket Service expects a "name" per message and
@@ -78,14 +75,12 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
   }
   "routing-example" in compileOnlySpec {
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.{ Source, Flow }
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.ws.{ TextMessage, Message }
     import akka.http.scaladsl.server.Directives
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     import Directives._
 
@@ -120,8 +115,8 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
   }
 
   "ping-server-example" in compileOnlySpec {
-    implicit val system: ActorSystem = ???
-    implicit val mat: ActorMaterializer = ???
+    implicit val system: ActorSystem = null
+    val route = null
     //#websocket-ping-payload-server
     val defaultSettings = ServerSettings(system)
 
@@ -133,13 +128,12 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
     val customServerSettings =
       defaultSettings.withWebsocketSettings(customWebsocketSettings)
 
-    Http().bindAndHandle(???, "127.0.0.1", settings = customServerSettings)
+    Http().bindAndHandle(route, "127.0.0.1", settings = customServerSettings)
     //#websocket-ping-payload-server
   }
 
   "ping-example" in compileOnlySpec {
-    implicit val system: ActorSystem = ???
-    implicit val mat: ActorMaterializer = ???
+    implicit val system: ActorSystem = null
     //#websocket-client-ping-payload
     val defaultSettings = ClientConnectionSettings(system)
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
@@ -11,7 +11,7 @@ import akka.http.scaladsl.model.headers.{ RawHeader, Server }
 import akka.http.scaladsl.server.RouteResult.{ Complete, Rejected }
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.settings.RoutingSettings
-import akka.stream.ActorMaterializer
+import akka.stream.{ Materializer, SystemMaterializer }
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
 import docs.CompileOnlySpec
@@ -50,7 +50,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   }
   "withMaterializer-0" in {
     //#withMaterializer-0
-    val special = ActorMaterializer(namePrefix = Some("special"))
+    val special = Materializer(system).withNamePrefix("special")
 
     def sample() =
       path("sample") {
@@ -72,7 +72,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
     // tests:
     Get("/sample") ~> route ~> check {
-      responseAs[String] shouldEqual s"Materialized by ${materializer.##}!"
+      responseAs[String] shouldEqual s"Materialized by ${SystemMaterializer(system).materializer.##}!"
     }
     Get("/special/sample") ~> route ~> check {
       responseAs[String] shouldEqual s"Materialized by ${special.##}!"
@@ -86,7 +86,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
         extractMaterializer { materializer =>
           complete {
             // explicitly use the `materializer`:
-            Source.single(s"Materialized by ${materializer.##}!")
+            Source.single(s"Materialized by ${SystemMaterializer(system).materializer.##}!")
               .runWith(Sink.head)(materializer)
           }
         }
@@ -94,7 +94,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
     // tests:
     Get("/sample") ~> route ~> check {
-      responseAs[String] shouldEqual s"Materialized by ${materializer.##}!"
+      responseAs[String] shouldEqual s"Materialized by ${SystemMaterializer(system).materializer.##}!"
     }
     //#extractMaterializer-0
   }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
@@ -10,7 +10,6 @@ import akka.http.scaladsl.model.HttpProtocols._
 import akka.http.scaladsl.model.RequestEntityAcceptance.Expected
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives
-import akka.stream.ActorMaterializer
 import akka.testkit.{ AkkaSpec, SocketUtil }
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
@@ -19,8 +18,6 @@ import scala.concurrent.duration._
 
 class CustomHttpMethodSpec extends AkkaSpec with ScalaFutures
   with Directives with RequestBuilding {
-
-  implicit val mat = ActorMaterializer()
 
   "Http" should {
     "allow registering custom method" in {

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
@@ -17,7 +17,6 @@ class JsonStreamingFullExamples extends AnyWordSpec {
   import akka.http.scaladsl.common.{ EntityStreamingSupport, JsonEntityStreamingSupport }
   import akka.http.scaladsl.model.{ HttpEntity, _ }
   import akka.http.scaladsl.server.Directives._
-  import akka.stream.ActorMaterializer
   import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
   import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
   import akka.stream.scaladsl.Source
@@ -46,7 +45,6 @@ class JsonStreamingFullExamples extends AnyWordSpec {
 
   object ApiServer extends App with UserProtocol {
     implicit val system = ActorSystem("api")
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json()

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -9,13 +9,12 @@ import akka.http.scaladsl.server.Route
 import docs.CompileOnlySpec
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
-import akka.stream.ActorMaterializer
 import akka.http.scaladsl.model.HttpEntity._
 import akka.http.scaladsl.model._
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.duration._
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import akka.testkit.{ AkkaSpec, SocketUtil }
 
 private[this] object TimeoutDirectivesInfiniteTimeoutTestConfig {
@@ -31,8 +30,7 @@ private[this] object TimeoutDirectivesInfiniteTimeoutTestConfig {
 class TimeoutDirectivesExamplesSpec extends AkkaSpec(TimeoutDirectivesInfiniteTimeoutTestConfig.testConf)
   with ScalaFutures with CompileOnlySpec {
   //#testSetup
-  import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   def slowFuture(): Future[String] = Promise[String].future // TODO: move to Future.never in Scala 2.12
 
@@ -161,8 +159,7 @@ private[this] object TimeoutDirectivesFiniteTimeoutTestConfig {
 
 class TimeoutDirectivesFiniteTimeoutExamplesSpec extends AkkaSpec(TimeoutDirectivesFiniteTimeoutTestConfig.testConf)
   with ScalaFutures with CompileOnlySpec {
-  import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   def slowFuture(): Future[String] = Promise[String].future // TODO: move to Future.never in Scala 2.12
 

--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -15,7 +15,7 @@ object AkkaDependency {
   // else if akka.version is anything else, then the given version will be used
 
   // Updated only when needed, https://github.com/akka/akka/issues/26985
-  val defaultAkkaVersion = "2.5.26"
+  val defaultAkkaVersion = "2.6.3"
   val akkaVersion =
     System.getProperty("akka.http.build.akka.version", defaultAkkaVersion) match {
       case "default" => defaultAkkaVersion


### PR DESCRIPTION
Refs #2886

This PR only does the mostly mechanical changes: updating,
removing ActorMaterializer references where possible,
and propagating the onDownstreamFinish cancellation reason.

Before we close #2886 we should updating the Java API to work
without an explicit Materializer, but that could be a separate
PR