### PR TITLE
core: remove getDefaultPort and its usages

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/remove-getDefaultPort.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/remove-getDefaultPort.excludes
@@ -1,0 +1,8 @@
+# Removal of deprecated methods
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.HttpsConnectionContext.getDefaultPort")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.HttpConnectionContext.getDefaultPort")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.ConnectionContext.getDefaultPort")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.scaladsl.ConnectionContext.$init$")
+
+# Added to @DoNotInherit
+ProblemFilters.exclude[DirectAbstractMethodProblem]("akka.http.scaladsl.ConnectionContext.defaultPort")

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -66,22 +66,17 @@ object ConnectionContext {
 abstract class ConnectionContext {
   def isSecure: Boolean
   def sslConfig: Option[AkkaSSLConfig]
-
-  @deprecated("'default-http-port' and 'default-https-port' configuration properties are used instead", since = "10.0.11")
-  def getDefaultPort: Int
 }
 
 @DoNotInherit
 abstract class HttpConnectionContext extends akka.http.javadsl.ConnectionContext {
   override final def isSecure = false
-  override final def getDefaultPort = 80
   override def sslConfig: Option[AkkaSSLConfig] = None
 }
 
 @DoNotInherit
 abstract class HttpsConnectionContext extends akka.http.javadsl.ConnectionContext {
   override final def isSecure = true
-  override final def getDefaultPort = 443
 
   /** Java API */
   def getEnabledCipherSuites: Optional[JCollection[String]]

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -17,7 +17,8 @@ import scala.collection.immutable
 import scala.compat.java8.OptionConverters._
 
 trait ConnectionContext extends akka.http.javadsl.ConnectionContext {
-  final def defaultPort = getDefaultPort
+  @deprecated("Internal method, left for binary compatibility", since = "10.2.0")
+  protected[http] def defaultPort: Int
 }
 
 object ConnectionContext {
@@ -53,6 +54,7 @@ final class HttpsConnectionContext(
   val clientAuth:          Option[TLSClientAuth]         = None,
   val sslParameters:       Option[SSLParameters]         = None)
   extends akka.http.javadsl.HttpsConnectionContext with ConnectionContext {
+  protected[http] override final def defaultPort: Int = 443
 
   @deprecated("for binary-compatibility", since = "2.4.7")
   def this(
@@ -72,7 +74,9 @@ final class HttpsConnectionContext(
   override def getSslParameters: Optional[SSLParameters] = sslParameters.asJava
 }
 
-sealed class HttpConnectionContext extends akka.http.javadsl.HttpConnectionContext with ConnectionContext
+sealed class HttpConnectionContext extends akka.http.javadsl.HttpConnectionContext with ConnectionContext {
+  protected[http] override final def defaultPort: Int = 80
+}
 
 final object HttpConnectionContext extends HttpConnectionContext {
   /** Java API */


### PR DESCRIPTION
But deprecated and keep scaladsl `defaultPort` because it had not been
deprecated before.