### PR TITLE
core: move ParsingErrorHandler creation to ControllerStage

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/configure-parsing-error-response.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/configure-parsing-error-response.excludes
@@ -1,6 +1,8 @@
 # Not for user extension or pattern-matching
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ServerSettings.getParsingErrorHandler")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ServerSettings.parsingErrorHandler")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ServerSettings.parsingErrorHandlerInstance")
+
 # Internal
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.apply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.copy")
@@ -11,3 +13,5 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.server
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.server.HttpServerBluePrint.apply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.server.HttpServerBluePrint.apply")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.server.HttpServerBluePrint.controller")
+
+

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -382,8 +382,8 @@ private[http] object HttpServerBluePrint {
 
     val shape = new BidiShape(requestParsingIn, requestPrepOut, httpResponseIn, responseCtxOut)
 
-    override private[akka] def createLogicAndMaterializedValue(inheritedAttributes: Attributes, materializer: Materializer) = new GraphStageLogic(shape) {
-      val parsingErrorHandler: ParsingErrorHandler = settings.parsingErrorHandlerInstance(ActorMaterializerHelper.downcast(materializer).system)
+    override private[akka] def createLogicAndMaterializedValue(inheritedAttributes: Attributes, outerMaterializer: Materializer) = new GraphStageLogic(shape) {
+      val parsingErrorHandler: ParsingErrorHandler = settings.parsingErrorHandlerInstance(ActorMaterializerHelper.downcast(outerMaterializer).system)
       val pullHttpResponseIn = () => tryPull(httpResponseIn)
       var openRequests = immutable.Queue[RequestStart]()
       var oneHundredContinueResponsePending = false

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
@@ -14,7 +14,9 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import akka.http.javadsl.{ settings => js }
 import akka.ConfigurationException
+import akka.actor.{ ActorSystem, ExtendedActorSystem }
 import akka.annotation.InternalApi
+import akka.http.ParsingErrorHandler
 import akka.io.Inet.SocketOption
 import akka.http.impl.util._
 import akka.http.scaladsl.model.{ HttpHeader, HttpResponse, StatusCodes }
@@ -56,6 +58,8 @@ private[akka] final case class ServerSettingsImpl(
 
   override def productPrefix = "ServerSettings"
 
+  private[http] def parsingErrorHandlerInstance(system: ActorSystem): ParsingErrorHandler =
+    system.asInstanceOf[ExtendedActorSystem].dynamicAccess.createInstanceFor[ParsingErrorHandler](parsingErrorHandler, Nil).get
 }
 
 /** INTERNAL API */

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -13,7 +13,6 @@ import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
 import akka.event.{ Logging, LoggingAdapter }
-import akka.http.ParsingErrorHandler
 import akka.http.impl.engine.Http2Shadow
 import akka.http.impl.engine.HttpConnectionIdleTimeoutBidi
 import akka.http.impl.engine.client.PoolMasterActor.{ PoolSize, ShutdownAll }
@@ -361,8 +360,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
     remoteAddress:      Option[InetSocketAddress] = None,
     log:                LoggingAdapter            = system.log,
     isSecureConnection: Boolean                   = false): ServerLayer = {
-    val parsingErrorHandler = system.dynamicAccess.createInstanceFor[ParsingErrorHandler](settings.parsingErrorHandler, Nil).get
-    val server = HttpServerBluePrint(settings, parsingErrorHandler, log, isSecureConnection)
+    val server = HttpServerBluePrint(settings, log, isSecureConnection)
       .addAttributes(HttpAttributes.remoteAddress(remoteAddress))
 
     server atop delayCancellationStage(settings)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -7,7 +7,9 @@ package akka.http.scaladsl.settings
 import java.util.Random
 import java.util.function.Supplier
 
-import akka.annotation.DoNotInherit
+import akka.actor.ActorSystem
+import akka.annotation.{ DoNotInherit, InternalApi }
+import akka.http.ParsingErrorHandler
 import akka.http.impl.settings.ServerSettingsImpl
 import akka.http.impl.util._
 import akka.http.impl.util.JavaMapping.Implicits._
@@ -122,6 +124,14 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def mapPreviewServerSettings(f: PreviewServerSettings => PreviewServerSettings): ServerSettings = withPreviewServerSettings(f(previewServerSettings))
   def mapWebsocketSettings(f: WebSocketSettings => WebSocketSettings): ServerSettings = withWebsocketSettings(f(websocketSettings))
   def mapTimeouts(f: ServerSettings.Timeouts => ServerSettings.Timeouts): ServerSettings = withTimeouts(f(timeouts))
+
+  /**
+   * INTERNAL API
+   *
+   * Returns an instance of the ParsingErrorHandler as specified by `parsingErrorHandler`
+   */
+  @InternalApi
+  private[http] def parsingErrorHandlerInstance(system: ActorSystem): ParsingErrorHandler
 }
 
 object ServerSettings extends SettingsCompanion[ServerSettings] {


### PR DESCRIPTION
Fixes a compilation error in bench-jmh tests.

WDYT, @raboof. This is not necessarily better than your previous solution as it requires two casts to get there. On the other hand it's nice to be able to keep the signatures in HttpServerBluePrint clean and do things where they are needed.