### PR TITLE
Akka 2.5.31; accept ClassicActorSystemProvider in extensions

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -6,18 +6,20 @@ package akka.http.javadsl
 
 import java.net.InetSocketAddress
 import java.util.Optional
+
 import akka.http.impl.util.JavaMapping
 import akka.http.impl.util.JavaMapping.HttpsConnectionContext
 import akka.http.javadsl.model.ws._
-import akka.http.javadsl.settings.{ ConnectionPoolSettings, ClientConnectionSettings, ServerSettings }
+import akka.http.javadsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings, ServerSettings }
 import akka.{ NotUsed, stream }
 import akka.stream.TLSProtocol._
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
+
 import scala.concurrent.Future
 import scala.util.Try
 import akka.stream.scaladsl.Keep
-import akka.japi.{ Pair, Function }
-import akka.actor.{ ExtendedActorSystem, ActorSystem, ExtensionIdProvider, ExtensionId }
+import akka.japi.{ Function, Pair }
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider, ExtendedActorSystem, ExtensionId, ExtensionIdProvider }
 import akka.event.LoggingAdapter
 import akka.stream.Materializer
 import akka.stream.javadsl.{ BidiFlow, Flow, Source }
@@ -25,12 +27,14 @@ import akka.http.impl.util.JavaMapping.Implicits._
 import akka.http.scaladsl.{ model => sm }
 import akka.http.javadsl.model._
 import akka.http._
+
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 import java.util.concurrent.CompletionStage
 
 object Http extends ExtensionId[Http] with ExtensionIdProvider {
   override def get(system: ActorSystem): Http = super.get(system)
+  override def get(system: ClassicActorSystemProvider): Http = super.get(system)
   def lookup() = Http
   def createExtension(system: ExtendedActorSystem): Http = new Http(system)
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -1124,7 +1124,8 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
 
   //////////////////// EXTENSION SETUP ///////////////////
 
-  def apply()(implicit system: ActorSystem): HttpExt = super.apply(system)
+  def apply()(implicit system: ClassicActorSystemProvider): HttpExt = super.apply(system)
+  override def apply(system: ActorSystem): HttpExt = super.apply(system)
 
   def lookup() = Http
 

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -5,17 +5,17 @@
 package akka.http.scaladsl
 
 import akka.{ Done, NotUsed }
-import akka.actor.{ ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
 import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
-import akka.http.impl.engine.http2.{ ProtocolSwitch, Http2AlpnSupport, Http2Blueprint }
+import akka.http.impl.engine.http2.{ Http2AlpnSupport, Http2Blueprint, ProtocolSwitch }
 import akka.http.impl.engine.server.MasterServerTerminator
 import akka.http.impl.engine.server.UpgradeToOtherProtocolResponseHeader
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
-import akka.stream.scaladsl.{ BidiFlow, Flow, Keep, Source, Sink, TLS, TLSPlacebo, Tcp }
+import akka.stream.scaladsl.{ BidiFlow, Flow, Keep, Sink, Source, TLS, TLSPlacebo, Tcp }
 import akka.http.scaladsl.model.headers.{ Connection, RawHeader, Upgrade, UpgradeProtocol }
 import akka.http.scaladsl.model.http2.{ Http2SettingsHeader, Http2StreamIdHeader }
 import akka.stream.{ IgnoreComplete, Materializer }
@@ -197,7 +197,9 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
 
 object Http2 extends ExtensionId[Http2Ext] with ExtensionIdProvider {
   override def get(system: ActorSystem): Http2Ext = super.get(system)
-  def apply()(implicit system: ActorSystem): Http2Ext = super.apply(system)
+  override def get(system: ClassicActorSystemProvider): Http2Ext = super.get(system)
+  def apply()(implicit system: ClassicActorSystemProvider): Http2Ext = super.apply(system)
+  override def apply(system: ActorSystem): Http2Ext = super.apply(system)
   def lookup(): ExtensionId[_ <: Extension] = Http2
   def createExtension(system: ExtendedActorSystem): Http2Ext =
     new Http2Ext(system.settings.config getConfig "akka.http")(system)

--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -16,7 +16,7 @@ object AkkaDependency {
 
   // Updated only when needed
   // https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
-  val defaultAkkaVersion = "2.5.30"
+  val defaultAkkaVersion = "2.5.31"
   val akkaVersion =
     System.getProperty("akka.http.build.akka.version", defaultAkkaVersion) match {
       case "default" => defaultAkkaVersion


### PR DESCRIPTION
Upgrade to Akka 2.5.31.
So that `ClassicActorSystemProvider` can be used to accept both classic and new actor systems to create the Akka HTTP extensions.

Methods with `akka.actor.ActorSystem` are kept for bin-compatiblity.