### PR TITLE
Specify a non-snapshot minimum expected Akka version

### DIFF
--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -39,7 +39,8 @@ object AkkaDependency {
   }
 
   // Default version updated only when needed, https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
-  val default = akkaDependency(defaultVersion = "2.5.31")
+  val minimumExpectedAkkaVersion = "2.5.31"
+  val default = akkaDependency(defaultVersion = minimumExpectedAkkaVersion)
   val docs = akkaDependency(defaultVersion = "2.6.4")
 
   val akkaVersion: String = default match {

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -38,7 +38,7 @@ object VersionGenerator {
 
   def generateVersion(dir: SettingKey[File], locate: File => File, template: String) = Def.task[Seq[File]] {
     val file = locate(dir.value)
-    val content = template.stripMargin.format(version.value, AkkaDependency.akkaVersion)
+    val content = template.stripMargin.format(version.value, AkkaDependency.minimumExpectedAkkaVersion)
     if (!file.exists || IO.read(file) != content) IO.write(file, content)
     Seq(file)
   }


### PR DESCRIPTION
To allow building against a 2.5 snapshot while running
(the tests) against 2.6. Without this change the
`AkkaVersion.require("akka-http", akka.http.Version.supportedAkkaVersion)`
check would fail at run time because it can't parse the 2.5 snapshot.