### PR TITLE
core: mark SensitiveHttpHeader.toString as final

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
@@ -26,7 +26,7 @@ trait SensitiveHttpHeader {
   this: HttpHeader =>
 
   // This header is tagged as potentially containing personal sensitive information
-  override def toString: String = name
+  final override def toString: String = name
 }
 
 /**


### PR DESCRIPTION
Follow up to #2560

To avoid accidental overriding in complex inheritance scenarios.

That would prevent that people override it e.g. in cases where only some information is sensitive and they want to report the rest. So, I'm not completely sure, it's a good idea.