### PR TITLE
Test: Inspect chunked responses during termination

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -102,21 +102,9 @@ class GracefulTerminationSpec
         response.expectNext().utf8String should ===("reply3")
         response.expectNext().utf8String should ===("reply4")
         response.expectNext().utf8String should ===("reply5")
-        val e1 = response.expectEvent()
-        if (e1.isInstanceOf[OnNext[_]]) {
-          val e2 = response.expectEvent()
-          if (e2.isInstanceOf[OnNext[_]]) {
-            val e3 = response.expectEvent()
-            if (e3.isInstanceOf[OnNext[_]]) {
-              fail("the chunked entity stream is expected to fail")
-            } else if (!e3.isInstanceOf[OnError]) {
-              fail(s"the chunked entity stream is expected to fail, got $e3")
-            }
-          } else if (!e2.isInstanceOf[OnError]) {
-            fail(s"the chunked entity stream is expected to fail, got $e2")
-          }
-        } else if (!e1.isInstanceOf[OnError]) {
-          fail(s"the chunked entity stream is expected to fail, got $e1")
+
+        eventually {
+          response.expectEvent() shouldBe a[OnError]
         }
         termination.futureValue shouldBe Http.HttpServerTerminated
       } finally {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -16,7 +16,7 @@ import akka.http.scaladsl.model.headers.Connection
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.settings.{ ConnectionPoolSettings, ServerSettings }
 import akka.stream.scaladsl._
-import akka.stream.testkit.TestSubscriber.{ OnError, OnNext }
+import akka.stream.testkit.TestSubscriber.OnError
 import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.{ Server => _, _ }
 import akka.testkit._
@@ -87,6 +87,41 @@ class GracefulTerminationSpec
         .fromIterator(() => Iterator.from(1).map(v => ChunkStreamPart(s"reply$v,")))
         .throttle(1, 300.millis)
       reply(_ => HttpResponse(entity = HttpEntity.Chunked(ContentTypes.`text/plain(UTF-8)`, chunks)))
+
+      // start reading the response
+      val response = r1.futureValue.entity.dataBytes
+        .via(Framing.delimiter(ByteString(","), 20))
+        .runWith(TestSink.probe[ByteString])
+      response.requestNext().utf8String should ===("reply1")
+
+      try {
+        val termination = serverBinding.terminate(hardDeadline = 50.millis)
+        response.request(20)
+        // local testing shows the stream fails long after the 50 ms deadline
+        response.expectNext().utf8String should ===("reply2")
+        response.expectNext().utf8String should ===("reply3")
+        response.expectNext().utf8String should ===("reply4")
+        response.expectNext().utf8String should ===("reply5")
+
+        eventually {
+          response.expectEvent() shouldBe a[OnError]
+        }
+        termination.futureValue shouldBe Http.HttpServerTerminated
+      } finally {
+        TestKit.shutdownActorSystem(clientSystem)
+      }
+    }
+
+    "fail close delimited response streams" ignore new TestSetup {
+      val clientSystem = ActorSystem("client")
+      val r1 =
+        Http()(clientSystem).singleRequest(nextRequest, connectionContext = clientConnectionContext, settings = basePoolSettings)
+
+      // reply with an infinite entity stream
+      val chunks = Source
+        .fromIterator(() => Iterator.from(1).map(v => ByteString(s"reply$v,")))
+        .throttle(1, 300.millis)
+      reply(_ => HttpResponse(entity = HttpEntity.CloseDelimited(ContentTypes.`text/plain(UTF-8)`, chunks)))
 
       // start reading the response
       val response = r1.futureValue.entity.dataBytes

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -134,9 +134,6 @@ class GracefulTerminationSpec
         response.request(20)
         // local testing shows the stream fails long after the 50 ms deadline
         response.expectNext().utf8String should ===("reply2")
-        response.expectNext().utf8String should ===("reply3")
-        response.expectNext().utf8String should ===("reply4")
-        response.expectNext().utf8String should ===("reply5")
 
         eventually {
           response.expectEvent() shouldBe a[OnError]

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -99,10 +99,6 @@ class GracefulTerminationSpec
         response.request(20)
         // local testing shows the stream fails long after the 50 ms deadline
         response.expectNext().utf8String should ===("reply2")
-        response.expectNext().utf8String should ===("reply3")
-        response.expectNext().utf8String should ===("reply4")
-        response.expectNext().utf8String should ===("reply5")
-
         eventually {
           response.expectEvent() shouldBe a[OnError]
         }
@@ -134,7 +130,6 @@ class GracefulTerminationSpec
         response.request(20)
         // local testing shows the stream fails long after the 50 ms deadline
         response.expectNext().utf8String should ===("reply2")
-
         eventually {
           response.expectEvent() shouldBe a[OnError]
         }


### PR DESCRIPTION
Tests that a chunked HTTP response stream fails when the server terminates. 

The Akka HTTP client reacts as it should with "EntityStreamException: Entity stream truncation. The HTTP parser was receiving an entity when the underlying connection was closed unexpectedly."

https://github.com/akka/akka-http/issues/1210#issuecomment-488136833 made me curious how a client will see server termination on a chunked HTTP response stream.

I expect this test to be flaky, so I'm not sure if it is worth merging.

References #1210
