### PR TITLE
Allow customizing parsing errors

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/configure-parsing-error-response.backwards.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/configure-parsing-error-response.backwards.excludes
@@ -1,0 +1,13 @@
+# Not for user extension or pattern-matching
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ServerSettings.getParsingErrorHandler")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ServerSettings.parsingErrorHandler")
+# Internal
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.settings.ServerSettingsImpl.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.server.HttpServerBluePrint.controller")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.server.HttpServerBluePrint#ControllerStage.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.server.HttpServerBluePrint.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.server.HttpServerBluePrint.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.server.HttpServerBluePrint.controller")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -169,6 +169,15 @@ akka.http {
     # Modify to tweak parsing settings on the server-side only.
     parsing {
       # no overrides by default, see `akka.http.parsing` for default values
+
+      # Server-specific parsing settings:
+
+      # When a request is so malformed we cannot create a RequestContext out of it,
+      # the regular exception handling does not apply, and a default error handling
+      # is applied that only has access to the parse error and not the actual request.
+      # To customize this error response, set error-handler to the FQCN of an
+      # implementation of akka.http.ParsingErrorHandler
+      error-handler = "akka.http.DefaultParsingErrorHandler$"
     }
 
     # Enables/disables the logging of unencrypted HTTP traffic to and from the HTTP

--- a/akka-http-core/src/main/scala/akka/http/ParsingErrorHandler.scala
+++ b/akka-http-core/src/main/scala/akka/http/ParsingErrorHandler.scala
@@ -1,0 +1,22 @@
+package akka.http
+
+import akka.event.LoggingAdapter
+import akka.http.javadsl.{ model => jm }
+import akka.http.scaladsl.model.{ ErrorInfo, HttpResponse, StatusCode }
+import akka.http.scaladsl.settings.ServerSettings
+
+abstract class ParsingErrorHandler {
+  def handle(status: StatusCode, error: ErrorInfo, log: LoggingAdapter, settings: ServerSettings): jm.HttpResponse
+}
+
+object DefaultParsingErrorHandler extends ParsingErrorHandler {
+  import akka.http.impl.engine.parsing.logParsingError
+
+  override def handle(status: StatusCode, info: ErrorInfo, log: LoggingAdapter, settings: ServerSettings): HttpResponse = {
+    logParsingError(
+      info withSummaryPrepended s"Illegal request, responding with status '$status'",
+      log, settings.parserSettings.errorLoggingVerbosity)
+    val msg = if (settings.verboseErrorMessages) info.formatPretty else info.summary
+    HttpResponse(status, entity = msg)
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/ParsingErrorHandler.scala
+++ b/akka-http-core/src/main/scala/akka/http/ParsingErrorHandler.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http
 
 import akka.event.LoggingAdapter

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
@@ -43,7 +43,8 @@ private[akka] final case class ServerSettingsImpl(
   http2Settings:                       Http2ServerSettings,
   defaultHttpPort:                     Int,
   defaultHttpsPort:                    Int,
-  terminationDeadlineExceededResponse: HttpResponse) extends ServerSettings {
+  terminationDeadlineExceededResponse: HttpResponse,
+  parsingErrorHandler:                 String) extends ServerSettings {
 
   require(0 < maxConnections, "max-connections must be > 0")
   require(0 < pipeliningLimit && pipeliningLimit <= 1024, "pipelining-limit must be > 0 and <= 1024")
@@ -102,7 +103,8 @@ private[http] object ServerSettingsImpl extends SettingsCompanionImpl[ServerSett
     Http2ServerSettings.Http2ServerSettingsImpl.fromSubConfig(root, c.getConfig("http2")),
     c.getInt("default-http-port"),
     c.getInt("default-https-port"),
-    terminationDeadlineExceededResponseFrom(c)
+    terminationDeadlineExceededResponseFrom(c),
+    c.getString("parsing.error-handler")
   )
 
   private def terminationDeadlineExceededResponseFrom(c: Config): HttpResponse = {

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
@@ -46,6 +46,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def getDefaultHttpPort: Int
   def getDefaultHttpsPort: Int
   def getTerminationDeadlineExceededResponse: akka.http.javadsl.model.HttpResponse
+  def getParsingErrorHandler: String
 
   // ---
 
@@ -73,7 +74,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def withDefaultHttpsPort(newValue: Int): ServerSettings = self.copy(defaultHttpPort = newValue)
   def withTerminationDeadlineExceededResponse(response: akka.http.javadsl.model.HttpResponse): ServerSettings =
     self.copy(terminationDeadlineExceededResponse = response.asScala)
-
+  def withParsingErrorHandler(newValue: String): ServerSettings = self.copy(parsingErrorHandler = parsingErrorHandler)
 }
 
 object ServerSettings extends SettingsCompanion[ServerSettings] {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -13,6 +13,7 @@ import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
 import akka.event.{ Logging, LoggingAdapter }
+import akka.http.ParsingErrorHandler
 import akka.http.impl.engine.Http2Shadow
 import akka.http.impl.engine.HttpConnectionIdleTimeoutBidi
 import akka.http.impl.engine.client.PoolMasterActor.{ PoolSize, ShutdownAll }
@@ -360,7 +361,8 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
     remoteAddress:      Option[InetSocketAddress] = None,
     log:                LoggingAdapter            = system.log,
     isSecureConnection: Boolean                   = false): ServerLayer = {
-    val server = HttpServerBluePrint(settings, log, isSecureConnection)
+    val parsingErrorHandler = system.dynamicAccess.createInstanceFor[ParsingErrorHandler](settings.parsingErrorHandler, Nil).get
+    val server = HttpServerBluePrint(settings, parsingErrorHandler, log, isSecureConnection)
       .addAttributes(HttpAttributes.remoteAddress(remoteAddress))
 
     server atop delayCancellationStage(settings)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -51,6 +51,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def defaultHttpPort: Int
   def defaultHttpsPort: Int
   def terminationDeadlineExceededResponse: HttpResponse
+  def parsingErrorHandler: String
 
   /* Java APIs */
 
@@ -76,6 +77,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   override def getDefaultHttpsPort: Int = defaultHttpsPort
   override def getTerminationDeadlineExceededResponse: akka.http.javadsl.model.HttpResponse =
     terminationDeadlineExceededResponse
+  override def getParsingErrorHandler: String = parsingErrorHandler
   // ---
 
   // override for more specific return type
@@ -97,6 +99,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   override def withDefaultHttpsPort(newValue: Int): ServerSettings = self.copy(defaultHttpsPort = newValue)
   override def withTerminationDeadlineExceededResponse(response: akka.http.javadsl.model.HttpResponse): ServerSettings =
     self.copy(terminationDeadlineExceededResponse = response.asScala)
+  override def withParsingErrorHandler(newValue: String) = self.copy(parsingErrorHandler = newValue)
 
   // overloads for Scala idiomatic use
   def withTimeouts(newValue: ServerSettings.Timeouts): ServerSettings = self.copy(timeouts = newValue)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.http.impl.engine.server
 
-import java.net.{InetAddress, InetSocketAddress}
+import java.net.{ InetAddress, InetSocketAddress }
 
 import akka.event.LoggingAdapter
 import akka.http.ParsingErrorHandler

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -4,10 +4,13 @@
 
 package akka.http.impl.engine.server
 
-import java.net.{ InetAddress, InetSocketAddress }
+import java.net.{InetAddress, InetSocketAddress}
 
+import akka.event.LoggingAdapter
+import akka.http.ParsingErrorHandler
 import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.http.impl.util._
+import akka.http.javadsl.model
 import akka.http.scaladsl.Http.ServerLayer
 import akka.http.scaladsl.model.HttpEntity._
 import akka.http.scaladsl.model.HttpMethods._
@@ -32,6 +35,11 @@ import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.util.Random
+
+object TestParsingErrorHandler extends ParsingErrorHandler {
+  override def handle(status: StatusCode, error: ErrorInfo, log: LoggingAdapter, settings: ServerSettings): HttpResponse =
+    HttpResponse(StatusCodes.ImATeapot, entity = HttpEntity("Tea hea"))
+}
 
 class HttpServerSpec extends AkkaSpec(
   """akka.loggers = ["akka.http.impl.util.SilenceAllTestEventListener"]
@@ -1458,6 +1466,29 @@ class HttpServerSpec extends AkkaSpec(
       netOut.expectComplete()
     })
 
+    "allow overriding the URI parsing error response" in assertAllStagesStopped(new TestSetup {
+      override def settings: ServerSettings = super.settings.withParsingErrorHandler("akka.http.impl.engine.server.TestParsingErrorHandler$")
+
+      send("""GET http://www.example.com/unparsable HTTP/1.1
+             |Host: www.example.net
+             |
+             |""")
+
+      requests.request(1)
+
+      expectResponseWithWipedDate(
+        """|HTTP/1.1 418 I'm a teapot
+           |Server: akka-http/test
+           |Date: XXXX
+           |Connection: close
+           |Content-Type: text/plain; charset=UTF-8
+           |Content-Length: 7
+           |
+           |Tea hea""")
+
+      netIn.sendComplete()
+      netOut.expectComplete()
+    })
   }
   class TestSetup(maxContentLength: Int = -1) extends HttpServerTestSetupBase {
     implicit def system = spec.system


### PR DESCRIPTION
Refs #210

A bit unfortunate that ServerSettings includes the class name and
not the object, but to instantiate the class it'd be good to use
system.dynamicAccess and that is not available when creating the
settings...