### PR TITLE
build: configure travis git depth to fix sbt-dynver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ scala:
 
 sudo: false
 
+git:
+  depth: 500 # to make sure we have enough depth to power git describe for sbt-dynver (used for snapshot version numbers)
+
 before_install:
   # make comparing to origin/master work
   - git remote set-branches --add origin master && git fetch


### PR DESCRIPTION
Otherwise, git in travis will not know about tags sufficiently far in the
past and version numbers will be weird.

Fixes #3043