### PR TITLE
[backport] core: make sure to cancel response entity on failure (#3046)

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
@@ -67,7 +67,13 @@ private[http] object ByteStringSinkProbe {
           inBuffer = inBuffer.drop(length)
           res
         } else {
-          inBuffer ++= probe.requestNext()
+          try inBuffer ++= probe.requestNext()
+          catch {
+            case ex if ex.getMessage.contains("Expected OnNext") =>
+              throw new AssertionError(
+                s"Expected [$length] bytes but only got [${inBuffer.size}] bytes\n${PrettyByteString.asPretty(inBuffer).prettyPrint(1024)}"
+              )
+          }
           expectBytes(length)
         }
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -1080,7 +1080,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
 
         pollForWindowUpdates(duration)
       } catch {
-        case e: AssertionError if e.getMessage contains "Expected OnNext(_), yet no element signaled during" =>
+        case e: AssertionError if e.getMessage contains "but only got [0] bytes" =>
         // timeout, that's expected
         case e: AssertionError if (e.getMessage contains "block took") && (e.getMessage contains "exceeding") =>
           // pause like GC, poll again just to be sure


### PR DESCRIPTION
Backport of #3046 