### PR TITLE
[release 10.1] http2: support ALPN natively on JDK >= 8u252

### DIFF
--- a/docs/src/main/paradox/release-notes/10.1.x.md
+++ b/docs/src/main/paradox/release-notes/10.1.x.md
@@ -1,5 +1,13 @@
 # 10.1.x Release Notes
 
+## 10.1.12
+
+### ALPN support in JDK >= 8u252
+
+ALPN support was backported to recent JDK 8 updates. When using HTTP2 support with these JDKs, the `jetty-alpn-agent`
+is not needed anymore. If you want to run on older and newer JDKs with the same command line, make sure to use the
+most recent version of `jetty-alpn-agent` which will automatically disable itself for newer JDKs.
+
 ## 10.1.11
 
 ### Changes since 10.1.10

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -130,7 +130,8 @@ This shows `curl` declaring it is ready to speak `h2` (the shorthand name of HTT
 
 [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation) is used to negotiate whether both client and server support HTTP/2.
 
-ALPN support comes with the JVM starting from version 9. If you're on a previous version of the JVM, you'll have to load a Java Agent to provide this functionality. We recommend the agent from the [Jetty](http://www.eclipse.org/jetty/) project, `jetty-alpn-agent`.
+ALPN support comes with the JVM starting from version 9 and in version 8 from update 252. If you're on a previous version of the JVM, you'll have to load a Java Agent to provide this functionality.
+We recommend to use a JVM >= 8u252. If you need to run from an older JVM, you need to use the agent from the [Jetty](https://www.eclipse.org/jetty/) project, `jetty-alpn-agent`, >= 2.0.10.
 
 ### manually
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v${h2specVersion}/${h2specName}.zip"
-  val alpnAgentVersion = "2.0.9"
+  val alpnAgentVersion = "2.0.10"
 
   lazy val scalaTestVersion = settingKey[String]("The version of ScalaTest to use.")
   lazy val specs2Version = settingKey[String]("The version of Specs2 to use")


### PR DESCRIPTION
Crash if incompatible versions of JDK and jetty-alpn-agent are detected

10.1 version of #3117:
 * make it work on JDK 8 >= 8u252
 * fail if incompatible versions are detected
 * add a note to release notes