### PR TITLE
parsing: don't extend from Char => Boolean for CharPredicate

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
@@ -59,7 +59,7 @@ object HttpHeader {
    *    (http://tools.ietf.org/html/rfc7230#section-3.2). In this case the method returns a `ParsingResult.Error`.
    */
   def parse(name: String, value: String, settings: HeaderParser.Settings = HeaderParser.DefaultSettings): ParsingResult =
-    if (name.forall(CharacterClasses.tchar)) {
+    if (name.forall(c => CharacterClasses.tchar(c))) {
       import akka.parboiled2.Parser.DeliveryScheme.Try
       val parser = new HeaderParser(value, settings)
       parser.`header-field-value`.run() match {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -300,7 +300,7 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends AnyWo
       val regularKeys = Iterator.from(1).map(i => s"key_$i").take(numKeys)
       private val zeroHashStrings: Iterator[String] = HashCodeCollider.zeroHashCodeIterator()
       val collidingKeys = zeroHashStrings
-        .filter(_.forall(CharacterClasses.tchar))
+        .filter(_.forall(ch => CharacterClasses.tchar(ch)))
         .take(numKeys)
 
       def createHeader(keys: Iterator[String]): String = "Accept: text/plain" + keys.mkString(";", "=x;", "=x") + newLine + "x"


### PR DESCRIPTION
Slight performance improvement.

That's because Function1 is not specialized for Char so there's boxing involved
(if not elided by the JVM). The solution is provide an explicit
specialized apply method instead.