### PR TITLE
h2 frame parsing: improve handling of unknown values

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -65,17 +65,17 @@ private[http] object Http2Blueprint {
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
       hpackCoding() atop {
         settings.idleTimeout match {
-          case f: FiniteDuration => framing() atop HttpConnectionIdleTimeoutBidi(f, None)
-          case _ => framing()
+          case f: FiniteDuration => framing(log) atop HttpConnectionIdleTimeoutBidi(f, None)
+          case _ => framing(log)
         }
       }
   // LogByteStringTools.logToStringBidi("framing") atop // enable for debugging
   // format: ON
 
-  def framing(): BidiFlow[FrameEvent, ByteString, ByteString, FrameEvent, NotUsed] =
+  def framing(log: LoggingAdapter): BidiFlow[FrameEvent, ByteString, ByteString, FrameEvent, NotUsed] =
     BidiFlow.fromFlows(
       Flow[FrameEvent].via(new Http2FrameRendering),
-      Flow[ByteString].via(new Http2FrameParsing(shouldReadPreface = true)))
+      Flow[ByteString].via(new Http2FrameParsing(shouldReadPreface = true, log)))
 
   /**
    * Runs hpack encoding and decoding. Incoming frames that are processed are HEADERS and CONTINUATION.

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Protocol.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Protocol.scala
@@ -127,10 +127,10 @@ private[http] object Http2Protocol {
         CONTINUATION).toSeq
 
     // make sure that lookup works and `All` ordering isn't broken
-    All.foreach(f => require(f == byId(f.id), s"FrameType $f with id ${f.id} must be found"))
+    All.foreach(f => require(Some(f) == byId(f.id), s"FrameType $f with id ${f.id} must be found"))
 
-    def isKnownId(id: Int): Boolean = id < All.size
-    def byId(id: Int): FrameType = All(id)
+    def byId(id: Int): Option[FrameType] =
+      if (id < All.size) Some(All(id)) else None
   }
 
   sealed abstract class SettingIdentifier(val id: Int) extends Product
@@ -227,10 +227,10 @@ private[http] object Http2Protocol {
         SETTINGS_MAX_HEADER_LIST_SIZE).toSeq
 
     // make sure that lookup works and `All` ordering isn't broken
-    All.foreach(f => require(f == byId(f.id) && isKnownId(f.id), s"SettingIdentifier $f with id ${f.id} must be found"))
+    All.foreach(f => require(Some(f) == byId(f.id), s"SettingIdentifier $f with id ${f.id} must be found"))
 
-    def isKnownId(id: Int): Boolean = id > 0 && id <= All.size
-    def byId(id: Int): SettingIdentifier = All(id - 1)
+    def byId(id: Int): Option[SettingIdentifier] =
+      if (id > 0 && id <= All.size) Some(All(id - 1)) else None
   }
 
   sealed abstract class ErrorCode(val id: Int) extends Product
@@ -323,6 +323,8 @@ private[http] object Http2Protocol {
      */
     case object HTTP_1_1_REQUIRED extends ErrorCode(0xd)
 
+    case class Unknown private (override val id: Int) extends ErrorCode(id)
+
     val All =
       Array( // must start with id = 0 and don't have holes between ids
         NO_ERROR,
@@ -344,8 +346,8 @@ private[http] object Http2Protocol {
     // make sure that lookup works and `All` ordering isn't broken
     All.foreach(f => require(f == byId(f.id), s"ErrorCode $f with id ${f.id} must be found"))
 
-    def isKnownId(id: Int): Boolean = id < All.size
-    def byId(id: Int): ErrorCode = All(id)
+    def byId(id: Int): ErrorCode =
+      if (id < All.size) All(id) else Unknown(id)
   }
 
   /**

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Protocol.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Protocol.scala
@@ -5,7 +5,7 @@
 package akka.http.impl.engine.http2
 
 import akka.annotation.InternalApi
-import akka.util.ByteString
+import akka.util.{ ByteString, OptionVal }
 
 /**
  * INTERNAL API
@@ -127,10 +127,10 @@ private[http] object Http2Protocol {
         CONTINUATION).toSeq
 
     // make sure that lookup works and `All` ordering isn't broken
-    All.foreach(f => require(Some(f) == byId(f.id), s"FrameType $f with id ${f.id} must be found"))
+    All.foreach(f => require(OptionVal.Some(f) == byId(f.id), s"FrameType $f with id ${f.id} must be found"))
 
-    def byId(id: Int): Option[FrameType] =
-      if (id < All.size) Some(All(id)) else None
+    def byId(id: Int): OptionVal[FrameType] =
+      if (id < All.size) OptionVal.Some(All(id)) else OptionVal.None
   }
 
   sealed abstract class SettingIdentifier(val id: Int) extends Product
@@ -227,10 +227,10 @@ private[http] object Http2Protocol {
         SETTINGS_MAX_HEADER_LIST_SIZE).toSeq
 
     // make sure that lookup works and `All` ordering isn't broken
-    All.foreach(f => require(Some(f) == byId(f.id), s"SettingIdentifier $f with id ${f.id} must be found"))
+    All.foreach(f => require(OptionVal.Some(f) == byId(f.id), s"SettingIdentifier $f with id ${f.id} must be found"))
 
-    def byId(id: Int): Option[SettingIdentifier] =
-      if (id > 0 && id <= All.size) Some(All(id - 1)) else None
+    def byId(id: Int): OptionVal[SettingIdentifier] =
+      if (id > 0 && id <= All.size) OptionVal.Some(All(id - 1)) else OptionVal.None
   }
 
   sealed abstract class ErrorCode(val id: Int) extends Product

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -103,7 +103,7 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
         // https://http2.github.io/http2-spec/#Http2SettingsHeader 3.2.1 HTTP2-Settings Header Field
         val upgradeSettings = req.headers.collect {
           case raw: RawHeader if raw.lowercaseName == Http2SettingsHeader.name =>
-            Http2SettingsHeader.parse(raw.value)
+            Http2SettingsHeader.parse(raw.value, log)
         }
 
         upgradeSettings match {

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/Http2SettingsHeader.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/Http2SettingsHeader.scala
@@ -5,6 +5,7 @@
 package akka.http.scaladsl.model.http2
 
 import akka.annotation.InternalApi
+import akka.event.LoggingAdapter
 import akka.http.impl.engine.http2.framing.Http2FrameParsing
 import akka.http.impl.engine.http2.FrameEvent.Setting
 import akka.http.impl.model.parser.Base64Parsing
@@ -24,11 +25,11 @@ private[akka] object Http2SettingsHeader {
   def headerValueToBinary(value: String): ByteString =
     ByteString(Base64Parsing.base64UrlStringDecoder(value.toCharArray))
 
-  def parse(value: String): Try[immutable.Seq[Setting]] = Try {
+  def parse(value: String, log: LoggingAdapter): Try[immutable.Seq[Setting]] = Try {
     // settings are a base64url encoded Http2 settings frame
     // https://httpwg.org/specs/rfc7540.html#rfc.section.3.2.1
     val bytes = headerValueToBinary(value)
     val reader = new io.ByteStringParser.ByteReader(bytes)
-    Http2FrameParsing.readSettings(reader)
+    Http2FrameParsing.readSettings(reader, log)
   }
 }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameProbe.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameProbe.scala
@@ -178,7 +178,7 @@ object Http2FrameProbe extends Matchers {
 
         val reader = new ByteReader(headerBytes)
         val length = reader.readShortBE() << 8 | reader.readByte()
-        val tpe = Http2Protocol.FrameType.byId(reader.readByte())
+        val tpe = Http2Protocol.FrameType.byId(reader.readByte()).get
         val flags = new ByteFlag(reader.readByte())
         val streamId = reader.readIntBE()
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/framing/Http2FramingSpec.scala
@@ -5,6 +5,7 @@
 package akka.http.impl.engine.http2
 package framing
 
+import akka.event.Logging
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.ws.BitBuilder
 import akka.http.impl.util._
@@ -493,7 +494,7 @@ class Http2FramingSpec extends AkkaSpecWithMaterializer {
     }
 
   private def parseToEvents(bytes: Seq[ByteString]): immutable.Seq[FrameEvent] =
-    Source(bytes.toVector).via(new Http2FrameParsing(shouldReadPreface = false)).runWith(Sink.seq)
+    Source(bytes.toVector).via(new Http2FrameParsing(shouldReadPreface = false, Logging(system, getClass))).runWith(Sink.seq)
       .awaitResult(1.second.dilated)
   private def renderToByteString(events: immutable.Seq[FrameEvent]): ByteString =
     Source(events).map(FrameRenderer.render).runFold(ByteString.empty)(_ ++ _)


### PR DESCRIPTION
Follow-up of https://github.com/akka/akka-http/pull/3053#discussion_r408714500

The first commit tries to simplify the existence/lookup flow for spec elements, forcing a more graceful handling of unknown frame types & error codes (with a slightly different approach for error codes where I guess it's interesting to capture the code, even if it's not strongly typed).