### PR TITLE
http2: use reflection for accessing `setHandshakeApplicationProtocolSelector`

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
@@ -4,6 +4,7 @@
 
 package akka.http.impl.engine.http2
 
+import java.util.function.BiFunction
 import java.{ util => ju }
 
 import javax.net.ssl.SSLEngine
@@ -44,8 +45,11 @@ private[http] object Http2AlpnSupport {
           else true
         })
 
+  private type SSLEngineWithALPNSupport = {
+    def setHandshakeApplicationProtocolSelector(selector: BiFunction[SSLEngine, ju.List[String], String]): Unit
+  }
   def jdkAlpnSupport(engine: SSLEngine, setChosenProtocol: String => Unit): SSLEngine = {
-    engine.setHandshakeApplicationProtocolSelector { (engine: SSLEngine, protocols: ju.List[String]) =>
+    engine.asInstanceOf[SSLEngineWithALPNSupport].setHandshakeApplicationProtocolSelector { (engine: SSLEngine, protocols: ju.List[String]) =>
       val chosen = chooseProtocol(protocols)
       chosen.foreach(setChosenProtocol)
 


### PR DESCRIPTION
Even if that method is now in JDK 8u252, JDK 11 doesn't know about that and
fails compilation with `--release 8` because of that.

So, we go back to using this method with reflection. It's only called once
per SSLEngine/connection, so the overhead is negligible.

Will fix the JDK 11 nightlies.

Refs #3135