### PR TITLE
Docs: reduce redirects, prefer https

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/SimpleHeaders.scala
@@ -22,43 +22,43 @@ private[parser] trait SimpleHeaders { this: Parser with CommonRules with CommonA
     ("none" ~ push(Nil) | zeroOrMore(ws(',')) ~ oneOrMore(`range-unit`).separatedBy(listSep)) ~ EOI ~> (`Accept-Ranges`(_))
   }
 
-  // http://www.w3.org/TR/cors/#access-control-allow-credentials-response-header
+  // https://www.w3.org/TR/cors/#access-control-allow-credentials-response-header
   // in addition to the spec we also allow for a `false` value
   def `access-control-allow-credentials` = rule(
     ("true" ~ push(`Access-Control-Allow-Credentials`(true))
       | "false" ~ push(`Access-Control-Allow-Credentials`(false))) ~ EOI)
 
-  // http://www.w3.org/TR/cors/#access-control-allow-headers-response-header
+  // https://www.w3.org/TR/cors/#access-control-allow-headers-response-header
   def `access-control-allow-headers` = rule {
     zeroOrMore(token).separatedBy(listSep) ~ EOI ~> (`Access-Control-Allow-Headers`(_))
   }
 
-  // http://www.w3.org/TR/cors/#access-control-allow-methods-response-header
+  // https://www.w3.org/TR/cors/#access-control-allow-methods-response-header
   def `access-control-allow-methods` = rule {
     zeroOrMore(httpMethodDef).separatedBy(listSep) ~ EOI ~> (`Access-Control-Allow-Methods`(_))
   }
 
-  // http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
+  // https://www.w3.org/TR/cors/#access-control-allow-origin-response-header
   def `access-control-allow-origin` = rule(
     ws('*') ~ EOI ~ push(`Access-Control-Allow-Origin`.`*`)
       | `origin-list-or-null` ~ EOI ~> (origins => `Access-Control-Allow-Origin`.forRange(HttpOriginRange(origins: _*))))
 
-  // http://www.w3.org/TR/cors/#access-control-expose-headers-response-header
+  // https://www.w3.org/TR/cors/#access-control-expose-headers-response-header
   def `access-control-expose-headers` = rule {
     zeroOrMore(token).separatedBy(listSep) ~ EOI ~> (`Access-Control-Expose-Headers`(_))
   }
 
-  // http://www.w3.org/TR/cors/#access-control-max-age-response-header
+  // https://www.w3.org/TR/cors/#access-control-max-age-response-header
   def `access-control-max-age` = rule {
     `delta-seconds` ~ EOI ~> (`Access-Control-Max-Age`(_))
   }
 
-  // http://www.w3.org/TR/cors/#access-control-request-headers-request-header
+  // https://www.w3.org/TR/cors/#access-control-request-headers-request-header
   def `access-control-request-headers` = rule {
     zeroOrMore(token).separatedBy(listSep) ~ EOI ~> (`Access-Control-Request-Headers`(_))
   }
 
-  // http://www.w3.org/TR/cors/#access-control-request-method-request-header
+  // https://www.w3.org/TR/cors/#access-control-request-method-request-header
   def `access-control-request-method` = rule {
     httpMethodDef ~ EOI ~> (`Access-Control-Request-Method`(_))
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
@@ -229,7 +229,7 @@ private[http] final class UriParser(
     clearSB() ~ oneOrMore(`query-char` ~ appendSB() | `pct-encoded`) ~ run(setRawQueryString(sb.toString)) | run(setRawQueryString(""))
   }
 
-  // http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
+  // https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
   def query: Rule1[Query] = {
     def part(`query-char`: CharPredicate) =
       rule(clearSBForDecoding() ~

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -222,7 +222,7 @@ final case class `Accept-Ranges`(rangeUnits: immutable.Seq[RangeUnit]) extends j
   def getRangeUnits: Iterable[jm.headers.RangeUnit] = rangeUnits.asJava
 }
 
-// http://www.w3.org/TR/cors/#access-control-allow-credentials-response-header
+// https://www.w3.org/TR/cors/#access-control-allow-credentials-response-header
 object `Access-Control-Allow-Credentials` extends ModeledCompanion[`Access-Control-Allow-Credentials`]
 final case class `Access-Control-Allow-Credentials`(allow: Boolean)
   extends jm.headers.AccessControlAllowCredentials with ResponseHeader {
@@ -230,7 +230,7 @@ final case class `Access-Control-Allow-Credentials`(allow: Boolean)
   protected def companion = `Access-Control-Allow-Credentials`
 }
 
-// http://www.w3.org/TR/cors/#access-control-allow-headers-response-header
+// https://www.w3.org/TR/cors/#access-control-allow-headers-response-header
 object `Access-Control-Allow-Headers` extends ModeledCompanion[`Access-Control-Allow-Headers`] {
   @pre213
   def apply(headers: String*): `Access-Control-Allow-Headers` =
@@ -250,7 +250,7 @@ final case class `Access-Control-Allow-Headers`(headers: immutable.Seq[String])
   def getHeaders: Iterable[String] = headers.asJava
 }
 
-// http://www.w3.org/TR/cors/#access-control-allow-methods-response-header
+// https://www.w3.org/TR/cors/#access-control-allow-methods-response-header
 object `Access-Control-Allow-Methods` extends ModeledCompanion[`Access-Control-Allow-Methods`] {
   @pre213
   def apply(methods: HttpMethod*): `Access-Control-Allow-Methods` =
@@ -270,7 +270,7 @@ final case class `Access-Control-Allow-Methods`(methods: immutable.Seq[HttpMetho
   def getMethods: Iterable[jm.HttpMethod] = methods.asJava
 }
 
-// http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
+// https://www.w3.org/TR/cors/#access-control-allow-origin-response-header
 object `Access-Control-Allow-Origin` extends ModeledCompanion[`Access-Control-Allow-Origin`] {
   val `*` = forRange(HttpOriginRange.`*`)
   val `null` = forRange(HttpOriginRange())
@@ -279,7 +279,7 @@ object `Access-Control-Allow-Origin` extends ModeledCompanion[`Access-Control-Al
   /**
    * Creates an `Access-Control-Allow-Origin` header for the given origin range.
    *
-   * CAUTION: Even though allowed by the spec (http://www.w3.org/TR/cors/#access-control-allow-origin-response-header)
+   * CAUTION: Even though allowed by the spec (https://www.w3.org/TR/cors/#access-control-allow-origin-response-header)
    * `Access-Control-Allow-Origin` headers with more than a single origin appear to be largely unsupported in the field.
    * Make sure to thoroughly test such usages with all expected clients!
    */
@@ -291,7 +291,7 @@ final case class `Access-Control-Allow-Origin` private (range: HttpOriginRange)
   protected def companion = `Access-Control-Allow-Origin`
 }
 
-// http://www.w3.org/TR/cors/#access-control-expose-headers-response-header
+// https://www.w3.org/TR/cors/#access-control-expose-headers-response-header
 object `Access-Control-Expose-Headers` extends ModeledCompanion[`Access-Control-Expose-Headers`] {
   @pre213
   def apply(headers: String*): `Access-Control-Expose-Headers` =
@@ -311,7 +311,7 @@ final case class `Access-Control-Expose-Headers`(headers: immutable.Seq[String])
   def getHeaders: Iterable[String] = headers.asJava
 }
 
-// http://www.w3.org/TR/cors/#access-control-max-age-response-header
+// https://www.w3.org/TR/cors/#access-control-max-age-response-header
 object `Access-Control-Max-Age` extends ModeledCompanion[`Access-Control-Max-Age`]
 final case class `Access-Control-Max-Age`(deltaSeconds: Long) extends jm.headers.AccessControlMaxAge
   with ResponseHeader {
@@ -319,7 +319,7 @@ final case class `Access-Control-Max-Age`(deltaSeconds: Long) extends jm.headers
   protected def companion = `Access-Control-Max-Age`
 }
 
-// http://www.w3.org/TR/cors/#access-control-request-headers-request-header
+// https://www.w3.org/TR/cors/#access-control-request-headers-request-header
 object `Access-Control-Request-Headers` extends ModeledCompanion[`Access-Control-Request-Headers`] {
   @pre213
   def apply(headers: String*): `Access-Control-Request-Headers` =
@@ -339,7 +339,7 @@ final case class `Access-Control-Request-Headers`(headers: immutable.Seq[String]
   def getHeaders: Iterable[String] = headers.asJava
 }
 
-// http://www.w3.org/TR/cors/#access-control-request-method-request-header
+// https://www.w3.org/TR/cors/#access-control-request-method-request-header
 object `Access-Control-Request-Method` extends ModeledCompanion[`Access-Control-Request-Method`]
 final case class `Access-Control-Request-Method`(method: HttpMethod) extends jm.headers.AccessControlRequestMethod
   with RequestHeader {

--- a/build.sbt
+++ b/build.sbt
@@ -336,7 +336,6 @@ lazy val docs = project("docs")
       }),
       "jackson.version" -> Dependencies.jacksonVersion,
       "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/${AkkaDependency.akkaVersion}/%s",
-      "extref.akka25-docs.base_url" -> s"https://doc.akka.io/docs/akka/2.5/%s",
       "javadoc.akka.http.base_url" -> {
         val v = if (isSnapshot.value) "current" else version.value
         s"https://doc.akka.io/japi/akka-http/$v"

--- a/docs/src/main/paradox/client-side/client-https-support.md
+++ b/docs/src/main/paradox/client-side/client-https-support.md
@@ -52,7 +52,7 @@ SSL Config settings used by Akka HTTP (as well as Streaming TCP) are located und
 
 ## Detailed configuration and workarounds
 
-Akka HTTP relies on [Lightbend SSL-Config](https://lightbend.github.io/ssl-config) which is a library maintained by Lightbend that makes configuring
+Akka HTTP relies on [Lightbend SSL-Config](https://lightbend.github.io/ssl-config/) which is a library maintained by Lightbend that makes configuring
 things related to SSL/TLS much simpler than using the raw SSL APIs provided by the JDK. Please refer to its
 documentation to learn more about it.
 

--- a/docs/src/main/paradox/common/sse-support.md
+++ b/docs/src/main/paradox/common/sse-support.md
@@ -1,6 +1,6 @@
 # Server-Sent Events Support
 
-Server-Sent Events (SSE) is a lightweight and [standardized](https://www.w3.org/TR/eventsource)
+Server-Sent Events (SSE) is a lightweight and [standardized](https://www.w3.org/TR/eventsource/)
 protocol for pushing notifications from a HTTP server to a client. In contrast to WebSocket, which
 offers bi-directional communication, SSE only allows for one-way communication from the server to
 the client. If that's all you need, SSE has the advantages to be much simpler, to rely on HTTP only
@@ -57,5 +57,5 @@ Java
 :  @@snip [EventStreamMarshallingTest.java]($akka-http$/akka-http-tests/src/test/java/akka/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java) { #event-stream-unmarshalling-example }
 
 Notice that if you are looking for a resilient way to permanently subscribe to an event stream,
-Alpakka provides the [EventSource](https://developer.lightbend.com/docs/alpakka/current/sse.html)
+Alpakka provides the [EventSource](https://doc.akka.io/docs/alpakka/current/sse.html)
 connector which reconnects automatically with the id of the last seen event.

--- a/docs/src/main/paradox/contributing.md
+++ b/docs/src/main/paradox/contributing.md
@@ -2,6 +2,6 @@
 
 # Welcome!
 
-We follow the standard GitHub [fork & pull](https://help.github.com/articles/using-pull-requests/#fork--pull) approach to pull requests. Just fork the official repo, develop in a branch, and submit a PR!
+We follow the standard GitHub [fork & pull](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#fork--pull) approach to pull requests. Just fork the official repo, develop in a branch, and submit a PR!
 
 For a more detailed description of our process, please refer to the [CONTRIBUTING.md](https://github.com/akka/akka-http/blob/master/CONTRIBUTING.md) page on the github project.

--- a/docs/src/main/paradox/handling-blocking-operations-in-akka-http-routes.md
+++ b/docs/src/main/paradox/handling-blocking-operations-in-akka-http-routes.md
@@ -93,7 +93,7 @@ my-blocking-dispatcher {
 }
 ```
 
-There are many dispatcher options available which can be found in @extref[Dispatchers](akka-docs:scala/dispatchers.html).
+There are many dispatcher options available which can be found in @extref[Dispatchers](akka-docs:dispatchers.html).
 
 Here `thread-pool-executor` is used, which has a hardcoded limit of threads. It keeps a set number of threads
 available that allow for safe isolation of the blocking operations. The size settings should depend on the app's

--- a/docs/src/main/paradox/migration-guide/migration-from-old-http-javadsl.md
+++ b/docs/src/main/paradox/migration-guide/migration-from-old-http-javadsl.md
@@ -66,4 +66,4 @@ As always, feel free to reach out via the [akka-user](https://groups.google.com/
 to seek help or guidance when migrating from the old APIs. 
 
 For Lightbend subscription owners it is possible to reach out to the core team for help in the migration by asking specific 
-questions via the [Lightbend customer portal](https://portal.lightbend.com/).
+questions via the [Lightbend customer portal](https://portal.lightbend.com/account/login).

--- a/docs/src/main/paradox/routing-dsl/HttpApp.md
+++ b/docs/src/main/paradox/routing-dsl/HttpApp.md
@@ -68,7 +68,7 @@ Scala
 Java
 :   @@snip [HttpAppExampleTest.java]($test$/java/docs/http/javadsl/server/HttpAppExampleTest.java) { #minimal-imports #ownActorSystem }
 
-When you provide your own @apidoc[akka.actor.ActorSystem] you are responsible for terminating it. For more fine-grained control over the shutdown of various parts of the application, take a look at @scala[@extref[Coordinated Shutdown](akka25-docs:scala/actors.html#coordinated-shutdown)]@java[@extref[Coordinated Shutdown](akka25-docs:java/actors.html#coordinated-shutdown)] extension which is available since Akka 2.5.0.
+When you provide your own @apidoc[akka.actor.ActorSystem] you are responsible for terminating it. For more fine-grained control over the shutdown of various parts of the application, take a look at @extref[Coordinated Shutdown](akka-docs:actors.html#coordinated-shutdown) extension which is available since Akka 2.5.
 
 
 

--- a/docs/src/main/paradox/routing-dsl/directives/cache-condition-directives/conditional.md
+++ b/docs/src/main/paradox/routing-dsl/directives/cache-condition-directives/conditional.md
@@ -11,14 +11,14 @@
 ## Description
 
 Wraps its inner route with support for Conditional Requests as defined
-by [http://tools.ietf.org/html/draft-ietf-httpbis-p4-conditional-26](http://tools.ietf.org/html/draft-ietf-httpbis-p4-conditional-26).
+by [https://tools.ietf.org/html/draft-ietf-httpbis-p4-conditional-26](https://tools.ietf.org/html/draft-ietf-httpbis-p4-conditional-26).
 
 Depending on the given `eTag` and `lastModified` values this directive immediately responds with
 `304 Not Modified` or `412 Precondition Failed` (without calling its inner route) if the request comes with the
 respective conditional headers. Otherwise the request is simply passed on to its inner route.
 
-The algorithm implemented by this directive closely follows what is defined in [this section](http://tools.ietf.org/html/draft-ietf-httpbis-p4-conditional-26#section-6) of the
-[HTTPbis spec](https://datatracker.ietf.org/wg/httpbis/).
+The algorithm implemented by this directive closely follows what is defined in [this section](https://tools.ietf.org/html/draft-ietf-httpbis-p4-conditional-26#section-6) of the
+[HTTPbis spec](https://datatracker.ietf.org/wg/httpbis/documents/).
 
 All responses (the ones produces by this directive itself as well as the ones coming back from the inner route) are
 augmented with respective @apidoc[ETag] and `Last-Modified` response headers.

--- a/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formField.md
+++ b/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formField.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Allows extracting a single Form field sent in the request. Data posted from [HTML Forms](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type `multipart/form-data`.
+Allows extracting a single Form field sent in the request. Data posted from [HTML Forms](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type `multipart/form-data`.
 
 @scala[See @ref[formFields](formFields.md) for an in-depth description.]
 

--- a/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFieldMap.md
+++ b/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFieldMap.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Extracts all HTTP form fields at once as a @scala[`Map[String, String]`]@java[`Map<String, String>`] mapping form field names to form field values. Data posted from [HTML Forms](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type `multipart/form-data`.
+Extracts all HTTP form fields at once as a @scala[`Map[String, String]`]@java[`Map<String, String>`] mapping form field names to form field values. Data posted from [HTML Forms](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type `multipart/form-data`.
 
 If form data contain a field value several times, the map will contain the last one.
 

--- a/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFieldMultiMap.md
+++ b/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFieldMultiMap.md
@@ -11,7 +11,7 @@
 ## Description
 
 Extracts all HTTP form fields at once as a multi-map of type @scala[`Map[String, List[String]]`]@java[`Map<String, List<String>>`] mapping
-a form name to a list of all its values. Data posted from [HTML Forms](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type `multipart/form-data`.
+a form name to a list of all its values. Data posted from [HTML Forms](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type `multipart/form-data`.
 
 This directive can be used if form fields can occur several times.
 

--- a/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFieldSeq.md
+++ b/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFieldSeq.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-Extracts all HTTP form fields at once in the original order as (name, value) tuples of type @scala[`(String, String)`]@java[`Map.Entry<String, String>`]. Data posted from [HTML Forms](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type `multipart/form-data`.
+Extracts all HTTP form fields at once in the original order as (name, value) tuples of type @scala[`(String, String)`]@java[`Map.Entry<String, String>`]. Data posted from [HTML Forms](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type `multipart/form-data`.
 
 This directive can be used if the exact order of form fields is important or if parameters can occur several times.
 

--- a/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFields.md
+++ b/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFields.md
@@ -69,7 +69,7 @@ Query parameters can be handled in a similar way, see @ref[parameters](../parame
 
 ## Unmarshalling
 
-Data POSTed from [HTML forms](http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type
+Data POSTed from [HTML forms](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4) is either of type `application/x-www-form-urlencoded` or of type
 `multipart/form-data`. The value of an url-encoded field is a `String` while the value of a
 `multipart/form-data`-encoded field is a "body part" containing an entity. This means that different kind of unmarshallers are needed depending
 on what the Content-Type of the request is:

--- a/docs/src/main/paradox/routing-dsl/directives/security-directives/authenticateOrRejectWithChallenge.md
+++ b/docs/src/main/paradox/routing-dsl/directives/security-directives/authenticateOrRejectWithChallenge.md
@@ -15,7 +15,7 @@ Lifts an authenticator function into a directive.
 
 This directive allows implementing the low level challenge-response type of authentication that some services may require.
 
-More details about challenge-response authentication are available in the [RFC 2617](https://tools.ietf.org/html/rfc2617), [RFC 7616](https://tools.ietf.org/html/rfc7616) and [RFC 7617](http://tools.ietf.org/html/rfc7617).
+More details about challenge-response authentication are available in the [RFC 2617](https://tools.ietf.org/html/rfc2617), [RFC 7616](https://tools.ietf.org/html/rfc7616) and [RFC 7617](https://tools.ietf.org/html/rfc7617).
 
 ## Example
 

--- a/docs/src/main/paradox/routing-dsl/directives/security-directives/index.md
+++ b/docs/src/main/paradox/routing-dsl/directives/security-directives/index.md
@@ -49,7 +49,7 @@ The "HTTP Authentication Scheme Registry" defines the namespace for the authenti
 credentials. You can see the currently registered schemes at [IANA HTTP Authentication Scheme Registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
 
 At this point Akka HTTP only implements the "'Basic' HTTP Authentication Scheme" whose most current specification can be
-found here: <https://datatracker.ietf.org/doc/draft-ietf-httpauth-basicauth-update>.
+found here: <https://datatracker.ietf.org/doc/rfc7617/>.
 
 ## Low-level OAuth2 "Bearer Token" directives
 

--- a/docs/src/main/paradox/routing-dsl/directives/websocket-directives/handleWebSocketMessagesForOptionalProtocol.md
+++ b/docs/src/main/paradox/routing-dsl/directives/websocket-directives/handleWebSocketMessagesForOptionalProtocol.md
@@ -13,7 +13,7 @@
 Handles WebSocket requests with the given handler and rejects other requests with an
 @apidoc[ExpectedWebSocketRequestRejection$].
 
-If the `subprotocol` parameter is @scala[None]@java[@javadoc:[empty](java.util.optional#empty--)] any WebSocket request is accepted. If the `subprotocol` parameter is
+If the `subprotocol` parameter is @scala[None]@java[@javadoc:[empty](java.util.Optional#empty())] any WebSocket request is accepted. If the `subprotocol` parameter is
 @scala[`Some(protocol)`]@java[a non-empty @javadoc:[Optional](java.util.Optional)] a WebSocket request is only accepted if the list of subprotocols supported by the client (as
 announced in the WebSocket request) @scala[contains `protocol`]@java[matches the contained subprotocol]. If the client did not offer the protocol in question
 the request is rejected with an @apidoc[UnsupportedWebSocketSubprotocolRejection].

--- a/docs/src/main/paradox/routing-dsl/exception-handling.md
+++ b/docs/src/main/paradox/routing-dsl/exception-handling.md
@@ -84,7 +84,7 @@ so as a rule of thumb, you should try to minimize the number of `Throwable` inst
 reaching the exception handler.
 
 To understand the performance implications of (mis-)using exceptions,
-have a read at this excellent post by A. Shipilёv: [The Exceptional Performance of Lil' Exception](https://shipilev.net/blog/2014/exceptional-performance).
+have a read at this excellent post by A. Shipilёv: [The Exceptional Performance of Lil' Exception](https://shipilev.net/blog/2014/exceptional-performance/).
 @@@
 
 

--- a/docs/src/main/paradox/routing-dsl/overview.md
+++ b/docs/src/main/paradox/routing-dsl/overview.md
@@ -13,7 +13,7 @@ Java
 While it'd be perfectly possible to define a complete REST API service purely by @scala[pattern-matching against]@java[inspecting] the incoming
 @apidoc[HttpRequest] @scala[(maybe with the help of a few extractors in the way of [Unfiltered](https://unfiltered.ws/))] this approach becomes somewhat
 unwieldy for larger services due to the amount of syntax "ceremony" required. Also, it doesn't help in keeping your
-service definition as [DRY](http://en.wikipedia.org/wiki/Don%27t_repeat_yourself) as you might like.
+service definition as [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) as you might like.
 
 As an alternative Akka HTTP provides a flexible DSL for expressing your service behavior as a structure of
 composable elements (called @ref[Directives](directives/index.md)) in a concise and readable way. Directives are assembled into a so called

--- a/docs/src/main/paradox/routing-dsl/source-streaming-support.md
+++ b/docs/src/main/paradox/routing-dsl/source-streaming-support.md
@@ -37,7 +37,7 @@ Scala
 
 ## Responding with JSON Streams
 
-In this example we implement an API representing an infinite stream of tweets, very much like Twitter's [Streaming API](https://dev.twitter.com/streaming/overview).
+In this example we implement an API representing an infinite stream of tweets, very much like Twitter's [Streaming API](https://developer.twitter.com/en/docs).
 
 @@@ div { .group-scala }
 
@@ -132,7 +132,7 @@ the server and is feeding it with one line of measurement data.
 
 In this example, we want to consume this data in a streaming fashion from the request entity and also apply
 back pressure to the underlying TCP connection should the server be unable to cope with the rate of incoming data. Back pressure
-is automatically applied thanks to @extref[Akka Streams](akka-docs:scala/stream/index.html).
+is automatically applied thanks to @extref[Akka Streams](akka-docs:stream/index.html).
 
 Scala
 :   @@snip [JsonStreamingExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/JsonStreamingExamplesSpec.scala) { #measurement-model #measurement-format }

--- a/docs/src/main/paradox/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/routing-dsl/testkit.md
@@ -205,7 +205,7 @@ Java
 The timeouts you consciously defined on your lightning fast development environment might be too tight for your, most
 probably, high-loaded Continuous Integration server, invariably causing spurious failures. To account for such
 situations, timeout durations can be scaled by a given factor on such environments. Check the
-@scala[@extref[Akka Docs](akka-docs:scala/testing.html#accounting-for-slow-test-systems)]@java[@extref[Akka Docs](akka-docs:java/testing.html#accounting-for-slow-test-systems)]
+@extref[Akka Docs](akka-docs:testing.html#accounting-for-slow-test-systems)
 for further information.
 
 

--- a/docs/src/main/paradox/security/2017-01-23-denial-of-service-via-leak-on-unconsumed-closed-connections.md
+++ b/docs/src/main/paradox/security/2017-01-23-denial-of-service-via-leak-on-unconsumed-closed-connections.md
@@ -14,7 +14,7 @@ Please subscribe to the [akka-security](https://groups.google.com/forum/#!forum/
 
 ## Severity
 
-The [CVSS](https://en.wikipedia.org/wiki/CVSS) score of this vulnerability is 6.4 (Medium), based on vector [AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C](https://nvd.nist.gov/cvss.cfm?calculator&version=2&vector=%28AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C%29).
+The [CVSS](https://en.wikipedia.org/wiki/CVSS) score of this vulnerability is 6.4 (Medium), based on vector [AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C](https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?calculator&version=2&vector=%28AV:N/AC:L/Au:N/C:N/I:N/A:C/E:F/RL:OF/RC:C%29).
 
 ## Affected Versions
 

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -45,7 +45,7 @@ Note that `bindAndHandle` currently does not support HTTP/2, you must use `bindA
 While un-encrypted connections are allowed by HTTP/2, this is [sometimes discouraged](https://http2.github.io/faq/#does-http2-require-encryption).
 
 There are 2 ways to implement un-encrypted HTTP/2 connections: by using the
-[HTTP Upgrade mechanism](http://httpwg.org/specs/rfc7540.html#discover-http)
+[HTTP Upgrade mechanism](https://httpwg.org/specs/rfc7540.html#discover-http)
 or by starting communication in HTTP/2 directly which requires the client to
 have [Prior Knowledge](https://httpwg.org/specs/rfc7540.html#known-http) of
 HTTP/2 support.
@@ -61,7 +61,7 @@ Java
 #### h2c Upgrade
 
 The advantage of switching from HTTP/1.1 to HTTP/2 using the
-[HTTP Upgrade mechanism](http://httpwg.org/specs/rfc7540.html#discover-http)
+[HTTP Upgrade mechanism](https://httpwg.org/specs/rfc7540.html#discover-http)
 is that both HTTP/1.1 and HTTP/2 clients can connect to the server on the
 same port, without being aware beforehand which protocol the server supports.
 
@@ -77,7 +77,7 @@ The other option is to connect and start communicating in HTTP/2 immediately.
 The downside of this approach is the client must know beforehand that the
 server supports HTTP/2.
 For the reason this approach is known as h2c with
-Prior Knowledge](http://httpwg.org/specs/rfc7540.html#known-http) of HTTP/2
+[Prior Knowledge](https://httpwg.org/specs/rfc7540.html#known-http) of HTTP/2
 support.
 
 ## Testing with cURL
@@ -130,7 +130,7 @@ This shows `curl` declaring it is ready to speak `h2` (the shorthand name of HTT
 
 [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation) is used to negotiate whether both client and server support HTTP/2.
 
-ALPN support comes with the JVM starting from version 9. If you're on a previous version of the JVM, you'll have to load a Java Agent to provide this functionality. We recommend the agent from the [Jetty](http://www.eclipse.org/jetty/) project, `jetty-alpn-agent`.
+ALPN support comes with the JVM starting from version 9. If you're on a previous version of the JVM, you'll have to load a Java Agent to provide this functionality. We recommend the agent from the [Jetty](https://www.eclipse.org/jetty/) project, `jetty-alpn-agent`.
 
 ### manually
 

--- a/docs/src/main/paradox/server-side/index.md
+++ b/docs/src/main/paradox/server-side/index.md
@@ -1,7 +1,7 @@
 # 4. Server API
 
 Apart from the @ref[HTTP Client](../client-side/index.md) Akka HTTP also provides an embedded,
-[Reactive-Streams](https://www.reactive-streams.org/)-based, fully asynchronous HTTP/1.1 server implemented on top of @scala[@extref[Streams](akka-docs:scala/stream/index.html)]@java[@extref[Streams](akka-docs:java/stream/index.html)].
+[Reactive-Streams](https://www.reactive-streams.org/)-based, fully asynchronous HTTP/1.1 server implemented on top of @extref[Streams](akka-docs:stream/index.html).
 
 It supports the following features:
 

--- a/docs/src/main/paradox/server-side/low-level-api.md
+++ b/docs/src/main/paradox/server-side/low-level-api.md
@@ -20,10 +20,10 @@ from a background with non-"streaming first" HTTP Servers.
 
 ## Streams and HTTP
 
-The Akka HTTP server is implemented on top of @scala[@extref[Streams](akka-docs:scala/stream/index.html)]@java[@extref[Streams](akka-docs:java/stream/index.html)] and makes heavy use of it - in its
+The Akka HTTP server is implemented on top of @extref[Streams](akka-docs:stream/index.html) and makes heavy use of it - in its
 implementation as well as on all levels of its API.
 
-On the connection level Akka HTTP offers basically the same kind of interface as @scala[@extref[Working with streaming IO](akka-docs:scala/stream/stream-io.html)]@java[@extref[Working with streaming IO](akka-docs:java/stream/stream-io.html)]:
+On the connection level Akka HTTP offers basically the same kind of interface as @extref[Working with streaming IO](akka-docs:stream/stream-io.html):
 A socket binding is represented as a stream of incoming connections. The application pulls connections from this stream
 source and, for each of them, provides a @apidoc[Flow[HttpRequest, HttpResponse, \_]] to "translate" requests into responses.
 
@@ -205,7 +205,7 @@ through the stream starting from the stage which failed, all the way downstream 
 #### Connections Source failures
 
 In the example below we add a custom @apidoc[GraphStage] in order to react to the
-stream's failure. See @scala[@extref[Custom stream processing](akka-docs:scala/stream/stream-customize.html)]@java[@extref[Custom stream processing](akka-docs:java/stream/stream-customize.html)]) for more on custom stages. We signal a `failureMonitor` actor with the cause why the stream is going down, and let the Actor
+stream's failure. See @extref[Custom stream processing](akka-docs:stream/stream-customize.html) for more on custom stages. We signal a `failureMonitor` actor with the cause why the stream is going down, and let the Actor
 handle the rest – maybe it'll decide to restart the server or shutdown the ActorSystem, that however is not our concern anymore.
 
 Scala


### PR DESCRIPTION
* Change links to point to the final destination.
* Prefer https where possible.

Most important thing left is rewriting the API doc links to JDK 11 Javadocs which require to add the `java.base` module.