### PR TITLE
Docs: routing DSL compared with Play routes

### DIFF
--- a/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
+++ b/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
@@ -117,7 +117,7 @@ Java
 
 ### Parameter with required value
 
-@scala[The `!` decorator makes the route match only if the parameter contains the specified value.]
+@scala[The `requiredValue` decorator makes the route match only if the parameter contains the specified value.]
 @java[The directive `parameterRequiredValue` makes the route match only if the parameter contains the specified value.]
 
 Scala

--- a/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
+++ b/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
@@ -117,7 +117,7 @@ Java
 
 ### Parameter with required value
 
-@java[The `!` decorator makes the route match only if the parameter contains the specified value.]
+@scala[The `!` decorator makes the route match only if the parameter contains the specified value.]
 @java[The directive `parameterRequiredValue` makes the route match only if the parameter contains the specified value.]
 
 Scala

--- a/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
+++ b/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
@@ -117,6 +117,9 @@ Java
 
 ### Parameter with required value
 
+@java[The `!` decorator makes the route match only if the parameter contains the specified value.]
+@java[The directive `parameterRequiredValue` makes the route match only if the parameter contains the specified value.]
+
 Scala
 :   @@snip [ParameterDirectivesExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala) { #required-value }
 

--- a/docs/src/main/paradox/routing-dsl/index.md
+++ b/docs/src/main/paradox/routing-dsl/index.md
@@ -72,7 +72,7 @@ the Routing DSL will look like:
 
 ## Compared with Play framework routes
 
-If you have been using Play framework's routes file notation before this @ref[Play! comparison](play-comparison.md) may help you to get started with Akka HTTP routing.
+If you have been using Play framework's routes file notation before this @ref[Play comparison](play-comparison.md) may help you to get started with Akka HTTP routing.
 
 <a name="interaction-with-akka-typed">
 ## Interaction with Actors

--- a/docs/src/main/paradox/routing-dsl/index.md
+++ b/docs/src/main/paradox/routing-dsl/index.md
@@ -16,6 +16,7 @@ from a background with non-"streaming first" HTTP Servers.
 @@@ index
 
 * [overview](overview.md)
+* [play](play-comparison.md)
 * [routes](routes.md)
 * [directives/index](directives/index.md)
 * [rejections](rejections.md)
@@ -68,6 +69,10 @@ the Routing DSL will look like:
 @@snip [HttpServerExampleSpec.scala]($test$/scala/docs/http/scaladsl/HttpServerExampleSpec.scala) { #long-routing-example }
 
 @@@
+
+## Compared with Play framework routes
+
+If you have been using Play framework's routes file notation before this @ref[Play! comparison](play-comparison.md) may help you to get started with Akka HTTP routing.
 
 <a name="interaction-with-akka-typed">
 ## Interaction with Actors

--- a/docs/src/main/paradox/routing-dsl/overview.md
+++ b/docs/src/main/paradox/routing-dsl/overview.md
@@ -1,7 +1,7 @@
 # Routing DSL Overview
 
 The Akka HTTP @ref[Core Server API](../server-side/low-level-api.md) provides a @apidoc[Flow]- or `Function`-level interface that allows
-an application to respond to incoming HTTP requests by simply mapping requests to responses
+an application to respond to incoming HTTP requests by mapping requests to responses
 (excerpt from @ref[Low-level server side example](../server-side/low-level-api.md#http-low-level-server-side-example)):
 
 Scala

--- a/docs/src/main/paradox/routing-dsl/play-comparison.md
+++ b/docs/src/main/paradox/routing-dsl/play-comparison.md
@@ -4,9 +4,9 @@ If you have been using @scala[[Play's routes file syntax](https://www.playframew
 
 ## Conceptual differences
 
-The most apparent difference is Play's use of special purpose syntax implemented as an [external DSL](https://en.wikipedia.org/wiki/Domain-specific_language#External_and_Embedded_Domain_Specific_Languages), whereas Akka HTTP routes are described in @scala[Scala source code]@java[Java source code] with regular methods and values (as "embedded DSL"). Both are crafted to make the reader "grasp the codes intention".
+The most apparent difference is Play's use of special purpose syntax implemented as an [external DSL](https://en.wikipedia.org/wiki/Domain-specific_language#External_and_Embedded_Domain_Specific_Languages), whereas Akka HTTP routes are described in @scala[Scala source code]@java[Java source code] with regular methods and values (as "embedded DSL"). Both are crafted to make the reader "grasp the code's intention".
 
-The Akka HTTP DSL uses @ref[Directives](directives/index.md) to describe how incoming requests translate to functionality in the server. Play allows splitting the routes definitions in multiple routes files. The Akka HTTP DSL is very flexible and allows for composition so that different concerns can be properly split and organized as other source could would be.
+The Akka HTTP DSL uses @ref[Directives](directives/index.md) to describe how incoming requests translate to functionality in the server. Play allows splitting the routes definitions in multiple routes files. The Akka HTTP DSL is very flexible and allows for composition so that different concerns can be properly split and organized as other source code would be.
 
 Both Play and Akka HTTP choose the first matching route within the routes file/routes definition. In Play routes are listed with one route per line, in Akka HTTP multiple routes must be concatenated with the `concat` method.
 

--- a/docs/src/main/paradox/routing-dsl/play-comparison.md
+++ b/docs/src/main/paradox/routing-dsl/play-comparison.md
@@ -8,7 +8,7 @@ Both Play and Akka HTTP choose the first matching route within the routes file/r
 
 ### Static path
 
-For example, to exactly match incoming `GET /clients/all` requests, you can define this route in Play!.
+For example, to exactly match incoming `GET /clients/all` requests, you can define this route in Play.
 
 ```
 GET   /clients/all          controllers.Clients.list()

--- a/docs/src/main/paradox/routing-dsl/play-comparison.md
+++ b/docs/src/main/paradox/routing-dsl/play-comparison.md
@@ -117,7 +117,7 @@ GET   /api/list-all         controllers.Api.list(version: Option[String])
 ```
 
 @@@ div { .group-scala }
-The parameter name may be decorated with a `?` to mark it as optional (for other variants see @ref[other parameter extractors](directives/parameter-directives/parameters.md#description)).]
+The parameter name may be decorated with a `?` to mark it as optional (for other variants see @ref[other parameter extractors](directives/parameter-directives/parameters.md#description)).
 @@@
 @@@ div { .group-java }
 The `parameterOptional` directive passes the parameter as `Optional<String>`. 

--- a/docs/src/main/paradox/routing-dsl/play-comparison.md
+++ b/docs/src/main/paradox/routing-dsl/play-comparison.md
@@ -117,7 +117,7 @@ GET   /api/list-all         controllers.Api.list(version: Option[String])
 ```
 
 @@@ div { .group-scala }
-The parameter name may be decorated with a `?` to mark it as optional (for other variants see @ref[other parameter extractors](directives/parameter-directives/parameters.md#description)).
+The parameter name may be decorated with `.optional` to mark it as optional (for other variants see @ref[other parameter extractors](directives/parameter-directives/parameters.md#description)).
 @@@
 @@@ div { .group-java }
 The `parameterOptional` directive passes the parameter as `Optional<String>`. 
@@ -151,7 +151,7 @@ GET   /api/list-items      controllers.Api.listItems(item: List[String])
 ```
 
 @@@ div { .group-scala }
-Decorating the parameter name with a `*` makes Akka HTTP pass all values of that parameter as an `Iterable[String]`].
+Decorating the parameter name with a `.repeated` makes Akka HTTP pass all values of that parameter as an `Iterable[String]`].
 @@@
 @@@ div { .group-java }
 The `parameterList` directive may take a parameter name to specify a single parameter name to pass on as a `List<String>`.]

--- a/docs/src/main/paradox/routing-dsl/play-comparison.md
+++ b/docs/src/main/paradox/routing-dsl/play-comparison.md
@@ -2,9 +2,17 @@
 
 If you have been using @scala[[Play's routes file syntax](https://www.playframework.com/documentation/2.8.x/ScalaRouting#The-routes-file-syntax)]@java[[Play's routes file syntax](https://www.playframework.com/documentation/2.8.x/JavaRouting#The-routes-file-syntax)] earlier, this page may help you to use the Akka HTTP routing DSL.
 
-Where Play routes require to specify the HTTP method for every entry, in Akka HTTP it may be specified on different levels of the `Route`.
+## Conceptual differences
+
+The most apparent difference is Play's use of special purpose syntax implemented as an [external DSL](https://en.wikipedia.org/wiki/Domain-specific_language#External_and_Embedded_Domain_Specific_Languages), whereas Akka HTTP routes are described in @scala[Scala source code]@java[Java source code] with regular methods and values (as "embedded DSL"). Both are crafted to make the reader "grasp the codes intention".
+
+The Akka HTTP DSL uses @ref[Directives](directives/index.md) to describe how incoming requests translate to functionality in the server. Play allows splitting the routes definitions in multiple routes files. The Akka HTTP DSL is very flexible and allows for composition so that different concerns can be properly split and organized as other source could would be.
 
 Both Play and Akka HTTP choose the first matching route within the routes file/routes definition. In Play routes are listed with one route per line, in Akka HTTP multiple routes must be concatenated with the `concat` method.
+
+## Side-by-side
+
+These examples are a non-comprehensive list of how Play routes could be written in Akka HTTP. They try to mimic the structure which Play uses, to aid understanding, even though it might not be the most Akka HTTP-idiomatic notation. 
 
 ### Static path
 
@@ -60,19 +68,19 @@ You may want to capture a dynamic part of more than one URI path segment, separa
 GET   /files/*name          controllers.Application.download(name)
 ```
 
-The Akka HTTP directive @scala[`Segments`]@java[segments()] makes a list of the segments to be passed.
+The Akka HTTP directive @scala[`Remaining`]@java[remaining()] makes a list of the segments to be passed. (See @ref[Path Matchers](path-matchers.md#basic-pathmatchers) for other ways to extract the path.)
 
 Scala
-:   @@snip [snip](/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala) { #segments }
+:   @@snip [snip](/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala) { #remaining }
 
 Scala test
-:   @@snip [snip](/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala) { #segments-test }
+:   @@snip [snip](/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala) { #remaining-test }
 
 Java
-:   @@snip [snip](/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java) { #segments }
+:   @@snip [snip](/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java) { #remaining }
 
 Java test
-:   @@snip [snip](/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java) { #segments-test }
+:   @@snip [snip](/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java) { #remaining-test }
 
 
 ### Access parameters

--- a/docs/src/main/paradox/routing-dsl/routes.md
+++ b/docs/src/main/paradox/routing-dsl/routes.md
@@ -173,7 +173,7 @@ A sealed route has these properties:
 As described in @ref[Rejections](rejections.md) and @ref[Exception Handling](exception-handling.md),
 there are generally two ways to handle rejections and exceptions.
 
- * Bring rejection/exception handlers @scala[into `implicit` scope at the top-level]@java[`seal()` method of the @apidoc[Route]]
+ * Bring rejection/exception handlers @scala[`into implicit scope at the top-level`]@java[`seal()` method of the @scala[@scaladoc[Route](akka.http.scaladsl.server.index#Route=akka.http.scaladsl.server.RequestContext=%3Escala.concurrent.Future[akka.http.scaladsl.server.RouteResult])]@java[@apidoc[Route]]]
  * Supply handlers as arguments to @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections) and @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions) directives 
 
 In the first case your handlers will be "sealed", (which means that it will receive the default handler as a fallback for all cases your handler doesn't handle itself) 

--- a/docs/src/main/paradox/routing-dsl/routes.md
+++ b/docs/src/main/paradox/routing-dsl/routes.md
@@ -88,8 +88,8 @@ of either the incoming request, the outgoing response or both
  * Route filtering, which only lets requests satisfying a given filter condition pass and rejects all others
  * Route chaining, which tries a second route if a given first one was rejected
 
-The last point is achieved with the concatenation operator `~`, which is an extension method that becomes available
-when you `import akka.http.scaladsl.server.Directives._`.
+@scala[The last point is achieved with the concatenation operator `~` (or the `concat` method), which is an extension method that becomes available
+when you `import akka.http.scaladsl.server.Directives._`.]
 The first two points are provided by so-called @ref[Directives](directives/index.md#directives) of which a large number is already predefined by Akka
 HTTP and which you can also easily create yourself.
 @ref[Directives](directives/index.md#directives) deliver most of Akka HTTP's power and flexibility.
@@ -173,7 +173,7 @@ A sealed route has these properties:
 As described in @ref[Rejections](rejections.md) and @ref[Exception Handling](exception-handling.md),
 there are generally two ways to handle rejections and exceptions.
 
- * Bring rejection/exception handlers @scala[`into implicit scope at the top-level`]@java[`seal()` method of the @scala[@scaladoc[Route](akka.http.scaladsl.server.index#Route=akka.http.scaladsl.server.RequestContext=%3Escala.concurrent.Future[akka.http.scaladsl.server.RouteResult])]@java[@apidoc[Route]]]
+ * Bring rejection/exception handlers @scala[into `implicit` scope at the top-level]@java[`seal()` method of the @apidoc[Route]]
  * Supply handlers as arguments to @ref[handleRejections](directives/execution-directives/handleRejections.md#handlerejections) and @ref[handleExceptions](directives/execution-directives/handleExceptions.md#handleexceptions) directives 
 
 In the first case your handlers will be "sealed", (which means that it will receive the default handler as a fallback for all cases your handler doesn't handle itself) 
@@ -184,7 +184,7 @@ and used for all rejections/exceptions that are not handled within the route str
 In application code, unlike @ref[test code](testkit.md#testing-sealed-routes), you don't need to use the `Route.seal()` method to seal a route.
 As long as you bring implicit rejection and/or exception handlers to the top-level scope, your route is sealed. 
 
-However, you can use `Route.seal()` to perform modification on HttpResponse from the route.
+However, you can use `Route.seal()` to perform modification on @apidoc[HttpResponse$] from the route.
 For example, if you want to add a special header, but still use the default rejection handler, then you can do the following.
 In the below case, the special header is added to rejected responses which did not match the route, as well as successful responses which matched the route.
 

--- a/docs/src/main/paradox/routing-dsl/routes.md
+++ b/docs/src/main/paradox/routing-dsl/routes.md
@@ -88,13 +88,13 @@ of either the incoming request, the outgoing response or both
  * Route filtering, which only lets requests satisfying a given filter condition pass and rejects all others
  * Route chaining, which tries a second route if a given first one was rejected
 
-@scala[The last point is achieved with the concatenation operator `~` (or the `concat` method), which is an extension method that becomes available
-when you `import akka.http.scaladsl.server.Directives._`.]
 The first two points are provided by so-called @ref[Directives](directives/index.md#directives) of which a large number is already predefined by Akka
-HTTP and which you can also easily create yourself.
+HTTP and is extensible with user code.
+
+The last point is achieved with the `concat` method.
+
 @ref[Directives](directives/index.md#directives) deliver most of Akka HTTP's power and flexibility.
 
-<a id="the-routing-tree"></a>
 ## The Routing Tree
 
 Essentially, when you combine directives and custom routes via the `concat` method, you build a routing

--- a/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java
@@ -26,6 +26,7 @@ public class PlayRoutesComparisonTest extends JUnitRouteTest {
         static String list() {
             return "clientA,clientB,clientC";
         }
+
         static String get(long id) {
             return "clientB";
         }
@@ -52,45 +53,66 @@ public class PlayRoutesComparisonTest extends JUnitRouteTest {
         Route clientsAll() {
             return
                     // #fixed
-                    get(() -> path(segment("clients").slash("all"), () -> complete(Clients.list())));
+                    get(() ->
+                            path(segment("clients").slash("all"), () ->
+                                    complete(Clients.list())
+                            )
+                    );
             // #fixed
         }
 
         Route clientById() {
             return
                     // #long
-                    get(() -> path(segment("client").slash(longSegment()), id -> complete(Clients.get(id))));
+                    get(() ->
+                            path(segment("client").slash(longSegment()), id ->
+                                    complete(Clients.get(id))
+                            )
+                    );
             // #long
         }
 
         Route files() {
             return
                     // #segments
-                    get(() -> path(segment("files").slash(segments()),
-                            names -> complete(download(names))));
+                    get(() ->
+                            path(segment("files").slash(segments()),
+                                    names -> complete(download(names))
+                            )
+                    );
             // #segments
         }
 
         Route pageParameter() {
             return
                     // #mandatory-parameter
-                    get(() -> parameter("page", page -> complete(getPage(page))));
+                    get(() ->
+                            parameter("page", page ->
+                                    complete(getPage(page))
+                            )
+                    );
             // #mandatory-parameter
         }
 
         Route apiListWithVersion() {
             return
                     // #optional-parameter
-                    get(() -> path(segment("api").slash("list"), () ->
-                            parameterOptional("version", version -> complete(apiList(version)))));
+                    get(() ->
+                            path(segment("api").slash("list"), () ->
+                                    parameterOptional("version", version -> complete(apiList(version)))
+                            )
+                    );
             // #optional-parameter
         }
 
         Route apiListItems() {
             return
                     // #parameter-list
-                    get(() -> path(segment("api").slash("list-items"), () ->
-                            parameterList("item", items -> complete(apiItems(items)))));
+                    get(() ->
+                            path(segment("api").slash("list-items"), () ->
+                                    parameterList("item", items -> complete(apiItems(items)))
+                            )
+                    );
             // #parameter-list
         }
     }

--- a/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java
@@ -32,7 +32,7 @@ public class PlayRoutesComparisonTest extends JUnitRouteTest {
         }
     }
 
-    static String download(List<String> names) {
+    static String download(String names) {
         return "images/logo.png: file contents";
     }
 
@@ -74,13 +74,13 @@ public class PlayRoutesComparisonTest extends JUnitRouteTest {
 
         Route files() {
             return
-                    // #segments
+                    // #remaining
                     get(() ->
-                            path(segment("files").slash(segments()),
-                                    names -> complete(download(names))
+                            path(segment("files").slash(remaining()), names ->
+                                    complete(download(names))
                             )
                     );
-            // #segments
+            // #remaining
         }
 
         Route pageParameter() {
@@ -99,7 +99,8 @@ public class PlayRoutesComparisonTest extends JUnitRouteTest {
                     // #optional-parameter
                     get(() ->
                             path(segment("api").slash("list"), () ->
-                                    parameterOptional("version", version -> complete(apiList(version)))
+                                    parameterOptional("version", version ->
+                                            complete(apiList(version)))
                             )
                     );
             // #optional-parameter
@@ -110,7 +111,8 @@ public class PlayRoutesComparisonTest extends JUnitRouteTest {
                     // #parameter-list
                     get(() ->
                             path(segment("api").slash("list-items"), () ->
-                                    parameterList("item", items -> complete(apiItems(items)))
+                                    parameterList("item", items ->
+                                            complete(apiItems(items)))
                             )
                     );
             // #parameter-list
@@ -138,13 +140,13 @@ public class PlayRoutesComparisonTest extends JUnitRouteTest {
     }
 
     @Test
-    public void showSegments() {
-        // #segments-test
+    public void showRemaining() {
+        // #remaining-test
         TestRoute route = testRoute(new Routes().files());
         route.run(HttpRequest.GET("/files/images/logo.png"))
                 .assertStatusCode(StatusCodes.OK)
                 .assertEntity("images/logo.png: file contents");
-        // #segments-test
+        // #remaining-test
     }
 
     @Test

--- a/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/testkit/PlayRoutesComparisonTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2009-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.http.javadsl.server.testkit;
+
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.AllDirectives;
+import akka.http.javadsl.server.Route;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import akka.http.javadsl.testkit.TestRoute;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static akka.http.javadsl.server.PathMatchers.*;
+import static akka.http.javadsl.server.Directives.*;
+
+
+public class PlayRoutesComparisonTest extends JUnitRouteTest {
+
+    static class Clients {
+        static String list() {
+            return "clientA,clientB,clientC";
+        }
+        static String get(long id) {
+            return "clientB";
+        }
+    }
+
+    static String download(List<String> names) {
+        return "images/logo.png: file contents";
+    }
+
+    static String getPage(String page) {
+        return "The requested [" + page + "].";
+    }
+
+    static String apiList(Optional<String> version) {
+        return version.map(v -> "aa,bb,cc").orElse("ff");
+    }
+
+    static String apiItems(List<String> items) {
+        return items.stream().collect(Collectors.joining(","));
+    }
+
+    static class Routes extends AllDirectives {
+
+        Route clientsAll() {
+            return
+                    // #fixed
+                    get(() -> path(segment("clients").slash("all"), () -> complete(Clients.list())));
+            // #fixed
+        }
+
+        Route clientById() {
+            return
+                    // #long
+                    get(() -> path(segment("client").slash(longSegment()), id -> complete(Clients.get(id))));
+            // #long
+        }
+
+        Route files() {
+            return
+                    // #segments
+                    get(() -> path(segment("files").slash(segments()),
+                            names -> complete(download(names))));
+            // #segments
+        }
+
+        Route pageParameter() {
+            return
+                    // #mandatory-parameter
+                    get(() -> parameter("page", page -> complete(getPage(page))));
+            // #mandatory-parameter
+        }
+
+        Route apiListWithVersion() {
+            return
+                    // #optional-parameter
+                    get(() -> path(segment("api").slash("list"), () ->
+                            parameterOptional("version", version -> complete(apiList(version)))));
+            // #optional-parameter
+        }
+
+        Route apiListItems() {
+            return
+                    // #parameter-list
+                    get(() -> path(segment("api").slash("list-items"), () ->
+                            parameterList("item", items -> complete(apiItems(items)))));
+            // #parameter-list
+        }
+    }
+
+    @Test
+    public void showFixed() {
+        // #fixed-test
+        TestRoute route = testRoute(new Routes().clientsAll());
+        route.run(HttpRequest.GET("/clients/all"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("clientA,clientB,clientC");
+        // #fixed-test
+    }
+
+    @Test
+    public void showLong() {
+        // #long-test
+        TestRoute route = testRoute(new Routes().clientById());
+        route.run(HttpRequest.GET("/client/321433"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("clientB");
+        // #long-test
+    }
+
+    @Test
+    public void showSegments() {
+        // #segments-test
+        TestRoute route = testRoute(new Routes().files());
+        route.run(HttpRequest.GET("/files/images/logo.png"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("images/logo.png: file contents");
+        // #segments-test
+    }
+
+    @Test
+    public void showMandatoryParameter() {
+        // #mandatory-parameter-test
+        TestRoute route = testRoute(new Routes().pageParameter());
+        route.run(HttpRequest.GET("?page=example.txt"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("The requested [example.txt].");
+        route.run(HttpRequest.GET("/"))
+                .assertStatusCode(StatusCodes.NOT_FOUND);
+        // #mandatory-parameter-test
+    }
+
+    @Test
+    public void optionalParameter() {
+        // #optional-parameter-test
+        TestRoute route = testRoute(new Routes().apiListWithVersion());
+        route.run(HttpRequest.GET("/api/list?version=3.0"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("aa,bb,cc");
+        route.run(HttpRequest.GET("/api/list"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("ff");
+        // #optional-parameter-test
+    }
+
+    @Test
+    public void parameterList() {
+        // #parameter-list-test
+        TestRoute route = testRoute(new Routes().apiListItems());
+        route.run(HttpRequest.GET("/api/list-items?item=red&item=new&item=slippers"))
+                .assertStatusCode(StatusCodes.OK)
+                .assertEntity("slippers,new,red"); // order is not kept
+        // #parameter-list-test
+    }
+}

--- a/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
@@ -4,8 +4,6 @@
 
 package docs.http.scaladsl.server
 
-import akka.http.scaladsl.common.ToNameReceptacleEnhancements
-import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -74,7 +72,7 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
 
       val pageParameter: Route =
         // #mandatory-parameter
-        (get & parameter("page")) { page =>
+        (get & path("") & parameter("page")) { page =>
           complete(getPage(page))
         }
       // #mandatory-parameter
@@ -91,10 +89,8 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
 
       val optionalPageParameter: Route =
         // #optional-parameter
-        get {
-          (path("api" / "list-all") & parameter("version".optional)) { version =>
-            complete(listAll(version))
-          }
+        (get & path("api" / "list-all") & parameter("version".optional)) { version =>
+          complete(listAll(version))
         }
       // #optional-parameter
 
@@ -113,10 +109,8 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
 
       val itemParameterList: Route =
         // #parameter-list
-        get {
-          (path("api" / "list-items") & parameters("item".repeated)) { items =>
-            complete(listItems(items))
-          }
+        (get & path("api" / "list-items") & parameters("item".repeated)) { items =>
+          complete(listItems(items))
         }
       // #parameter-list
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
@@ -114,14 +114,8 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
 
       val itemParameterList: Route =
         // #parameter-list
-        // TODO:
-        // Note that implicit conversions are not applicable because they are ambiguous:
-        //  both method augmentString in object Predef of type (x: String)scala.collection.immutable.StringOps
-        //  and method _string2NR in trait ToNameReceptacleEnhancements of type (string: String)akka.http.scaladsl.common.NameReceptacle[String]
-        //  are possible conversion functions from String("item") to ?{def *: ?}
-        //         path("api" / "list-items")(parameters("item".*) { items =>
         get {
-          path("api" / "list-items")(parameters(ToNameReceptacleEnhancements._string2NR("item").*) { items =>
+          path("api" / "list-items")(parameters('item.*) { items =>
             complete(listItems(items))
           })
         }

--- a/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
@@ -40,7 +40,7 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
     "show reading a long" in {
       val clientById: Route =
         // #long
-        (get & pathPrefix("client" / LongNumber)) { id =>
+        (get & path("client" / LongNumber)) { id =>
           complete(Clients.get(id))
         }
       // #long
@@ -56,18 +56,17 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
       def download(name: String) = s"$name: file contents"
 
       val files: Route =
-        // #segments
-        (get & pathPrefix("files" / Segments)) { names =>
-          val name = names.mkString("/")
+        // #remaining
+        (get & path("files" / Remaining)) { name =>
           complete(download(name))
         }
-      // #segments
+      // #remaining
 
-      // #segments-test
+      // #remaining-test
       Get("/files/images/logo.png") ~> files ~> check {
         responseAs[String] shouldEqual "images/logo.png: file contents"
       }
-      // #segments-test
+      // #remaining-test
     }
 
     "require a parameter" in {
@@ -93,9 +92,9 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
       val optionalPageParameter: Route =
         // #optional-parameter
         get {
-          path("api" / "list-all")(parameter("version".?) { version =>
+          (path("api" / "list-all") & parameter("version".?)) { version =>
             complete(listAll(version))
-          })
+          }
         }
       // #optional-parameter
 
@@ -115,9 +114,9 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
       val itemParameterList: Route =
         // #parameter-list
         get {
-          path("api" / "list-items")(parameters('item.*) { items =>
+          (path("api" / "list-items") & parameters('item.*)) { items =>
             complete(listItems(items))
-          })
+          }
         }
       // #parameter-list
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
@@ -92,7 +92,7 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
       val optionalPageParameter: Route =
         // #optional-parameter
         get {
-          (path("api" / "list-all") & parameter("version".?)) { version =>
+          (path("api" / "list-all") & parameter("version".optional)) { version =>
             complete(listAll(version))
           }
         }
@@ -114,7 +114,7 @@ class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestR
       val itemParameterList: Route =
         // #parameter-list
         get {
-          (path("api" / "list-items") & parameters('item.*)) { items =>
+          (path("api" / "list-items") & parameters("item".repeated)) { items =>
             complete(listItems(items))
           }
         }

--- a/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/PlayRoutesComparisonSpec.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2009-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.http.scaladsl.server
+
+import akka.http.scaladsl.common.ToNameReceptacleEnhancements
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class PlayRoutesComparisonSpec extends AnyWordSpec with Matchers with ScalatestRouteTest {
+
+  object Clients {
+    def list(): String = "clientA,clientB,clientC"
+
+    def get(id: Long): String = "clientB"
+  }
+
+  "Play examples" should {
+
+    "show a fixed URL" in {
+      val clientsAll: Route =
+        // #fixed
+        (get & path("clients" / "all")) {
+          complete(Clients.list())
+        }
+      // #fixed
+
+      // #fixed-test
+      Get("/clients/all") ~> clientsAll ~> check {
+        responseAs[String] shouldEqual "clientA,clientB,clientC"
+      }
+      // #fixed-test
+    }
+
+    "show reading a long" in {
+      val clientById: Route =
+        // #long
+        (get & pathPrefix("client" / LongNumber)) { id =>
+          complete(Clients.get(id))
+        }
+      // #long
+
+      // #long-test
+      Get("/client/321433") ~> clientById ~> check {
+        responseAs[String] shouldEqual "clientB"
+      }
+      // #long-test
+    }
+
+    "use multiple segments" in {
+      def download(name: String) = s"$name: file contents"
+
+      val files: Route =
+        // #segments
+        (get & pathPrefix("files" / Segments)) { names =>
+          val name = names.mkString("/")
+          complete(download(name))
+        }
+      // #segments
+
+      // #segments-test
+      Get("/files/images/logo.png") ~> files ~> check {
+        responseAs[String] shouldEqual "images/logo.png: file contents"
+      }
+      // #segments-test
+    }
+
+    "require a parameter" in {
+      def getPage(name: String) = s"The requested [$name]."
+
+      val pageParameter: Route =
+        // #mandatory-parameter
+        (get & parameter("page")) { page =>
+          complete(getPage(page))
+        }
+      // #mandatory-parameter
+
+      // #mandatory-parameter-test
+      Get("/?page=example.txt") ~> pageParameter ~> check {
+        responseAs[String] shouldEqual "The requested [example.txt]."
+      }
+      // #mandatory-parameter-test
+    }
+
+    "accept a parameter" in {
+      def listAll(version: Option[String]) = version.fold("ff")(_ => "aa,bb,cc")
+
+      val optionalPageParameter: Route =
+        // #optional-parameter
+        get {
+          path("api" / "list-all")(parameter("version".?) { version =>
+            complete(listAll(version))
+          })
+        }
+      // #optional-parameter
+
+      // #optional-parameter-test
+      Get("/api/list-all?version=3.0") ~> optionalPageParameter ~> check {
+        responseAs[String] shouldEqual "aa,bb,cc"
+      }
+      Get("/api/list-all") ~> optionalPageParameter ~> check {
+        responseAs[String] shouldEqual "ff"
+      }
+      // #optional-parameter-test
+    }
+
+    "accept a parameter list" in {
+      def listItems(items: Iterable[String]) = items.mkString(",")
+
+      val itemParameterList: Route =
+        // #parameter-list
+        // TODO:
+        // Note that implicit conversions are not applicable because they are ambiguous:
+        //  both method augmentString in object Predef of type (x: String)scala.collection.immutable.StringOps
+        //  and method _string2NR in trait ToNameReceptacleEnhancements of type (string: String)akka.http.scaladsl.common.NameReceptacle[String]
+        //  are possible conversion functions from String("item") to ?{def *: ?}
+        //         path("api" / "list-items")(parameters("item".*) { items =>
+        get {
+          path("api" / "list-items")(parameters(ToNameReceptacleEnhancements._string2NR("item").*) { items =>
+            complete(listItems(items))
+          })
+        }
+      // #parameter-list
+
+      // #parameter-list-test
+      Get("/api/list-items?item=red&item=new&item=slippers") ~> itemParameterList ~> check {
+        responseAs[String] shouldEqual "slippers,new,red"
+      }
+      // #parameter-list-test
+    }
+  }
+}


### PR DESCRIPTION
Add a page in the routing docs which shows the examples from the Play docs in Akka HTTP notation with accompanying tests.

References #2980
