### PR TITLE
Docs: show symbolic Akka verson for dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,7 +332,7 @@ lazy val docs = project("docs")
     paradoxProperties in Compile ++= Map(
       "project.name" -> "Akka HTTP",
       "canonical.base_url" -> "https://doc.akka.io/docs/akka-http/current",
-      "akka.version" -> AkkaDependency.docs.link,
+      "akka.version" -> AkkaDependency.docs.version,
       "alpn-agent.version" -> Dependencies.alpnAgentVersion,
       "scala.binary_version" -> scalaBinaryVersion.value, // to be consistent with Akka build
       "scala.binaryVersion" -> scalaBinaryVersion.value,
@@ -342,7 +342,7 @@ lazy val docs = project("docs")
         case _                  => "cross CrossVersion.full"
       }),
       "jackson.version" -> Dependencies.jacksonVersion,
-      "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/${AkkaDependency.akkaVersion}/%s",
+      "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/${AkkaDependency.docs.link}/%s",
       "javadoc.akka.http.base_url" -> {
         val v = if (isSnapshot.value) "current" else version.value
         s"https://doc.akka.io/japi/akka-http/$v"

--- a/docs/src/main/paradox/introduction.md
+++ b/docs/src/main/paradox/introduction.md
@@ -28,48 +28,22 @@ On the other hand, if you prefer to build your applications with the guidance of
 ## Using Akka HTTP
 
 Akka HTTP is provided as independent modules from Akka itself under its own release cycle. Akka HTTP is @ref[compatible](compatibility-guidelines.md)
-with Akka 2.5 and any later 2.x versions released during the lifetime of Akka HTTP 10.1.x. The modules, however, do *not* depend on `akka-actor` or `akka-stream`, so the user is required to
+with Akka 2.5, Akka 2.6 and  any later 2.x versions released during the lifetime of Akka HTTP 10.2.x. The modules, however, do *not* depend on `akka-actor` or `akka-stream`, so the user is required to
 choose an Akka version to run against and add a manual dependency to `akka-stream` of the chosen version.
 
-sbt
-:   @@@vars
-    ```
-    "com.typesafe.akka" %% "akka-http"   % "$project.version$" $crossString$
-    "com.typesafe.akka" %% "akka-stream" % "$akka.version$" // or whatever the latest version is
-    ```
-    @@@
-
-Gradle
-:   @@@vars
-    ```
-    compile group: 'com.typesafe.akka', name: 'akka-http_$scala.binary_version$',   version: '$project.version$'
-    compile group: 'com.typesafe.akka', name: 'akka-stream_$scala.binary_version$', version: '$akka.version$'
-    ```
-    @@@
-
-Maven
-:   @@@vars
-    ```
-    <dependency>
-      <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-http_$scala.binary_version$</artifactId>
-      <version>$project.version$</version>
-    </dependency>
-    <dependency>
-      <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-stream_$scala.binary_version$</artifactId>
-      <version>$akka.version$</version> <!-- Or whatever the latest version is -->
-    </dependency>
-    ```
-    @@@
-
+@@dependency [sbt,Gradle,Maven] {
+  symbol1=AkkaVersion
+  value1=$akka.version$
+  group1="com.typesafe.akka" artifact1="akka-stream_$scala.binary.version$" version1=AkkaVersion
+  group2="com.typesafe.akka" artifact2="akka-http_$scala.binary.version$" version2="$project.version$"
+}
 
 Alternatively, you can bootstrap a new sbt project with Akka HTTP already
 configured using the [Giter8](http://www.foundweekends.org/giter8/) template:
 
 @@@ div { .group-scala }
 ```sh
-sbt -Dsbt.version=0.13.15 new https://github.com/akka/akka-http-quickstart-scala.g8
+sbt -Dsbt.version=1.2.8 new https://github.com/akka/akka-http-quickstart-scala.g8
 ```
 @@@
 @@@ div { .group-java }

--- a/docs/src/main/paradox/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/routing-dsl/testkit.md
@@ -9,13 +9,11 @@ route logic easy and convenient. This "route test DSL" is made available with th
 To use Akka HTTP TestKit, add the module to your project:
 
 @@dependency [sbt,Gradle,Maven] {
-  group="com.typesafe.akka" artifact="akka-stream-testkit_$scala.binary.version$" version="$akka.version$"
+  symbol1=AkkaVersion
+  value1=$akka.version$
+  group1="com.typesafe.akka" artifact1="akka-stream-testkit_$scala.binary.version$" version1=AkkaVersion
   group2="com.typesafe.akka" artifact2="akka-http-testkit_$scala.binary.version$" version2="$project.version$"
 }
-
-@@@ note
-Since version `10.1.6`, `akka-stream-testkit` is a provided dependency, please remember to add it to your build dependencies.
-@@@
 
 ## Usage
 

--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -10,6 +10,7 @@ import Keys._
 object AkkaDependency {
 
   sealed trait Akka {
+    def version: String
     // The version to use in api/japi/docs links,
     // so 'x.y', 'x.y.z', 'current' or 'snapshot'
     def link: String
@@ -17,7 +18,9 @@ object AkkaDependency {
   case class Artifact(version: String, isSnapshot: Boolean = false) extends Akka {
     override def link = VersionNumber(version) match { case VersionNumber(Seq(x, y, _*), _, _) => s"$x.$y" }
   }
-  case class Sources(uri: String, link: String = "current") extends Akka
+  case class Sources(uri: String, link: String = "current") extends Akka {
+    def version = link
+  }
 
   def akkaDependency(defaultVersion: String): Akka = {
     Option(System.getProperty("akka.sources")) match {


### PR DESCRIPTION
Show the Akka version as a parameter in the dependency examples.

![image](https://user-images.githubusercontent.com/458526/80607211-86577600-8a35-11ea-9976-ec4176c83fb9.png)

![image](https://user-images.githubusercontent.com/458526/80607328-a9822580-8a35-11ea-85a4-4180c1abcf85.png)

![image](https://user-images.githubusercontent.com/458526/80607384-b868d800-8a35-11ea-8fe3-b4ee65e1df47.png)
