### PR TITLE
HTTP/2 client implementation stub

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/introduce-http2-client-settings.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/introduce-http2-client-settings.excludes
@@ -1,0 +1,10 @@
+# Introduction of new setting to @DoNotInherit
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ClientConnectionSettings.http2Settings")
+
+# Changes to internal class
+ProblemFilters.exclude[Problem]("akka.http.impl.settings.ClientConnectionSettingsImpl.*")
+
+# Changed hierarchy of @DoNotInherit settings classes
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings.logFrames")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings.outgoingControlFrameBufferSize")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings.maxConcurrentStreams")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -369,6 +369,60 @@ akka.http {
     # Int   : determines how many bytes should be logged per data chunk
     log-unencrypted-network-bytes = off
 
+    // FIXME: unify with server-side part (by importing or similar to parsing)
+    http2 {
+      # The maximum number of request per connection concurrently dispatched to the request handler.
+      max-concurrent-streams = 256
+
+      # The maximum number of bytes to receive from a request entity in a single chunk.
+      #
+      # The reasoning to limit that amount (instead of delivering all buffered data for a stream) is that
+      # the amount of data in the internal buffers will drive backpressure and flow control on the HTTP/2 level. Bigger
+      # chunks would mean that the user-level entity reader will have to buffer all that data if it cannot read it in one
+      # go. The implementation would not be able to backpressure further data in that case because it does not know about
+      # this user-level buffer.
+      request-entity-chunk-size = 65536 b
+
+      # The number of request data bytes the HTTP/2 implementation is allowed to buffer internally per connection. Free
+      # space in this buffer is communicated to the peer using HTTP/2 flow-control messages to backpressure data if it
+      # isn't read fast enough.
+      #
+      # When there is no backpressure, this amount will limit the amount of in-flight data. It might need to be increased
+      # for high bandwidth-delay-product connections.
+      #
+      # There is a relation between the `incoming-connection-level-buffer-size` and the `incoming-stream-level-buffer-size`:
+      # If incoming-connection-level-buffer-size < incoming-stream-level-buffer-size * number_of_streams, then
+      # head-of-line blocking is possible between different streams on the same connection.
+      incoming-connection-level-buffer-size = 10 MB
+
+      # The number of request data bytes the HTTP/2 implementation is allowed to buffer internally per stream. Free space
+      # in this buffer is communicated to the peer using HTTP/2 flow-control messages to backpressure data if it isn't
+      # read fast enough.
+      #
+      # When there is no backpressure, this amount will limit the amount of in-flight data per stream. It might need to
+      # be increased for high bandwidth-delay-product connections.
+      incoming-stream-level-buffer-size = 512kB
+
+      # The maximum number of outgoing control frames to buffer when the peer does not read from its TCP connection before
+      # backpressuring incoming frames.
+      #
+      # On a healthy HTTP/2 connection this setting should have little effect because control frames are given priority over
+      # data frames and should not be buffered for a long time.
+      #
+      # The limit is necessary to prevent a malicious peer to solicit buffering of outgoing control frames (e.g. by sending PINGs)
+      # without ever reading frames ultimately leading to an out of memory situation. With the limit in place, the implementation
+      # stops reading incoming frames when the number of outgoing control frames has reached the given amount. This way an attacker
+      # isn't able to communicate any further without first freeing space in the TCP window, draining the buffered control frames.
+      #
+      # See CVE-2019-9512 for an example of such an attack.
+      #
+      # Note that only control frames are affected because data frames, in contrast, are covered by the HTTP/2 flow control.
+      outgoing-control-frame-buffer-size = 1024
+
+      # Enable verbose debug logging for all ingoing and outgoing frames
+      log-frames = false
+    }
+
     websocket {
       # periodic keep alive may be implemented using by sending Ping frames
       # upon which the other side is expected to reply with a Pong frame,

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ClientConnectionSettingsImpl.scala
@@ -12,7 +12,8 @@ import akka.http.impl.util._
 import akka.http.scaladsl.ClientTransport
 import akka.http.scaladsl.model.headers.`User-Agent`
 import akka.http.scaladsl.settings.ClientConnectionSettings.LogUnencryptedNetworkBytes
-import akka.http.scaladsl.settings.{ ParserSettings, WebSocketSettings }
+import akka.http.scaladsl.settings.Http2ClientSettings.Http2ClientSettingsImpl
+import akka.http.scaladsl.settings.{ Http2ClientSettings, ParserSettings, WebSocketSettings }
 import akka.io.Inet.SocketOption
 import com.typesafe.config.Config
 
@@ -33,6 +34,7 @@ private[akka] final case class ClientConnectionSettingsImpl(
   parserSettings:             ParserSettings,
   streamCancellationDelay:    FiniteDuration,
   localAddress:               Option[InetSocketAddress],
+  http2Settings:              Http2ClientSettings,
   transport:                  ClientTransport)
   extends akka.http.scaladsl.settings.ClientConnectionSettings {
 
@@ -63,6 +65,7 @@ private[akka] object ClientConnectionSettingsImpl extends SettingsCompanionImpl[
       parserSettings = ParserSettingsImpl.fromSubConfig(root, c.getConfig("parsing")),
       streamCancellationDelay = c.getFiniteDuration("stream-cancellation-delay"),
       localAddress = None,
+      http2Settings = Http2ClientSettingsImpl.fromSubConfig(root, c.getConfig("http2")),
       transport = ClientTransport.TCP)
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ClientConnectionSettings.scala
@@ -36,6 +36,7 @@ abstract class ClientConnectionSettings private[akka] () extends akka.http.javad
   def logUnencryptedNetworkBytes: Option[Int]
   def streamCancellationDelay: FiniteDuration
   def localAddress: Option[InetSocketAddress]
+  def http2Settings: Http2ClientSettings
 
   /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
   @ApiMayChange

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
@@ -11,6 +11,23 @@ import akka.http.impl.util._
 import com.typesafe.config.Config
 
 /**
+ * INTERNAL API
+ *
+ * Settings which are common for server and client side.
+ */
+@InternalApi
+@DoNotInherit
+private[http] trait Http2CommonSettings {
+  def requestEntityChunkSize: Int
+  def incomingConnectionLevelBufferSize: Int
+  def incomingStreamLevelBufferSize: Int
+
+  def logFrames: Boolean
+  def maxConcurrentStreams: Int
+  def outgoingControlFrameBufferSize: Int
+}
+
+/**
  * Placeholder for any kind of internal settings that might be interesting for HTTP/2 (like custom strategies)
  */
 @InternalApi
@@ -19,7 +36,7 @@ private[http] trait Http2InternalServerSettings
 
 @ApiMayChange
 @DoNotInherit
-trait Http2ServerSettings extends javadsl.settings.Http2ServerSettings { self: Http2ServerSettings.Http2ServerSettingsImpl =>
+trait Http2ServerSettings extends javadsl.settings.Http2ServerSettings with Http2CommonSettings { self: Http2ServerSettings.Http2ServerSettingsImpl =>
   def requestEntityChunkSize: Int
   def withRequestEntityChunkSize(newValue: Int): Http2ServerSettings = copy(requestEntityChunkSize = newValue)
 
@@ -67,6 +84,74 @@ object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
 
   private[http] object Http2ServerSettingsImpl extends akka.http.impl.util.SettingsCompanionImpl[Http2ServerSettingsImpl]("akka.http.server.http2") {
     def fromSubConfig(root: Config, c: Config): Http2ServerSettingsImpl = Http2ServerSettingsImpl(
+      maxConcurrentStreams = c.getInt("max-concurrent-streams"),
+      requestEntityChunkSize = c.getIntBytes("request-entity-chunk-size"),
+      incomingConnectionLevelBufferSize = c.getIntBytes("incoming-connection-level-buffer-size"),
+      incomingStreamLevelBufferSize = c.getIntBytes("incoming-stream-level-buffer-size"),
+      outgoingControlFrameBufferSize = c.getIntBytes("outgoing-control-frame-buffer-size"),
+      logFrames = c.getBoolean("log-frames"),
+      None // no possibility to configure internal settings with config
+    )
+  }
+}
+
+/**
+ * Placeholder for any kind of internal settings that might be interesting for HTTP/2 (like custom strategies)
+ */
+@InternalApi
+@DoNotInherit
+private[http] trait Http2InternalClientSettings
+
+@ApiMayChange
+@DoNotInherit
+trait Http2ClientSettings extends /*FIXME: javadsl.settings.Http2ClientSettings with*/ Http2CommonSettings { self: Http2ClientSettings.Http2ClientSettingsImpl =>
+  def requestEntityChunkSize: Int
+  def withRequestEntityChunkSize(newValue: Int): Http2ClientSettings = copy(requestEntityChunkSize = newValue)
+
+  def incomingConnectionLevelBufferSize: Int
+  def withIncomingConnectionLevelBufferSize(newValue: Int): Http2ClientSettings = copy(incomingConnectionLevelBufferSize = newValue)
+
+  def incomingStreamLevelBufferSize: Int
+  def withIncomingStreamLevelBufferSize(newValue: Int): Http2ClientSettings = copy(incomingStreamLevelBufferSize = newValue)
+
+  def maxConcurrentStreams: Int
+  def withMaxConcurrentStreams(newValue: Int): Http2ClientSettings = copy(maxConcurrentStreams = newValue)
+
+  def outgoingControlFrameBufferSize: Int
+  def withOutgoingControlFrameBufferSize(newValue: Int): Http2ClientSettings = copy(outgoingControlFrameBufferSize = newValue)
+
+  def logFrames: Boolean
+  def withLogFrames(shouldLog: Boolean): Http2ClientSettings = copy(logFrames = shouldLog)
+
+  @InternalApi
+  private[http] def internalSettings: Option[Http2InternalClientSettings]
+  @InternalApi
+  private[http] def withInternalSettings(newValue: Http2InternalClientSettings): Http2ClientSettings =
+    copy(internalSettings = Some(newValue))
+}
+
+@ApiMayChange
+object Http2ClientSettings extends SettingsCompanion[Http2ClientSettings] {
+  def apply(config: Config): Http2ClientSettings = Http2ClientSettingsImpl(config)
+  def apply(configOverrides: String): Http2ClientSettings = Http2ClientSettingsImpl(configOverrides)
+
+  private[http] case class Http2ClientSettingsImpl(
+    maxConcurrentStreams:              Int,
+    requestEntityChunkSize:            Int,
+    incomingConnectionLevelBufferSize: Int,
+    incomingStreamLevelBufferSize:     Int,
+    outgoingControlFrameBufferSize:    Int,
+    logFrames:                         Boolean,
+    internalSettings:                  Option[Http2InternalClientSettings])
+    extends Http2ClientSettings {
+    require(requestEntityChunkSize > 0, "request-entity-chunk-size must be > 0")
+    require(incomingConnectionLevelBufferSize > 0, "incoming-connection-level-buffer-size must be > 0")
+    require(incomingStreamLevelBufferSize > 0, "incoming-stream-level-buffer-size must be > 0")
+    require(outgoingControlFrameBufferSize > 0, "outgoing-control-frame-buffer-size must be > 0")
+  }
+
+  private[http] object Http2ClientSettingsImpl extends akka.http.impl.util.SettingsCompanionImpl[Http2ClientSettingsImpl]("akka.http.client.http2") {
+    def fromSubConfig(root: Config, c: Config): Http2ClientSettingsImpl = Http2ClientSettingsImpl(
       maxConcurrentStreams = c.getInt("max-concurrent-streams"),
       requestEntityChunkSize = c.getIntBytes("request-entity-chunk-size"),
       incomingConnectionLevelBufferSize = c.getIntBytes("incoming-connection-level-buffer-size"),

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -13,7 +13,7 @@ import scala.collection.immutable
 import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler, StageLogging }
 import akka.util.ByteString
 import FrameEvent._
-import akka.http.scaladsl.settings.Http2ServerSettings
+import akka.http.scaladsl.settings.Http2CommonSettings
 
 /**
  * INTERNAL API
@@ -49,7 +49,8 @@ private[http2] trait Http2Multiplexer {
  */
 @InternalApi
 private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with StageLogging =>
-  def settings: Http2ServerSettings
+  def isServer: Boolean
+  def settings: Http2CommonSettings
 
   /**
    * Signal an outgoing stream has ended, so when the incoming side is also finished it can be cleaned up.
@@ -147,7 +148,7 @@ private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with Stage
             case newData: ByteString          => buffer ++= newData
             case HttpEntity.Chunk(newData, _) => buffer ++= newData
             case HttpEntity.LastChunk(_, headers) =>
-              trailer = Some(ParsedHeadersFrame(streamId, endStream = true, ResponseRendering.renderHeaders(headers, log), None))
+              trailer = Some(ParsedHeadersFrame(streamId, endStream = true, ResponseRendering.renderHeaders(headers, log, isServer), None))
           }
 
           maybePull()

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -7,7 +7,7 @@ package akka.http.impl.engine.http2
 import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.scaladsl.model.http2.PeerClosedStreamException
-import akka.http.scaladsl.settings.Http2ServerSettings
+import akka.http.scaladsl.settings.Http2CommonSettings
 import akka.stream.scaladsl.Source
 import akka.stream.stage.{ GraphStageLogic, OutHandler, StageLogging }
 import akka.util.ByteString
@@ -30,7 +30,7 @@ import scala.util.control.NoStackTrace
 private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLogging =>
   // required API from demux
   def multiplexer: Http2Multiplexer
-  def settings: Http2ServerSettings
+  def settings: Http2CommonSettings
   def pushGOAWAY(errorCode: ErrorCode, debug: String): Unit
   def dispatchSubstream(sub: Http2SubStream): Unit
   def isUpgraded: Boolean
@@ -62,10 +62,15 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
   def handleStreamEvent(e: StreamFrameEvent): Unit = {
     updateState(e.streamId, _.handle(e))
   }
+
+  def handleOutgoingCreated(stream: Http2SubStream): Unit =
+    updateState(stream.streamId, _.handleOutgoingCreated(stream))
+
   // Called by the outgoing stream multiplexer when that side of the stream is ended.
   def handleOutgoingEnded(streamId: Int): Unit = {
     updateState(streamId, _.handleOutgoingEnded())
   }
+
   private def updateState(streamId: Int, handle: IncomingStreamState => IncomingStreamState): Unit = {
     val oldState = streamFor(streamId)
     val newState = handle(oldState)
@@ -89,6 +94,10 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
     def handle(event: StreamFrameEvent): IncomingStreamState
 
     def stateName: String = productPrefix
+    def handleOutgoingCreated(stream: Http2SubStream): IncomingStreamState = {
+      log.warning(s"handleOutgoingCreated received unexpectedly in state $stateName. This indicates a bug in Akka HTTP, please report it to the issue tracker.")
+      this
+    }
     def handleOutgoingEnded(): IncomingStreamState = {
       log.warning(s"handleOutgoingEnded received unexpectedly in state $stateName. This indicates a bug in Akka HTTP, please report it to the issue tracker.")
       this
@@ -98,28 +107,44 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
       Closed
     }
 
+    protected def expectIncomingStream(
+      event:           StreamFrameEvent,
+      nextStateEmpty:  IncomingStreamState,
+      nextStateStream: IncomingStreamBuffer => IncomingStreamState,
+      mapStream:       Http2SubStream => Http2SubStream            = identity): IncomingStreamState =
+      event match {
+        case frame @ ParsedHeadersFrame(streamId, endStream, _, _) =>
+          val (data, nextState) =
+            if (endStream)
+              (Source.empty, nextStateEmpty)
+            else {
+              val subSource = new SubSourceOutlet[ByteString](s"substream-out-$streamId")
+              (Source.fromGraph(subSource.source), nextStateStream(new IncomingStreamBuffer(streamId, subSource)))
+            }
+
+          // FIXME: after multiplexer PR is merged
+          // prioInfo.foreach(multiplexer.updatePriority)
+          dispatchSubstream(mapStream(ByteHttp2SubStream(frame, data)))
+          nextState
+
+        case x => receivedUnexpectedFrame(x)
+      }
+
     /** Called to cleanup any state when the connection is torn down */
     def shutdown(): IncomingStreamState
   }
   case object Idle extends IncomingStreamState {
-    def handle(event: StreamFrameEvent): IncomingStreamState = event match {
-      case frame @ ParsedHeadersFrame(streamId, endStream, headers, prioInfo) =>
-        val (data, nextState) =
-          if (endStream)
-            (Source.empty, HalfClosedRemote)
-          else {
-            val subSource = new SubSourceOutlet[ByteString](s"substream-out-$streamId")
-            (Source.fromGraph(subSource.source), Open(new IncomingStreamBuffer(streamId, subSource)))
-          }
-
-        // FIXME: after multiplexer PR is merged
-        // prioInfo.foreach(multiplexer.updatePriority)
-        dispatchSubstream(ByteHttp2SubStream(frame, data))
-        nextState
-
-      case x => receivedUnexpectedFrame(x)
-    }
-
+    def handle(event: StreamFrameEvent): IncomingStreamState = expectIncomingStream(event, HalfClosedRemote, Open)
+    override def handleOutgoingCreated(stream: Http2SubStream): IncomingStreamState = SendingData(stream)
+    override def shutdown(): IncomingStreamState = Closed
+  }
+  case class SendingData(outgoingStream: Http2SubStream) extends IncomingStreamState {
+    override def handle(event: StreamFrameEvent): IncomingStreamState = expectIncomingStream(event, HalfClosedRemote, Open, _.withCorrelationAttributes(outgoingStream.correlationAttributes))
+    override def handleOutgoingEnded(): IncomingStreamState = SendingDataHalfClosedLocal(outgoingStream)
+    override def shutdown(): IncomingStreamState = Closed
+  }
+  case class SendingDataHalfClosedLocal(outgoingStream: Http2SubStream) extends IncomingStreamState {
+    override def handle(event: StreamFrameEvent): IncomingStreamState = expectIncomingStream(event, Closed, HalfClosedLocal, _.withCorrelationAttributes(outgoingStream.correlationAttributes))
     override def shutdown(): IncomingStreamState = Closed
   }
   sealed abstract class ReceivingData(afterEndStreamReceived: IncomingStreamState) extends IncomingStreamState { _: Product =>
@@ -196,6 +221,10 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
         Closed
       case _ => receivedUnexpectedFrame(event)
     }
+
+    override def handleOutgoingCreated(stream: Http2SubStream): IncomingStreamState =
+      // other side has sent its complete message and now we use the channel for the response
+      this
     override def handleOutgoingEnded(): IncomingStreamState = Closed
     override def shutdown(): IncomingStreamState = Closed
   }

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/IncomingFlowController.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/IncomingFlowController.scala
@@ -5,7 +5,7 @@
 package akka.http.impl.engine.http2
 
 import akka.annotation.InternalApi
-import akka.http.scaladsl.settings.Http2ServerSettings
+import akka.http.scaladsl.settings.Http2CommonSettings
 
 /** INTERNAL API */
 @InternalApi
@@ -27,7 +27,7 @@ private[http2] object IncomingFlowController {
     val NoIncrements = WindowIncrements(0, 0)
   }
 
-  def default(settings: Http2ServerSettings): IncomingFlowController =
+  def default(settings: Http2CommonSettings): IncomingFlowController =
     default(settings.incomingConnectionLevelBufferSize, settings.incomingStreamLevelBufferSize)
 
   /** The default scheme sends out WINDOW_UPDATE frames when buffered + outstanding data falls below half of the maximum configured size */

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -4,8 +4,6 @@
 
 package akka.http.impl.engine.http2
 
-import java.lang.StringBuilder
-
 import akka.annotation.InternalApi
 import akka.http.impl.engine.parsing.HttpHeaderParser
 import akka.http.impl.engine.server.HttpAttributes
@@ -15,7 +13,6 @@ import akka.http.scaladsl.model.headers.{ `Remote-Address`, `Tls-Session-Info` }
 import akka.http.scaladsl.model.http2.Http2StreamIdHeader
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.Attributes
-import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.github.ghik.silencer.silent
 
@@ -57,7 +54,7 @@ private[http2] object RequestParsing {
         headers:           VectorBuilder[HttpHeader]  = new VectorBuilder[HttpHeader]
       ): HttpRequest =
         if (remainingHeaders.isEmpty) {
-          // 8.1.2.3: these pseudo header fields are mandatory for a request
+          // https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.3: these pseudo header fields are mandatory for a request
           checkRequiredPseudoHeader(":scheme", scheme)
           checkRequiredPseudoHeader(":method", method)
           checkRequiredPseudoHeader(":path", pathAndRawQuery)
@@ -71,14 +68,7 @@ private[http2] object RequestParsing {
 
           if (tlsSessionInfoHeader.isDefined) headers += tlsSessionInfoHeader.get
 
-          val entity = subStream match {
-            case s if s.data == Source.empty || contentLength == 0 => HttpEntity.Empty
-            case ByteHttp2SubStream(_, data) if contentLength > 0  => HttpEntity.Default(contentType, contentLength, data)
-            /* contentLength undefined */
-            case ByteHttp2SubStream(_, data)                       => HttpEntity.Chunked.fromData(contentType, data)
-            case ChunkedHttp2SubStream(_, data)                    => HttpEntity.Chunked(contentType, data)
-          }
-
+          val entity = subStream.createEntity(contentLength, contentType)
           val (path, rawQueryString) = pathAndRawQuery
           val authorityOrDefault: Uri.Authority = if (authority == null) Uri.Authority.Empty else authority
           val uri = Uri(scheme, authorityOrDefault, path, rawQueryString)
@@ -143,7 +133,7 @@ private[http2] object RequestParsing {
     }
   }
 
-  private def parseHeaderPair(httpHeaderParser: HttpHeaderParser, name: String, value: String): HttpHeader = {
+  private[http2] def parseHeaderPair(httpHeaderParser: HttpHeaderParser, name: String, value: String): HttpHeader = {
     // FIXME: later modify by adding HttpHeaderParser.parseHttp2Header that would use (name, value) pair directly
     //        or use a separate, simpler, parser for Http2
     // FIXME: add correctness checks (e.g. duplicated content-length) modeled after ones in HttpMessageParser
@@ -155,12 +145,12 @@ private[http2] object RequestParsing {
     httpHeaderParser.resultHeader
   }
 
-  def checkRequiredPseudoHeader(name: String, value: AnyRef): Unit =
+  private[http2] def checkRequiredPseudoHeader(name: String, value: AnyRef): Unit =
     if (value eq null) malformedRequest(s"Mandatory pseudo-header '$name' missing")
-  private def checkUniquePseudoHeader(name: String, value: AnyRef): Unit =
+  private[http2] def checkUniquePseudoHeader(name: String, value: AnyRef): Unit =
     if (value ne null) malformedRequest(s"Pseudo-header '$name' must not occur more than once")
-  private def checkNoRegularHeadersBeforePseudoHeader(name: String, seenRegularHeader: Boolean): Unit =
+  private[http2] def checkNoRegularHeadersBeforePseudoHeader(name: String, seenRegularHeader: Boolean): Unit =
     if (seenRegularHeader) malformedRequest(s"Pseudo-header field '$name' must not appear after a regular header")
-  def malformedRequest(msg: String): Nothing =
+  private[http2] def malformedRequest(msg: String): Nothing =
     throw new RuntimeException(s"Malformed request: $msg")
 }

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/client/RequestRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/client/RequestRendering.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+package client
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.annotation.InternalApi
+import akka.event.LoggingAdapter
+import akka.http.impl.engine.http2.FrameEvent.ParsedHeadersFrame
+import akka.http.scaladsl.model.http2.RequestResponseAssociation
+import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpRequest }
+
+import scala.collection.immutable.VectorBuilder
+
+@InternalApi
+private[http2] object RequestRendering {
+  def createRenderer(log: LoggingAdapter): HttpRequest => Http2SubStream = {
+    val streamId = new AtomicInteger(1)
+
+    { request =>
+      val headerPairs = new VectorBuilder[(String, String)]()
+      headerPairs += ":method" -> request.method.value
+      headerPairs += ":scheme" -> "https" // FIXME: should that be the real scheme?
+      headerPairs += ":authority" -> request.uri.authority.toString
+      headerPairs += ":path" -> request.uri.toHttpRequestTargetOriginForm.toString
+
+      if (request.entity.contentType != ContentTypes.NoContentType)
+        headerPairs += "content-type" -> request.entity.contentType.toString
+      request.entity.contentLengthOption.foreach(headerPairs += "content-length" -> _.toString)
+      ResponseRendering.renderHeaders(request.headers, headerPairs, None /* FIXME: render user agent */ , log, isServer = false)
+
+      val headersFrame = ParsedHeadersFrame(streamId.getAndAdd(2), endStream = request.entity.isKnownEmpty, headerPairs.result(), None)
+
+      val substream =
+        request.entity match {
+          case HttpEntity.Chunked(_, chunks) =>
+            ChunkedHttp2SubStream(headersFrame, chunks)
+          case _ =>
+            ByteHttp2SubStream(headersFrame, request.entity.dataBytes)
+        }
+      substream.withCorrelationAttributes(request.attributes.filter(_._2.isInstanceOf[RequestResponseAssociation]))
+    }
+  }
+}

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+package client
+
+import akka.annotation.InternalApi
+import akka.http.impl.engine.http2.RequestParsing._
+import akka.http.impl.engine.parsing.HttpHeaderParser
+import akka.http.scaladsl.model._
+
+import scala.annotation.tailrec
+import scala.collection.immutable.VectorBuilder
+
+@InternalApi
+private[http2] object ResponseParsing {
+  def parseResponse(httpHeaderParser: HttpHeaderParser): Http2SubStream => HttpResponse = { subStream =>
+    @tailrec
+    def rec(
+      remainingHeaders:  Seq[(String, String)],
+      status:            StatusCode                = null,
+      contentType:       ContentType               = ContentTypes.`application/octet-stream`,
+      contentLength:     Long                      = -1,
+      seenRegularHeader: Boolean                   = false,
+      headers:           VectorBuilder[HttpHeader] = new VectorBuilder[HttpHeader]
+    ): HttpResponse =
+      if (remainingHeaders.isEmpty) {
+        // https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.4: these pseudo header fields are mandatory for a response
+        checkRequiredPseudoHeader(":status", status)
+
+        val entity = subStream.createEntity(contentLength, contentType)
+
+        HttpResponse(
+          status = status,
+          headers = headers.result(),
+          entity = entity,
+          HttpProtocols.`HTTP/2.0`
+        ).withAttributes(subStream.correlationAttributes)
+      } else remainingHeaders.head match {
+        case (":status", statusCodeValue) =>
+          checkUniquePseudoHeader(":status", status)
+          checkNoRegularHeadersBeforePseudoHeader(":status", seenRegularHeader)
+          rec(remainingHeaders.tail, statusCodeValue.toInt, contentType, contentLength, seenRegularHeader, headers)
+
+        case ("content-type", ct) =>
+          val contentType = ContentType.parse(ct).right.getOrElse(malformedRequest(s"Invalid content-type: '$ct'"))
+          rec(remainingHeaders.tail, status, contentType, contentLength, seenRegularHeader, headers)
+
+        case ("content-length", length) =>
+          val contentLength = length.toLong
+          rec(remainingHeaders.tail, status, contentType, contentLength, seenRegularHeader, headers)
+
+        case (name, _) if name.startsWith(":") =>
+          malformedRequest(s"Unexpected pseudo-header '$name' in response")
+
+        case (name, value) =>
+          val httpHeader = parseHeaderPair(httpHeaderParser, name, value)
+          rec(remainingHeaders.tail, status, contentType, contentLength, seenRegularHeader = true, headers += httpHeader)
+      }
+
+    rec(subStream.initialHeaders.keyValuePairs)
+  }
+}

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -4,30 +4,30 @@
 
 package akka.http.scaladsl
 
-import akka.{ Done, NotUsed }
 import akka.actor.{ ActorSystem, ClassicActorSystemProvider, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
 import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
 import akka.http.impl.engine.http2.{ Http2AlpnSupport, Http2Blueprint, ProtocolSwitch }
-import akka.http.impl.engine.server.MasterServerTerminator
-import akka.http.impl.engine.server.UpgradeToOtherProtocolResponseHeader
+import akka.http.impl.engine.server.{ MasterServerTerminator, UpgradeToOtherProtocolResponseHeader }
+import akka.http.impl.util.LogByteStringTools
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
-import akka.stream.scaladsl.{ Flow, Keep, Sink, Source, TLS, TLSPlacebo, Tcp }
 import akka.http.scaladsl.model.headers.{ Connection, RawHeader, Upgrade, UpgradeProtocol }
 import akka.http.scaladsl.model.http2.{ Http2SettingsHeader, Http2StreamIdHeader }
-import akka.stream.{ IgnoreComplete, Materializer }
+import akka.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
+import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source, TLS, TLSPlacebo, Tcp }
+import akka.stream.{ IgnoreComplete, Materializer, TLSClosing }
 import akka.util.ByteString
+import akka.{ Done, NotUsed }
 import com.typesafe.config.Config
 import javax.net.ssl.SSLEngine
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.Future
 import scala.collection.immutable
-import scala.util.{ Failure, Success }
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 import scala.util.control.NonFatal
+import scala.util.{ Failure, Success }
 
 /** Entry point for Http/2 server */
 final class Http2Ext(private val config: Config)(implicit val system: ActorSystem)
@@ -179,6 +179,29 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
 
     ProtocolSwitch(_ => getChosenProtocol(), http1, http2) join
       tls
+  }
+
+  def outgoingConnection(
+    host:              String,
+    port:              Int                      = 443,
+    settings:          ClientConnectionSettings = ClientConnectionSettings(system),
+    connectionContext: HttpsConnectionContext   = Http().defaultClientHttpsContext,
+    log:               LoggingAdapter           = system.log): Flow[HttpRequest, HttpResponse, Any] = {
+    def createEngine(): SSLEngine = {
+      val engine = connectionContext.sslContext.createSSLEngine(host, port)
+      engine.setUseClientMode(true)
+      Http2AlpnSupport.applySessionParameters(engine, connectionContext.firstSession)
+      val params = engine.getSSLParameters
+      params.setApplicationProtocols(Array("h2"))
+      engine.setSSLParameters(params)
+      engine
+    }
+
+    Http2Blueprint.clientStack(settings, log) atop
+      Http2Blueprint.unwrapTls atop
+      LogByteStringTools.logTLSBidiBySetting("client-plain-text", settings.logUnencryptedNetworkBytes) atop
+      TLS(createEngine _, closing = TLSClosing.eagerClose) join
+      settings.transport.connectTo(host, port, settings)
   }
 }
 

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/RequestResponseAssociation.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/model/http2/RequestResponseAssociation.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.scaladsl.model.http2
+
+/**
+ * A marker trait for attribute values that should be (automatically) carried over from request to response.
+ */
+trait RequestResponseAssociation
+final case class SimpleRequestResponseAttribute[T](value: T) extends RequestResponseAssociation

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+
+import akka.http.impl.engine.ws.ByteStringSinkProbe
+import akka.http.impl.util.{ AkkaSpecWithMaterializer, ExampleHttpContexts }
+import akka.http.scaladsl.model.headers
+import akka.http.scaladsl.model.headers.HttpEncodings
+import akka.http.scaladsl.model.http2.{ Http2StreamIdHeader, RequestResponseAssociation }
+import akka.http.scaladsl.model.{ AttributeKey, ContentTypes, HttpEntity, HttpHeader, HttpMethod, HttpMethods, HttpRequest, HttpResponse, StatusCode, StatusCodes, Uri }
+import akka.http.scaladsl.settings.ClientConnectionSettings
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.{ Http, Http2 }
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.testkit.{ TestPublisher, TestSubscriber }
+import akka.testkit.TestProbe
+import akka.util.ByteString
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.collection.immutable
+import scala.concurrent.{ Future, Promise }
+
+class Http2ClientServerSpec extends AkkaSpecWithMaterializer(
+  """akka.http.server.remote-address-header = on
+     akka.http.server.http2.log-frames = on
+     akka.http.server.log-unencrypted-network-bytes = 100
+     akka.http.server.preview.enable-http2 = on
+     akka.actor.serialize-messages = false
+  """) with ScalaFutures {
+  case class RequestId(id: String) extends RequestResponseAssociation
+  val requestIdAttr = AttributeKey[RequestId]("requestId")
+
+  "HTTP 2 implementation" should {
+    "support simple round-trips" in new TestSetup {
+      sendClientRequest(
+        HttpRequest(
+          method = HttpMethods.POST,
+          entity = "ping",
+          headers = headers.`Accept-Encoding`(HttpEncodings.gzip) :: Nil
+        )
+          .addAttribute(requestIdAttr, RequestId("request-1"))
+      )
+
+      val serverRequest = expectServerRequest()
+      serverRequest.request.header[Http2StreamIdHeader] shouldBe Symbol("nonEmpty")
+      serverRequest.request.method shouldBe HttpMethods.POST
+      serverRequest.request.header[headers.`Accept-Encoding`] should not be empty
+      Unmarshal(serverRequest.request.entity).to[String].futureValue shouldBe "ping"
+      serverRequest.sendResponse(HttpResponse(entity = "pong"))
+
+      val response = expectClientResponse()
+      Unmarshal(response.entity).to[String].futureValue shouldBe "pong"
+      response.attribute(requestIdAttr).get.id shouldBe "request-1"
+    }
+    "support multiple interleaved concurrent streams" in new TestSetup {
+      val reqPub1 = sendClientRequestWithEntityStream("request-1")
+
+      val serverRequest1 = expectServerRequest()
+      serverRequest1.request.header[Http2StreamIdHeader] shouldBe Symbol("nonEmpty")
+      serverRequest1.request.method shouldBe HttpMethods.POST
+
+      val reqSub1 = serverRequest1.expectRequestEntityStream()
+      reqPub1.sendNext(ByteString("ping"))
+      reqSub1.expectUtf8EncodedString("ping")
+
+      val reqPub2 = sendClientRequestWithEntityStream("request-2")
+      val serverRequest2 = expectServerRequest()
+      serverRequest2.request.header[Http2StreamIdHeader] shouldBe Symbol("nonEmpty")
+      serverRequest2.request.method shouldBe HttpMethods.POST
+      val reqSub2 = serverRequest2.expectRequestEntityStream()
+      reqPub2.sendNext(ByteString("blub"))
+      reqSub2.expectUtf8EncodedString("blub")
+
+      // send and receive response to second request first
+
+      val resPub2 = serverRequest2.sendResponseWithEntityStream()
+
+      val (response2, resSub2) = expectClientResponseWithStream()
+      response2.attribute(requestIdAttr).get.id shouldBe "request-2"
+      resPub2.sendNext(ByteString("blip blup"))
+      resSub2.expectUtf8EncodedString("blip blup")
+
+      serverRequest1.sendResponse(HttpResponse(entity = "pong"))
+      val response1 = expectClientResponse()
+      response1.attribute(requestIdAttr).get.id shouldBe "request-1"
+      Unmarshal(response1.entity).to[String].futureValue shouldBe "pong"
+    }
+  }
+
+  case class ServerRequest(request: HttpRequest, promise: Promise[HttpResponse]) {
+    def sendResponse(response: HttpResponse): Unit =
+      promise.success(response.addHeader(request.header[Http2StreamIdHeader].get))
+
+    def sendResponseWithEntityStream(
+      status:  StatusCode                = StatusCodes.OK,
+      headers: immutable.Seq[HttpHeader] = Nil): TestPublisher.Probe[ByteString] = {
+      val probe = TestPublisher.probe[ByteString]()
+      sendResponse(HttpResponse(status, headers, HttpEntity(ContentTypes.`application/octet-stream`, Source.fromPublisher(probe))))
+      probe
+    }
+
+    def expectRequestEntityStream(): ByteStringSinkProbe = {
+      val probe = ByteStringSinkProbe()
+      request.entity.dataBytes.runWith(probe.sink)
+      probe
+    }
+  }
+  class TestSetup {
+    private lazy val serverRequestProbe = TestProbe()
+    private lazy val handler: HttpRequest => Future[HttpResponse] = { req =>
+      val p = Promise[HttpResponse]()
+      serverRequestProbe.ref ! ServerRequest(req, p)
+      p.future
+    }
+    lazy val binding =
+      Http().bindAndHandleAsync(handler, "localhost", 0, connectionContext = ExampleHttpContexts.exampleServerContext).futureValue
+
+    // FIXME: use public API
+    lazy val clientFlow = {
+      val clientSettings = ClientConnectionSettings(system).withTransport(ExampleHttpContexts.proxyTransport(binding.localAddress))
+      Http2().outgoingConnection(
+        host = "akka.example.org",
+        port = 443,
+        connectionContext = ExampleHttpContexts.exampleClientContext,
+        settings = clientSettings
+      )
+    }
+    lazy val clientRequestsOut = TestPublisher.probe[HttpRequest]()
+    lazy val clientResponsesIn = TestSubscriber.probe[HttpResponse]()
+    Source.fromPublisher(clientRequestsOut)
+      .via(clientFlow)
+      .runWith(Sink.fromSubscriber(clientResponsesIn))
+
+    // client-side
+    def sendClientRequestWithEntityStream(
+      requestId: String,
+      method:    HttpMethod                = HttpMethods.POST,
+      uri:       Uri                       = Uri./,
+      headers:   immutable.Seq[HttpHeader] = Nil): TestPublisher.Probe[ByteString] = {
+      val probe = TestPublisher.probe[ByteString]()
+      sendClientRequest(
+        HttpRequest(method, uri, headers, HttpEntity(ContentTypes.`application/octet-stream`, Source.fromPublisher(probe)))
+          .addAttribute(requestIdAttr, RequestId(requestId))
+      )
+      probe
+    }
+    def sendClientRequest(request: HttpRequest = HttpRequest()): Unit = clientRequestsOut.sendNext(request)
+    def expectClientResponse(): HttpResponse = clientResponsesIn.requestNext()
+    def expectClientResponseWithStream(): (HttpResponse, ByteStringSinkProbe) = {
+      val res = expectClientResponse()
+      val probe = ByteStringSinkProbe()
+      res.entity.dataBytes.runWith(probe.sink)
+      res -> probe
+    }
+
+    // server-side
+    def expectServerRequest(): ServerRequest = serverRequestProbe.expectMsgType[ServerRequest]
+  }
+}

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ResponseRenderingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ResponseRenderingSpec.scala
@@ -36,7 +36,7 @@ class ResponseRenderingSpec extends AnyWordSpec with Matchers {
         RawHeader("raw", "whatever"),
         new MyCustomHeader("whatever", renderInResponses = true)
       )
-      ResponseRendering.renderHeaders(headers, builder, None, NoLogging)
+      ResponseRendering.renderHeaders(headers, builder, None, NoLogging, isServer = true)
       val out = builder.result()
       out.exists(_._1 == "etag") shouldBe true
       out.exists(_._1 == "raw") shouldBe true
@@ -45,7 +45,7 @@ class ResponseRenderingSpec extends AnyWordSpec with Matchers {
 
     "add a date header when none is present" in {
       val builder = new VectorBuilder[(String, String)]
-      ResponseRendering.renderHeaders(Seq.empty, builder, None, NoLogging)
+      ResponseRendering.renderHeaders(Seq.empty, builder, None, NoLogging, isServer = true)
       val date = builder.result().collectFirst {
         case ("date", str) => str
       }
@@ -59,7 +59,7 @@ class ResponseRenderingSpec extends AnyWordSpec with Matchers {
     "keep the date header if it already is present" in {
       val builder = new VectorBuilder[(String, String)]
       val originalDateTime = DateTime(1981, 3, 6, 20, 30, 24)
-      ResponseRendering.renderHeaders(Seq(Date(originalDateTime)), builder, None, NoLogging)
+      ResponseRendering.renderHeaders(Seq(Date(originalDateTime)), builder, None, NoLogging, isServer = true)
       val date = builder.result().collectFirst {
         case ("date", str) => str
       }
@@ -69,14 +69,14 @@ class ResponseRenderingSpec extends AnyWordSpec with Matchers {
 
     "add server header if default provided" in {
       val builder = new VectorBuilder[(String, String)]
-      ResponseRendering.renderHeaders(Seq.empty, builder, Some(("server", "default server")), NoLogging)
+      ResponseRendering.renderHeaders(Seq.empty, builder, Some(("server", "default server")), NoLogging, isServer = true)
       val result = builder.result().find(_._1 == "server").map(_._2)
       result shouldEqual Some("default server")
     }
 
     "keep server header if explicitly provided" in {
       val builder = new VectorBuilder[(String, String)]
-      ResponseRendering.renderHeaders(Seq(Server("explicit server")), builder, Some(("server", "default server")), NoLogging)
+      ResponseRendering.renderHeaders(Seq(Server("explicit server")), builder, Some(("server", "default server")), NoLogging, isServer = true)
       val result = builder.result().find(_._1 == "server").map(_._2)
       result shouldEqual Some("explicit server")
     }
@@ -89,7 +89,7 @@ class ResponseRenderingSpec extends AnyWordSpec with Matchers {
         `Content-Type`(ContentTypes.`application/json`),
         `Transfer-Encoding`(TransferEncodings.gzip)
       )
-      ResponseRendering.renderHeaders(invalidExplicitHeaders, builder, None, NoLogging)
+      ResponseRendering.renderHeaders(invalidExplicitHeaders, builder, None, NoLogging, isServer = true)
       builder.result().exists(_._1 != "date") shouldBe false
     }
 
@@ -99,7 +99,7 @@ class ResponseRenderingSpec extends AnyWordSpec with Matchers {
         Host("example.com", 80),
         new MyCustomHeader("whatever", renderInResponses = false)
       )
-      ResponseRendering.renderHeaders(shouldNotBeRendered, builder, None, NoLogging)
+      ResponseRendering.renderHeaders(shouldNotBeRendered, builder, None, NoLogging, isServer = true)
       builder.result().exists(_._1 != "date") shouldBe false
 
     }
@@ -109,7 +109,7 @@ class ResponseRenderingSpec extends AnyWordSpec with Matchers {
       val invalidRawHeaders = Seq(
         "connection", "content-length", "content-type", "transfer-encoding", "date", "server"
       ).map(name => RawHeader(name, "whatever"))
-      ResponseRendering.renderHeaders(invalidRawHeaders, builder, None, NoLogging)
+      ResponseRendering.renderHeaders(invalidRawHeaders, builder, None, NoLogging, isServer = true)
       builder.result().exists(_._1 != "date") shouldBe false
     }
 

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ClientApp.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ClientApp.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.scaladsl
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.headers
+import akka.http.scaladsl.model.headers.HttpEncodings
+import akka.http.scaladsl.model.http2.RequestResponseAssociation
+import akka.http.scaladsl.model.{ AttributeKey, HttpRequest, HttpResponse }
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{ Flow, Sink, Source }
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.{ Future, Promise }
+import scala.concurrent.duration._
+
+/** A small example app that shows how to use the HTTP/2 client API currently against actual internet servers */
+object Http2ClientApp extends App {
+  val config =
+    ConfigFactory.parseString(
+      """
+         #akka.loglevel = debug
+         akka.http.client.http2.log-frames = true
+         akka.http.client.parsing.max-content-length = 20m
+      """
+    ).withFallback(ConfigFactory.defaultApplication())
+
+  implicit val system = ActorSystem("Http2ClientApp", config)
+  implicit val ec = system.dispatcher
+
+  val dispatch = singleRequest(Http2().outgoingConnection("doc.akka.io"))
+
+  dispatch(HttpRequest(uri = "https://doc.akka.io/api/akka/current/akka/actor/typed/scaladsl/index.html", headers = headers.`Accept-Encoding`(HttpEncodings.gzip) :: Nil)).onComplete { res =>
+    println(s"[1] Got index.html: $res")
+    res.get.entity.dataBytes.runWith(Sink.ignore).onComplete(res => println(s"Finished reading [1] $res"))
+  }
+  dispatch(HttpRequest(uri = "https://doc.akka.io/api/akka/current/index.js", headers = /*headers.`Accept-Encoding`(HttpEncodings.gzip) ::*/ Nil)).onComplete { res =>
+    println(s"[2] Got index.js: $res")
+    res.get.entity.dataBytes.runWith(Sink.ignore).onComplete(res => println(s"Finished reading [2] $res"))
+  }
+  dispatch(HttpRequest(uri = "https://doc.akka.io/api/akka/current/lib/MaterialIcons-Regular.woff")).flatMap(_.toStrict(1.second)).onComplete(res => println(s"[3] Got font: $res"))
+  dispatch(HttpRequest(uri = "https://doc.akka.io/favicon.ico/logo-cloud.png")).flatMap(_.toStrict(1.second)).onComplete(res => println(s"[4] Got favicon: $res"))
+
+  def singleRequest(connection: Flow[HttpRequest, HttpResponse, Any], bufferSize: Int = 100): HttpRequest => Future[HttpResponse] = {
+    val queue =
+      Source.queue(bufferSize, OverflowStrategy.dropNew)
+        .via(connection)
+        .to(Sink.foreach { res =>
+          res.attribute(ResponsePromise.Key).get.promise.trySuccess(res)
+        })
+        .run()
+
+    req => {
+      val p = Promise[HttpResponse]()
+      queue.offer(req.addAttribute(ResponsePromise.Key, ResponsePromise(p)))
+        .flatMap(_ => p.future)
+    }
+  }
+}
+
+case class ResponsePromise(promise: Promise[HttpResponse]) extends RequestResponseAssociation
+object ResponsePromise {
+  val Key = AttributeKey[ResponsePromise]("association-handle")
+}

--- a/docs/src/main/paradox/compatibility-guidelines.md
+++ b/docs/src/main/paradox/compatibility-guidelines.md
@@ -73,6 +73,7 @@ Scala
     akka.http.scaladsl.settings.ConnectionPoolSettings#withResponseEntitySubscriptionTimeout
     akka.http.scaladsl.settings.HostOverride
     akka.http.scaladsl.settings.Http2ServerSettings
+    akka.http.scaladsl.settings.Http2ClientSettings
     akka.http.scaladsl.settings.PreviewServerSettings
     akka.http.scaladsl.settings.ServerSentEventSettings
     akka.http.scaladsl.model.headers.CacheDirectives.immutableDirective


### PR DESCRIPTION
Refs #1883 

Doing the minimum to make the simplest test pass. Interestingly enough, only request rendering and response parsing had to be implemented anew. Everything else seems to mostly "just work", even the demux (which is somewhat surprising).

Things that are needed

 * Http2ServerDemux and Http2ClientDemux are almost identical which looks as if they could be the same
 * Parsing and rendering need more complete implementations
 * Backpressure handling in demux needs to be reviewed to make sure that peer-imposed limits work (most importantly, max_concurrent_streams).
 * Some initial handshake related things (settings exchange) might be different between server and client and need to be adapted
 * Settings classes need to be figured out
 * API needs to be reviewed
 * Proper TLS setup/testing
 * More tests for more scenarios
 * Ultimately, integration into the pool API would be nice (automatic negotiation of h2 vs http1, maybe if we know that an endpoint speaks h2 (which could be probed) the flow implemented here could be a drop-in replacement for the PoolInterface? That would be great)

Maybe we should strive to make that effort here as minimal and as least intrusive as possible, so we can do incremental improvements and try it out in akka-grpc as soon as possible.