### PR TITLE
core: don't fail slot after previous connection failed in special condition

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -257,6 +257,7 @@ private[client] object NewHostConnectionPool {
 
                 debug(s"Before event [${event.name}] In state [${state.name}] for [${timeInState / 1000000} ms]")
                 state = event.transition(state, this, arg)
+                require(state != Unconnected, "Slot must not change to Unconnected state") // Use ToBeClosed or Failed instead from state impls
                 debug(s"After event [${event.name}] State change [${previousState.name}] -> [${state.name}]")
 
                 state.stateTimeout match {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -340,12 +340,12 @@ private[pool] object SlotState {
     final override def isIdle = false
 
     override def onRequestEntityCompleted(ctx: SlotContext): SlotState =
-      if (ctx.isConnectionClosed) Unconnected
+      if (ctx.isConnectionClosed) ToBeClosed
       else Idle
     override def onRequestEntityFailed(ctx: SlotContext, cause: Throwable): SlotState =
-      if (ctx.isConnectionClosed) Unconnected
+      if (ctx.isConnectionClosed) ToBeClosed // ignore error here
       else Idle
-    override def onConnectionCompleted(ctx: SlotContext): SlotState = Unconnected
-    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = Unconnected
+    override def onConnectionCompleted(ctx: SlotContext): SlotState = ToBeClosed
+    override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = Failed(cause)
   }
 }


### PR DESCRIPTION
The special condition is that the previous request got an early response and
the connection afterwards broke while waiting for the rest of the request.

Fixes #1439