### PR TITLE
core: parse empty query `?` to Query.empty

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
@@ -263,7 +263,7 @@ private[http] final class UriParser(
       if (valueStack.size + 5 <= maxValueStackSize) keyValuePairsWithReversalAvoidance
       else keyValuePairsWithLimitedStackUse
 
-    rule { keyValuePairs }
+    rule { (EOI ~ push(Query.Empty)) | keyValuePairs }
   }
 
   def fragment = rule(

--- a/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
@@ -150,7 +150,7 @@ public class UriTest extends JUnitSuite {
     //query component (name: "a", and value: "b") is equal to parsed query string "a=b"
     assertEquals(Query.create(Pair.create("a", "b")), strict("a=b"));
 
-    assertEquals(Query.create(Pair.create("", "")), strict(""));
+    assertEquals(Query.EMPTY, strict(""));
     assertEquals(Query.create(Pair.create("a", "")), strict("a"));
     assertEquals(Query.create(Pair.create("a", "")), strict("a="));
     assertEquals(Query.create(Pair.create("a", " ")), strict("a=+"));
@@ -237,7 +237,7 @@ public class UriTest extends JUnitSuite {
   @Test
   public void testRelaxedMode() {
     //#query-relaxed-mode
-    assertEquals(Query.create(Pair.create("", "")), relaxed(""));
+    assertEquals(Query.EMPTY, relaxed(""));
     assertEquals(Query.create(Pair.create("a", "")), relaxed("a"));
     assertEquals(Query.create(Pair.create("a", "")), relaxed("a="));
     assertEquals(Query.create(Pair.create("a", " ")), relaxed("a=+"));

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -533,6 +533,9 @@ class UriSpec extends AnyWordSpec with Matchers {
       Uri("http://:8000/foo") shouldEqual Uri("http", Authority(Host.Empty, 8000), Path / "foo")
       Uri("http://:80/foo") shouldEqual Uri("http", Authority(Host.Empty, 0), Path / "foo")
 
+      Uri("").query() shouldBe empty
+      Uri("").query().toMap shouldBe empty
+
       Uri("?").query() shouldBe empty
       Uri("?").query().toMap shouldBe empty
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -317,7 +317,7 @@ class UriSpec extends AnyWordSpec with Matchers {
       //query component "a=b" is parsed into parameter name: "a", and value: "b"
       strict("a=b") shouldEqual ("a", "b") +: Query.Empty
 
-      strict("") shouldEqual ("", "") +: Query.Empty
+      strict("") shouldEqual Query.Empty
       strict("a") shouldEqual ("a", "") +: Query.Empty
       strict("a=") shouldEqual ("a", "") +: Query.Empty
       strict("a=+") shouldEqual ("a", " ") +: Query.Empty //'+' is parsed to ' '
@@ -385,7 +385,7 @@ class UriSpec extends AnyWordSpec with Matchers {
       def relaxed(queryString: String): Query = Query(queryString, mode = Uri.ParsingMode.Relaxed)
       //#query-relaxed-mode
 
-      relaxed("") shouldEqual ("", "") +: Query.Empty
+      relaxed("") shouldEqual Query.Empty
       relaxed("a") shouldEqual ("a", "") +: Query.Empty
       relaxed("a=") shouldEqual ("a", "") +: Query.Empty
       relaxed("a=+") shouldEqual ("a", " ") +: Query.Empty
@@ -532,6 +532,9 @@ class UriSpec extends AnyWordSpec with Matchers {
       // empty host
       Uri("http://:8000/foo") shouldEqual Uri("http", Authority(Host.Empty, 8000), Path / "foo")
       Uri("http://:80/foo") shouldEqual Uri("http", Authority(Host.Empty, 0), Path / "foo")
+
+      Uri("?").query() shouldBe empty
+      Uri("?").query().toMap shouldBe empty
     }
 
     "properly complete a normalization cycle" in {


### PR DESCRIPTION
This still doesn't mean `Uri("") == Uri("?")`, because we'd like to keep
the distinction between "no query" and "empty query" (at least for historical
reasons).

Fixes #2769