### PR TITLE
Silence JavaConverters warnings

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -22,6 +22,8 @@ object Common extends AutoPlugin {
       // "-Yno-adapted-args", //akka-http heavily depends on adapted args and => Unit implicits break otherwise
       "-Ywarn-dead-code",
       // "-Xfuture" // breaks => Unit implicits
+      // Can be removed when we drop support for Scala 2.12:
+      "-P:silencer:globalFilters=object JavaConverters in package collection is deprecated",
       // TODO https://github.com/akka/akka-http/issues/2738
       "-P:silencer:globalFilters=(Adapting\\ argument\\ list\\ by\\ creating|Adaptation\\ of\\ argument\\ list\\ by\\ inserting)"
     ),


### PR DESCRIPTION
This warning will be with us until we drop support for 2.12.

We could also consider introducing 'ccompat' wrappers for this, but I'm not
sure it's worth it.