### PR TITLE
Fix HeaderParserBenchmark

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HeaderParserBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HeaderParserBenchmark.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Array(Mode.Throughput))
-final class HeaderParserBenchmark {
+private[engine] class HeaderParserBenchmark {
   implicit val system: ActorSystem = ActorSystem("header-parser-benchmark")
 
   @Param(Array("no", "yes"))


### PR DESCRIPTION
See https://github.com/akka/akka-http/commit/41788d857c11a711eb07dff8b0ec1654b20e367e#r38505067

Without re-introducing warning about access

```
[warn] /home/aengelen/dev/akka-http/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HeaderParserBenchmark.scala:25:7: variable parser in class HeaderParserBenchmark references private[engine] class HttpHeaderParser.
[warn] Classes which cannot access HttpHeaderParser may be unable to override parser_=.
[warn]   var parser: HttpHeaderParser = _
[warn]       ^
[warn] one warning found
```