### PR TITLE
Increase the resetTimeout to assert the circuit breaker is open

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
@@ -4,6 +4,7 @@
 
 package docs.http.javadsl.server.directives;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -46,138 +47,143 @@ import static akka.http.javadsl.server.Directives.path;
 
 public class FutureDirectivesExamplesTest extends JUnitRouteTest {
 
-  @Test
-  public void testOnComplete() {
-    //#onComplete
-    // import static scala.compat.java8.JFunction.func;
-    // import static akka.http.javadsl.server.PathMatchers.*;
+    @Test
+    public void testOnComplete() {
+        //#onComplete
+        // import static scala.compat.java8.JFunction.func;
+        // import static akka.http.javadsl.server.PathMatchers.*;
 
-    final Route route = path(segment("divide").slash(integerSegment()).slash(integerSegment()),
-      (a, b) -> onComplete(
-        () -> CompletableFuture.supplyAsync(() -> a / b),
-        maybeResult -> maybeResult
-          .map(func(result -> complete("The result was " + result)))
-          .recover(new PFBuilder<Throwable, Route>()
-            .matchAny(ex -> complete(StatusCodes.InternalServerError(),
-              "An error occurred: " + ex.getMessage())
-            )
-            .build())
-          .get()
-      )
-    );
+        final Route route = path(segment("divide").slash(integerSegment()).slash(integerSegment()),
+                (a, b) -> onComplete(
+                        () -> CompletableFuture.supplyAsync(() -> a / b),
+                        maybeResult -> maybeResult
+                                .map(func(result -> complete("The result was " + result)))
+                                .recover(new PFBuilder<Throwable, Route>()
+                                        .matchAny(ex -> complete(StatusCodes.InternalServerError(),
+                                                "An error occurred: " + ex.getMessage())
+                                        )
+                                        .build())
+                                .get()
+                )
+        );
 
-    testRoute(route).run(HttpRequest.GET("/divide/10/2"))
-      .assertEntity("The result was 5");
+        testRoute(route).run(HttpRequest.GET("/divide/10/2"))
+                .assertEntity("The result was 5");
 
-    testRoute(route).run(HttpRequest.GET("/divide/10/0"))
-      .assertStatusCode(StatusCodes.InternalServerError())
-      .assertEntity("An error occurred: / by zero");
-    //#onComplete
-  }
+        testRoute(route).run(HttpRequest.GET("/divide/10/0"))
+                .assertStatusCode(StatusCodes.InternalServerError())
+                .assertEntity("An error occurred: / by zero");
+        //#onComplete
+    }
 
-  @Test
-  public void testOnSuccess() {
-    //#onSuccess
-    final Route route = path("success", () ->
-      onSuccess(CompletableFuture.supplyAsync(() -> "Ok"),
-        extraction -> complete(extraction)
-      )
-    ).orElse(path("failure", () ->
-      onSuccess(CompletableFuture.supplyAsync(() -> {
-          throw new RuntimeException();
-        }),
-        extraction -> complete("never reaches here"))
-    ));
+    @Test
+    public void testOnSuccess() {
+        //#onSuccess
+        final Route route = path("success", () ->
+                onSuccess(CompletableFuture.supplyAsync(() -> "Ok"),
+                        extraction -> complete(extraction)
+                )
+        ).orElse(path("failure", () ->
+                onSuccess(CompletableFuture.supplyAsync(() -> {
+                            throw new RuntimeException();
+                        }),
+                        extraction -> complete("never reaches here"))
+        ));
 
-    testRoute(route).run(HttpRequest.GET("/success"))
-      .assertEntity("Ok");
+        testRoute(route).run(HttpRequest.GET("/success"))
+                .assertEntity("Ok");
 
-    testRoute(route).run(HttpRequest.GET("/failure"))
-      .assertStatusCode(StatusCodes.InternalServerError())
-      .assertEntity("There was an internal server error.");
-    //#onSuccess
-  }
+        testRoute(route).run(HttpRequest.GET("/failure"))
+                .assertStatusCode(StatusCodes.InternalServerError())
+                .assertEntity("There was an internal server error.");
+        //#onSuccess
+    }
 
-  @Test
-  public void testCompleteOrRecoverWith() {
-    //#completeOrRecoverWith
-    final Route route = path("success", () ->
-      completeOrRecoverWith(
-        () -> CompletableFuture.supplyAsync(() -> "Ok"),
-        Marshaller.stringToEntity(),
-        extraction -> failWith(extraction) // not executed
-      )
-    ).orElse(path("failure", () ->
-      completeOrRecoverWith(
-        () -> CompletableFuture.supplyAsync(() -> {
-          throw new RuntimeException();
-        }),
-        Marshaller.stringToEntity(),
-        extraction -> failWith(extraction))
-    ));
+    @Test
+    public void testCompleteOrRecoverWith() {
+        //#completeOrRecoverWith
+        final Route route = path("success", () ->
+                completeOrRecoverWith(
+                        () -> CompletableFuture.supplyAsync(() -> "Ok"),
+                        Marshaller.stringToEntity(),
+                        extraction -> failWith(extraction) // not executed
+                )
+        ).orElse(path("failure", () ->
+                completeOrRecoverWith(
+                        () -> CompletableFuture.supplyAsync(() -> {
+                            throw new RuntimeException();
+                        }),
+                        Marshaller.stringToEntity(),
+                        extraction -> failWith(extraction))
+        ));
 
-    testRoute(route).run(HttpRequest.GET("/success"))
-      .assertEntity("Ok");
+        testRoute(route).run(HttpRequest.GET("/success"))
+                .assertEntity("Ok");
 
-    testRoute(route).run(HttpRequest.GET("/failure"))
-      .assertStatusCode(StatusCodes.InternalServerError())
-      .assertEntity("There was an internal server error.");
-    //#completeOrRecoverWith
-  }
-  
-  @Test
-  public void testOnCompleteWithBreaker() throws InterruptedException {
-    //#onCompleteWithBreaker
-    // import static scala.compat.java8.JFunction.func;
-    // import static akka.http.javadsl.server.PathMatchers.*;
+        testRoute(route).run(HttpRequest.GET("/failure"))
+                .assertStatusCode(StatusCodes.InternalServerError())
+                .assertEntity("There was an internal server error.");
+        //#completeOrRecoverWith
+    }
 
-    final int maxFailures = 1;
-    final FiniteDuration callTimeout = FiniteDuration.create(5, TimeUnit.SECONDS);
-    final FiniteDuration resetTimeout = FiniteDuration.create(1, TimeUnit.SECONDS);
-    final CircuitBreaker breaker = CircuitBreaker.create(system().scheduler(), maxFailures, callTimeout, resetTimeout);
-    
-    final Route route = path(segment("divide").slash(integerSegment()).slash(integerSegment()),
-      (a, b) -> onCompleteWithBreaker(breaker,
-        () ->  CompletableFuture.supplyAsync(() -> a / b),
-        maybeResult -> maybeResult
-          .map(func(result -> complete("The result was " + result)))
-          .recover(new PFBuilder<Throwable, Route>()
-            .matchAny(ex -> complete(StatusCodes.InternalServerError(),
-              "An error occurred: " + ex.toString())
-            )
-            .build())
-          .get()
-      )
-    );
+    @Test
+    public void testOnCompleteWithBreaker() throws InterruptedException {
+        //#onCompleteWithBreaker
+        // import static scala.compat.java8.JFunction.func;
+        // import static akka.http.javadsl.server.PathMatchers.*;
 
-    testRoute(route).run(HttpRequest.GET("/divide/10/2"))
-      .assertEntity("The result was 5");
+        final int maxFailures = 1;
+        final FiniteDuration callTimeout = FiniteDuration.create(5, TimeUnit.SECONDS);
+        final FiniteDuration resetTimeout = FiniteDuration.create(1, TimeUnit.SECONDS);
+        final CircuitBreaker breaker = CircuitBreaker.create(system().scheduler(), maxFailures, callTimeout, resetTimeout);
 
-    testRoute(route).run(HttpRequest.GET("/divide/10/0"))
-      .assertStatusCode(StatusCodes.InternalServerError())
-      .assertEntity("An error occurred: java.lang.ArithmeticException: / by zero");
-    // opened the circuit-breaker 
+        final Route route = path(segment("divide").slash(integerSegment()).slash(integerSegment()),
+                (a, b) -> onCompleteWithBreaker(breaker,
+                        () -> CompletableFuture.supplyAsync(() -> a / b),
+                        maybeResult -> maybeResult
+                                .map(func(result -> complete("The result was " + result)))
+                                .recover(new PFBuilder<Throwable, Route>()
+                                        .matchAny(ex -> complete(StatusCodes.InternalServerError(),
+                                                "An error occurred: " + ex.toString())
+                                        )
+                                        .build())
+                                .get()
+                )
+        );
 
-    testRoute(route).run(HttpRequest.GET("/divide/10/0"))
-          .assertEntity("The server is currently unavailable (because it is overloaded or down for maintenance).")
-          .assertStatusCode(StatusCodes.ServiceUnavailable());
+        testRoute(route).run(HttpRequest.GET("/divide/10/2"))
+                .assertEntity("The result was 5");
 
-    Thread.sleep(resetTimeout.toMillis());
+        testRoute(route).run(HttpRequest.GET("/divide/10/0"))
+                .assertStatusCode(StatusCodes.InternalServerError())
+                .assertEntity("An error occurred: java.lang.ArithmeticException: / by zero");
 
-    // circuit breaker resets after this time, but observing it
-    // is timing sensitive so retry a few times within a timeout
-    new TestKit(system()) {
-      {
-        awaitAssert(
-            FiniteDuration.create(500, TimeUnit.MILLISECONDS),
-            () -> {
-              testRoute(route).run(HttpRequest.GET("/divide/8/2"))
-                  .assertEntity("The result was 4");
-              return null;
-            });
-      }
-    };
-    //#onCompleteWithBreaker
-  }
+        // The circuit-breaker will eventually be opened
+        new TestKit(system()) {
+            {
+                awaitAssert(
+                        Duration.ofSeconds(500),
+                        () -> {
+                            testRoute(route).run(HttpRequest.GET("/divide/10/0"))
+                                    .assertEntity("The server is currently unavailable (because it is overloaded or down for maintenance).")
+                                    .assertStatusCode(StatusCodes.ServiceUnavailable());
+                            return null;
+                        });
+
+                Thread.sleep(resetTimeout.toMillis());
+
+                // circuit breaker resets after this time, but observing it
+                // is timing sensitive so retry a few times within a timeout
+                awaitAssert(
+                        Duration.ofSeconds(500),
+                        () -> {
+                            testRoute(route).run(HttpRequest.GET("/divide/8/2"))
+                                    .assertEntity("The result was 4");
+                            return null;
+                        });
+            }
+        };
+        //#onCompleteWithBreaker
+    }
 
 }


### PR DESCRIPTION
References #2952 

A pause (GC, noisy neighbor) before:

https://github.com/akka/akka-http/blob/7683d53d97ed6878ac132c6575a714b199db14ba/docs/src/test/java/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java#L161

allows the circuit breaker to close again. Increasing the `resetTimeout` should reduce the odds.

