### PR TITLE
Support native ALPN in JDK >=8u251

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
@@ -4,18 +4,14 @@
 
 package akka.http.impl.engine.http2
 
-import java.util.function.BiFunction
 import java.{ util => ju }
 
-import javax.net.ssl.{ SSLEngine, SSLException }
+import javax.net.ssl.SSLEngine
 import akka.annotation.InternalApi
 import akka.http.impl.util.JavaVersion
 import akka.stream.TLSProtocol.NegotiateNewSession
 import akka.stream.impl.io.TlsUtils
-import org.eclipse.jetty.alpn.ALPN
-import org.eclipse.jetty.alpn.ALPN.ServerProvider
 
-import scala.language.reflectiveCalls
 import scala.util.Try
 
 /**
@@ -33,7 +29,7 @@ private[http] object Http2AlpnSupport {
    */
   def enableForServer(engine: SSLEngine, setChosenProtocol: String => Unit): SSLEngine =
     if (isAlpnSupportedByJDK) jdkAlpnSupport(engine, setChosenProtocol)
-    else jettyAlpnSupport(engine, setChosenProtocol)
+    else throw new RuntimeException(s"Need to run on a JVM >= 8u252 for ALPN support needed for HTTP/2. Running on ${sys.props("java.version")}")
 
   def isAlpnSupportedByJDK: Boolean =
     // ALPN is supported starting with JDK 9
@@ -48,42 +44,16 @@ private[http] object Http2AlpnSupport {
           else true
         })
 
-  private type JDK9SSLEngine = {
-    def setHandshakeApplicationProtocolSelector(selector: BiFunction[SSLEngine, ju.List[String], String]): Unit
-  }
   def jdkAlpnSupport(engine: SSLEngine, setChosenProtocol: String => Unit): SSLEngine = {
-    engine.asInstanceOf[JDK9SSLEngine].setHandshakeApplicationProtocolSelector(new BiFunction[SSLEngine, ju.List[String], String] {
-      // explicit style needed here as automatic SAM-support doesn't seem to work out with Scala 2.11
-      override def apply(engine: SSLEngine, protocols: ju.List[String]): String = {
-        val chosen = chooseProtocol(protocols)
-        chosen.foreach(setChosenProtocol)
+    engine.setHandshakeApplicationProtocolSelector { (engine: SSLEngine, protocols: ju.List[String]) =>
+      val chosen = chooseProtocol(protocols)
+      chosen.foreach(setChosenProtocol)
 
-        //returning null here means aborting the handshake
-        //see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/net/ssl/SSLEngine.html#setHandshakeApplicationProtocolSelector(java.util.function.BiFunction)
-        chosen.orNull
-      }
-    })
+      //returning null here means aborting the handshake
+      //see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/net/ssl/SSLEngine.html#setHandshakeApplicationProtocolSelector(java.util.function.BiFunction)
+      chosen.orNull
+    }
 
-    engine
-  }
-
-  def jettyAlpnSupport(engine: SSLEngine, setChosenProtocol: String => Unit): SSLEngine = {
-    ALPN.put(engine, new ServerProvider {
-      override def select(protocols: ju.List[String]): String =
-        choose {
-          //throwing an exception means aborting the handshake
-          //see http://git.eclipse.org/c/jetty/org.eclipse.jetty.alpn.git/tree/src/main/java/org/eclipse/jetty/alpn/ALPN.java#n236
-          chooseProtocol(protocols).getOrElse(throw new SSLException("No protocols"))
-        }
-
-      override def unsupported(): Unit =
-        choose(HTTP11)
-
-      def choose(protocol: String): String = try {
-        setChosenProtocol(protocol)
-        protocol
-      } finally ALPN.remove(engine)
-    })
     engine
   }
 
@@ -93,8 +63,4 @@ private[http] object Http2AlpnSupport {
     else None
 
   def applySessionParameters(engine: SSLEngine, sessionParameters: NegotiateNewSession): Unit = TlsUtils.applySessionParameters(engine, sessionParameters)
-
-  def cleanupForServer(engine: SSLEngine): Unit =
-    if (!isAlpnSupportedByJDK) ALPN.remove(engine)
-
 }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -305,9 +305,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
 
       // Reproducing https://github.com/akka/akka-http/issues/2957
       "close the stream when we receive a RST after we have half-closed ourselves as well" in new WaitingForRequestData {
-        import akka.http.scaladsl.client.RequestBuilding._
         // Client sends the request, but doesn't close the stream yet. This is a bit weird, but it's whet grpcurl does ;)
-        val post = Post("/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo")
         sendHEADERS(streamId = 1, endStream = false, endHeaders = true, encodeRequestHeaders(request))
         sendDATA(streamId = 1, endStream = false, ByteString(0, 0, 0, 0, 0x10, 0x22, 0x0e) ++ ByteString.fromString("GreeterService"))
 

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -11,7 +11,6 @@ import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream._
 import akka.stream.scaladsl.FileIO
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory

--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,6 @@ lazy val http2Support = project("akka-http2-support")
       (target in Test).value / h2specName / h2specExe
     }
     Seq(
-      javaAgents += Dependencies.Compile.Test.alpnAgent,
       fork in run in Test := true,
       fork in Test := true,
       sbt.Keys.connectInput in run in Test := true,
@@ -347,7 +346,6 @@ lazy val docs = project("docs")
       "project.name" -> "Akka HTTP",
       "canonical.base_url" -> "https://doc.akka.io/docs/akka-http/current",
       "akka.version" -> AkkaDependency.docs.version,
-      "alpn-agent.version" -> Dependencies.alpnAgentVersion,
       "scala.binary_version" -> scalaBinaryVersion.value, // to be consistent with Akka build
       "scala.binaryVersion" -> scalaBinaryVersion.value,
       "scaladoc.version" -> scalaVersion.value,

--- a/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
+++ b/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
@@ -12,13 +12,17 @@ If you find an unexpected incompatibility please let us know, so we can check wh
 
 ## Akka HTTP 10.1.11 -> 10.2.0
 
+### Jetty ALPN agent not supported any more for HTTP/2
+
+JVM support for ALPN has been backported to JDK 8u252 which is now widely available. Support for using the Jetty ALPN
+agent has been dropped in 10.2.0. HTTP/2 support therefore now requires to be run on JVM >= 8u252.
+
 ### Scalatest dependency upgraded to 3.1.0
 
 The Scalatest dependency for akka-http-testkit was upgraded to version 3.1.0. This version is incompatible with previous
 versions. This is relevant for user code if it uses methods from @scaladoc[ScalatestUtils](akka.http.scaladsl.testkit.ScalatestUtils)
 (which are in scope if your test extends from @scaladoc[ScalaTestRouteTest](akka.http.scaladsl.testkit.ScalaTestRouteTest)).
 In this case, the project itself needs to be updated to use Scalatest >= 3.1.0.
-
 
 ### Providing route settings, exception and rejection handling
 

--- a/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
+++ b/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
@@ -12,7 +12,7 @@ If you find an unexpected incompatibility please let us know, so we can check wh
 
 ## Akka HTTP 10.1.11 -> 10.2.0
 
-### Jetty ALPN agent not supported any more for HTTP/2
+### HTTP/2 support requires JDK 8 update 252 or later
 
 JVM support for ALPN has been backported to JDK 8u252 which is now widely available. Support for using the Jetty ALPN
 agent has been dropped in 10.2.0. HTTP/2 support therefore now requires to be run on JVM >= 8u252.

--- a/docs/src/main/paradox/release-notes/10.1.x.md
+++ b/docs/src/main/paradox/release-notes/10.1.x.md
@@ -1,5 +1,13 @@
 # 10.1.x Release Notes
 
+## 10.1.12
+
+### ALPN support in JDK >= 8u252
+
+ALPN support was backported to recent JDK 8 updates. When using HTTP2 support with these JDKs, the `jetty-alpn-agent`
+is not needed anymore. If you want to run on older and newer JDKs with the same command line, make sure to use the
+most recent version of `jetty-alpn-agent` which will automatically disable itself for newer JDKs.
+
 ## 10.1.11
 
 ### Changes since 10.1.10

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -130,7 +130,8 @@ This shows `curl` declaring it is ready to speak `h2` (the shorthand name of HTT
 
 [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation) is used to negotiate whether both client and server support HTTP/2.
 
-ALPN support comes with the JVM starting from version 9. If you're on a previous version of the JVM, you'll have to load a Java Agent to provide this functionality. We recommend the agent from the [Jetty](https://www.eclipse.org/jetty/) project, `jetty-alpn-agent`.
+ALPN support comes with the JVM starting from version 9 and in version 8 from update 252. If you're on a previous version of the JVM, you'll have to load a Java Agent to provide this functionality.
+We recommend to use a JVM >= 8u252. If you need to run from an older JVM, you need to use the agent from the [Jetty](https://www.eclipse.org/jetty/) project, `jetty-alpn-agent`, >= 2.0.10.
 
 ### manually
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,6 @@ object Dependencies {
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v${h2specVersion}/${h2specName}.zip"
-  val alpnAgentVersion = "2.0.10"
   val silencerVersion = "1.6.0"
 
   lazy val scalaTestVersion = settingKey[String]("The version of ScalaTest to use.")
@@ -52,8 +51,6 @@ object Dependencies {
 
     val hpack       = "com.twitter"                   % "hpack"                        % "1.0.2"       // ApacheV2
 
-    val alpnApi     = "org.eclipse.jetty.alpn"        % "alpn-api"                     % "1.1.3.v20160715" // ApacheV2
-
     val caffeine    = "com.github.ben-manes.caffeine" % "caffeine"                     % "2.8.2"
 
     object Docs {
@@ -74,7 +71,6 @@ object Dependencies {
       val sprayJson    = Compile.sprayJson                                                                   % "test" // ApacheV2
 
       // HTTP/2
-      val alpnAgent    = "org.mortbay.jetty.alpn"      % "jetty-alpn-agent"             % alpnAgentVersion  % "test" // ApacheV2
       val h2spec       = "io.github.summerwind"        % h2specName                     % h2specVersion      % "test" from(h2specUrl) // MIT
     }
   }
@@ -102,7 +98,7 @@ object Dependencies {
 
   lazy val http = Seq()
 
-  lazy val http2 = l ++= Seq(hpack, alpnApi)
+  lazy val http2 = l ++= Seq(hpack)
 
   lazy val http2Support = l ++= Seq(Test.h2spec)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v${h2specVersion}/${h2specName}.zip"
-  val alpnAgentVersion = "2.0.9"
+  val alpnAgentVersion = "2.0.10"
   val silencerVersion = "1.6.0"
 
   lazy val scalaTestVersion = settingKey[String]("The version of ScalaTest to use.")


### PR DESCRIPTION
Refs #3100

Not quite done, we need to decide if we want to 

 * drop HTTP2 support for JDK < 8u251 (and jetty-alpn agent)
 * still try to use jetty-alpn on JDK >= 8u251 if it's available (seems to be dangerous as jetty-alpn will replace SSL classes for which it is not clear whether they really support those newer JDKs)

Also needs appropriate changes in the documentation.

I tend to say that we should drop jetty-alpn support for 10.2.0 and just require a recent JDK 8 if you want to use HTTP/2. This requirement will transitively propagate to akka-grpc as well so that should be taken into account as well.