### PR TITLE
core: header rendering with less indirection

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/internal-RenderSupport-changes.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/internal-RenderSupport-changes.excludes
@@ -1,0 +1,2 @@
+# Changes to internal methods
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.engine.rendering.RenderSupport.CrLf")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -252,7 +252,7 @@ private[http] class HttpResponseRendererFactory(
           }
 
           def renderContentLengthHeader(contentLength: Long) =
-            if (status.allowsEntity) r ~~ `Content-Length` ~~ contentLength ~~ CrLf else r
+            if (status.allowsEntity) r ~~ ContentLengthBytes ~~ contentLength ~~ CrLf else r
 
           def headersAndEntity(entityBytes: => Source[ByteString, Any]): StrictOrStreamed =
             if (noEntity) {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/RenderSupport.scala
@@ -23,12 +23,14 @@ import akka.stream.scaladsl.{ Flow, Sink, Source }
  * INTERNAL API
  */
 @InternalApi
-private[rendering] object RenderSupport {
+private[http] object RenderSupport {
   val DefaultStatusLineBytes = "HTTP/1.1 200 OK\r\n".asciiBytes
   val StatusLineStartBytes = "HTTP/1.1 ".asciiBytes
   val ChunkedBytes = "chunked".asciiBytes
   val KeepAliveBytes = "Keep-Alive".asciiBytes
   val CloseBytes = "close".asciiBytes
+  val CrLf = "\r\n".asciiBytes
+  val ContentLengthBytes = "Content-Length: ".asciiBytes
 
   private def preRenderContentType(ct: ContentType): Array[Byte] =
     (new ByteArrayRendering(32) ~~ headers.`Content-Type` ~~ ct ~~ CrLf).get
@@ -39,9 +41,7 @@ private[rendering] object RenderSupport {
   private val TextHtmlContentType = preRenderContentType(`text/html(UTF-8)`)
   private val TextCsvContentType = preRenderContentType(`text/csv(UTF-8)`)
 
-  def CrLf = Rendering.CrLf
-
-  implicit val trailerRenderer = Renderer.genericSeqRenderer[Renderable, HttpHeader](CrLf, Rendering.Empty)
+  implicit val trailerRenderer = Renderer.genericSeqRenderer[Renderable, HttpHeader](Rendering.CrLf, Rendering.Empty)
 
   val defaultLastChunkBytes: ByteString = renderChunk(HttpEntity.LastChunk)
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -27,8 +27,8 @@ import akka.http.scaladsl.model._
 sealed abstract class ModeledCompanion[T: ClassTag] extends Renderable {
   val name = ModeledCompanion.nameFromClass(getClass)
   val lowercaseName = name.toRootLowerCase
-  private[this] val nameBytes = name.asciiBytes
-  final def render[R <: Rendering](r: R): r.type = r ~~ nameBytes ~~ ':' ~~ ' '
+  private[this] val nameAndColonSpaceBytes = (name + ": ").asciiBytes
+  final def render[R <: Rendering](r: R): r.type = r ~~ nameAndColonSpaceBytes
 
   /**
    * Parses the given value into a header of this type. Returns `Right[T]` if parsing
@@ -62,7 +62,7 @@ sealed trait ModeledHeader extends HttpHeader with Serializable {
   def name: String = companion.name
   def value: String = renderValue(new StringRendering).get
   def lowercaseName: String = companion.lowercaseName
-  final def render[R <: Rendering](r: R): r.type = renderValue(r ~~ companion)
+  final def render[R <: Rendering](r: R): r.type = renderValue(companion.render(r))
   protected[http] def renderValue[R <: Rendering](r: R): r.type
   protected def companion: ModeledCompanion[_]
 }


### PR DESCRIPTION
Slight performance improvements:

 * precompute some often used string combinations
 * in `ModeledHeader` avoid `~~` syntax and use direct call instead