### PR TITLE
http: remove deprecated fileIODispatcher setting

### DIFF
--- a/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/remove-deprecated-fileIODispatcher-setting.excludes
+++ b/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/remove-deprecated-fileIODispatcher-setting.excludes
@@ -1,0 +1,7 @@
+# Removal of deprecated methods
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.settings.RoutingSettings.getFileIODispatcher")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.settings.RoutingSettings.withFileIODispatcher")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.settings.RoutingSettings.fileIODispatcher")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.settings.RoutingSettings.getFileIODispatcher")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.settings.RoutingSettings.withFileIODispatcher")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.RoutingSettingsImpl.fileIODispatcher")

--- a/akka-http/src/main/scala/akka/http/impl/settings/RoutingSettingsImpl.scala
+++ b/akka-http/src/main/scala/akka/http/impl/settings/RoutingSettingsImpl.scala
@@ -19,9 +19,6 @@ private[http] final case class RoutingSettingsImpl(
   decodeMaxBytesPerChunk:   Int,
   decodeMaxSize:            Long) extends akka.http.scaladsl.settings.RoutingSettings {
 
-  @deprecated("binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher", since = "10.1.6")
-  override def fileIODispatcher: String = ""
-
   override def productPrefix = "RoutingSettings"
 }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/settings/RoutingSettings.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/settings/RoutingSettings.scala
@@ -20,9 +20,6 @@ abstract class RoutingSettings private[akka] () { self: RoutingSettingsImpl =>
   def getRangeCountLimit: Int
   def getRangeCoalescingThreshold: Long
   def getDecodeMaxBytesPerChunk: Int
-  @deprecated("binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher", since = "10.1.6")
-  @Deprecated
-  def getFileIODispatcher: String
 
   def withVerboseErrorMessages(verboseErrorMessages: Boolean): RoutingSettings = self.copy(verboseErrorMessages = verboseErrorMessages)
   def withFileGetConditional(fileGetConditional: Boolean): RoutingSettings = self.copy(fileGetConditional = fileGetConditional)
@@ -31,9 +28,6 @@ abstract class RoutingSettings private[akka] () { self: RoutingSettingsImpl =>
   def withRangeCoalescingThreshold(rangeCoalescingThreshold: Long): RoutingSettings = self.copy(rangeCoalescingThreshold = rangeCoalescingThreshold)
   def withDecodeMaxBytesPerChunk(decodeMaxBytesPerChunk: Int): RoutingSettings = self.copy(decodeMaxBytesPerChunk = decodeMaxBytesPerChunk)
   def withDecodeMaxSize(decodeMaxSize: Long): RoutingSettings = self.copy(decodeMaxSize = decodeMaxSize)
-  @deprecated("binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher", since = "10.1.6")
-  @Deprecated
-  def withFileIODispatcher(fileIODispatcher: String): RoutingSettings = self
 }
 
 object RoutingSettings extends SettingsCompanion[RoutingSettings] {

--- a/akka-http/src/main/scala/akka/http/scaladsl/settings/RoutingSettings.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/settings/RoutingSettings.scala
@@ -20,8 +20,6 @@ abstract class RoutingSettings private[akka] () extends akka.http.javadsl.settin
   def rangeCoalescingThreshold: Long
   def decodeMaxBytesPerChunk: Int
   def decodeMaxSize: Long
-  @deprecated("binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher", since = "10.1.6")
-  def fileIODispatcher: String
 
   /* Java APIs */
   def getVerboseErrorMessages: Boolean = verboseErrorMessages
@@ -31,9 +29,6 @@ abstract class RoutingSettings private[akka] () extends akka.http.javadsl.settin
   def getRangeCoalescingThreshold: Long = rangeCoalescingThreshold
   def getDecodeMaxBytesPerChunk: Int = decodeMaxBytesPerChunk
   def getDecodeMaxSize: Long = decodeMaxSize
-  @deprecated("binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher", since = "10.1.6")
-  @Deprecated
-  def getFileIODispatcher: String = fileIODispatcher
 
   override def withVerboseErrorMessages(verboseErrorMessages: Boolean): RoutingSettings = self.copy(verboseErrorMessages = verboseErrorMessages)
   override def withFileGetConditional(fileGetConditional: Boolean): RoutingSettings = self.copy(fileGetConditional = fileGetConditional)
@@ -42,9 +37,6 @@ abstract class RoutingSettings private[akka] () extends akka.http.javadsl.settin
   override def withRangeCoalescingThreshold(rangeCoalescingThreshold: Long): RoutingSettings = self.copy(rangeCoalescingThreshold = rangeCoalescingThreshold)
   override def withDecodeMaxBytesPerChunk(decodeMaxBytesPerChunk: Int): RoutingSettings = self.copy(decodeMaxBytesPerChunk = decodeMaxBytesPerChunk)
   override def withDecodeMaxSize(decodeMaxSize: Long): RoutingSettings = self.copy(decodeMaxSize = decodeMaxSize)
-  @deprecated("binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher", since = "10.1.6")
-  @Deprecated
-  override def withFileIODispatcher(fileIODispatcher: String): RoutingSettings = self
 }
 
 object RoutingSettings extends SettingsCompanion[RoutingSettings] {


### PR DESCRIPTION
Has been deprecated a long time ago in 10.1.6