### PR TITLE
Routing DSL: Names for to symbolic enhancements

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -41,21 +41,21 @@ class FormFieldDirectivesSpec extends RoutingSpec {
   "The 'formFields' extraction directive" should {
     "properly extract the value of www-urlencoded form fields" in {
       Post("/", urlEncodedForm) ~> {
-        formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) { (firstName, age, sex, vip) =>
+        formFields("firstName", "age".as[Int], "sex".optional, "VIP".withDefault(false)) { (firstName, age, sex, vip) =>
           complete(firstName + age + sex + vip)
         }
       } ~> check { responseAs[String] shouldEqual "Mike42Nonefalse" }
     }
     "properly extract the value of www-urlencoded form fields when an explicit unmarshaller is given" in {
       Post("/", urlEncodedForm) ~> {
-        formFields('firstName, "age".as(HexInt), 'sex.?, "VIP" ? false) { (firstName, age, sex, vip) =>
+        formFields("firstName", "age".as(HexInt), "sex".optional, "VIP".withDefault(false)) { (firstName, age, sex, vip) =>
           complete(firstName + age + sex + vip)
         }
       } ~> check { responseAs[String] shouldEqual "Mike66Nonefalse" }
     }
     "properly extract the value of multipart form fields" in {
       Post("/", multipartForm) ~> {
-        formFields('firstName, "age", 'sex.?, "VIP" ? nodeSeq) { (firstName, age, sex, vip) =>
+        formFields("firstName", "age", "sex".optional, "VIP".withDefault(nodeSeq)) { (firstName, age, sex, vip) =>
           complete(firstName + age + sex + vip)
         }
       } ~> check { responseAs[String] shouldEqual "Mike<int>42</int>None<b>yes</b>" }
@@ -70,7 +70,7 @@ class FormFieldDirectivesSpec extends RoutingSpec {
     }
     "reject the request with a MissingFormFieldRejection if a required form field is missing" in {
       Post("/", urlEncodedForm) ~> {
-        formFields('firstName, "age", 'sex, "VIP" ? false) { (firstName, age, sex, vip) =>
+        formFields("firstName", "age", 'sex, "VIP".withDefault(false)) { (firstName, age, sex, vip) =>
           complete(firstName + age + sex + vip)
         }
       } ~> check { rejection shouldEqual MissingFormFieldRejection("sex") }
@@ -78,7 +78,7 @@ class FormFieldDirectivesSpec extends RoutingSpec {
     "properly extract the value if only a urlencoded deserializer is available for a multipart field that comes without a" +
       "Content-Type (or text/plain)" in {
         Post("/", multipartForm) ~> {
-          formFields('firstName, "age", 'sex.?, "VIPBoolean" ? false) { (firstName, age, sex, vip) =>
+          formFields("firstName", "age", "sex".optional, "VIPBoolean".withDefault(false)) { (firstName, age, sex, vip) =>
             complete(firstName + age + sex + vip)
           }
         } ~> check {
@@ -87,7 +87,7 @@ class FormFieldDirectivesSpec extends RoutingSpec {
       }
     "work even if only a FromStringUnmarshaller is available for a multipart field with custom Content-Type" in {
       Post("/", multipartFormWithTextHtml) ~> {
-        formFields(('firstName, "age", 'super ? false)) { (firstName, age, vip) =>
+        formFields(("firstName", "age", "super".withDefault(false))) { (firstName, age, vip) =>
           complete(firstName + age + vip)
         }
       } ~> check {
@@ -96,7 +96,7 @@ class FormFieldDirectivesSpec extends RoutingSpec {
     }
     "work even if only a FromEntityUnmarshaller is available for a www-urlencoded field" in {
       Post("/", urlEncodedFormWithVip) ~> {
-        formFields('firstName, "age", 'sex.?, "super" ? nodeSeq) { (firstName, age, sex, vip) =>
+        formFields("firstName", "age", "sex".optional, "super".withDefault(nodeSeq)) { (firstName, age, sex, vip) =>
           complete(firstName + age + sex + vip)
         }
       } ~> check {
@@ -113,7 +113,7 @@ class FormFieldDirectivesSpec extends RoutingSpec {
       request.entity shouldNot be('strict)
 
       request ~> {
-        formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) { (firstName, age, sex, vip) =>
+        formFields("firstName", "age".as[Int], "sex".optional, "VIP".withDefault(false)) { (firstName, age, sex, vip) =>
           complete(firstName + age + sex + vip)
         }
       } ~> check { responseAs[String] shouldEqual "Mike42Nonefalse" }
@@ -129,9 +129,9 @@ class FormFieldDirectivesSpec extends RoutingSpec {
       request.entity shouldNot be('strict)
 
       request ~> {
-        formFields('firstName) { firstName =>
-          formFields("age".as[Int], 'sex.?) { (age, sex) =>
-            formFields("VIP" ? false) { vip =>
+        formFields("firstName") { firstName =>
+          formFields("age".as[Int], "sex".optional) { (age, sex) =>
+            formFields("VIP".withDefault(false)) { vip =>
               complete(firstName + age + sex + vip)
             }
           }
@@ -150,13 +150,13 @@ class FormFieldDirectivesSpec extends RoutingSpec {
 
       request ~> {
         concat(
-          formFields('firstName, "age".as[Int]) { (firstName, age) =>
+          formFields("firstName", "age".as[Int]) { (firstName, age) =>
             println("firstName", age)
             reject
           },
-          formFields('firstName, "age".as[Int]) { (firstName, age) =>
-            formFields('sex.?) { sex =>
-              formFields("VIP" ? false) { vip =>
+          formFields("firstName", "age".as[Int]) { (firstName, age) =>
+            formFields("sex".optional) { sex =>
+              formFields("VIP".withDefault(false)) { vip =>
                 complete(firstName + age + sex + vip)
               }
             }
@@ -168,17 +168,17 @@ class FormFieldDirectivesSpec extends RoutingSpec {
   "The 'formField' requirement directive" should {
     "block requests that do not contain the required formField" in {
       Post("/", urlEncodedForm) ~> {
-        formField('name ! "Mr. Mike") { completeOk }
+        formField("name".requiredValue("Mr. Mike")) { completeOk }
       } ~> check { handled shouldEqual false }
     }
     "block requests that contain the required parameter but with an unmatching value" in {
       Post("/", urlEncodedForm) ~> {
-        formField('firstName ! "Pete") { completeOk }
+        formField("firstName".requiredValue("Pete")) { completeOk }
       } ~> check { handled shouldEqual false }
     }
     "let requests pass that contain the required parameter with its required value" in {
       Post("/", urlEncodedForm) ~> {
-        formField('firstName ! "Mike") { completeOk }
+        formField("firstName".requiredValue("Mike")) { completeOk }
       } ~> check { response shouldEqual Ok }
     }
   }
@@ -186,17 +186,17 @@ class FormFieldDirectivesSpec extends RoutingSpec {
   "The 'formField' requirement with explicit unmarshaller directive" should {
     "block requests that do not contain the required formField" in {
       Post("/", urlEncodedForm) ~> {
-        formField('oldAge.as(HexInt) ! 78) { completeOk }
+        formField("oldAge".as(HexInt).requiredValue(78)) { completeOk }
       } ~> check { handled shouldEqual false }
     }
     "block requests that contain the required parameter but with an unmatching value" in {
       Post("/", urlEncodedForm) ~> {
-        formField('age.as(HexInt) ! 78) { completeOk }
+        formField("age".as(HexInt).requiredValue(78)) { completeOk }
       } ~> check { handled shouldEqual false }
     }
     "let requests pass that contain the required parameter with its required value" in {
       Post("/", urlEncodedForm) ~> {
-        formField('age.as(HexInt) ! 66 /* hex! */ ) { completeOk }
+        formField("age".as(HexInt).requiredValue(66) /* hex! */ ) { completeOk }
       } ~> check { response shouldEqual Ok }
     }
   }
@@ -204,22 +204,22 @@ class FormFieldDirectivesSpec extends RoutingSpec {
   "The 'formField' repeated directive" should {
     "extract an empty Iterable when the parameter is absent" in {
       Post("/", FormData("age" -> "42")) ~> {
-        formField('hobby.*) { echoComplete }
+        formField("hobby".repeated) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "Vector()" }
     }
     "extract all occurrences into an Iterable when parameter is present" in {
       Post("/", FormData("age" -> "42", "hobby" -> "cooking", "hobby" -> "reading")) ~> {
-        formField('hobby.*) { echoComplete }
+        formField("hobby".repeated) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "Vector(cooking, reading)" }
     }
     "extract as Iterable[Int]" in {
       Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "5")) ~> {
-        formField('number.as[Int].*) { echoComplete }
+        formField("number".as[Int].repeated) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "Vector(3, 5)" }
     }
     "extract as Iterable[Int] with an explicit deserializer" in {
       Post("/", FormData("age" -> "42", "number" -> "3", "number" -> "A")) ~> {
-        formField('number.as(HexInt).*) { echoComplete }
+        formField("number".as(HexInt).repeated) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "Vector(3, 10)" }
     }
   }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -168,7 +168,7 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
   "The 'parameters' extraction directive should" - {
     "extract the value of given parameters" in {
       Get("/?name=Parsons&FirstName=Ellen") ~> {
-        parameters("name", 'FirstName) { (name, firstName) =>
+        parameters("name", "FirstName") { (name, firstName) =>
           complete(firstName + name)
         }
       } ~> check { responseAs[String] shouldEqual "EllenParsons" }
@@ -179,14 +179,14 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
     }
     "ignore additional parameters" in {
       Get("/?name=Parsons&FirstName=Ellen&age=29") ~> {
-        parameters("name", 'FirstName) { (name, firstName) =>
+        parameters("name", "FirstName") { (name, firstName) =>
           complete(firstName + name)
         }
       } ~> check { responseAs[String] shouldEqual "EllenParsons" }
     }
     "reject the request with a MissingQueryParamRejection if a required parameter is missing" in {
       Get("/?name=Parsons&sex=female") ~> {
-        parameters('name, 'FirstName, 'age) { (name, firstName, age) =>
+        parameters("name", "FirstName", "age") { (name, firstName, age) =>
           completeOk
         }
       } ~> check { rejection shouldEqual MissingQueryParamRejection("FirstName") }
@@ -203,17 +203,17 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
   "The 'parameter' requirement directive should" - {
     "reject the request with a MissingQueryParamRejection if request do not contain the required parameter" in {
       Get("/person?age=19") ~> {
-        parameter("node".requiredValue("large")) { completeOk }
+        parameter("nose".requiredValue("large")) { completeOk }
       } ~> check { rejection shouldEqual MissingQueryParamRejection("nose") }
     }
     "reject the request with a InvalidRequiredValueForQueryParamRejection if the required parameter has an unmatching value" in {
       Get("/person?age=19&nose=small") ~> {
-        parameter("node".requiredValue("large")) { completeOk }
+        parameter("nose".requiredValue("large")) { completeOk }
       } ~> check { rejection shouldEqual InvalidRequiredValueForQueryParamRejection("nose", "large", "small") }
     }
     "let requests pass that contain the required parameter with its required value" in {
       Get("/person?nose=large&eyes=blue") ~> {
-        parameter("node".requiredValue("large")) { completeOk }
+        parameter("nose".requiredValue("large")) { completeOk }
       } ~> check { response shouldEqual Ok }
     }
     "be useable for method tunneling" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -14,12 +14,12 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
   "when used with 'as[Int]' the parameter directive should" - {
     "extract a parameter value as Int" in {
       Get("/?amount=123") ~> {
-        parameter('amount.as[Int]) { echoComplete }
+        parameter("amount".as[Int]) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "123" }
     }
     "cause a MalformedQueryParamRejection on illegal Int values" in {
       Get("/?amount=1x3") ~> {
-        parameter('amount.as[Int]) { echoComplete }
+        parameter("amount".as[Int]) { echoComplete }
       } ~> check {
         inside(rejection) {
           case MalformedQueryParamRejection("amount", "'1x3' is not a valid 32-bit signed integer value", Some(_)) =>
@@ -28,23 +28,23 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
     }
     "supply typed default values" in {
       Get() ~> {
-        parameter('amount ? 45) { echoComplete }
+        parameter("amount".withDefault(45)) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "45" }
     }
     "create typed optional parameters that" - {
       "extract Some(value) when present" in {
         Get("/?amount=12") ~> {
-          parameter("amount".as[Int].?) { echoComplete }
+          parameter("amount".as[Int].optional) { echoComplete }
         } ~> check { responseAs[String] shouldEqual "Some(12)" }
       }
       "extract None when not present" in {
         Get() ~> {
-          parameter("amount".as[Int].?) { echoComplete }
+          parameter("amount".as[Int].optional) { echoComplete }
         } ~> check { responseAs[String] shouldEqual "None" }
       }
       "cause a MalformedQueryParamRejection on illegal Int values" in {
         Get("/?amount=x") ~> {
-          parameter("amount".as[Int].?) { echoComplete }
+          parameter("amount".as[Int].optional) { echoComplete }
         } ~> check {
           inside(rejection) {
             case MalformedQueryParamRejection("amount", "'x' is not a valid 32-bit signed integer value", Some(_)) =>
@@ -58,10 +58,10 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
       val UserIdUnmarshaller = Unmarshaller.strict[Int, UserId](UserId)
       implicit val AnotherUserIdUnmarshaller = Unmarshaller.strict[UserId, AnotherUserId](userId => AnotherUserId(userId.id))
       Get("/?id=45") ~> {
-        parameter('id.as[Int].as(UserIdUnmarshaller)) { echoComplete }
+        parameter("id".as[Int].as(UserIdUnmarshaller)) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "UserId(45)" }
       Get("/?id=45") ~> {
-        parameter('id.as[Int].as(UserIdUnmarshaller).as[AnotherUserId]) { echoComplete }
+        parameter("id".as[Int].as(UserIdUnmarshaller).as[AnotherUserId]) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "AnotherUserId(45)" }
     }
   }
@@ -92,12 +92,12 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
   "when used with 'as(HexInt)' the parameter directive should" - {
     "extract parameter values as Int" in {
       Get("/?amount=1f") ~> {
-        parameter('amount.as(HexInt)) { echoComplete }
+        parameter("amount".as(HexInt)) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "31" }
     }
     "cause a MalformedQueryParamRejection on illegal Int values" in {
       Get("/?amount=1x3") ~> {
-        parameter('amount.as(HexInt)) { echoComplete }
+        parameter("amount".as(HexInt)) { echoComplete }
       } ~> check {
         inside(rejection) {
           case MalformedQueryParamRejection("amount", "'1x3' is not a valid 32-bit hexadecimal integer value", Some(_)) =>
@@ -106,23 +106,23 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
     }
     "supply typed default values" in {
       Get() ~> {
-        parameter('amount.as(HexInt) ? 45) { echoComplete }
+        parameter("amount".as(HexInt).withDefault(45)) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "45" }
     }
     "create typed optional parameters that" - {
       "extract Some(value) when present" in {
         Get("/?amount=A") ~> {
-          parameter("amount".as(HexInt).?) { echoComplete }
+          parameter("amount".as(HexInt).optional) { echoComplete }
         } ~> check { responseAs[String] shouldEqual "Some(10)" }
       }
       "extract None when not present" in {
         Get() ~> {
-          parameter("amount".as(HexInt).?) { echoComplete }
+          parameter("amount".as(HexInt).optional) { echoComplete }
         } ~> check { responseAs[String] shouldEqual "None" }
       }
       "cause a MalformedQueryParamRejection on illegal Int values" in {
         Get("/?amount=x") ~> {
-          parameter("amount".as(HexInt).?) { echoComplete }
+          parameter("amount".as(HexInt).optional) { echoComplete }
         } ~> check {
           inside(rejection) {
             case MalformedQueryParamRejection("amount", "'x' is not a valid 32-bit hexadecimal integer value", Some(_)) =>
@@ -135,28 +135,28 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
   "when used with 'as[Boolean]' the parameter directive should" - {
     "extract parameter values as Boolean" in {
       Get("/?really=true") ~> {
-        parameter('really.as[Boolean]) { echoComplete }
+        parameter("really".as[Boolean]) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "true" }
       Get("/?really=no") ~> {
-        parameter('really.as[Boolean]) { echoComplete }
+        parameter("really".as[Boolean]) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "false" }
     }
     "extract numeric parameter value as Boolean" in {
       Get("/?really=1") ~> {
-        parameter('really.as[Boolean]) { echoComplete }
+        parameter("really".as[Boolean]) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "true" }
       Get("/?really=0") ~> {
-        parameter('really.as[Boolean]) { echoComplete }
+        parameter("really".as[Boolean]) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "false" }
     }
     "extract optional parameter values as Boolean" in {
       Get() ~> {
-        parameter('really.as[Boolean] ? false) { echoComplete }
+        parameter("really".as[Boolean].withDefault(false)) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "false" }
     }
     "cause a MalformedQueryParamRejection on illegal Boolean values" in {
       Get("/?really=absolutely") ~> {
-        parameter('really.as[Boolean]) { echoComplete }
+        parameter("really".as[Boolean]) { echoComplete }
       } ~> check {
         inside(rejection) {
           case MalformedQueryParamRejection("really", "'absolutely' is not a valid Boolean value", None) =>
@@ -174,8 +174,8 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
       } ~> check { responseAs[String] shouldEqual "EllenParsons" }
     }
     "correctly extract an optional parameter" in {
-      Get("/?foo=bar") ~> parameters('foo.?) { echoComplete } ~> check { responseAs[String] shouldEqual "Some(bar)" }
-      Get("/?foo=bar") ~> parameters('baz.?) { echoComplete } ~> check { responseAs[String] shouldEqual "None" }
+      Get("/?foo=bar") ~> parameters("foo".optional) { echoComplete } ~> check { responseAs[String] shouldEqual "Some(bar)" }
+      Get("/?foo=bar") ~> parameters("baz".optional) { echoComplete } ~> check { responseAs[String] shouldEqual "None" }
     }
     "ignore additional parameters" in {
       Get("/?name=Parsons&FirstName=Ellen&age=29") ~> {
@@ -193,7 +193,7 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
     }
     "supply the default value if an optional parameter is missing" in {
       Get("/?name=Parsons&FirstName=Ellen") ~> {
-        parameters("name".?, 'FirstName, 'age ? "29", 'eyes.?) { (name, firstName, age, eyes) =>
+        parameters("name".optional, "FirstName", "age".withDefault("29"), "eyes".optional) { (name, firstName, age, eyes) =>
           complete(firstName + name + age + eyes)
         }
       } ~> check { responseAs[String] shouldEqual "EllenSome(Parsons)29None" }
@@ -203,22 +203,22 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
   "The 'parameter' requirement directive should" - {
     "reject the request with a MissingQueryParamRejection if request do not contain the required parameter" in {
       Get("/person?age=19") ~> {
-        parameter('nose ! "large") { completeOk }
+        parameter("node".requiredValue("large")) { completeOk }
       } ~> check { rejection shouldEqual MissingQueryParamRejection("nose") }
     }
     "reject the request with a InvalidRequiredValueForQueryParamRejection if the required parameter has an unmatching value" in {
       Get("/person?age=19&nose=small") ~> {
-        parameter('nose ! "large") { completeOk }
+        parameter("node".requiredValue("large")) { completeOk }
       } ~> check { rejection shouldEqual InvalidRequiredValueForQueryParamRejection("nose", "large", "small") }
     }
     "let requests pass that contain the required parameter with its required value" in {
       Get("/person?nose=large&eyes=blue") ~> {
-        parameter('nose ! "large") { completeOk }
+        parameter("node".requiredValue("large")) { completeOk }
       } ~> check { response shouldEqual Ok }
     }
     "be useable for method tunneling" in {
       val route = {
-        (post | parameter('method ! "post")) { complete("POST") } ~
+        (post | parameter("method".requiredValue("post"))) { complete("POST") } ~
           get { complete("GET") }
       }
       Get("/?method=post") ~> route ~> check { responseAs[String] shouldEqual "POST" }
@@ -230,22 +230,22 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
   "The 'parameter' repeated directive should" - {
     "extract an empty Iterable when the parameter is absent" in {
       Get("/person?age=19") ~> {
-        parameter('hobby.*) { echoComplete }
+        parameter("hobby".repeated) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "List()" }
     }
     "extract all occurrences into an Iterable when parameter is present" in {
       Get("/person?age=19&hobby=cooking&hobby=reading") ~> {
-        parameter('hobby.*) { echoComplete }
+        parameter("hobby".repeated) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "List(reading, cooking)" }
     }
     "extract as Iterable[Int]" in {
       Get("/person?age=19&number=3&number=5") ~> {
-        parameter('number.as[Int].*) { echoComplete }
+        parameter("number".as[Int].repeated) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "List(5, 3)" }
     }
     "extract as Iterable[Int] with an explicit deserializer" in {
       Get("/person?age=19&number=3&number=A") ~> {
-        parameter('number.as(HexInt).*) { echoComplete }
+        parameter("number".as(HexInt).repeated) { echoComplete }
       } ~> check { responseAs[String] shouldEqual "List(10, 3)" }
     }
   }
@@ -273,7 +273,7 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
     "extract a parameter value as Case Class" in {
       case class Color(red: Int, green: Int, blue: Int)
       Get("/?red=90&green=50&blue=0") ~> {
-        parameter('red.as[Int], 'green.as[Int], 'blue.as[Int]).as(Color) { color =>
+        parameter("red".as[Int], "green".as[Int], "blue".as[Int]).as(Color) { color =>
           complete(s"${color.red} ${color.green} ${color.blue}")
         }
       } ~> check { responseAs[String] shouldEqual "90 50 0" }
@@ -285,7 +285,7 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
         require(0 <= blue && blue <= 255)
       }
       Get("/?red=500&green=0&blue=0") ~> {
-        parameter('red.as[Int], 'green.as[Int], 'blue.as[Int]).as(Color) { color =>
+        parameter("red".as[Int], "green".as[Int], "blue".as[Int]).as(Color) { color =>
           complete(s"${color.red} ${color.green} ${color.blue}")
         }
       } ~> check {
@@ -299,7 +299,7 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
         require(0 <= blue && blue <= 255)
       }
       Get("/?red=0&green=0&blue=0") ~> {
-        parameter('red.as[Int], 'green.as[Int], 'blue.as[Int]).as(Color) { _ =>
+        parameter("red".as[Int], "green".as[Int], "blue".as[Int]).as(Color) { _ =>
           throw new IllegalArgumentException
         }
       } ~> check {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/PathDirectivesSpec.scala
@@ -312,7 +312,7 @@ class PathDirectivesSpec extends RoutingSpec with Inside {
   }
 
   """pathPrefix("foo".?)""" should {
-    val test = testFor(pathPrefix("foo".?) { echoUnmatchedPath })
+    val test = testFor(pathPrefix("foo".optional) { echoUnmatchedPath })
     "accept [/foo]" inThe test("")
     "accept [/fool]" inThe test("l")
     "accept [/bar]" inThe test("bar")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FormFieldDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FormFieldDirectives.scala
@@ -30,13 +30,13 @@ abstract class FormFieldDirectives extends FileUploadDirectives {
 
   @CorrespondsTo("formField")
   def formFieldOptional(name: String, inner: JFunction[Optional[String], Route]): Route = RouteAdapter(
-    D.formField(name.?) { value =>
+    D.formField(name.optional) { value =>
       inner.apply(value.asJava).delegate
     })
 
   @CorrespondsTo("formFieldSeq")
   def formFieldList(name: String, inner: JFunction[java.util.List[String], Route]): Route = RouteAdapter(
-    D.formField(_string2NR(name).*) { values =>
+    D.formField(name.repeated) { values =>
       inner.apply(values.toSeq.asJava).delegate
     })
 
@@ -52,7 +52,7 @@ abstract class FormFieldDirectives extends FileUploadDirectives {
   def formFieldOptional[T](t: Unmarshaller[String, T], name: String, inner: JFunction[Optional[T], Route]): Route = {
     import t.asScala
     RouteAdapter(
-      D.formField(name.as[T].?) { value =>
+      D.formField(name.as[T].optional) { value =>
         inner.apply(OptionConverters.toJava(value)).delegate
       })
   }
@@ -61,7 +61,7 @@ abstract class FormFieldDirectives extends FileUploadDirectives {
   def formFieldList[T](t: Unmarshaller[String, T], name: String, inner: JFunction[java.util.List[T], Route]): Route = {
     import t.asScala
     RouteAdapter(
-      D.formField(name.as[T].*) { values =>
+      D.formField(name.as[T].optional) { values =>
         inner.apply(values.toSeq.asJava).delegate
       })
   }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/ParameterDirectives.scala
@@ -25,7 +25,7 @@ abstract class ParameterDirectives extends MiscDirectives {
 
   @CorrespondsTo("parameter")
   def parameterOptional(name: String, inner: java.util.function.Function[Optional[String], Route]): Route = RouteAdapter(
-    D.parameter(name.?) { value =>
+    D.parameter(name.optional) { value =>
       inner.apply(value.asJava).delegate
     })
 
@@ -33,13 +33,13 @@ abstract class ParameterDirectives extends MiscDirectives {
   def parameterRequiredValue[T](t: Unmarshaller[String, T], requiredValue: T, name: String, inner: java.util.function.Supplier[Route]): Route = {
     import t.asScala
     RouteAdapter(
-      D.parameter(name.as[T].!(requiredValue)) { inner.get.delegate }
+      D.parameter(name.as[T].requiredValue(requiredValue)) { inner.get.delegate }
     )
   }
 
   @CorrespondsTo("parameterSeq")
   def parameterList(name: String, inner: java.util.function.Function[java.util.List[String], Route]): Route = RouteAdapter(
-    D.parameter(_string2NR(name).*) { values =>
+    D.parameter(name.repeated) { values =>
       inner.apply(values.toSeq.asJava).delegate
     })
 
@@ -55,7 +55,7 @@ abstract class ParameterDirectives extends MiscDirectives {
   def parameterOptional[T](t: Unmarshaller[String, T], name: String, inner: java.util.function.Function[Optional[T], Route]): Route = {
     import t.asScala
     RouteAdapter(
-      D.parameter(name.as[T].?) { value =>
+      D.parameter(name.as[T].optional) { value =>
         inner.apply(value.asJava).delegate
       })
   }
@@ -64,7 +64,7 @@ abstract class ParameterDirectives extends MiscDirectives {
   def parameterOrDefault[T](t: Unmarshaller[String, T], defaultValue: T, name: String, inner: java.util.function.Function[T, Route]): Route = {
     import t.asScala
     RouteAdapter(
-      D.parameter(name.as[T].?(defaultValue)) { value =>
+      D.parameter(name.as[T].withDefault(defaultValue)) { value =>
         inner.apply(value).delegate
       })
   }
@@ -73,7 +73,7 @@ abstract class ParameterDirectives extends MiscDirectives {
   def parameterList[T](t: Unmarshaller[String, T], name: String, inner: java.util.function.Function[java.util.List[T], Route]): Route = {
     import t.asScala
     RouteAdapter(
-      D.parameter(name.as[T].*) { values =>
+      D.parameter(name.as[T].repeated) { values =>
         inner.apply(values.toSeq.asJava).delegate
       })
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.unmarshalling.{ Unmarshaller, FromStringUnmarshaller =
 
 private[http] trait ToNameReceptacleEnhancements {
   implicit def _symbol2NR(symbol: Symbol): NameReceptacle[String] = new NameReceptacle[String](symbol.name)
+  @annotation.implicitAmbiguous("Akka HTTP's `*` decorator conflicts with Scala's String.`*` method. Use `.repeated` instead.")
   implicit def _string2NR(string: String): NameReceptacle[String] = new NameReceptacle[String](string)
 }
 object ToNameReceptacleEnhancements extends ToNameReceptacleEnhancements
@@ -16,19 +17,35 @@ class NameReceptacle[T](val name: String) {
   def as[B] = new NameReceptacle[B](name)
   def as[B](unmarshaller: Unmarshaller[T, B])(implicit fsu: FSU[T]) =
     new NameUnmarshallerReceptacle(name, fsu.transform[B](implicit ec => implicit mat => { _ flatMap unmarshaller.apply }))
+  /** Symbolic alias for [[optional]]. */
   def ? = new NameOptionReceptacle[T](name)
+  def optional = new NameOptionReceptacle[T](name)
+  /** Symbolic alias for [[withDefault]]. */
   def ?[B](default: B) = new NameDefaultReceptacle(name, default)
+  def withDefault[B](default: B) = new NameDefaultReceptacle(name, default)
+  /** Symbolic alias for [[requiredValue]]. */
   def ![B](requiredValue: B) = new RequiredValueReceptacle(name, requiredValue)
+  def requiredValue[B](requiredValue: B) = new RequiredValueReceptacle(name, requiredValue)
+  /** Symbolic alias for [[repeated]]. */
   def * = new RepeatedValueReceptacle[T](name)
+  def repeated = new RepeatedValueReceptacle[T](name)
 }
 
 class NameUnmarshallerReceptacle[T](val name: String, val um: FSU[T]) {
   def as[B](implicit unmarshaller: Unmarshaller[T, B]) =
     new NameUnmarshallerReceptacle(name, um.transform[B](implicit ec => implicit mat => { _ flatMap unmarshaller.apply }))
+  /** Symbolic alias for [[optional]]. */
   def ? = new NameOptionUnmarshallerReceptacle[T](name, um)
+  def optional = new NameOptionUnmarshallerReceptacle[T](name, um)
+  /** Symbolic alias for [[withDefault]]. */
   def ?(default: T) = new NameDefaultUnmarshallerReceptacle(name, default, um)
+  def withDefault(default: T) = new NameDefaultUnmarshallerReceptacle(name, default, um)
+  /** Symbolic alias for [[requiredValue]]. */
   def !(requiredValue: T) = new RequiredValueUnmarshallerReceptacle(name, requiredValue, um)
+  def requiredValue(requiredValue: T) = new RequiredValueUnmarshallerReceptacle(name, requiredValue, um)
+  /** Symbolic alias for [[repeated]]. */
   def * = new RepeatedValueUnmarshallerReceptacle[T](name, um)
+  def repeated = new RepeatedValueUnmarshallerReceptacle[T](name, um)
 }
 
 class NameOptionReceptacle[T](val name: String)

--- a/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/common/NameReceptacle.scala
@@ -14,37 +14,118 @@ private[http] trait ToNameReceptacleEnhancements {
 object ToNameReceptacleEnhancements extends ToNameReceptacleEnhancements
 
 class NameReceptacle[T](val name: String) {
+  /**
+   * Extract the value as the specified type.
+   * You need a matching [[akka.http.scaladsl.unmarshalling.Unmarshaller]] in scope for that to work.
+   */
   def as[B] = new NameReceptacle[B](name)
+
+  /**
+   * Extract the value as the specified type with the given [[akka.http.scaladsl.unmarshalling.Unmarshaller]].
+   */
   def as[B](unmarshaller: Unmarshaller[T, B])(implicit fsu: FSU[T]) =
     new NameUnmarshallerReceptacle(name, fsu.transform[B](implicit ec => implicit mat => { _ flatMap unmarshaller.apply }))
-  /** Symbolic alias for [[optional]]. */
+
+  /**
+   * Extract the optional value as `Option[String]`.
+   * Symbolic alias for [[optional]].
+   */
   def ? = new NameOptionReceptacle[T](name)
+
+  /**
+   * Extract the optional value as `Option[String]`.
+   */
   def optional = new NameOptionReceptacle[T](name)
-  /** Symbolic alias for [[withDefault]]. */
+
+  /**
+   * Extract the optional value as `String`, if it is missing use the given default value.
+   * Symbolic alias for [[withDefault]].
+   */
   def ?[B](default: B) = new NameDefaultReceptacle(name, default)
+
+  /**
+   * Extract the optional value as `String`, if it is missing use the given default value.
+   */
   def withDefault[B](default: B) = new NameDefaultReceptacle(name, default)
-  /** Symbolic alias for [[requiredValue]]. */
+
+  /**
+   * Require the given value and extract nothing.
+   * Reject if it is missing or has a different value.
+   * Symbolic alias for [[requiredValue]].
+   */
   def ![B](requiredValue: B) = new RequiredValueReceptacle(name, requiredValue)
+
+  /**
+   * Require the given value and extract nothing.
+   * Reject if it is missing or has a different value.
+   */
   def requiredValue[B](requiredValue: B) = new RequiredValueReceptacle(name, requiredValue)
-  /** Symbolic alias for [[repeated]]. */
+
+  /**
+   * Extract multiple occurrences as `Iterable[String]`.
+   * Symbolic alias for [[repeated]].
+   */
   def * = new RepeatedValueReceptacle[T](name)
+
+  /**
+   * Extract multiple occurrences as `Iterable[String]`.
+   */
   def repeated = new RepeatedValueReceptacle[T](name)
 }
 
 class NameUnmarshallerReceptacle[T](val name: String, val um: FSU[T]) {
+  /**
+   * Extract the value as the specified type.
+   * You need a matching [[akka.http.scaladsl.unmarshalling.Unmarshaller]] in scope for that to work.
+   */
   def as[B](implicit unmarshaller: Unmarshaller[T, B]) =
     new NameUnmarshallerReceptacle(name, um.transform[B](implicit ec => implicit mat => { _ flatMap unmarshaller.apply }))
-  /** Symbolic alias for [[optional]]. */
+
+  /**
+   * Extract the optional value as `Option[T]`.
+   * Symbolic alias for [[optional]].
+   */
   def ? = new NameOptionUnmarshallerReceptacle[T](name, um)
+
+  /**
+   * Extract the optional value as `Option[T]`.
+   * Symbolic alias for [[optional]].
+   */
   def optional = new NameOptionUnmarshallerReceptacle[T](name, um)
-  /** Symbolic alias for [[withDefault]]. */
+
+  /**
+   * Extract the optional value as `T`, if it is missing use the given default value.
+   * Symbolic alias for [[withDefault]].
+   */
   def ?(default: T) = new NameDefaultUnmarshallerReceptacle(name, default, um)
+
+  /**
+   * Extract the optional value as `T`, if it is missing use the given default value.
+   */
   def withDefault(default: T) = new NameDefaultUnmarshallerReceptacle(name, default, um)
-  /** Symbolic alias for [[requiredValue]]. */
+
+  /**
+   * Require the given value and extract nothing.
+   * Reject if it is missing or has a different value.
+   * Symbolic alias for [[requiredValue]].
+   */
   def !(requiredValue: T) = new RequiredValueUnmarshallerReceptacle(name, requiredValue, um)
+
+  /**
+   * Require the given value and extract nothing.
+   * Reject if it is missing or has a different value.
+   */
   def requiredValue(requiredValue: T) = new RequiredValueUnmarshallerReceptacle(name, requiredValue, um)
-  /** Symbolic alias for [[repeated]]. */
+
+  /**
+   * Extract multiple occurrences as `Iterable[String]`.
+   * Symbolic alias for [[repeated]].
+   */
   def * = new RepeatedValueUnmarshallerReceptacle[T](name, um)
+
+  /**
+   * Extract multiple occurrences as `Iterable[String]`.
+   */
   def repeated = new RepeatedValueUnmarshallerReceptacle[T](name, um)
 }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -8,6 +8,7 @@ import scala.util.control.NonFatal
 import akka.http.scaladsl.settings.RoutingSettings
 import akka.http.scaladsl.model._
 import StatusCodes._
+import scala.language.implicitConversions
 
 trait ExceptionHandler extends ExceptionHandler.PF {
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
@@ -99,7 +99,7 @@ trait MethodDirectives {
    * @group method
    */
   def overrideMethodWithParameter(paramName: String): Directive0 =
-    parameter(paramName?) flatMap {
+    parameter(paramName.optional) flatMap {
       case Some(method) =>
         getForKey(method.toUpperCase) match {
           case Some(m) => mapRequest(_.withMethod(m))

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -43,11 +43,6 @@ trait ParameterDirectives extends ToNameReceptacleEnhancements {
    * Extracts a query parameter value from the request.
    * Rejects the request if the defined query parameter matcher(s) don't match.
    *
-   * Due to a bug in Scala 2.10, invocations of this method sometimes fail to compile with an
-   * "too many arguments for method parameter" or "type mismatch" error.
-   *
-   * As a workaround add an `import ParameterDirectives.ParamMagnet` or use Scala 2.11.x.
-   *
    * @group param
    */
   def parameter(pdm: ParamMagnet): pdm.Out = pdm()
@@ -55,11 +50,6 @@ trait ParameterDirectives extends ToNameReceptacleEnhancements {
   /**
    * Extracts a number of query parameter values from the request.
    * Rejects the request if the defined query parameter matcher(s) don't match.
-   *
-   * Due to a bug in Scala 2.10, invocations of this method sometimes fail to compile with an
-   * "too many arguments for method parameters" or "type mismatch" error.
-   *
-   * As a workaround add an `import ParameterDirectives.ParamMagnet` or use Scala 2.11.x.
    *
    * @group param
    */

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/SecurityDirectives.scala
@@ -147,7 +147,7 @@ trait SecurityDirectives {
     extractExecutionContext.flatMap { implicit ec =>
       def extractAccessTokenParameterAsBearerToken = {
         import akka.http.scaladsl.server.Directives._
-        parameter('access_token.?).map(_.map(OAuth2BearerToken))
+        parameter("access_token".optional).map(_.map(OAuth2BearerToken))
       }
       val extractCreds: Directive1[Option[OAuth2BearerToken]] =
         extractCredentials.flatMap {

--- a/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFields.md
+++ b/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFields.md
@@ -31,14 +31,14 @@ as required, optional, or repeated, or to filter requests where a form field has
 `"color"`
 : extract value of field "color" as `String`
 
-`"color".?`
-: extract optional value of field "color" as `Option[String]`
+`"color".optional`
+: extract optional value of field "color" as `Option[String]` (symbolic notation `"color".?`)
 
-`"color" ? "red"`
-: extract optional value of field "color" as `String` with default value `"red"`
+`"color".withDefault("red")`
+: extract optional value of field "color" as `String` with default value `"red"` (symbolic notation `"color" ? "red"`)
 
-`"color" ! "blue"`
-: require value of field "color" to be `"blue"` and extract nothing
+`"color".requiredValue("blue")`
+: require value of field "color" to be `"blue"` and extract nothing (symbolic notation `"color" ! "blue"`)
 
 `"amount".as[Int]`
 : extract value of field "amount" as `Int`, you need a matching implicit @apidoc[Unmarshaller] in scope for that to work
@@ -47,14 +47,14 @@ as required, optional, or repeated, or to filter requests where a form field has
 `"amount".as(unmarshaller)`
 : extract value of field "amount" with an explicit @apidoc[Unmarshaller]
 
-`"distance".*`
+`"distance".repeated`
 : extract multiple occurrences of field "distance" as `Iterable[String]`
 
-`"distance".as[Int].*`
+`"distance".as[Int].repeated`
 : extract multiple occurrences of field "distance" as `Iterable[Int]`, you need a matching implicit @apidoc[Unmarshaller] in scope for that to work
 (see also @ref[Unmarshalling](../../../common/unmarshalling.md))
 
-`"distance".as(unmarshaller).*`
+`"distance".as(unmarshaller).repeated`
 : extract multiple occurrences of field "distance" with an explicit @apidoc[Unmarshaller]
 
 

--- a/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFields.md
+++ b/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFields.md
@@ -29,23 +29,30 @@ can be supplied either as a String or as a Symbol. Form field extraction can be 
 as required, optional, or repeated, or to filter requests where a form field has a certain value:
 
 `"color"`
-: extract value of field "color" as `String`
+: extract the value of field "color" as `String`
+: reject if the field is missing
 
 `"color".optional`
-: extract optional value of field "color" as `Option[String]` (symbolic notation `"color".?`)
+: (symbolic notation `"color".?`)
+: extract the optional value of field "color" as `Option[String]`
 
 `"color".withDefault("red")`
-: extract optional value of field "color" as `String` with default value `"red"` (symbolic notation `"color" ? "red"`)
+: (symbolic notation `"color" ? "red"`)
+: extract the optional value of field "color" as `String` with default value `"red"`
 
 `"color".requiredValue("blue")`
-: require value of field "color" to be `"blue"` and extract nothing (symbolic notation `"color" ! "blue"`)
+: (symbolic notation `"color" ! "blue"`)
+: require the value of field "color" to be `"blue"` and extract nothing
+: reject if the field is missing or can't be unmarshalled to the given type
 
 `"amount".as[Int]`
-: extract value of field "amount" as `Int`, you need a matching implicit @apidoc[Unmarshaller] in scope for that to work
+: extract the value of field "amount" as `Int`, you need a matching implicit @apidoc[Unmarshaller] in scope for that to work
 (see also @ref[Unmarshalling](../../../common/unmarshalling.md))
+: reject if the field is missing or can't be unmarshalled to the given type
 
 `"amount".as(unmarshaller)`
-: extract value of field "amount" with an explicit @apidoc[Unmarshaller]
+: extract the value of field "amount" with an explicit @apidoc[Unmarshaller]
+: reject if the field is missing or can't be unmarshalled to the given type
 
 `"distance".repeated`
 : extract multiple occurrences of field "distance" as `Iterable[String]`

--- a/docs/src/main/paradox/routing-dsl/directives/index.md
+++ b/docs/src/main/paradox/routing-dsl/directives/index.md
@@ -360,7 +360,7 @@ Also the number of extractions and their types have to match up:
 Scala
 :  ```scala
 val route = path("order" / IntNumber) | path("order" / DoubleNumber)   // doesn't compile
-val route = path("order" / IntNumber) | parameter('order.as[Int])      // ok
+val route = path("order" / IntNumber) | parameter("order".as[Int])     // ok
 ```
 
 Java
@@ -383,7 +383,7 @@ When you combine directives producing extractions with the @scala[`&` operator]@
 
 Scala
 :  ```scala
-val order = path("order" / IntNumber) & parameters('oem, 'expired ?)
+val order = path("order" / IntNumber) & parameters("oem", "expired".optional)
 val route =
   order { (orderId, oem, expired) =>
     ...

--- a/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
+++ b/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
@@ -31,14 +31,14 @@ as required, optional, or repeated, or to filter requests where a parameter has 
 `"color"`
 : extract value of parameter "color" as `String`
 
-`"color".?`
-: extract optional value of parameter "color" as `Option[String]`
+`"color".optional`
+: extract optional value of parameter "color" as `Option[String]` (symbolic notation `"color".?`)
 
-`"color" ? "red"`
-: extract optional value of parameter "color" as `String` with default value `"red"`
+`"color".withDefault("red")`
+: extract optional value of parameter "color" as `String` with default value `"red"` (symbolic notation `"color" ? "red"`)
 
-`"color" ! "blue"`
-: require value of parameter "color" to be `"blue"` and extract nothing
+`"color".requiredValue("blue")`
+: require value of parameter "color" to be `"blue"` and extract nothing (symbolic notation `"color" ! "blue"`)
 
 `"amount".as[Int]`
 : extract value of parameter "amount" as `Int`, you need a matching @apidoc[Unmarshaller] in scope for that to work
@@ -47,17 +47,17 @@ as required, optional, or repeated, or to filter requests where a parameter has 
 `"amount".as(deserializer)`
 : extract value of parameter "amount" with an explicit @apidoc[Unmarshaller] as described in @ref[Unmarshalling](../../../common/unmarshalling.md)
 
-`"distance".*`
+`"distance".repeated`
 : extract multiple occurrences of parameter "distance" as `Iterable[String]`
 
-`"distance".as[Int].*`
+`"distance".as[Int].repeated`
 : extract multiple occurrences of parameter "distance" as `Iterable[Int]`, you need a matching @apidoc[Unmarshaller] in scope for that to work
 (see also @ref[Unmarshalling](../../../common/unmarshalling.md))
 
-`"distance".as(deserializer).*`
+`"distance".as(unmarshaller).repeated`
 : extract multiple occurrences of parameter "distance" with an explicit @apidoc[Unmarshaller] as described in @ref[Unmarshalling](../../../common/unmarshalling.md)
 
-You can use @scala[@ref[Case Class Extraction](../../case-class-extraction.md)] to group several extracted values together into a case-class
+You can use @ref[Case Class Extraction](../../case-class-extraction.md) to group several extracted values together into a case-class
 instance.
 
 @@@

--- a/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
+++ b/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
@@ -1,11 +1,7 @@
 # parameters
 
-@@@ div { .group-java }
-
 This page explains how to extract multiple *query* parameter values from the request, or parameters that might or might 
 not be present.
-
-@@@
 
 @@@ div { .group-scala }
 ## Signature
@@ -29,7 +25,7 @@ The signature shown is simplified and written in pseudo-syntax, the real signatu
 The parameters directive filters on the existence of several query parameters and extract their values.
 
 Query parameters can be either extracted as a String or can be converted to another type. The parameter name
-can be supplied either as a String or as a Symbol. Parameter extraction can be modified to mark a query parameter
+is supplied as a String. Parameter extraction can be modified to mark a query parameter
 as required, optional, or repeated, or to filter requests where a parameter has a certain value:
 
 `"color"`
@@ -49,7 +45,7 @@ as required, optional, or repeated, or to filter requests where a parameter has 
 (see also @ref[Unmarshalling](../../../common/unmarshalling.md))
 
 `"amount".as(deserializer)`
-: extract value of parameter "amount" with an explicit @apidoc[Unmarshaller]
+: extract value of parameter "amount" with an explicit @apidoc[Unmarshaller] as described in @ref[Unmarshalling](../../../common/unmarshalling.md)
 
 `"distance".*`
 : extract multiple occurrences of parameter "distance" as `Iterable[String]`
@@ -59,7 +55,7 @@ as required, optional, or repeated, or to filter requests where a parameter has 
 (see also @ref[Unmarshalling](../../../common/unmarshalling.md))
 
 `"distance".as(deserializer).*`
-: extract multiple occurrences of parameter "distance" with an explicit @apidoc[Unmarshaller]
+: extract multiple occurrences of parameter "distance" with an explicit @apidoc[Unmarshaller] as described in @ref[Unmarshalling](../../../common/unmarshalling.md)
 
 You can use @scala[@ref[Case Class Extraction](../../case-class-extraction.md)] to group several extracted values together into a case-class
 instance.
@@ -69,7 +65,7 @@ instance.
 @@@ div { .group-java }
 In order to filter on the existence of several query parameters, you need to nest as many @ref[parameter](parameter.md) directives as desired.
 
-Query parameters can be either extracted as a String or can be converted to another type. Different methods must be used
+Query parameters can be either extracted as a `String` or can be converted to another type. Different methods must be used
 when the desired parameter is required, optional or repeated.
 
 @@@
@@ -81,8 +77,8 @@ if the unmarshaller threw an `Unmarshaller.NoContentException` or a @apidoc[Malf
 (see also @ref[Rejections](../../../routing-dsl/rejections.md))
 
 @@@ div { .group-scala }
-There's also a singular version, @ref[parameter](parameter.md). Form fields can be handled in a similar way, see `formFields`. If
-you want unified handling for both query parameters and form fields, see `anyParams`.
+There's also a singular version, @ref[parameter](parameter.md). Form fields can be handled in a similar way, see @ref[`formFields`](../form-field-directives/index.md). If
+you want unified handling for both query parameters and form fields, see `anyParams`<!-- TODO: Does it exist? -->.
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
+++ b/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
@@ -77,8 +77,7 @@ if the unmarshaller threw an `Unmarshaller.NoContentException` or a @apidoc[Malf
 (see also @ref[Rejections](../../../routing-dsl/rejections.md))
 
 @@@ div { .group-scala }
-There's also a singular version, @ref[parameter](parameter.md). Form fields can be handled in a similar way, see @ref[`formFields`](../form-field-directives/index.md). If
-you want unified handling for both query parameters and form fields, see `anyParams`<!-- TODO: Does it exist? -->.
+There's also a singular version, @ref[parameter](parameter.md). Form fields can be handled in a similar way, see @ref[`formFields`](../form-field-directives/index.md).
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
+++ b/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
@@ -29,23 +29,30 @@ is supplied as a String. Parameter extraction can be modified to mark a query pa
 as required, optional, or repeated, or to filter requests where a parameter has a certain value:
 
 `"color"`
-: extract value of parameter "color" as `String`
+: extract the value of parameter "color" as `String`
+: reject if the parameter is missing
 
 `"color".optional`
-: extract optional value of parameter "color" as `Option[String]` (symbolic notation `"color".?`)
+: (symbolic notation `"color".?`)
+: extract the optional value of parameter "color" as `Option[String]`
 
 `"color".withDefault("red")`
-: extract optional value of parameter "color" as `String` with default value `"red"` (symbolic notation `"color" ? "red"`)
+: (symbolic notation `"color" ? "red"`)
+: extract the optional value of parameter "color" as `String` with default value `"red"`
 
 `"color".requiredValue("blue")`
-: require value of parameter "color" to be `"blue"` and extract nothing (symbolic notation `"color" ! "blue"`)
+: (symbolic notation `"color" ! "blue"`)
+: require the value of parameter "color" to be `"blue"` and extract nothing
+: reject if the parameter is missing or has a different value
 
 `"amount".as[Int]`
-: extract value of parameter "amount" as `Int`, you need a matching @apidoc[Unmarshaller] in scope for that to work
+: extract the value of parameter "amount" as `Int`, you need a matching @apidoc[Unmarshaller] in scope for that to work
 (see also @ref[Unmarshalling](../../../common/unmarshalling.md))
+: reject if the parameter is missing or can't be unmarshalled to the given type
 
-`"amount".as(deserializer)`
-: extract value of parameter "amount" with an explicit @apidoc[Unmarshaller] as described in @ref[Unmarshalling](../../../common/unmarshalling.md)
+`"amount".as(unmarshaller)`
+: extract the value of parameter "amount" with an explicit @apidoc[Unmarshaller] as described in @ref[Unmarshalling](../../../common/unmarshalling.md)
+: reject if the parameter is missing or can't be unmarshalled to the given type
 
 `"distance".repeated`
 : extract multiple occurrences of parameter "distance" as `Iterable[String]`

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -4,8 +4,6 @@
 
 package docs.http.scaladsl
 
-import akka.actor.CoordinatedShutdown
-import akka.actor.CoordinatedShutdown.UnknownReason
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes
@@ -396,9 +394,9 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
         concat(
           pathEnd {
             concat(
-              (put | parameter('method ! "put")) {
+              (put | parameter("method" ! "put")) {
                 // form extraction from multipart or www-url-encoded forms
-                formFields(('email, 'total.as[Money])).as(Order) { order =>
+                formFields(("email", "total".as[Money])).as(Order) { order =>
                   complete {
                     // complete with serialized Future result
                     (myDbActor ? Update(order)).mapTo[TransactionResult]
@@ -419,7 +417,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
           path("items") {
             get {
               // parameters to case class extraction
-              parameters(('size.as[Int], 'color ?, 'dangerous ? "no"))
+              parameters(("size".as[Int], "color" ?, "dangerous" ? "no"))
                 .as(OrderItem) { orderItem =>
                   // ... route using case class instance created from
                   // required and optional query parameters

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -394,7 +394,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
         concat(
           pathEnd {
             concat(
-              (put | parameter("method" ! "put")) {
+              (put | parameter("method".requiredValue("put"))) {
                 // form extraction from multipart or www-url-encoded forms
                 formFields(("email", "total".as[Money])).as(Order) { order =>
                   complete {
@@ -417,7 +417,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
           path("items") {
             get {
               // parameters to case class extraction
-              parameters(("size".as[Int], "color" ?, "dangerous" ? "no"))
+              parameters(("size".as[Int], "color".optional, "dangerous".withDefault("no")))
                 .as(OrderItem) { orderItem =>
                   // ... route using case class instance created from
                   // required and optional query parameters

--- a/docs/src/test/scala/docs/http/scaladsl/server/CaseClassExtractionExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/CaseClassExtractionExamplesSpec.scala
@@ -4,17 +4,10 @@
 
 package docs.http.scaladsl.server
 
-
-
-/*
 import org.scalatest.Inside
 import akka.http.scaladsl.server._
 
 class CaseClassExtractionExamplesSpec extends RoutingSpec with Inside {
-  // FIXME: investigate why it doesn't work without this import
-  import akka.http.scaladsl.server.directives.ParameterDirectives.ParamMagnet
-
-  // format: OFF
 
   "example-1" in {
     //#example-1
@@ -22,10 +15,10 @@ class CaseClassExtractionExamplesSpec extends RoutingSpec with Inside {
 
     val route =
       path("color") {
-        parameters('red.as[Int], 'green.as[Int], 'blue.as[Int]) { (red, green, blue) =>
+        parameters("red".as[Int], "green".as[Int], "blue".as[Int]) { (red, green, blue) =>
           val color = Color(red, green, blue)
           // ... route working with the `color` instance
-          null // #hide
+          doSomethingWith(color) // #hide
         }
       }
     Get("/color?red=1&green=2&blue=3") ~> route ~> check { responseAs[String] shouldEqual "Color(1,2,3)" } // #hide
@@ -33,14 +26,15 @@ class CaseClassExtractionExamplesSpec extends RoutingSpec with Inside {
   }
 
   "example-2" in {
+    object Color {}
     //#example-2
     case class Color(red: Int, green: Int, blue: Int)
 
     val route =
       path("color") {
-        parameters('red.as[Int], 'green.as[Int], 'blue.as[Int]).as(Color) { color =>
+        parameters("red".as[Int], "green".as[Int], "blue".as[Int]).as(Color.apply) { color =>
           // ... route working with the `color` instance
-          null // #hide
+          doSomethingWith(color) // #hide
         }
       }
     Get("/color?red=1&green=2&blue=3") ~> route ~> check { responseAs[String] shouldEqual "Color(1,2,3)" } // #hide
@@ -48,14 +42,15 @@ class CaseClassExtractionExamplesSpec extends RoutingSpec with Inside {
   }
 
   "example-3" in {
+    object Color {}
     //#example-3
     case class Color(name: String, red: Int, green: Int, blue: Int)
 
     val route =
-      (path("color" / Segment) & parameters('r.as[Int], 'g.as[Int], 'b.as[Int]))
-        .as(Color) { color =>
+      (path("color" / Segment) & parameters("r".as[Int], "g".as[Int], "b".as[Int]))
+        .as(Color.apply) { color =>
           // ... route working with the `color` instance
-          null // #hide
+          doSomethingWith(color) // #hide
         }
     Get("/color/abc?r=1&g=2&b=3") ~> route ~> check { responseAs[String] shouldEqual "Color(abc,1,2,3)" } // #hide
     //#example-3
@@ -73,9 +68,10 @@ class CaseClassExtractionExamplesSpec extends RoutingSpec with Inside {
   "example 4 test" in {
     val route =
       (path("color" / Segment) &
-        parameters('r.as[Int], 'g.as[Int], 'b.as[Int])).as(Color) { color =>
-        doSomethingWith(color) // route working with the Color instance
-      }
+        parameters("r".as[Int], "g".as[Int], "b".as[Int])).as(Color) { color =>
+          // ... route working with the `color` instance
+          doSomethingWith(color) // #hide
+        }
     Get("/color/abc?r=1&g=2&b=3") ~> route ~> check {
       responseAs[String] shouldEqual "Color(abc,1,2,3)"
     }
@@ -87,4 +83,4 @@ class CaseClassExtractionExamplesSpec extends RoutingSpec with Inside {
   }
 
   def doSomethingWith(x: Any) = complete(x.toString)
-}*/
+}

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
@@ -13,7 +13,7 @@ class FormFieldDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "formFields" in {
     //#formFields
     val route =
-      formFields('color, 'age.as[Int]) { (color, age) =>
+      formFields("color", "age".as[Int]) { (color, age) =>
         complete(s"The color is '$color' and the age ten years ago was ${age - 10}")
       }
 
@@ -32,10 +32,10 @@ class FormFieldDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     //#formField
     val route =
       concat(
-        formField('color) { color =>
+        formField("color") { color =>
           complete(s"The color is '$color'")
         },
-        formField('id.as[Int]) { id =>
+        formField("id".as[Int]) { id =>
           complete(s"The id is '$id'")
         }
       )

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
@@ -14,7 +14,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "example-1" in {
     //#example-1
     val route =
-      parameter('color) { color =>
+      parameter("color") { color =>
         complete(s"The color is '$color'")
       }
 
@@ -32,7 +32,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "required-1" in {
     //#required-1
     val route =
-      parameters('color, 'backgroundColor) { (color, backgroundColor) =>
+      parameters("color", "backgroundColor") { (color, backgroundColor) =>
         complete(s"The color is '$color' and the background is '$backgroundColor'")
       }
 
@@ -49,7 +49,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "optional" in {
     //#optional
     val route =
-      parameters('color, 'backgroundColor.?) { (color, backgroundColor) =>
+      parameters("color", "backgroundColor".?) { (color, backgroundColor) =>
         val backgroundStr = backgroundColor.getOrElse("<undefined>")
         complete(s"The color is '$color' and the background is '$backgroundStr'")
       }
@@ -66,7 +66,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "optional-with-default" in {
     //#optional-with-default
     val route =
-      parameters('color, 'backgroundColor ? "white") { (color, backgroundColor) =>
+      parameters("color", "backgroundColor" ? "white") { (color, backgroundColor) =>
         complete(s"The color is '$color' and the background is '$backgroundColor'")
       }
 
@@ -82,7 +82,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "required-value" in {
     //#required-value
     val route =
-      parameters('color, 'action ! "true") { (color) =>
+      parameters("color", "action" ! "true") { (color) =>
         complete(s"The color is '$color'.")
       }
 
@@ -100,7 +100,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "mapped-value" in {
     //#mapped-value
     val route =
-      parameters('color, 'count.as[Int]) { (color, count) =>
+      parameters("color", "count".as[Int]) { (color, count) =>
         complete(s"The color is '$color' and you have $count of it.")
       }
 
@@ -119,7 +119,8 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "repeated" in {
     //#repeated
     val route =
-      parameters('color, 'city.*) { (color, cities) =>
+      // TODO https://github.com/akka/akka-http/issues/3081
+      parameters("color", _string2NR("city").*) { (color, cities) =>
         cities.toList match {
           case Nil         => complete(s"The color is '$color' and there are no cities.")
           case city :: Nil => complete(s"The color is '$color' and the city is $city.")
@@ -144,7 +145,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "mapped-repeated" in {
     //#mapped-repeated
     val route =
-      parameters('color, 'distance.as[Int].*) { (color, distances) =>
+      parameters("color", "distance".as[Int].*) { (color, distances) =>
         distances.toList match {
           case Nil             => complete(s"The color is '$color' and there are no distances.")
           case distance :: Nil => complete(s"The color is '$color' and the distance is $distance.")

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/ParameterDirectivesExamplesSpec.scala
@@ -49,7 +49,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "optional" in {
     //#optional
     val route =
-      parameters("color", "backgroundColor".?) { (color, backgroundColor) =>
+      parameters("color", "backgroundColor".optional) { (color, backgroundColor) =>
         val backgroundStr = backgroundColor.getOrElse("<undefined>")
         complete(s"The color is '$color' and the background is '$backgroundStr'")
       }
@@ -66,7 +66,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "optional-with-default" in {
     //#optional-with-default
     val route =
-      parameters("color", "backgroundColor" ? "white") { (color, backgroundColor) =>
+      parameters("color", "backgroundColor".withDefault("white")) { (color, backgroundColor) =>
         complete(s"The color is '$color' and the background is '$backgroundColor'")
       }
 
@@ -82,7 +82,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "required-value" in {
     //#required-value
     val route =
-      parameters("color", "action" ! "true") { (color) =>
+      parameters("color", "action".requiredValue("true")) { (color) =>
         complete(s"The color is '$color'.")
       }
 
@@ -119,8 +119,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "repeated" in {
     //#repeated
     val route =
-      // TODO https://github.com/akka/akka-http/issues/3081
-      parameters("color", _string2NR("city").*) { (color, cities) =>
+      parameters("color", "city".repeated) { (color, cities) =>
         cities.toList match {
           case Nil         => complete(s"The color is '$color' and there are no cities.")
           case city :: Nil => complete(s"The color is '$color' and the city is $city.")
@@ -145,7 +144,7 @@ class ParameterDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec w
   "mapped-repeated" in {
     //#mapped-repeated
     val route =
-      parameters("color", "distance".as[Int].*) { (color, distances) =>
+      parameters("color", "distance".as[Int].repeated) { (color, distances) =>
         distances.toList match {
           case Nil             => complete(s"The color is '$color' and there are no distances.")
           case distance :: Nil => complete(s"The color is '$color' and the distance is $distance.")


### PR DESCRIPTION
As Scala symbols lose their language support in Scala 2.13 users should switch to using regular strings in the parameters and form fields directives.

The `String.*` enhancement conflicts with the `StringOps.*` enhancement from `Predef` (see #3081), so with Strings users must switch to the new `.repeated` enhancer.

* Complement the symbolic methods with regular method names in `NameReceptacle` and `NameUnmarshallerReceptacle`
* The names mimic the names used in the Java DSL
* Remove the use of Scala symbols in the docs.

