### PR TITLE
Build: silence warnings for argument adaptation

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -22,6 +22,7 @@ object Common extends AutoPlugin {
       // "-Yno-adapted-args", //akka-http heavily depends on adapted args and => Unit implicits break otherwise
       "-Ywarn-dead-code",
       // "-Xfuture" // breaks => Unit implicits
+      // TODO https://github.com/akka/akka-http/issues/2738
       "-P:silencer:globalFilters=(Adapting\\ argument\\ list\\ by\\ creating|Adaptation\\ of\\ argument\\ list\\ by\\ inserting)"
     ),
     // '-release' parameter is restricted to 'Compile, compile' scope because

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -20,8 +20,9 @@ object Common extends AutoPlugin {
       "-unchecked",
       "-Xlint",
       // "-Yno-adapted-args", //akka-http heavily depends on adapted args and => Unit implicits break otherwise
-      "-Ywarn-dead-code"
+      "-Ywarn-dead-code",
       // "-Xfuture" // breaks => Unit implicits
+      "-P:silencer:globalFilters=(Adapting\\ argument\\ list\\ by\\ creating|Adaptation\\ of\\ argument\\ list\\ by\\ inserting)"
     ),
     // '-release' parameter is restricted to 'Compile, compile' scope because
     // otherwise `sbt akka-http-xml/compile:doc` fails with it on Scala 2.12.9
@@ -36,6 +37,10 @@ object Common extends AutoPlugin {
       // From jdk9 onwards this is covered by the '-release' flag above
       onlyOnJdk8("-target", "1.8"),
     mimaReportSignatureProblems := true,
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % Dependencies.silencerVersion cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % Dependencies.silencerVersion % Provided cross CrossVersion.full
+    )
   )
 
   val specificationVersion: String = sys.props("java.specification.version")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v${h2specVersion}/${h2specName}.zip"
   val alpnAgentVersion = "2.0.9"
+  val silencerVersion = "1.6.0"
 
   lazy val scalaTestVersion = settingKey[String]("The version of ScalaTest to use.")
   lazy val specs2Version = settingKey[String]("The version of Specs2 to use")


### PR DESCRIPTION
Introduce the scalac silencer to silence warnings for argument adaptation (auto tupleing) as they risk to hide other (for the time being) more relevant warnings.

Depending on the solutions to #2738 we would remove this again.
