### PR TITLE
Enable mima for akka-http2-support

### DIFF
--- a/akka-http2-support/src/main/mima-filters/10.1.10.backwards.excludes/http2.backwards.excludes
+++ b/akka-http2-support/src/main/mima-filters/10.1.10.backwards.excludes/http2.backwards.excludes
@@ -1,0 +1,3 @@
+# The module was experimental, so we're not interested in changes to versions before
+# 10.1.11
+ProblemFilters.exclude[Problem]("*")

--- a/akka-http2-support/src/main/mima-filters/10.1.x.backwards.excludes/http2.backwards.excludes
+++ b/akka-http2-support/src/main/mima-filters/10.1.x.backwards.excludes/http2.backwards.excludes
@@ -1,0 +1,17 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.model.http2.Http2SettingsHeader.parse")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.Http2AlpnSupport.cleanupForServer")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.Http2AlpnSupport.jettyAlpnSupport")
+
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.engine.http2.Http2StreamHandling#ReceivingData.onReset")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.Http2Blueprint.framing")
+
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.engine.http2.Http2Protocol#FrameType.byId")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.engine.http2.Http2Protocol#SettingIdentifier.byId")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.Http2Protocol#FrameType.isKnownId")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.Http2Protocol#SettingIdentifier.isKnownId")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.Http2Protocol#ErrorCode.isKnownId")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.framing.Http2FrameParsing.readSettings")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.framing.Http2FrameParsing.this")

--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,6 @@ lazy val http2Support = project("akka-http2-support")
     )
   }
   .enablePlugins(JavaAgent, BootstrapGenjavadoc)
-  .disablePlugins(MimaPlugin) // experimental module still
 
 lazy val httpTestkit = project("akka-http-testkit")
   .settings(commonSettings)


### PR DESCRIPTION
Even if we still call it 'experimental', we should protect ourselves against
accidental binary incompatible changes

Will fail on travis because of #3135