### PR TITLE
gracefully discard unsupported h2 SETTINGS

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
@@ -25,7 +25,7 @@ private[http] object Http2FrameParsing {
       if (payload.hasRemaining) {
         val id = payload.readShortBE()
         val value = payload.readIntBE()
-        if (isKnownId(id)) readSettings(Setting(SettingIdentifier.byId(id), value) :: read)
+        if (SettingIdentifier.isKnownId(id)) readSettings(Setting(SettingIdentifier.byId(id), value) :: read)
         else readSettings(read)
       } else read.reverse
 

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
@@ -9,7 +9,6 @@ import scala.collection.immutable
 import akka.stream.Attributes
 import akka.stream.impl.io.ByteStringParser
 import akka.stream.stage.GraphStageLogic
-import Http2Protocol.FrameType._
 import Http2Protocol.{ ErrorCode, Flags, FrameType, SettingIdentifier }
 import akka.annotation.InternalApi
 import FrameEvent._
@@ -75,11 +74,11 @@ private[http2] class Http2FrameParsing(shouldReadPreface: Boolean) extends ByteS
       def parseFrame(tpe: FrameType, flags: ByteFlag, streamId: Int, payload: ByteReader): FrameEvent = {
         // TODO: add @switch? seems non-trivial for now
         tpe match {
-          case GOAWAY =>
+          case FrameType.GOAWAY =>
             Http2Compliance.requireZeroStreamId(streamId)
             GoAwayFrame(payload.readIntBE(), ErrorCode.byId(payload.readIntBE()), payload.takeAll())
 
-          case HEADERS =>
+          case FrameType.HEADERS =>
             val pad = Flags.PADDED.isSet(flags)
             val endStream = Flags.END_STREAM.isSet(flags)
             val endHeaders = Flags.END_HEADERS.isSet(flags)
@@ -103,7 +102,7 @@ private[http2] class Http2FrameParsing(shouldReadPreface: Boolean) extends ByteS
 
             HeadersFrame(streamId, endStream, endHeaders, payload.take(payload.remainingSize - paddingLength), priorityInfo)
 
-          case DATA =>
+          case FrameType.DATA =>
             val pad = Flags.PADDED.isSet(flags)
             val endStream = Flags.END_STREAM.isSet(flags)
 
@@ -113,7 +112,7 @@ private[http2] class Http2FrameParsing(shouldReadPreface: Boolean) extends ByteS
 
             DataFrame(streamId, endStream, payload.take(payload.remainingSize - paddingLength))
 
-          case SETTINGS =>
+          case FrameType.SETTINGS =>
             val ack = Flags.ACK.isSet(flags)
             Http2Compliance.requireZeroStreamId(streamId)
 
@@ -129,7 +128,7 @@ private[http2] class Http2FrameParsing(shouldReadPreface: Boolean) extends ByteS
               SettingsFrame(readSettings(payload))
             }
 
-          case WINDOW_UPDATE =>
+          case FrameType.WINDOW_UPDATE =>
             // TODO: check frame size
             // TODO: check flags
             val increment = payload.readIntBE()
@@ -137,24 +136,24 @@ private[http2] class Http2FrameParsing(shouldReadPreface: Boolean) extends ByteS
 
             WindowUpdateFrame(streamId, increment)
 
-          case CONTINUATION =>
+          case FrameType.CONTINUATION =>
             val endHeaders = Flags.END_HEADERS.isSet(flags)
 
             ContinuationFrame(streamId, endHeaders, payload.remainingData)
 
-          case PING =>
+          case FrameType.PING =>
             // see 6.7
             Http2Compliance.requireFrameSize(payload.remainingSize, 8)
             Http2Compliance.requireZeroStreamId(streamId)
             val ack = Flags.ACK.isSet(flags)
             PingFrame(ack, payload.remainingData)
 
-          case RST_STREAM =>
+          case FrameType.RST_STREAM =>
             Http2Compliance.requireFrameSize(payload.remainingSize, 4)
             Http2Compliance.requireNonZeroStreamId(streamId)
             RstStreamFrame(streamId, ErrorCode.byId(payload.readIntBE()))
 
-          case PRIORITY =>
+          case FrameType.PRIORITY =>
             Http2Compliance.requireFrameSize(payload.remainingSize, 5)
             val streamDependency = payload.readIntBE() // whole word
             val exclusiveFlag = (streamDependency >>> 31) == 1 // most significant bit for exclusive flag
@@ -163,7 +162,7 @@ private[http2] class Http2FrameParsing(shouldReadPreface: Boolean) extends ByteS
             Http2Compliance.requireNoSelfDependency(streamId, dependencyId)
             PriorityFrame(streamId, exclusiveFlag, dependencyId, priority)
 
-          case PUSH_PROMISE =>
+          case FrameType.PUSH_PROMISE =>
             val pad = Flags.PADDED.isSet(flags)
             val endHeaders = Flags.END_HEADERS.isSet(flags)
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
@@ -263,7 +263,7 @@ class Http2FramingSpec extends AkkaSpecWithMaterializer {
         )))
       }
       // 6.5.3: An endpoint that receives a SETTINGS frame with any unknown or unsupported identifier MUST ignore that setting
-      "with an unknown setting" in {
+      "with an experimental, unknown setting" in {
         // As observed being sent by grpcc in the first SETTINGS frame:
         b"""xxxxxxxx
             xxxxxxxx
@@ -280,6 +280,26 @@ class Http2FramingSpec extends AkkaSpecWithMaterializer {
             xxxxxxxx
             xxxxxxxx
             xxxxxxxx=1
+         """ should parseTo(SettingsFrame(Nil), checkRendering = false)
+      }
+      // 6.5.3: An endpoint that receives a SETTINGS frame with any unknown or unsupported identifier MUST ignore that setting
+      "with an unsupported setting" in {
+        // As observed being sent by envoy 1.14.1 in the first SETTINGS frame:
+        b"""xxxxxxxx
+            xxxxxxxx
+            xxxxxxxx=6   # length
+            00000100     # type = 0x4 = SETTINGS
+            00000000     # no flags
+            xxxxxxxx
+            xxxxxxxx
+            xxxxxxxx
+            xxxxxxxx=0   # no stream ID
+            xxxxxxxx
+            xxxxxxxx=8   # SETTINGS_ENABLE_CONNECT_PROTOCOL https://www.iana.org/assignments/http2-parameters/http2-parameters.xhtml#settings
+            xxxxxxxx
+            xxxxxxxx
+            xxxxxxxx
+            xxxxxxxx=0
          """ should parseTo(SettingsFrame(Nil), checkRendering = false)
       }
       "ack" in {


### PR DESCRIPTION
References https://github.com/akka/akka-http/pull/2039

I ran into that when bumping Envoy, running in front of my `akka-grpc` service, from 1.13.0 to 1.14.1. 
```
15:40:39.584 [debug] a.i.TcpListener - New connection accepted
15:40:39.602 [debug] a.h.i.e.h.Http2ServerDemux - Changing state from Idle to WaitingForNetworkToSendControlFrames
15:40:39.603 [debug] a.h.i.e.h.Http2ServerDemux - Changing state from WaitingForNetworkToSendControlFrames to Idle
15:40:39.603 [debug] a.h.i.e.h.Http2ServerDemux - Changing state from Idle to WaitingForData
15:40:39.608 [debug] a.a.RepointableActorRef - Aborting tcp connection to /127.0.0.1:35878 because of upstream failure: akka.stream.impl.io.ByteStringParser$ParsingException: Parsing failed in step akka.http.impl.engine.http2.framing.Http2FrameParsing$$anon$1$ReadFrame$@1266e312
akka.stream.impl.io.ByteStringParser$ParsingLogic.doParseInner(ByteStringParser.scala:83)
akka.stream.impl.io.ByteStringParser$ParsingLogic.doParse(ByteStringParser.scala:106)
akka.stream.impl.io.ByteStringParser$ParsingLogic.onPush(ByteStringParser.scala:127)
akka.stream.impl.fusing.GraphInterpreter.processPush(GraphInterpreter.scala:541)
akka.stream.impl.fusing.GraphInterpreter.execute(GraphInterpreter.scala:423)
akka.stream.impl.fusing.GraphInterpreterShell.runBatch(ActorGraphInterpreter.scala:624)
akka.stream.impl.fusing.ActorGraphInterpreter$SimpleBoundaryEvent.execute(ActorGraphInterpreter.scala:55)
akka.stream.impl.fusing.ActorGraphInterpreter$SimpleBoundaryEvent.execute$(ActorGraphInterpreter.scala:51)
akka.stream.impl.fusing.ActorGraphInterpreter$BatchingActorInputBoundary$OnNext.execute(ActorGraphInterpreter.scala:94)
akka.stream.impl.fusing.GraphInterpreterShell.processEvent(ActorGraphInterpreter.scala:599)
akka.stream.impl.fusing.ActorGraphInterpreter.akka$stream$impl$fusing$ActorGraphInterpreter$$processEvent(ActorGraphInterpreter.scala:768)
akka.stream.impl.fusing.ActorGraphInterpreter$$anonfun$receive$1.applyOrElse(ActorGraphInterpreter.scala:783)
akka.actor.Actor.aroundReceive(Actor.scala:534)
akka.actor.Actor.aroundReceive$(Actor.scala:532)
akka.stream.impl.fusing.ActorGraphInterpreter.aroundReceive(ActorGraphInterpreter.scala:690)
akka.actor.ActorCell.receiveMessage(ActorCell.scala:573)
akka.actor.ActorCell.invoke(ActorCell.scala:543)
akka.dispatch.Mailbox.processMailbox(Mailbox.scala:269)
akka.dispatch.Mailbox.run(Mailbox.scala:230)
akka.dispatch.Mailbox.exec(Mailbox.scala:242)
java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
```

It turns out that Envoy is now sending [quite a few new settings including `SETTINGS_ENABLE_CONNECT_PROTOCOL/0x8`](ed138bc8d20eee664368960ecfa29a73R946), which is [quite recent](https://tools.ietf.org/html/rfc8441#section-9.1) (my wireshark does not recognize it).
```
HyperText Transfer Protocol 2
    Stream: Magic
        Magic: PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n
    Stream: SETTINGS, Stream ID: 0, Length 30
        Length: 30
        Type: SETTINGS (4)
        Flags: 0x00
        0... .... .... .... .... .... .... .... = Reserved: 0x0
        .000 0000 0000 0000 0000 0000 0000 0000 = Stream Identifier: 0
        Settings - Enable PUSH : 0
            Settings Identifier: Enable PUSH (2)
            Enable PUSH: 0
        Settings - Header table size : 4096
            Settings Identifier: Header table size (1)
            Header table size: 4096
        Settings - Unknown (8) : 0
            Settings Identifier: Unknown (8)
            Unknown Settings: 0
        Settings - Max concurrent streams : 2147483647
            Settings Identifier: Max concurrent streams (3)
            Max concurrent streams: 2147483647
        Settings - Initial Windows size : 268435456
            Settings Identifier: Initial Windows size (4)
            Initial Windows Size: 268435456
```