### PR TITLE
Forward port of 10.1.12 release notes

### DIFF
--- a/docs/src/main/paradox/release-notes/10.1.x.md
+++ b/docs/src/main/paradox/release-notes/10.1.x.md
@@ -8,6 +8,41 @@ ALPN support was backported to recent JDK 8 updates. When using HTTP2 support wi
 is not needed anymore. If you want to run on older and newer JDKs with the same command line, make sure to use the
 most recent version of `jetty-alpn-agent` which will automatically disable itself for newer JDKs.
 
+### Changes since 10.1.11
+
+#### akka-http-core
+
+* Fix EOL detection for body part parsing [#3144](https://github.com/akka/akka-http/pull/3144)
+* Fix parsing of partly cached headers with UTF-8 values [#3096](https://github.com/akka/akka-http/pull/3096)
+* Fix cancellation race conditions on the client-side [#2965](https://github.com/akka/akka-http/pull/2965)
+* Make sure to cancel response entity on failure [#3046](https://github.com/akka/akka-http/pull/3046)
+* Make sure reference.conf files end with a new-line character.[#2841](https://github.com/akka/akka-http/pull/2841)
+* Only catch NonFatal Exceptions while parsing responses [#2853](https://github.com/akka/akka-http/pull/2853)
+* Add the remote address in parse errors when possible (when remote-address-header is enabled) [#2899](https://github.com/akka/akka-http/pull/2899)
+* Silence outgoing request stream error (and make it more useful) [#2816](https://github.com/akka/akka-http/pull/2816)
+* Identify Content-Type `charset` parameter even if not lower case [#2926](https://github.com/akka/akka-http/pull/2926)
+* Prevent initialization NPE which might fail all retries quickly [#2958](https://github.com/akka/akka-http/pull/2958)
+* Add exclusion for Extension issues when building against Akka 2.6 [#2945](https://github.com/akka/akka-http/pull/2945)
+* Nest correctly in NewHostConnectionPool [#2964](https://github.com/akka/akka-http/pull/2964)
+
+#### akka-http-marshallers
+
+* Jackson: better JSON validation error when unmarshalling [#2901](https://github.com/akka/akka-http/pull/2901)
+
+#### docs
+
+* Small typo in docs/src/main/paradox/common/marshalling.md [#2864](https://github.com/akka/akka-http/pull/2864)
+* Add warning on usage on extractClientIP [#2922](https://github.com/akka/akka-http/pull/2922)
+* Show RequestBuilding in client examples [#2968](https://github.com/akka/akka-http/pull/2968)
+* Fix project-info links to API docs [#2857](https://github.com/akka/akka-http/pull/2857)
+
+#### akka-http2-support
+
+* Support ALPN natively on JDK >= 8u252 [#3125](https://github.com/akka/akka-http/pull/3125)
+* Gracefully discard unsupported h2 SETTINGS [#3053](https://github.com/akka/akka-http/pull/3053)
+* Potential fix for idle timeouts in http2 [#2776](https://github.com/akka/akka-http/pull/2776)
+* Fix HeaderCompression updating table size without giving notice to peer [#2888](https://github.com/akka/akka-http/pull/2888)
+
 ## 10.1.11
 
 ### Changes since 10.1.10

--- a/scripts/release-train-issue-template.md
+++ b/scripts/release-train-issue-template.md
@@ -82,5 +82,6 @@ Wind down PR queue. There has to be enough time after the last (non-trivial) PR 
 
 ### Afterwards
 - [ ] Add the released version to `project/MiMa.scala` to the `mimaPreviousArtifacts` key *of all current compatible branches*.
+- [ ] Forward port release notes from old releases to master
 - [ ] Update Akka HTTP reference in [lightbend-platform-docs](https://github.com/lightbend/lightbend-platform-docs/blob/master/docs/modules/getting-help/examples/build.sbt#L149)
 - Close this issue


### PR DESCRIPTION
Otherwise, the current version of the docs might not contain all release notes
when we release a final from master.

Also added a line to the release train template to do that for previous versions.