### PR TITLE
http: remove deprecated javadsl.server.Directives.route

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
@@ -94,9 +94,4 @@ public class RouteDirectivesTest extends JUnitRouteTest {
 	      "a decoder limit (set via `akka.http.routing.decode-max-size`), " +
               "or a custom limit set with `withSizeLimit`.");
   }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testEmptyRoutesConcatenation() {
-    route();
-  }
 }

--- a/akka-http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
+++ b/akka-http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
@@ -24,7 +24,6 @@ import akka.http.javadsl.testkit.TestRoute;
 
 //#simple-handler-example-full
 import static akka.http.javadsl.server.Directives.get;
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.post;
 //#simple-handler

--- a/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/remove-javadsl-directives-routes.excludes
+++ b/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/remove-javadsl-directives-routes.excludes
@@ -1,0 +1,3 @@
+# Deprecated
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.server.Directives.route")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.server.directives.RouteDirectives.route")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
@@ -23,10 +23,6 @@ object Directives extends AllDirectives {
   // These are repeated here since sometimes (?) the Scala compiler won't actually generate java-compatible
   // signatures for varargs methods, making them show up as Seq<Object> instead of T... in Java.
 
-  @Deprecated
-  @varargs override def route(alternatives: Route*): Route =
-    super.route(alternatives: _*)
-
   @varargs override def getFromBrowseableDirectories(directories: String*): Route =
     super.getFromBrowseableDirectories(directories: _*)
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -33,23 +33,6 @@ abstract class RouteDirectives extends RespondWithDirectives {
   private implicit val conversionExecutionContext = ExecutionContexts.sameThreadExecutionContext
 
   /**
-   * Java-specific call added so you can chain together multiple alternate routes using comma,
-   * rather than having to explicitly call route1.orElse(route2).orElse(route3).
-   * @deprecated Use the `RouteDirectives.concat` method instead.
-   */
-  @Deprecated
-  @deprecated("Use the RouteDirectives.concat method instead.", "10.1.6")
-  @CorrespondsTo("concat")
-  @varargs def route(alternatives: Route*): Route = RouteAdapter {
-    import akka.http.scaladsl.server.Directives._
-
-    if (alternatives.isEmpty)
-      throw new IllegalArgumentException("Chaining empty list of routes is illegal.")
-
-    alternatives.map(_.delegate).reduce(_ ~ _)
-  }
-
-  /**
    * Used to chain multiple alternate routes using comma,
    * rather than having to explicitly call route1.orElse(route2).orElse(route3).
    */

--- a/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
+++ b/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
@@ -12,6 +12,12 @@ If you find an unexpected incompatibility please let us know, so we can check wh
 
 ## Akka HTTP 10.1.11 -> 10.2.0
 
+### Removal of deprecated methods
+
+Several methods that have been deprecated in 10.1.x (or before) have been removed. If you are migrating from old versions
+of Akka HTTP, try migrating to the latest 10.1.x first, so you get the benefit of deprecation messages guiding you towards
+the newer usages.
+
 ### HTTP/2 support requires JDK 8 update 252 or later
 
 JVM support for ALPN has been backported to JDK 8u252 which is now widely available. Support for using the Jetty ALPN

--- a/docs/src/test/java/docs/http/javadsl/server/DirectiveExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/DirectiveExamplesTest.java
@@ -27,8 +27,6 @@ import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.put;
-import static akka.http.javadsl.server.Directives.route;
-
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 import static akka.http.javadsl.server.PathMatchers.segment;
 
@@ -39,8 +37,6 @@ import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.head;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.put;
-import static akka.http.javadsl.server.Directives.route;
-
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 import static akka.http.javadsl.server.PathMatchers.segment;
 
@@ -52,8 +48,6 @@ import static akka.http.javadsl.server.Directives.extractMethod;
 import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.put;
-import static akka.http.javadsl.server.Directives.route;
-
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 import static akka.http.javadsl.server.PathMatchers.segment;
 

--- a/docs/src/test/java/docs/http/javadsl/server/PathDirectiveExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/PathDirectiveExampleTest.java
@@ -15,8 +15,6 @@ import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathEnd;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathSingleSlash;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-examples
 
 public class PathDirectiveExampleTest extends JUnitRouteTest {

--- a/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
@@ -26,8 +26,6 @@ import static akka.http.javadsl.server.Directives.decodeRequestWith;
 import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.post;
-import static akka.http.javadsl.server.Directives.route;
-
 //#example1
 //#custom-handler-example-java
 import static akka.http.javadsl.server.Directives.complete;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
@@ -31,7 +31,6 @@ import static akka.http.javadsl.model.RequestEntityAcceptances.Expected;
 
 //#customHttpMethod
 import static akka.http.javadsl.server.Directives.complete;
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.extractMethod;
 
 //#customHttpMethod

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MethodDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MethodDirectivesExamplesTest.java
@@ -57,7 +57,6 @@ import static akka.http.javadsl.server.Directives.extractMethod;
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.post;
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.overrideMethodWithParameter;
 
 //#overrideMethodWithParameter

--- a/docs/src/test/java/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
@@ -50,84 +50,60 @@ import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathEnd;
-import static akka.http.javadsl.server.Directives.route;
-
 //#pathPrefix
 
 //#path-end-or-single-slash
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathEndOrSingleSlash;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-end-or-single-slash
 //#path-prefix
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathEnd;
 import static akka.http.javadsl.server.Directives.pathPrefix;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-prefix
 //#path-prefix-test
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathEnd;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathPrefixTest;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-prefix-test
 //#path-single-slash
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathSingleSlash;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-single-slash
 //#path-suffix
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathSuffix;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-suffix
 //#path-suffix-test
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.pathSuffixTest;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-suffix-test
 //#raw-path-prefix
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.rawPathPrefix;
-import static akka.http.javadsl.server.Directives.route;
-
 //#raw-path-prefix
 //#raw-path-prefix-test
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.rawPathPrefixTest;
-import static akka.http.javadsl.server.Directives.route;
-
 //#raw-path-prefix-test
 //#redirect-notrailing-slash-missing
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.redirectToTrailingSlashIfMissing;
-import static akka.http.javadsl.server.Directives.route;
-
 //#redirect-notrailing-slash-missing
 //#redirect-notrailing-slash-present
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.redirectToNoTrailingSlashIfPresent;
-import static akka.http.javadsl.server.Directives.route;
-
 //#redirect-notrailing-slash-present
 //#ignoreTrailingSlash
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.ignoreTrailingSlash;
-import static akka.http.javadsl.server.Directives.route;
-
 //#ignoreTrailingSlash
 
 public class PathDirectivesExamplesTest extends JUnitRouteTest {

--- a/docs/src/test/java/docs/http/javadsl/server/directives/RouteDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/RouteDirectivesExamplesTest.java
@@ -30,8 +30,6 @@ import akka.http.javadsl.server.Directives;
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.reject;
-import static akka.http.javadsl.server.Directives.route;
-
 //#reject
 //#redirect
 import static akka.http.javadsl.server.Directives.complete;
@@ -39,8 +37,6 @@ import static akka.http.javadsl.server.Directives.pathEnd;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathSingleSlash;
 import static akka.http.javadsl.server.Directives.redirect;
-import static akka.http.javadsl.server.Directives.route;
-
 //#redirect
 //#failWith
 import static akka.http.javadsl.server.Directives.failWith;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
@@ -21,7 +21,6 @@ import static akka.http.javadsl.server.Directives.extractScheme;
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.extract;
 import static akka.http.javadsl.server.Directives.redirect;
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.scheme;
 
 //#scheme

--- a/docs/src/test/java/docs/http/javadsl/server/directives/WebSocketDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/WebSocketDirectivesExamplesTest.java
@@ -33,19 +33,16 @@ import static akka.http.javadsl.server.Directives.handleWebSocketMessages;
 
 //#handleWebSocketMessages
 //#handleWebSocketMessagesForProtocol
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.handleWebSocketMessagesForProtocol;
 
 //#handleWebSocketMessagesForProtocol
 //#extractUpgradeToWebSocket
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.extractUpgradeToWebSocket;
-import static akka.http.javadsl.server.Directives.route;
 
 
 //#extractUpgradeToWebSocket
 //#extractOfferedWsProtocols
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.extractOfferedWsProtocols;
 import static akka.http.javadsl.server.Directives.handleWebSocketMessagesForOptionalProtocol;
 


### PR DESCRIPTION
Has been replaced by `concat`

This has been deprecated in 10.1.6 which was released in Dec 2018, so it's probably good to go.