### PR TITLE
Remove unnecessary backward compatibility exclusion

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/2560-hide-body-and-headers-in-tostring.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/2560-hide-body-and-headers-in-tostring.excludes
@@ -1,2 +1,0 @@
-# This affects a sealed trait which, therefore can't be extended by third party code
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.headers.ModeledHeader.safeToString")


### PR DESCRIPTION
References https://github.com/akka/akka-http/pull/2560

In the aforementioned PR, the file `akka-http-core/src/main/mima-filters/10.1.11.backwards.excludes/2560-hide-body-and-headers-in-tostring.excludes` was added as part of a previously used solution in the same PR.

It is not longer necessary and therefore this _housekeeping_ change.