### PR TITLE
Update docs to Akka 2.6, de-emphasize Materializer

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HeaderParserBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HeaderParserBenchmark.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
-class HeaderParserBenchmark {
+final class HeaderParserBenchmark {
   implicit val system: ActorSystem = ActorSystem("header-parser-benchmark")
 
   @Param(Array("no", "yes"))

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -389,7 +389,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
   // ** CLIENT ** //
 
   private[this] val poolMasterActorRef = system.systemActorOf(PoolMasterActor.props, "pool-master")
-  private[this] val systemMaterializer = ActorMaterializer()
+  private[this] val systemMaterializer = SystemMaterializer(system).materializer
 
   /**
    * Creates a [[akka.stream.scaladsl.Flow]] representing a prospective HTTP client connection to the given endpoint.

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -8,7 +8,7 @@ import java.util
 import java.util.Optional
 import java.util.function.Function
 
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.annotation.DoNotInherit
 import akka.http.impl.settings.ParserSettingsImpl
 import akka.http.impl.util._
@@ -162,5 +162,5 @@ object ParserSettings extends SettingsCompanion[ParserSettings] {
   override def apply(config: Config): ParserSettings = ParserSettingsImpl(config)
   override def apply(configOverrides: String): ParserSettings = ParserSettingsImpl(configOverrides)
 
-  def forServer(system: ActorSystem): ParserSettings = ParserSettingsImpl.forServer(system.settings.config)
+  def forServer(implicit system: ClassicActorSystemProvider): ParserSettings = ParserSettingsImpl.forServer(system.classicSystem.settings.config)
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/SettingsCompanion.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/SettingsCompanion.scala
@@ -4,7 +4,7 @@
 
 package akka.http.scaladsl.settings
 
-import akka.actor.{ ActorRefFactory, ActorSystem }
+import akka.actor.{ ActorRefFactory, ActorSystem, ClassicActorSystemProvider }
 import akka.annotation.InternalApi
 import com.typesafe.config.Config
 import akka.http.impl.util._
@@ -17,7 +17,9 @@ private[akka] trait SettingsCompanion[T] {
    * Creates an instance of settings using the configuration provided by the given ActorSystem.
    */
   final def apply(system: ActorSystem): T = apply(system.settings.config)
-  implicit def default(implicit system: ActorRefFactory): T = apply(actorSystem)
+  final def apply(system: ClassicActorSystemProvider): T = apply(system.classicSystem.settings.config)
+  implicit def default(implicit system: ClassicActorSystemProvider): T = apply(system.classicSystem)
+  def default(actorRefFactory: ActorRefFactory): T = apply(actorSystem(actorRefFactory))
 
   /**
    * Creates an instance of settings using the given Config.

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/EntityDiscardingTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/EntityDiscardingTest.java
@@ -7,7 +7,8 @@ package akka.http.javadsl.model;
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.japi.function.Procedure;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.SystemMaterializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.util.ByteString;
@@ -24,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class EntityDiscardingTest extends JUnitSuite {
 
   private ActorSystem sys = ActorSystem.create("test");
-  private ActorMaterializer mat = ActorMaterializer.create(sys);
+  private Materializer mat = SystemMaterializer.get(sys).materializer();
   private Iterable<ByteString> testData = Arrays.asList(ByteString.fromString("abc"), ByteString.fromString("def"));
 
   @Test

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
@@ -12,13 +12,14 @@ import scala.concurrent.duration._
 import akka.http.impl.util.AkkaSpecWithMaterializer
 import akka.http.scaladsl.{ ConnectionContext, Http }
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
-import akka.stream.ActorMaterializer
+import akka.stream.SystemMaterializer
 import akka.stream.scaladsl.{ Flow, Sink, Source }
 import akka.stream.testkit.{ TestPublisher, TestSubscriber, Utils }
 import akka.http.scaladsl.model.headers
 
 class ClientCancellationSpec extends AkkaSpecWithMaterializer {
-  val noncheckedMaterializer = ActorMaterializer()
+  // TODO document why this explicit materializer is needed here?
+  val noncheckedMaterializer = SystemMaterializer(system).materializer
 
   "Http client connections" must {
     val address = Await.result(

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -203,7 +203,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         pendingIn(targetImpl = LegacyPoolImplementation) // not implemented in legacy
         pendingIn(targetTrans = PassThrough) // infra seems to be missing something
 
-        // FIXME: set subscription timeout to value relating to below `expectNoMsg`
+        // FIXME: set subscription timeout to value relating to below `expectNoMessage`
 
         pushRequest(HttpRequest(uri = "/1"))
         val conn1 = expectNextConnection()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
@@ -11,8 +11,7 @@ import akka.http.impl.engine.parsing.{ HttpHeaderParser, HttpResponseParser, Par
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ParserSettings
 import akka.stream.TLSProtocol.SessionBytes
-import akka.stream.javadsl.RunnableGraph
-import akka.stream.scaladsl.{ GraphDSL, Sink, Source }
+import akka.stream.scaladsl.{ GraphDSL, RunnableGraph, Sink, Source }
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
 import akka.stream.{ ActorMaterializer, Attributes, ClosedShape }
 import akka.testkit.AkkaSpec
@@ -47,7 +46,7 @@ class ResponseParsingMergeSpec extends AkkaSpec {
 
           ClosedShape
         }.withAttributes(Attributes.inputBuffer(1, 8))
-      ).run(mat)
+      ).run()
 
       val inSessionBytesSub = inSessionBytesProbe.expectSubscription()
       val inBypassSub = inBypassProbe.expectSubscription()

--- a/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
@@ -17,7 +17,7 @@ import akka.actor.ActorSystem
 import akka.event.NoLogging
 import akka.http.javadsl.model._
 import akka.japi.Function
-import akka.stream.ActorMaterializer
+import akka.stream.SystemMaterializer
 import akka.stream.javadsl.{ Flow, Keep, Sink, Source }
 import akka.stream.testkit.TestSubscriber
 import akka.testkit.TestKit
@@ -46,7 +46,7 @@ class HttpExtensionApiSpec extends AnyWordSpec with Matchers with BeforeAndAfter
 
     ActorSystem(getClass.getSimpleName, testConf)
   }
-  implicit val materializer = ActorMaterializer()
+  val materializer = SystemMaterializer.get(system).materializer
 
   val http = Http.get(system)
   val connectionContext = ConnectionContext.noEncryption()

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
@@ -11,8 +11,8 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.scalatest.{ BeforeAndAfterAll, Inside }
-import akka.stream.ActorMaterializer
 import akka.actor.ActorSystem
+import akka.stream.SystemMaterializer
 import akka.stream.javadsl.Source
 import akka.testkit._
 
@@ -26,7 +26,7 @@ class MultipartsSpec extends AnyWordSpec with Matchers with Inside with BeforeAn
   akka.event-handlers = ["akka.testkit.TestEventListener"]
   akka.loglevel = WARNING""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
-  implicit val materializer = ActorMaterializer()
+  val materializer = SystemMaterializer.get(system).materializer
   override def afterAll() = TestKit.shutdownActorSystem(system)
 
   "Multiparts.createFormDataFromParts" should {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -59,7 +59,7 @@ class ClientServerSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll 
     ConfigFactory.parseString("akka.stream.materializer.subscription-timeout.timeout = 1 s")
       .withFallback(testConf)
   val system2 = ActorSystem(getClass.getSimpleName, testConf2)
-  val materializer2 = ActorMaterializer.create(system2)
+  val materializer2 = SystemMaterializer(system2).materializer
 
   "The low-level HTTP infrastructure" should {
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
@@ -81,8 +81,6 @@ object TestClient extends App {
     akka.log-dead-letters = off
     akka.io.tcp.trace-logging = off""")
     implicit val system = ActorSystem("ServerTest", testConf)
-    implicit val fm = ActorMaterializer()
-    import system.dispatcher
 
     try {
       val done = Future.traverse(urls.zipWithIndex) {

--- a/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.http.scaladsl.marshallers.sprayjson
 
+import scala.concurrent.ExecutionContext
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.MessageEntity
@@ -24,7 +26,7 @@ class SprayJsonSupportSpec extends AnyWordSpec with Matchers with ScalaFutures {
   implicit val exampleFormat = jsonFormat1(Example.apply)
   implicit val sys = ActorSystem("SprayJsonSupportSpec")
   implicit val mat = ActorMaterializer()
-  import sys.dispatcher
+  implicit val ec: ExecutionContext = sys.dispatcher
 
   val TestString = "Contains all UTF-8 characters: 2-byte: £, 3-byte: ﾖ, 4-byte: 😁, 4-byte as a literal surrogate pair: \uD83D\uDE01"
 

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.settings.RoutingSettings
 import akka.http.scaladsl.unmarshalling._
 import akka.http.scaladsl.util.FastFuture._
-import akka.stream.{ ActorMaterializer, Materializer }
+import akka.stream.{ Materializer, SystemMaterializer }
 import akka.testkit.TestKit
 import akka.util.ConstantFun
 import com.typesafe.config.{ Config, ConfigFactory }
@@ -44,7 +44,7 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
   }
   implicit val system = createActorSystem()
   implicit def executor = system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer = SystemMaterializer(system).materializer
 
   def cleanUp(): Unit = TestKit.shutdownActorSystem(system)
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -15,6 +15,7 @@ import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.common.EntityStreamingSupport
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.io.StdIn
 
@@ -26,7 +27,7 @@ object TestServer extends App {
     """)
 
   implicit val system = ActorSystem("ServerTest", testConf)
-  import system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
   implicit val materializer = ActorMaterializer()
 
   import spray.json.DefaultJsonProtocol._

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallersSpec.scala
@@ -5,7 +5,7 @@
 package akka.http.scaladsl.unmarshalling
 
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{ Await, ExecutionContext, Future }
 import org.scalatest.matchers.Matcher
 import org.scalatest.BeforeAndAfterAll
 import akka.http.scaladsl.testkit.ScalatestUtils
@@ -26,7 +26,7 @@ import org.scalatest.matchers.should.Matchers
 trait MultipartUnmarshallersSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
   implicit val materializer = ActorMaterializer()
-  import system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
 
   def lineFeed: String
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -18,13 +18,13 @@ import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class UnmarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
   implicit val system = ActorSystem(getClass.getSimpleName)
   implicit val materializer = ActorMaterializer()
-  import system.dispatcher
 
   override val testConfig = ConfigFactory.load()
 
@@ -99,6 +99,8 @@ class UnmarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll
   }
 
   "Unmarshaller.forContentTypes" - {
+    implicit val ec: ExecutionContext = system.dispatcher
+
     "should handle media ranges of types with missing charset by assuming UTF-8 charset when matching" in {
       val um = Unmarshaller.stringUnmarshaller.forContentTypes(MediaTypes.`text/plain`)
       Await.result(um(HttpEntity(MediaTypes.`text/plain`.withMissingCharset, "Hêllö".getBytes("utf-8"))), 1.second.dilated) should ===("Hêllö")

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -57,7 +57,7 @@ object Route {
    * This conversion is also implicitly available whereever a `Route` is used through [[RouteResult#routeToFlow]].
    */
   def toFlow(route: Route)(implicit system: ClassicActorSystemProvider): Flow[HttpRequest, HttpResponse, NotUsed] =
-    Flow[HttpRequest].mapAsync(1)(asyncHandler(route, RoutingSettings(system.classicSystem), ParserSettings.forServer(system.classicSystem)))
+    Flow[HttpRequest].mapAsync(1)(asyncHandler(route, RoutingSettings(system), ParserSettings.forServer))
 
   /**
    * Turns a `Route` into a server flow.

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -5,7 +5,7 @@
 package akka.http.scaladsl.server
 
 import akka.NotUsed
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.http.javadsl
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
@@ -40,7 +40,7 @@ object RouteResult {
    * is in that type means this implicit conversion come into scope whereever
    * a `Route` is given but a `Flow` is expected.
    */
-  implicit def routeToFlow(route: Route)(implicit system: ActorSystem): Flow[HttpRequest, HttpResponse, NotUsed] =
+  implicit def routeToFlow(route: Route)(implicit system: ClassicActorSystemProvider): Flow[HttpRequest, HttpResponse, NotUsed] =
     Route.toFlow(route)
 
   @deprecated("Replaced by routeToFlow", "10.2.0")

--- a/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
@@ -15,6 +15,7 @@ import akka.stream.ActorMaterializer
 import akka.testkit._
 import org.scalatest.concurrent.ScalaFutures
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.sys.process._
 
@@ -33,7 +34,7 @@ class H2SpecIntegrationSpec extends AkkaSpec(
      }
   """) with Directives with ScalaFutures with WithLogCapturing {
 
-  import system.dispatcher
+  implicit val ec: ExecutionContext = system.dispatcher
   implicit val mat = ActorMaterializer()
 
   override def expectedTestDuration = 5.minutes // because slow jenkins, generally finishes below 1 or 2 minutes

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -17,6 +17,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.io.StdIn
@@ -36,13 +37,8 @@ object Http2ServerTest extends App {
     akka.http.server.preview.enable-http2 = true
                                                    """)
   implicit val system = ActorSystem("ServerTest", testConf)
-  import system.dispatcher
-
-  val settings = ActorMaterializerSettings(system)
-    .withFuzzing(false)
-    //    .withSyncProcessingLimit(Int.MaxValue)
-    .withInputBuffer(128, 128)
-  implicit val fm = ActorMaterializer(settings)
+  implicit val ec: ExecutionContext = system.dispatcher
+  implicit val fm = ActorMaterializer()
 
   def slowDown[T](millis: Int): T => Future[T] = { t =>
     akka.pattern.after(millis.millis, system.scheduler)(Future.successful(t))

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -38,7 +38,6 @@ object Http2ServerTest extends App {
                                                    """)
   implicit val system = ActorSystem("ServerTest", testConf)
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val fm = ActorMaterializer()
 
   def slowDown[T](millis: Int): T => Future[T] = { t =>
     akka.pattern.after(millis.millis, system.scheduler)(Future.successful(t))

--- a/build.sbt
+++ b/build.sbt
@@ -138,8 +138,7 @@ lazy val httpCore = project("akka-http-core")
   .addAkkaModuleDependency(
     "akka-stream-testkit",
     "test",
-    shouldUseSourceDependency = true,
-    uri("git://github.com/akka/akka.git#master"),
+    AkkaDependency.Sources("git://github.com/akka/akka.git#master"),
     onlyIf = System.getProperty("akka.http.test-against-akka-master", "false") == "true"
   )
   .settings(Dependencies.httpCore)

--- a/build.sbt
+++ b/build.sbt
@@ -309,8 +309,10 @@ def httpMarshallersJavaSubproject(name: String) =
 lazy val docs = project("docs")
   .enablePlugins(AkkaParadoxPlugin, NoPublish, DeployRsync)
   .disablePlugins(BintrayPlugin, MimaPlugin)
-  .addAkkaModuleDependency("akka-stream", "provided")
-  .addAkkaModuleDependency("akka-actor-typed", "provided")
+  .addAkkaModuleDependency("akka-stream", "provided", AkkaDependency.docs)
+  .addAkkaModuleDependency("akka-actor-typed", "provided", AkkaDependency.docs)
+  .addAkkaModuleDependency("akka-multi-node-testkit", "provided", AkkaDependency.docs)
+  .addAkkaModuleDependency("akka-stream-testkit", "provided", AkkaDependency.docs)
   .dependsOn(
     httpCore, http, httpXml, http2Support, httpMarshallersJava, httpMarshallersScala, httpCaching,
     httpTests % "compile;test->test", httpTestkit % "compile;test->test"

--- a/docs/src/main/paradox/routing-dsl/directives/basic-directives/extractActorSystem.md
+++ b/docs/src/main/paradox/routing-dsl/directives/basic-directives/extractActorSystem.md
@@ -13,10 +13,6 @@
 Extracts the @apidoc[akka.actor.ActorSystem] from the @apidoc[RequestContext], which can be useful when the external API
 in your route needs one.
 
-@@@ warning
-This is only supported when the available Materializer is an ActorMaterializer.
-@@@
-
 ## Example
 
 Scala

--- a/docs/src/main/paradox/routing-dsl/index.md
+++ b/docs/src/main/paradox/routing-dsl/index.md
@@ -104,9 +104,6 @@ Scala
 :  @@snip [HttpServerWithTypedSample.scala]($test$/scala/docs/http/scaladsl/HttpServerWithTypedSample.scala) { #akka-typed-bootstrap }
 
 
-Note that the `akka.actor.typed.ActorSystem` is converted with `toClassic`, which comes from
-`import akka.actor.typed.scaladsl.adapter._`.
-
 ## Dynamic Routing Example
 
 As the routes are evaluated for each request, it is possible to make changes at runtime. Please note that every access

--- a/docs/src/main/paradox/routing-dsl/index.md
+++ b/docs/src/main/paradox/routing-dsl/index.md
@@ -105,7 +105,7 @@ Scala
 
 
 Note that the `akka.actor.typed.ActorSystem` is converted with `toClassic`, which comes from
-`import akka.actor.typed.scaladsl.adapter._`. If you are using an earlier version than Akka 2.5.26 this conversion method is named `toUntyped`.
+`import akka.actor.typed.scaladsl.adapter._`.
 
 ## Dynamic Routing Example
 

--- a/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/RangeDirectivesExamplesTest.java
@@ -15,7 +15,7 @@ import akka.http.javadsl.server.Route;
 import akka.http.javadsl.unmarshalling.Unmarshaller;
 import akka.http.javadsl.testkit.JUnitRouteTest;
 import akka.http.javadsl.testkit.TestRouteResult;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import akka.util.ByteString;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -51,7 +51,7 @@ public class RangeDirectivesExamplesTest extends JUnitRouteTest {
                 akka.http.javadsl.model.ContentRange.create(0, 2, 8);
         final akka.http.javadsl.model.ContentRange bytes678Range =
                 akka.http.javadsl.model.ContentRange.create(6, 7, 8);
-        final ActorMaterializer materializer = systemResource().materializer();
+        final Materializer materializer = systemResource().materializer();
 
         testRoute(route).run(HttpRequest.GET("/")
                 .addHeader(Range.create(RangeUnits.BYTES, ByteRange.createSlice(3, 4))))

--- a/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
@@ -6,7 +6,6 @@ package docs.http.scaladsl
 
 import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
-import akka.stream.ActorMaterializer
 
 //#bindAndHandleSecure
 import scala.concurrent.Future
@@ -33,7 +32,6 @@ object Http2Spec {
   val asyncHandler: HttpRequest => Future[HttpResponse] = _ => Future.successful(HttpResponse(status = StatusCodes.ImATeapot))
   val httpsServerContext: HttpsConnectionContext = ExampleHttpContexts.exampleServerContext
   implicit val system: ActorSystem = ActorSystem()
-  implicit val materializer: Materializer = ActorMaterializer()
 
   //#bindAndHandleSecure
   Http().bindAndHandleAsync(

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientDecodingExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientDecodingExampleSpec.scala
@@ -6,6 +6,7 @@ package docs.http.scaladsl
 
 import docs.CompileOnlySpec
 import org.scalatest.concurrent.ScalaFutures
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import akka.testkit.AkkaSpec
 
@@ -16,13 +17,11 @@ class HttpClientDecodingExampleSpec extends AkkaSpec with CompileOnlySpec with S
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.coding.{ Gzip, Deflate, NoCoding }
     import akka.http.scaladsl.model._, headers.HttpEncodings
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.Future
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
-    import system.dispatcher
+    implicit val ec: ExecutionContext = system.dispatcher
 
     val http = Http()
 

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -23,13 +23,10 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
 
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.{ FileIO, Framing }
     import akka.util.ByteString
 
     implicit val system = ActorSystem()
-    implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     val response: HttpResponse = ???
 
@@ -50,12 +47,10 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
 
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.util.ByteString
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     case class ExamplePerson(name: String)
     def parse(line: ByteString): ExamplePerson = ???
@@ -78,20 +73,17 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
 
   "manual-entity-consume-example-3" in compileOnlySpec {
     //#manual-entity-consume-example-3
-    import scala.concurrent.duration._
     import scala.concurrent.Future
 
     import akka.NotUsed
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.util.ByteString
     import akka.stream.scaladsl.{ Flow, Sink, Source }
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     case class ExamplePerson(name: String)
 
@@ -132,11 +124,9 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model.HttpMessage.DiscardedEntity
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     val response1: HttpResponse = ??? // obtained from an HTTP call (see examples below)
 
@@ -151,12 +141,10 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.Done
     import akka.actor.ActorSystem
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.Sink
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     //#manual-entity-discard-example-2
     val response1: HttpResponse = ??? // obtained from an HTTP call (see examples below)
@@ -171,7 +159,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
 
     import scala.concurrent.Future
@@ -180,7 +167,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     object WebClient {
       def main(args: Array[String]): Unit = {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         implicit val executionContext = system.dispatcher
 
         val connectionFlow: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] =
@@ -223,14 +209,12 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
 
     import akka.stream.{ OverflowStrategy, QueueOfferResult }
 
     implicit val system = ActorSystem()
     import system.dispatcher // to get an implicit ExecutionContext into scope
-    implicit val materializer = ActorMaterializer()
 
     val QueueSize = 10
 
@@ -271,7 +255,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
 
     import akka.http.scaladsl.model.Multipart.FormData
@@ -279,7 +262,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
 
     implicit val system = ActorSystem()
     import system.dispatcher // to get an implicit ExecutionContext into scope
-    implicit val materializer = ActorMaterializer()
 
     case class FileToUpload(name: String, location: Path)
 
@@ -333,7 +315,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.Future
     import scala.util.{ Failure, Success }
@@ -341,7 +322,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     object Client {
       def main(args: Array[String]): Unit = {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -377,7 +357,7 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     Post("https://userservice.example/users", "data")
     //#create-post-request
 
-    implicit val materializer: ActorMaterializer = null
+    implicit val system: ActorSystem = null
     val response: HttpResponse = null
     //#unmarshal-response-body
     import akka.http.scaladsl.unmarshalling.Unmarshal
@@ -396,7 +376,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.actor.{ Actor, ActorLogging }
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
     import akka.util.ByteString
 
     class Myself extends Actor
@@ -405,9 +384,8 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
       import akka.pattern.pipe
       import context.dispatcher
 
-      final implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(context.system))
-
-      val http = Http(context.system)
+      implicit val system = context.system
+      val http = Http(system)
 
       override def preStart() = {
         http.singleRequest(HttpRequest(uri = "http://akka.io"))
@@ -433,11 +411,9 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import java.net.InetSocketAddress
 
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.{ ClientTransport, Http }
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val proxyHost = "localhost"
     val proxyPort = 8888
@@ -455,11 +431,9 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import java.net.InetSocketAddress
 
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.{ ClientTransport, Http }
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val proxyHost = "localhost"
     val proxyPort = 8888
@@ -485,7 +459,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.headers.`Set-Cookie`
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.ExecutionContextExecutor
     import scala.concurrent.Future
@@ -493,7 +466,6 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     object Client {
       def main(args: Array[String]): Unit = {
         implicit val system: ActorSystem = ActorSystem()
-        implicit val materializer: ActorMaterializer = ActorMaterializer()
         implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
         val responseFuture: Future[HttpResponse] = Http().singleRequest(HttpRequest(uri = "http://akka.io"))

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -27,11 +27,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     //#binding-example
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     val serverSource: Source[Http.IncomingConnection, Future[Http.ServerBinding]] =
@@ -50,14 +48,12 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.Http.ServerBinding
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.Future
 
     object WebServer {
       def main(args: Array[String]) {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future foreach in the end
         implicit val executionContext = system.dispatcher
 
@@ -89,12 +85,10 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.Http.ServerBinding
-    import akka.stream.ActorMaterializer
 
     import scala.concurrent.Future
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future foreach in the end
     implicit val executionContext = system.dispatcher
 
@@ -121,11 +115,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.actor.ActorRef
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.Flow
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     import Http._
@@ -151,11 +143,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.Flow
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     val (host, port) = ("localhost", 8080)
@@ -188,11 +178,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.HttpMethods._
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.Sink
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     val serverSource = Http().bind(interface = "localhost", port = 8080)
@@ -231,14 +219,12 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.HttpMethods._
     import akka.http.scaladsl.model._
-    import akka.stream.ActorMaterializer
     import scala.io.StdIn
 
     object WebServer {
 
       def main(args: Array[String]) {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future map/flatmap in the end
         implicit val executionContext = system.dispatcher
 
@@ -277,13 +263,11 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import scala.io.StdIn
 
     object WebServer {
       def main(args: Array[String]) {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -320,14 +304,12 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model._
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import scala.io.StdIn
 
     object WebServer {
       def main(args: Array[String]) {
 
         implicit val system = ActorSystem("my-system")
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -359,7 +341,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
     import akka.pattern.ask
-    import akka.stream.ActorMaterializer
     import akka.util.Timeout
 
     // types used by the API routes
@@ -376,7 +357,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     implicit val orderSeqM: ToResponseMarshaller[Seq[Order]] = ???
     implicit val timeout: Timeout = ??? // for actor asks
     implicit val ec: ExecutionContext = ???
-    implicit val mat: ActorMaterializer = ???
     implicit val sys: ActorSystem = ???
 
     // backend entry points
@@ -471,7 +451,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.{ HttpEntity, ContentTypes }
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import scala.util.Random
     import scala.io.StdIn
 
@@ -480,7 +459,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
       def main(args: Array[String]) {
 
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -521,7 +499,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
     import akka.pattern.ask
-    import akka.stream.ActorMaterializer
     import akka.util.Timeout
     import spray.json.DefaultJsonProtocol._
     import scala.concurrent.Future
@@ -551,7 +528,6 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
 
       def main(args: Array[String]) {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         // needed for the future flatMap/onComplete in the end
         implicit val executionContext = system.dispatcher
 
@@ -594,11 +570,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-    import akka.stream.ActorMaterializer
     import spray.json.DefaultJsonProtocol._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future flatMap/onComplete in the end
     implicit val executionContext = system.dispatcher
 
@@ -624,11 +598,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.stream.scaladsl.FileIO
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import java.io.File
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future flatMap/onComplete in the end
     implicit val executionContext = system.dispatcher
 
@@ -652,11 +624,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     //#discard-discardEntityBytes
     import akka.actor.ActorSystem
     import akka.http.scaladsl.server.Directives._
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.model.HttpRequest
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future flatMap/onComplete in the end
     implicit val executionContext = system.dispatcher
 
@@ -682,10 +652,8 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.stream.scaladsl.Sink
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.model.headers.Connection
-    import akka.stream.ActorMaterializer
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     // needed for the future flatMap/onComplete in the end
     implicit val executionContext = system.dispatcher
 
@@ -713,12 +681,10 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.Route
-    import akka.stream.ActorMaterializer
     import spray.json.DefaultJsonProtocol._
     import spray.json._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#dynamic-routing-example
     case class MockDefinition(path: String, requests: Seq[JsValue], responses: Seq[JsValue])
@@ -761,12 +727,10 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     import akka.actor.ActorSystem
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server.Route
-    import akka.stream.ActorMaterializer
     import scala.concurrent.duration._
 
     implicit val system = ActorSystem()
     implicit val dispatcher = system.dispatcher
-    implicit val materializer = ActorMaterializer()
 
     val routes = get {
       complete("Hello world!")

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerWithTypedSample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerWithTypedSample.scala
@@ -144,7 +144,6 @@ object HttpServerWithTypedSample {
 
   //#akka-typed-bootstrap
   import akka.actor.typed.PostStop
-  import akka.actor.typed.scaladsl.adapter._
   import akka.http.scaladsl.Http.ServerBinding
   import akka.http.scaladsl.Http
   import akka.stream.SystemMaterializer
@@ -163,10 +162,6 @@ object HttpServerWithTypedSample {
     def apply(host: String, port: Int): Behavior[Message] = Behaviors.setup { ctx =>
 
       implicit val system = ctx.system
-      // http doesn't know about akka typed so provide untyped system
-      implicit val untypedSystem: akka.actor.ActorSystem = ctx.system.toClassic
-      // FIXME #2893 should not be needed
-      implicit val materializer = SystemMaterializer(untypedSystem).materializer
       implicit val ec: ExecutionContextExecutor = ctx.system.executionContext
 
       val buildJobRepository = ctx.spawn(JobRepository(), "JobRepository")

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerWithTypedSample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerWithTypedSample.scala
@@ -142,16 +142,13 @@ object HttpServerWithTypedSample {
   }
   //#akka-typed-route
 
-  /* there are still differences making this impossible to compile both for 2.5 and 2.6 at the same time
-     without passing implicits explicitly and making the sample somewhat weird. This is however verified
-     against 2.6.0-RC1 with those implicits noted removed.
-
   //#akka-typed-bootstrap
   import akka.actor.typed.PostStop
   import akka.actor.typed.scaladsl.adapter._
-  import akka.stream.ActorMaterializer
   import akka.http.scaladsl.Http.ServerBinding
   import akka.http.scaladsl.Http
+  import akka.stream.SystemMaterializer
+  import akka.stream.Materializer
 
   import scala.concurrent.ExecutionContextExecutor
   import scala.util.{ Success, Failure }
@@ -168,9 +165,8 @@ object HttpServerWithTypedSample {
       implicit val system = ctx.system
       // http doesn't know about akka typed so provide untyped system
       implicit val untypedSystem: akka.actor.ActorSystem = ctx.system.toClassic
-      // implicit materializer only required in Akka 2.5
-      // in 2.6 having an implicit classic or typed ActorSystem in scope is enough
-      implicit val materializer: ActorMaterializer = ActorMaterializer()(ctx.system.toClassic)
+      // FIXME #2893 should not be needed
+      implicit val materializer = SystemMaterializer(untypedSystem).materializer
       implicit val ec: ExecutionContextExecutor = ctx.system.executionContext
 
       val buildJobRepository = ctx.spawn(JobRepository(), "JobRepository")
@@ -223,6 +219,4 @@ object HttpServerWithTypedSample {
       ActorSystem(Server("localhost", 8080), "BuildJobsServer")
   }
   //#akka-typed-bootstrap
-
-  */
 }

--- a/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
@@ -6,7 +6,6 @@ package docs.http.scaladsl
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import docs.CompileOnlySpec
 import org.scalatest.matchers.should.Matchers
@@ -18,7 +17,6 @@ class HttpsExamplesSpec extends AnyWordSpec with Matchers with CompileOnlySpec {
     val unsafeHost = "example.com"
     //#disable-sni-connection
     implicit val system = ActorSystem()
-    implicit val mat = ActorMaterializer()
 
     // WARNING: disabling SNI is a very bad idea, please don't unless you have a very good reason to.
     val badSslConfig = AkkaSSLConfig().mapSettings(s => s.withLoose(s.loose.withDisableSNI(true)))

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExampleSpec.scala
@@ -53,7 +53,6 @@ class SprayJsonExampleSpec extends AnyWordSpec with Matchers {
     //#second-spray-json-example
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.Done
     import akka.http.scaladsl.server.Route
     import akka.http.scaladsl.server.Directives._
@@ -71,7 +70,6 @@ class SprayJsonExampleSpec extends AnyWordSpec with Matchers {
 
       // needed to run the route
       implicit val system = ActorSystem()
-      implicit val materializer = ActorMaterializer()
       // needed for the future map/flatmap in the end and future in fetchItem and saveOrder
       implicit val executionContext = system.dispatcher
 

--- a/docs/src/test/scala/docs/http/scaladsl/UnmarshalSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/UnmarshalSpec.scala
@@ -4,7 +4,6 @@
 
 package docs.http.scaladsl
 
-import akka.stream.{ Materializer, ActorMaterializer }
 import akka.testkit.AkkaSpec
 
 class UnmarshalSpec extends AkkaSpec {
@@ -13,7 +12,6 @@ class UnmarshalSpec extends AkkaSpec {
     //#use-unmarshal
     import akka.http.scaladsl.unmarshalling.Unmarshal
     import system.dispatcher // Optional ExecutionContext (default from Materializer)
-    implicit val materializer: Materializer = ActorMaterializer()
 
     import scala.concurrent.Await
     import scala.concurrent.duration._
@@ -30,7 +28,6 @@ class UnmarshalSpec extends AkkaSpec {
 
   "use unmarshal without execution context" in {
     import akka.http.scaladsl.unmarshalling.Unmarshal
-    implicit val materializer: Materializer = ActorMaterializer()
 
     import scala.concurrent.Await
     import scala.concurrent.duration._

--- a/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/WebSocketClientExampleSpec.scala
@@ -15,7 +15,6 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     import akka.actor.ActorSystem
     import akka.{ Done, NotUsed }
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model._
     import akka.http.scaladsl.model.ws._
@@ -25,7 +24,6 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     object SingleWebSocketRequest {
       def main(args: Array[String]) = {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         import system.dispatcher
 
         // print each incoming strict text message
@@ -72,12 +70,10 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     import akka.actor.ActorSystem
     import akka.NotUsed
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model.ws._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#half-closed-WebSocket-closing-example
 
@@ -98,14 +94,12 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
   "half-closed-WebSocket-working-example" in compileOnlySpec {
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model.ws._
 
     import scala.concurrent.Promise
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#half-closed-WebSocket-working-example
 
@@ -129,14 +123,12 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
   "half-closed-WebSocket-finite-working-example" in compileOnlySpec {
     import akka.actor.ActorSystem
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model.ws._
 
     import scala.concurrent.Promise
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#half-closed-WebSocket-finite-working-example
 
@@ -161,13 +153,11 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     import akka.actor.ActorSystem
     import akka.NotUsed
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model.headers.{ Authorization, BasicHttpCredentials }
     import akka.http.scaladsl.model.ws._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     import collection.immutable.Seq
 
     val flow: Flow[Message, Message, NotUsed] =
@@ -191,7 +181,6 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     import akka.actor.ActorSystem
     import akka.Done
     import akka.http.scaladsl.Http
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl._
     import akka.http.scaladsl.model._
     import akka.http.scaladsl.model.ws._
@@ -201,7 +190,6 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
     object WebSocketClientFlow {
       def main(args: Array[String]) = {
         implicit val system = ActorSystem()
-        implicit val materializer = ActorMaterializer()
         import system.dispatcher
 
         // Future[Done] is the materialized value of Sink.foreach,
@@ -252,14 +240,12 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
 
     import akka.actor.ActorSystem
     import akka.NotUsed
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.{ ClientTransport, Http }
     import akka.http.scaladsl.settings.ClientConnectionSettings
     import akka.http.scaladsl.model.ws._
     import akka.stream.scaladsl._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val flow: Flow[Message, Message, NotUsed] =
       Flow.fromSinkAndSource(
@@ -281,14 +267,12 @@ class WebSocketClientExampleSpec extends AnyWordSpec with Matchers with CompileO
 
     import akka.actor.ActorSystem
     import akka.NotUsed
-    import akka.stream.ActorMaterializer
     import akka.http.scaladsl.{ ClientTransport, Http }
     import akka.http.scaladsl.settings.ClientConnectionSettings
     import akka.http.scaladsl.model.ws._
     import akka.stream.scaladsl._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val flow: Flow[Message, Message, NotUsed] =
       Flow.fromSinkAndSource(

--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -19,7 +19,6 @@ object MyExplicitExceptionHandler {
   import StatusCodes._
   import akka.http.scaladsl.server._
   import Directives._
-  import akka.stream.ActorMaterializer
 
   val myExceptionHandler = ExceptionHandler {
     case _: ArithmeticException =>
@@ -32,7 +31,6 @@ object MyExplicitExceptionHandler {
   object MyApp extends App {
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val route: Route =
       handleExceptions(myExceptionHandler) {
@@ -55,7 +53,6 @@ object MyImplicitExceptionHandler {
   import StatusCodes._
   import akka.http.scaladsl.server._
   import Directives._
-  import akka.stream.ActorMaterializer
 
   implicit def myExceptionHandler: ExceptionHandler =
     ExceptionHandler {
@@ -69,7 +66,6 @@ object MyImplicitExceptionHandler {
   object MyApp extends App {
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val route: Route =
     // ... some route structure
@@ -118,7 +114,6 @@ object RespondWithHeaderExceptionHandlerExample {
   import akka.http.scaladsl.server._
   import Directives._
   import akka.http.scaladsl.Http
-  import akka.stream.ActorMaterializer
   import RespondWithHeaderExceptionHandler.route
 
 
@@ -153,7 +148,6 @@ object RespondWithHeaderExceptionHandlerExample {
 
   object MyApp extends App {
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     Http().bindAndHandle(route, "localhost", 8080)
   }

--- a/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -12,7 +12,6 @@ import javax.net.ssl.{ SSLContext, TrustManagerFactory, KeyManagerFactory }
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.{ Route, Directives }
 import akka.http.scaladsl.{ ConnectionContext, HttpsConnectionContext, Http }
-import akka.stream.ActorMaterializer
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
 //#imports
 
@@ -33,7 +32,6 @@ abstract class HttpsServerExampleSpec extends AnyWordSpec with Matchers
   "low level api" in compileOnlySpec {
     //#low-level-default
     implicit val system = ActorSystem()
-    implicit val mat = ActorMaterializer()
     implicit val dispatcher = system.dispatcher
 
     // Manual HTTPS configuration

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -13,7 +13,6 @@ object MyRejectionHandler {
 
   //#custom-handler-example
   import akka.actor.ActorSystem
-  import akka.stream.ActorMaterializer
   import akka.http.scaladsl.Http
   import akka.http.scaladsl.model._
   import akka.http.scaladsl.server._
@@ -43,7 +42,6 @@ object MyRejectionHandler {
         .result()
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     val route: Route =
       // ... some route structure

--- a/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
@@ -10,7 +10,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.ws.{ BinaryMessage, Message, WebSocketRequest }
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Sink }
 import akka.util.ByteString
 import docs.CompileOnlySpec
@@ -23,7 +22,6 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
   "core-example" in compileOnlySpec {
     //#websocket-example-using-core
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.{ Source, Flow }
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.ws.UpgradeToWebSocket
@@ -32,7 +30,6 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
     import akka.http.scaladsl.model.HttpMethods._
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     //#websocket-handler
     // The Greeter WebSocket Service expects a "name" per message and
@@ -78,14 +75,12 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
   }
   "routing-example" in compileOnlySpec {
     import akka.actor.ActorSystem
-    import akka.stream.ActorMaterializer
     import akka.stream.scaladsl.{ Source, Flow }
     import akka.http.scaladsl.Http
     import akka.http.scaladsl.model.ws.{ TextMessage, Message }
     import akka.http.scaladsl.server.Directives
 
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
 
     import Directives._
 
@@ -120,8 +115,8 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
   }
 
   "ping-server-example" in compileOnlySpec {
-    implicit val system: ActorSystem = ???
-    implicit val mat: ActorMaterializer = ???
+    implicit val system: ActorSystem = null
+    val route = null
     //#websocket-ping-payload-server
     val defaultSettings = ServerSettings(system)
 
@@ -133,13 +128,12 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
     val customServerSettings =
       defaultSettings.withWebsocketSettings(customWebsocketSettings)
 
-    Http().bindAndHandle(???, "127.0.0.1", settings = customServerSettings)
+    Http().bindAndHandle(route, "127.0.0.1", settings = customServerSettings)
     //#websocket-ping-payload-server
   }
 
   "ping-example" in compileOnlySpec {
-    implicit val system: ActorSystem = ???
-    implicit val mat: ActorMaterializer = ???
+    implicit val system: ActorSystem = null
     //#websocket-client-ping-payload
     val defaultSettings = ClientConnectionSettings(system)
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/BasicDirectivesExamplesSpec.scala
@@ -11,7 +11,7 @@ import akka.http.scaladsl.model.headers.{ RawHeader, Server }
 import akka.http.scaladsl.server.RouteResult.{ Complete, Rejected }
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.settings.RoutingSettings
-import akka.stream.ActorMaterializer
+import akka.stream.{ Materializer, SystemMaterializer }
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
 import docs.CompileOnlySpec
@@ -50,7 +50,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   }
   "withMaterializer-0" in {
     //#withMaterializer-0
-    val special = ActorMaterializer(namePrefix = Some("special"))
+    val special = Materializer(system).withNamePrefix("special")
 
     def sample() =
       path("sample") {
@@ -72,7 +72,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
     // tests:
     Get("/sample") ~> route ~> check {
-      responseAs[String] shouldEqual s"Materialized by ${materializer.##}!"
+      responseAs[String] shouldEqual s"Materialized by ${SystemMaterializer(system).materializer.##}!"
     }
     Get("/special/sample") ~> route ~> check {
       responseAs[String] shouldEqual s"Materialized by ${special.##}!"
@@ -86,7 +86,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
         extractMaterializer { materializer =>
           complete {
             // explicitly use the `materializer`:
-            Source.single(s"Materialized by ${materializer.##}!")
+            Source.single(s"Materialized by ${SystemMaterializer(system).materializer.##}!")
               .runWith(Sink.head)(materializer)
           }
         }
@@ -94,7 +94,7 @@ class BasicDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
     // tests:
     Get("/sample") ~> route ~> check {
-      responseAs[String] shouldEqual s"Materialized by ${materializer.##}!"
+      responseAs[String] shouldEqual s"Materialized by ${SystemMaterializer(system).materializer.##}!"
     }
     //#extractMaterializer-0
   }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.model.HttpProtocols._
 import akka.http.scaladsl.model.RequestEntityAcceptance.Expected
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives
-import akka.stream.ActorMaterializer
 import akka.testkit.{ AkkaSpec, SocketUtil }
 import org.scalatest.concurrent.ScalaFutures
 
@@ -17,8 +16,6 @@ import scala.concurrent.duration._
 
 class CustomHttpMethodSpec extends AkkaSpec with ScalaFutures
   with Directives {
-
-  implicit val mat = ActorMaterializer()
 
   "Http" should {
     "allow registering custom method" in {

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
@@ -17,7 +17,6 @@ class JsonStreamingFullExamples extends AnyWordSpec {
   import akka.http.scaladsl.common.{ EntityStreamingSupport, JsonEntityStreamingSupport }
   import akka.http.scaladsl.model.{ HttpEntity, _ }
   import akka.http.scaladsl.server.Directives._
-  import akka.stream.ActorMaterializer
   import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
   import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
   import akka.stream.scaladsl.Source
@@ -46,7 +45,6 @@ class JsonStreamingFullExamples extends AnyWordSpec {
 
   object ApiServer extends App with UserProtocol {
     implicit val system = ActorSystem("api")
-    implicit val materializer = ActorMaterializer()
     implicit val executionContext = system.dispatcher
 
     implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json()

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -9,13 +9,12 @@ import akka.http.scaladsl.server.Route
 import docs.CompileOnlySpec
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
-import akka.stream.ActorMaterializer
 import akka.http.scaladsl.model.HttpEntity._
 import akka.http.scaladsl.model._
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.duration._
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import akka.testkit.{ AkkaSpec, SocketUtil }
 
 private[this] object TimeoutDirectivesInfiniteTimeoutTestConfig {
@@ -31,8 +30,7 @@ private[this] object TimeoutDirectivesInfiniteTimeoutTestConfig {
 class TimeoutDirectivesExamplesSpec extends AkkaSpec(TimeoutDirectivesInfiniteTimeoutTestConfig.testConf)
   with ScalaFutures with CompileOnlySpec {
   //#testSetup
-  import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   def slowFuture(): Future[String] = Promise[String].future // TODO: move to Future.never in Scala 2.12
 
@@ -161,8 +159,7 @@ private[this] object TimeoutDirectivesFiniteTimeoutTestConfig {
 
 class TimeoutDirectivesFiniteTimeoutExamplesSpec extends AkkaSpec(TimeoutDirectivesFiniteTimeoutTestConfig.testConf)
   with ScalaFutures with CompileOnlySpec {
-  import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
 
   def slowFuture(): Future[String] = Promise[String].future // TODO: move to Future.never in Scala 2.12
 

--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -8,64 +8,59 @@ import sbt._
 import Keys._
 
 object AkkaDependency {
-  // Property semantics:
-  // If akka.sources is set, then the given URI will override everything else
-  // else if akka version is "master", then a source dependency to git://github.com/akka/akka.git#master will be used
-  // else if akka version is "default", then the hard coded default will be used (jenkins doesn't allow empty values for config axis)
-  // else if akka.version is anything else, then the given version will be used
 
-  // Updated only when needed
-  // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
-  val defaultAkkaVersion = "2.5.31"
-  val akkaVersion =
-    System.getProperty("akka.http.build.akka.version", defaultAkkaVersion) match {
-      case "default" => defaultAkkaVersion
-      case x => x
+  sealed trait Akka
+  case class Artifact(version: String) extends Akka
+  case class Sources(uri: String) extends Akka
+
+  def akkaDependency(defaultVersion: String): Akka = {
+    Option(System.getProperty("akka.sources")) match {
+      case Some(akkaSources) =>
+        Sources(akkaSources)
+      case None =>
+        Option(System.getProperty("akka.http.build.akka.version")) match {
+          case Some("master") => Sources("git://github.com/akka/akka.git#master")
+          case Some("release-2.5") => Sources("git://github.com/akka/akka.git#release-2.5")
+          case Some("default") => Artifact(defaultVersion)
+          case Some(other) => Artifact(other)
+          case None => Artifact(defaultVersion)
+        }
     }
-
-  // Needs to be a URI like git://github.com/akka/akka.git#master or file:///xyz/akka
-  val akkaSourceDependencyUri = {
-    val fallback =
-      akkaVersion match {
-        case "master" => "git://github.com/akka/akka.git#master"
-        case "release-2.5" => "git://github.com/akka/akka.git#release-2.5"
-        case x => ""
-      }
-
-    System.getProperty("akka.sources", fallback)
   }
-  val shouldUseSourceDependency = akkaSourceDependencyUri != ""
+  // Default version updated only when needed, https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
+  val default = akkaDependency(defaultVersion = "2.5.31")
 
-  val akkaRepository = {
-    // as a little hacky side effect also disable aggregation of samples
-    System.setProperty("akka.build.aggregateSamples", "false")
-
-    uri(akkaSourceDependencyUri)
+  val akkaVersion: String = default match {
+    case Artifact(version) => version
+    case Sources(uri) => uri
   }
 
   implicit class RichProject(project: Project) {
     /** Adds either a source or a binary dependency, depending on whether the above settings are set */
     def addAkkaModuleDependency(module: String,
                                 config: String = "",
-                                shouldUseSourceDependency: Boolean = AkkaDependency.shouldUseSourceDependency,
-                                akkaRepository: URI = AkkaDependency.akkaRepository,
+                                akka: Akka = default,
                                 onlyIf: Boolean = true): Project =
       if (onlyIf) {
-        if (shouldUseSourceDependency) {
-          val moduleRef = ProjectRef(akkaRepository, module)
-          val withConfig: ClasspathDependency =
-            if (config == "") moduleRef
-            else moduleRef % config
+        akka match {
+          case Sources(sources) =>
+            // as a little hacky side effect also disable aggregation of samples
+            System.setProperty("akka.build.aggregateSamples", "false")
 
-          project.dependsOn(withConfig)
-        } else {
-          project.settings(libraryDependencies += {
-            val dep = "com.typesafe.akka" %% module % akkaVersion
-            val withConfig =
-              if (config == "") dep
-              else dep % config
-            withConfig
-          })
+            val moduleRef = ProjectRef(uri(sources), module)
+            val withConfig: ClasspathDependency =
+              if (config == "") moduleRef
+              else moduleRef % config
+
+            project.dependsOn(withConfig)
+          case Artifact(akkaVersion) =>
+            project.settings(libraryDependencies += {
+              val dep = "com.typesafe.akka" %% module % akkaVersion
+                val withConfig =
+                if (config == "") dep
+                else dep % config
+              withConfig
+            })
         }
       }
       else project // return unchanged

--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -56,11 +56,10 @@ object AkkaDependency {
             project.dependsOn(withConfig)
           case Artifact(akkaVersion) =>
             project.settings(libraryDependencies += {
-              val dep = "com.typesafe.akka" %% module % akkaVersion
-                val withConfig =
-                if (config == "") dep
-                else dep % config
-              withConfig
+              if (config == "")
+                "com.typesafe.akka" %% module % akkaVersion
+              else
+                "com.typesafe.akka" %% module % akkaVersion % config
             })
         }
       }

--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -29,6 +29,7 @@ object AkkaDependency {
   }
   // Default version updated only when needed, https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
   val default = akkaDependency(defaultVersion = "2.5.31")
+  val docs = akkaDependency(defaultVersion = "2.6.4")
 
   val akkaVersion: String = default match {
     case Artifact(version) => version


### PR DESCRIPTION
This contains part of #2984, focusing on the Scala API's for now. It currently fails because Akka 2.5.29 doesn't have https://github.com/akka/akka/pull/28545 yet.