### PR TITLE
http: remove deprecated Route.seal

### DIFF
--- a/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/remove-deprecated-javadsl-Route-seal.excludes
+++ b/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/remove-deprecated-javadsl-Route-seal.excludes
@@ -1,0 +1,5 @@
+# Removal of deprecated methods
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.server.Route.seal")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.javadsl.server.Route.seal")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.javadsl.server.directives.RouteAdapter.seal")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.server.directives.RouteAdapter.seal")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -60,59 +60,8 @@ trait Route {
    *    `Success(RouteResult.Complete(response))`, never a failed future and never a rejected route. These
    *    will be already be handled using the default [[RejectionHandler]] and [[ExceptionHandler]].
    *  - Consequently, no route alternatives will be tried that were combined with this route.
-   * @deprecated Use the variant without [[ActorSystem]] and [[Materializer]]
-   */
-  @Deprecated
-  def seal(system: ActorSystem, materializer: Materializer): Route
-
-  /**
-   * Seals a route by wrapping it with default exception handling and rejection conversion.
-   *
-   * A sealed route has these properties:
-   *  - The result of the route will always be a complete response, i.e. the result of the future is a
-   *    `Success(RouteResult.Complete(response))`, never a failed future and never a rejected route. These
-   *    will be already be handled using the default [[RejectionHandler]] and [[ExceptionHandler]].
-   *  - Consequently, no route alternatives will be tried that were combined with this route.
    */
   def seal(): Route
-
-  /**
-   * Seals a route by wrapping it with explicit exception handling and rejection conversion.
-   *
-   * A sealed route has these properties:
-   *  - The result of the route will always be a complete response, i.e. the result of the future is a
-   *    `Success(RouteResult.Complete(response))`, never a failed future and never a rejected route. These
-   *    will be already be handled using the given [[RejectionHandler]] and [[ExceptionHandler]].
-   *  - Consequently, no route alternatives will be tried that were combined with this route.
-   * @deprecated Use the variant without [[ActorSystem]] and [[Materializer]]
-   */
-  @Deprecated
-  def seal(
-    routingSettings:  RoutingSettings,
-    parserSettings:   ParserSettings,
-    rejectionHandler: RejectionHandler,
-    exceptionHandler: ExceptionHandler,
-    system:           ActorSystem,
-    materializer:     Materializer): Route
-
-  /**
-   * Seals a route by wrapping it with explicit exception handling and rejection conversion.
-   *
-   * A sealed route has these properties:
-   *  - The result of the route will always be a complete response, i.e. the result of the future is a
-   *    `Success(RouteResult.Complete(response))`, never a failed future and never a rejected route. These
-   *    will be already be handled using the given [[RejectionHandler]] and [[ExceptionHandler]].
-   *  - Consequently, no route alternatives will be tried that were combined with this route.
-   *
-   * @deprecated Use the variant without [[RoutingSettings]] and [[ParserSettings]]
-   */
-  @Deprecated
-  @deprecated("Use the variant without RoutingSettings, ParserSettings parameters.", since = "10.1.1")
-  def seal(
-    routingSettings:  RoutingSettings,
-    parserSettings:   ParserSettings,
-    rejectionHandler: RejectionHandler,
-    exceptionHandler: ExceptionHandler): Route
 
   /**
    * Seals a route by wrapping it with explicit exception handling and rejection conversion.

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -35,31 +35,14 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
         RouteAdapter(delegate ~ adapt.delegate)
     }
 
-  override def seal(system: ActorSystem, materializer: Materializer): Route = {
-    seal()
-  }
+  override def seal(): Route = RouteAdapter(scaladsl.server.Route.seal(delegate))
 
-  override def seal(): Route = {
-    RouteAdapter(scaladsl.server.Route.seal(delegate))
-
-  }
-
-  override def seal(routingSettings: RoutingSettings, parserSettings: ParserSettings, rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler, system: ActorSystem, materializer: Materializer): Route = {
-    seal(routingSettings, parserSettings, rejectionHandler, exceptionHandler)
-  }
-
-  override def seal(routingSettings: RoutingSettings, parserSettings: ParserSettings, rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler): Route = {
-    seal(rejectionHandler, exceptionHandler)
-  }
-
-  override def seal(rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler): Route = {
+  override def seal(rejectionHandler: RejectionHandler, exceptionHandler: ExceptionHandler): Route =
     RouteAdapter(scaladsl.server.Route.seal(delegate)(
       rejectionHandler = rejectionHandler.asScala,
       exceptionHandler = exceptionHandler.asScala))
-  }
 
   override def toString = s"akka.http.javadsl.server.Route($delegate)"
-
 }
 
 object RouteAdapter {


### PR DESCRIPTION
Has been deprecated in 10.1.1 a long time ago.