### PR TITLE
Reduce flakiness of FileUploadDirectivesExamples (Test and Spec)

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/RouteTest.scala
@@ -34,7 +34,8 @@ abstract class RouteTest extends AllDirectives with WSTestRequestBuilding {
   implicit def materializer: Materializer
   implicit def executionContext: ExecutionContextExecutor = system.dispatcher
 
-  protected def awaitDuration: FiniteDuration = 3.seconds.dilated
+  protected def defaultAwaitDuration = 3.seconds
+  protected def awaitDuration: FiniteDuration = defaultAwaitDuration.dilated
 
   protected def defaultHostInfo: DefaultHostInfo = DefaultHostInfo(Host.create("example.com"), false)
 

--- a/docs/src/test/java/docs/http/javadsl/server/directives/FileUploadDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FileUploadDirectivesExamplesTest.java
@@ -15,6 +15,7 @@ import akka.stream.javadsl.Source;
 import akka.util.ByteString;
 import org.junit.Ignore;
 import org.junit.Test;
+import scala.concurrent.duration.FiniteDuration;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -59,6 +61,11 @@ import static akka.http.javadsl.server.Directives.onSuccess;
 //#fileUploadAll
 
 public class FileUploadDirectivesExamplesTest extends JUnitRouteTest {
+
+  @Override
+  public FiniteDuration defaultAwaitDuration() {
+    return new FiniteDuration(7, TimeUnit.SECONDS);
+  }
 
   @Test
   public void testUploadedFile() {

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FileUploadDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FileUploadDirectivesExamplesSpec.scala
@@ -23,7 +23,7 @@ class FileUploadDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec 
   override def testConfigSource = "akka.actor.default-mailbox.mailbox-type = \"akka.dispatch.UnboundedMailbox\""
 
   // test touches disk, so give it some time
-  implicit val routeTimeout = RouteTestTimeout(3.seconds.dilated)
+  implicit val routeTimeout = RouteTestTimeout(7.seconds.dilated)
 
   "uploadedFile" in {
     //#uploadedFile


### PR DESCRIPTION
References #2733 (#2930 is a duplicate of it) and #2691

As the code comment says:

`  // test touches disk, so give it some time`

so let's give it a little more time.
