### PR TITLE
[backport] core: fix parsing of partly cached headers with UTF-8 values

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -211,8 +211,8 @@ private[engine] final class HttpHeaderParser private (
   @tailrec
   private def insert(input: ByteString, value: AnyRef)(cursor: Int = 0, endIx: Int = input.length, nodeIx: Int = 0, colonIx: Int = 0): Unit = {
     val char =
-      if (cursor < colonIx) CharUtils.toLowerCase(input(cursor).toChar)
-      else if (cursor < endIx) input(cursor).toChar
+      if (cursor < colonIx) CharUtils.toLowerCase((input(cursor) & 0xff).toChar)
+      else if (cursor < endIx) (input(cursor) & 0xff).toChar
       else '\u0000'
     val node = nodes(nodeIx)
     if (char == node) insert(input, value)(cursor + 1, endIx, nodeIx + 1, colonIx) // fast match, descend into only subnode
@@ -258,7 +258,7 @@ private[engine] final class HttpHeaderParser private (
   private def insertRemainingCharsAsNewNodes(input: ByteString, value: AnyRef)(cursor: Int = 0, endIx: Int = input.length, valueIx: Int = newValueIndex, colonIx: Int = 0): Unit = {
     val newNodeIx = newNodeIndex
     if (cursor < endIx) {
-      val c = input(cursor).toChar
+      val c = (input(cursor) & 0xff).toChar
       val char = if (cursor < colonIx) CharUtils.toLowerCase(c) else c
       nodes(newNodeIx) = char
       insertRemainingCharsAsNewNodes(input, value)(cursor + 1, endIx, valueIx, colonIx)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/package.scala
@@ -26,7 +26,7 @@ package object parsing {
     case x                              => x.toString
   }
 
-  private[http] def byteChar(input: ByteString, ix: Int): Char = byteAt(input, ix).toChar
+  private[http] def byteChar(input: ByteString, ix: Int): Char = (byteAt(input, ix) & 0xff).toChar
 
   private[http] def byteAt(input: ByteString, ix: Int): Byte =
     if (ix < input.length) input(ix) else throw NotEnoughDataException

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -181,6 +181,16 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends WordS
         RawHeader("4-UTF8-Bytes", "Surrogate pairs: \uD801\uDC1B\uD801\uDC04\uD801\uDC1B!")
     }
 
+    "parse multiple header lines subsequently with UTF-8 characters one after another without crashing" in new TestSetup {
+      parseLine(s"""Content-Disposition: form-data; name="test"; filename="λ"${newLine}x""")
+      // The failing parsing line is one that must share a prefix with the utf-8 line up to the non-ascii char. The next character
+      // doesn't even have to be a non-ascii char.
+      parseLine(s"""Content-Disposition: form-data; name="test"; filename="test"${newLine}x""")
+      // But it could be
+      parseLine(s"""Content-Disposition: form-data; name="test"; filename="Б"${newLine}x""")
+
+    }
+
     "produce an error message for lines with an illegal header name" in new TestSetup() {
       the[ParsingException] thrownBy parseLine(s" Connection: close${newLine}x") should have message "Illegal character ' ' in header name"
       the[ParsingException] thrownBy parseLine(s"Connection : close${newLine}x") should have message "Illegal character ' ' in header name"


### PR DESCRIPTION
Backport of #2962

Fix #1484 for 10.1.x

(cherry picked from commit 78ec8a81f9c83e7d1d24ff3a34507ff31ad70d64)
