### PR TITLE
Reuse UriParser In HttpRequestParser

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/UriParser.scala
@@ -21,7 +21,7 @@ import akka.annotation.InternalApi
  */
 @InternalApi
 private[http] final class UriParser(
-  val input:             ParserInput,
+  var input:             ParserInput,
   val uriParsingCharset: Charset,
   val uriParsingMode:    Uri.ParsingMode,
   val maxValueStackSize: Int) extends Parser(maxValueStackSize)

--- a/akka-http-core/src/main/scala/akka/http/impl/util/ByteStringParserInput.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/ByteStringParserInput.scala
@@ -24,8 +24,8 @@ import akka.util.ByteString
  */
 @InternalApi
 final private[http] class ByteStringParserInput(bytes: ByteString) extends DefaultParserInput {
+  val length: Int = bytes.size
   override def charAt(ix: Int): Char = (bytes(ix) & 0xFF).toChar
-  override def length: Int = bytes.size
   override def sliceString(start: Int, end: Int): String = bytes.slice(start, end).decodeString(StandardCharsets.ISO_8859_1)
   override def sliceCharArray(start: Int, end: Int): Array[Char] =
     StandardCharsets.ISO_8859_1.decode(bytes.slice(start, end).asByteBuffer).array()

--- a/akka-parsing/src/main/scala/akka/parboiled2/RuleDSLBasics.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/RuleDSLBasics.scala
@@ -92,7 +92,7 @@ trait RuleDSLBasics {
   /**
    * Matches the EOI (end-of-input) character.
    */
-  def EOI: Char = akka.parboiled2.EOI
+  final def EOI: Char = akka.parboiled2.EOI
 
   /**
    * Matches no character (i.e. doesn't cause the parser to make any progress) but succeeds always (as a rule).


### PR DESCRIPTION
Seems to be a big performance improvement because the ValueStack in the UriParser can so be reused and doesn't have to be reallocated for each request.