### PR TITLE
core: remove deprecated javadsl entrypoints taking Materializer

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/remove-javadsl-entrypoints-with-materializer.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.x.backwards.excludes/remove-javadsl-entrypoints-with-materializer.excludes
@@ -1,0 +1,13 @@
+# Overloads taking a materializer have been deprecated for a while and are now removed
+# These exclusions over-exclude, so we need to be a bit careful not to introduce further accidental
+# incompatibilities.
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.Http.serverLayer")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.Http.bind")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.Http.cachedHostConnectionPool")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.Http.superPool")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.javadsl.Http.singleRequest")
+
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.javadsl.Http.serverLayer")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.javadsl.Http.bind")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.javadsl.Http.superPool")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.http.javadsl.Http.singleRequest")

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -84,43 +84,6 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     adaptServerLayer(delegate.serverLayerImpl(settings.asScala, remoteAddress.asScala, log))
 
   /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def serverLayer(materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
-    adaptServerLayer(delegate.serverLayerImpl())
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def serverLayer(
-    settings:     ServerSettings,
-    materializer: Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
-    adaptServerLayer(delegate.serverLayerImpl(settings.asScala))
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def serverLayer(
-    settings:      ServerSettings,
-    remoteAddress: Optional[InetSocketAddress],
-    materializer:  Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
-    adaptServerLayer(delegate.serverLayerImpl(settings.asScala, remoteAddress.asScala))
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def serverLayer(
-    settings:      ServerSettings,
-    remoteAddress: Optional[InetSocketAddress],
-    log:           LoggingAdapter,
-    materializer:  Materializer): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
-    adaptServerLayer(delegate.serverLayerImpl(settings.asScala, remoteAddress.asScala, log))
-
-  /**
    * Creates a [[akka.stream.javadsl.Source]] of [[IncomingConnection]] instances which represents a prospective HTTP server binding
    * on the given `endpoint`.
    *
@@ -191,33 +154,6 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
       .mapMaterializedValue(_.map(new ServerBinding(_))(ec).toJava))
   }
 
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def bind(connect: ConnectHttp, materializer: Materializer): Source[IncomingConnection, CompletionStage[ServerBinding]] =
-    bind(connect)
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def bind(
-    connect:      ConnectHttp,
-    settings:     ServerSettings,
-    materializer: Materializer): Source[IncomingConnection, CompletionStage[ServerBinding]] =
-    bind(connect, settings)
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def bind(
-    connect:      ConnectHttp,
-    settings:     ServerSettings,
-    log:          LoggingAdapter,
-    materializer: Materializer): Source[IncomingConnection, CompletionStage[ServerBinding]] =
-    bind(connect, settings, log)
   /**
    * Convenience method which starts a new HTTP server at the given endpoint and uses the given `handler`
    * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
@@ -556,30 +492,6 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
       .mapMaterializedValue(_.toJava))
 
   /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def cachedHostConnectionPool[T](host: String, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], HostConnectionPool] =
-    cachedHostConnectionPool(host)
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def cachedHostConnectionPool[T](to: ConnectHttp, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], HostConnectionPool] =
-    cachedHostConnectionPool(to)
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def cachedHostConnectionPool[T](
-    to:       ConnectHttp,
-    settings: ConnectionPoolSettings,
-    log:      LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], HostConnectionPool] =
-    cachedHostConnectionPool(to, settings, log)
-
-  /**
    * Creates a new "super connection pool flow", which routes incoming requests to a (cached) host connection pool
    * depending on their respective effective URIs. Note that incoming requests must have either an absolute URI or
    * a valid `Host` header.
@@ -634,57 +546,6 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
     settings: ConnectionPoolSettings,
     log:      LoggingAdapter): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], NotUsed] =
     adaptTupleFlow(delegate.superPool[T](defaultClientHttpsContext.asScala, settings.asScala, log))
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def superPool[T](materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], NotUsed] =
-    superPool()
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def superPool[T](
-    settings: ConnectionPoolSettings,
-    log:      LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], NotUsed] =
-    superPool(settings, log)
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def superPool[T](
-    settings:          ConnectionPoolSettings,
-    connectionContext: HttpsConnectionContext,
-    log:               LoggingAdapter, materializer: Materializer): Flow[Pair[HttpRequest, T], Pair[Try[HttpResponse], T], NotUsed] =
-    superPool(settings, connectionContext, log)
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def singleRequest(request: HttpRequest, materializer: Materializer): CompletionStage[HttpResponse] =
-    delegate.singleRequest(request.asScala).toJava
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def singleRequest(request: HttpRequest, connectionContext: HttpsConnectionContext, materializer: Materializer): CompletionStage[HttpResponse] =
-    delegate.singleRequest(request.asScala, connectionContext.asScala).toJava
-
-  /**
-   * @deprecated in favor of method that doesn't require materializer. You can just remove the materializer argument.
-   */
-  @Deprecated
-  def singleRequest(
-    request:           HttpRequest,
-    connectionContext: HttpsConnectionContext,
-    settings:          ConnectionPoolSettings,
-    log:               LoggingAdapter, materializer: Materializer): CompletionStage[HttpResponse] =
-    delegate.singleRequest(request.asScala, connectionContext.asScala, settings.asScala, log).toJava
 
   /**
    * Fires a single [[HttpRequest]] across the (cached) host connection pool for the request's

--- a/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/HttpExtensionApiSpec.scala
@@ -60,7 +60,7 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
     // all four bind method overloads
     "properly bind a server (with three parameters)" in {
       val probe = TestSubscriber.manualProbe[IncomingConnection]()
-      val binding = http.bind(toHost("127.0.0.1", 0), materializer)
+      val binding = http.bind(toHost("127.0.0.1", 0))
         .toMat(Sink.fromSubscriber(probe), Keep.left)
         .run(materializer)
       val sub = probe.expectSubscription()
@@ -70,7 +70,7 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
 
     "properly bind a server (with four parameters)" in {
       val probe = TestSubscriber.manualProbe[IncomingConnection]()
-      val binding = http.bind(toHost("127.0.0.1", 0), materializer)
+      val binding = http.bind(toHost("127.0.0.1", 0))
         .toMat(Sink.fromSubscriber(probe), Keep.left)
         .run(materializer)
       val sub = probe.expectSubscription()
@@ -80,7 +80,7 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
 
     "properly bind a server (with five parameters)" in {
       val probe = TestSubscriber.manualProbe[IncomingConnection]()
-      val binding = http.bind(toHost("127.0.0.1", 0), serverSettings, materializer)
+      val binding = http.bind(toHost("127.0.0.1", 0), serverSettings)
         .toMat(Sink.fromSubscriber(probe), Keep.left)
         .run(materializer)
       val sub = probe.expectSubscription()
@@ -90,7 +90,7 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
 
     "properly bind a server (with six parameters)" in {
       val probe = TestSubscriber.manualProbe[IncomingConnection]()
-      val binding = http.bind(toHost("127.0.0.1", 0), serverSettings, loggingAdapter, materializer)
+      val binding = http.bind(toHost("127.0.0.1", 0), serverSettings, loggingAdapter)
         .toMat(Sink.fromSubscriber(probe), Keep.left)
         .run(materializer)
       val sub = probe.expectSubscription()
@@ -145,23 +145,23 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
       // TODO actually cover these with runtime tests, compile only for now
       pending
 
-      http.serverLayer(materializer)
+      http.serverLayer()
 
       val serverSettings = ServerSettings.create(system)
-      http.serverLayer(serverSettings, materializer)
+      http.serverLayer(serverSettings)
 
       val remoteAddress = Optional.empty[InetSocketAddress]()
-      http.serverLayer(serverSettings, remoteAddress, materializer)
+      http.serverLayer(serverSettings, remoteAddress)
 
       val loggingAdapter = NoLogging
-      http.serverLayer(serverSettings, remoteAddress, loggingAdapter, materializer)
+      http.serverLayer(serverSettings, remoteAddress, loggingAdapter)
     }
 
     "create a cached connection pool (with a ConnectToHttp and a materializer)" in {
       val (host, port, binding) = runServer()
 
       val poolFlow: Flow[Pair[HttpRequest, NotUsed], Pair[Try[HttpResponse], NotUsed], HostConnectionPool] =
-        http.cachedHostConnectionPool[NotUsed](toHost(host, port), materializer)
+        http.cachedHostConnectionPool[NotUsed](toHost(host, port))
 
       val pair: Pair[HostConnectionPool, CompletionStage[Pair[Try[HttpResponse], NotUsed]]] =
         Source.single(new Pair(HttpRequest.GET(s"http://$host:$port/"), NotUsed.getInstance()))
@@ -181,7 +181,7 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
       val (host, port, binding) = runServer()
 
       val poolFlow: Flow[Pair[HttpRequest, NotUsed], Pair[Try[HttpResponse], NotUsed], HostConnectionPool] =
-        http.cachedHostConnectionPool[NotUsed](toHost(host, port), poolSettings, loggingAdapter, materializer)
+        http.cachedHostConnectionPool[NotUsed](toHost(host, port), poolSettings, loggingAdapter)
 
       val pair: Pair[HostConnectionPool, CompletionStage[Pair[Try[HttpResponse], NotUsed]]] =
         Source.single(new Pair(HttpRequest.GET(s"http://$host:$port/"), NotUsed.getInstance()))
@@ -199,7 +199,7 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
       val (host, port, binding) = runServer()
 
       val poolFlow: Flow[Pair[HttpRequest, NotUsed], Pair[Try[HttpResponse], NotUsed], HostConnectionPool] =
-        http.cachedHostConnectionPool[NotUsed](s"http://$host:$port", materializer)
+        http.cachedHostConnectionPool[NotUsed](s"http://$host:$port")
 
       val pair: Pair[HostConnectionPool, CompletionStage[Pair[Try[HttpResponse], NotUsed]]] =
         Source.single(new Pair(HttpRequest.GET(s"http://$host:$port/"), NotUsed.getInstance()))
@@ -324,7 +324,7 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
 
     "allow a single request (with two parameters)" in {
       val (host, port, binding) = runServer()
-      val response = http.singleRequest(HttpRequest.GET(s"http://$host:$port/"), materializer)
+      val response = http.singleRequest(HttpRequest.GET(s"http://$host:$port/"))
 
       waitFor(response).status() should be(StatusCodes.OK)
       waitFor(binding.unbind())
@@ -332,7 +332,7 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
 
     "allow a single request (with three parameters)" in {
       val (host, port, binding) = runServer()
-      val response = http.singleRequest(HttpRequest.GET(s"http://$host:$port/"), http.defaultClientHttpsContext, materializer)
+      val response = http.singleRequest(HttpRequest.GET(s"http://$host:$port/"), http.defaultClientHttpsContext)
 
       waitFor(response).status() should be(StatusCodes.OK)
       waitFor(binding.unbind())
@@ -340,7 +340,7 @@ class HttpExtensionApiSpec extends AkkaSpecWithMaterializer(
 
     "allow a single request (with five parameters)" in {
       val (host, port, binding) = runServer()
-      val response = http.singleRequest(HttpRequest.GET(s"http://$host:$port/"), http.defaultClientHttpsContext, poolSettings, loggingAdapter, materializer)
+      val response = http.singleRequest(HttpRequest.GET(s"http://$host:$port/"), http.defaultClientHttpsContext, poolSettings, loggingAdapter)
 
       waitFor(response).status() should be(StatusCodes.OK)
       waitFor(binding.unbind())

--- a/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
@@ -41,9 +41,9 @@ public class HttpAPIsTest extends JUnitRouteTest {
     ConnectionPoolSettings conSettings = null;
     LoggingAdapter log = null;
 
-    http.bind(toHost("127.0.0.1", 8080), materializer());
-    http.bind(toHost("127.0.0.1", 8080), materializer());
-    http.bind(toHostHttps("127.0.0.1", 8080), materializer());
+    http.bind(toHost("127.0.0.1", 8080) );
+    http.bind(toHost("127.0.0.1", 8080));
+    http.bind(toHostHttps("127.0.0.1", 8080));
 
     final Flow<HttpRequest, HttpResponse, ?> handler = null;
     http.bindAndHandle(handler, toHost("127.0.0.1", 8080), materializer());
@@ -59,9 +59,9 @@ public class HttpAPIsTest extends JUnitRouteTest {
     http.bindAndHandleSync(handler2, toHostHttps("127.0.0.1", 8080), materializer());
 
     final HttpRequest handler3 = null;
-    http.singleRequest(handler3, materializer());
-    http.singleRequest(handler3, httpsContext, materializer());
-    http.singleRequest(handler3, httpsContext, conSettings, log, materializer());
+    http.singleRequest(handler3);
+    http.singleRequest(handler3, httpsContext);
+    http.singleRequest(handler3, httpsContext, conSettings, log);
 
     http.outgoingConnection("akka.io");
     http.outgoingConnection("akka.io:8080");
@@ -89,18 +89,18 @@ public class HttpAPIsTest extends JUnitRouteTest {
     http.newHostConnectionPool(toHost(""), conSettings, log, materializer());
 
 
-    http.cachedHostConnectionPool("akka.io", materializer());
-    http.cachedHostConnectionPool("https://akka.io", materializer());
-    http.cachedHostConnectionPool("https://akka.io:8080", materializer());
-    http.cachedHostConnectionPool(toHost("akka.io"), materializer());
-    http.cachedHostConnectionPool(toHostHttps("smtp://akka.io"), materializer()); // throws, we explicitly require https or ""
-    http.cachedHostConnectionPool(toHostHttps("https://akka.io:2222"), materializer());
-    http.cachedHostConnectionPool(toHostHttps("akka.io"), materializer());
-    http.cachedHostConnectionPool(toHost("akka.io"), conSettings, log, materializer());
+    http.cachedHostConnectionPool("akka.io");
+    http.cachedHostConnectionPool("https://akka.io");
+    http.cachedHostConnectionPool("https://akka.io:8080");
+    http.cachedHostConnectionPool(toHost("akka.io"));
+    http.cachedHostConnectionPool(toHostHttps("smtp://akka.io")); // throws, we explicitly require https or ""
+    http.cachedHostConnectionPool(toHostHttps("https://akka.io:2222"));
+    http.cachedHostConnectionPool(toHostHttps("akka.io"));
+    http.cachedHostConnectionPool(toHost("akka.io"), conSettings, log);
 
-    http.superPool(materializer());
-    http.superPool(conSettings, log, materializer());
-    http.superPool(conSettings, httpsContext, log, materializer());
+    http.superPool();
+    http.superPool(conSettings, log);
+    http.superPool(conSettings, httpsContext, log);
 
     final ConnectWithHttps connect = toHostHttps("akka.io", 8081).withCustomHttpsContext(httpsContext).withDefaultHttpsContext();
     connect.effectiveHttpsConnectionContext(http.defaultClientHttpsContext()); // usage by us internally
@@ -111,15 +111,15 @@ public class HttpAPIsTest extends JUnitRouteTest {
     final Http http = Http.get(system());
     final HttpsConnectionContext httpsConnectionContext = null;
 
-    http.bind(toHost("127.0.0.1"), materializer()); // 80
-    http.bind(toHost("127.0.0.1", 8080), materializer()); // 8080
+    http.bind(toHost("127.0.0.1")); // 80
+    http.bind(toHost("127.0.0.1", 8080)); // 8080
 
-    http.bind(toHost("https://127.0.0.1"), materializer()); // HTTPS 443
-    http.bind(toHost("https://127.0.0.1", 9090), materializer()); // HTTPS 9090
+    http.bind(toHost("https://127.0.0.1")); // HTTPS 443
+    http.bind(toHost("https://127.0.0.1", 9090)); // HTTPS 9090
 
-    http.bind(toHostHttps("127.0.0.1"), materializer()); // HTTPS 443
-    http.bind(toHostHttps("127.0.0.1").withCustomHttpsContext(httpsConnectionContext), materializer()); // custom HTTPS 443
+    http.bind(toHostHttps("127.0.0.1")); // HTTPS 443
+    http.bind(toHostHttps("127.0.0.1").withCustomHttpsContext(httpsConnectionContext)); // custom HTTPS 443
 
-    http.bind(toHostHttps("http://127.0.0.1"), materializer()); // throws
+    http.bind(toHostHttps("http://127.0.0.1")); // throws
   }
 }

--- a/docs/src/test/java/docs/http/javadsl/CustomMediaTypesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/CustomMediaTypesExampleTest.java
@@ -78,7 +78,7 @@ public class CustomMediaTypesExampleTest extends JUnitRouteTest {
     final HttpResponse response = Http.get(system)
       .singleRequest(HttpRequest
         .GET("http://" + host + ":" + port + "/")
-        .withEntity(applicationCustom.toContentType(), "~~example~=~value~~"), materializer)
+        .withEntity(applicationCustom.toContentType(), "~~example~=~value~~"))
       .toCompletableFuture()
       .get();
 

--- a/docs/src/test/java/docs/http/javadsl/CustomStatusCodesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/CustomStatusCodesExampleTest.java
@@ -85,8 +85,7 @@ public class CustomStatusCodesExampleTest extends JUnitRouteTest {
         .GET("http://" + host + ":" + port + "/"),
         ConnectionContext.https(SSLContext.getDefault()),
         clientSettings,
-        system.log(),
-        materializer)
+        system.log())
       .toCompletableFuture()
       .get();
 

--- a/docs/src/test/java/docs/http/javadsl/HttpClientDecodingExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpClientDecodingExampleTest.java
@@ -54,7 +54,7 @@ public class HttpClientDecodingExampleTest {
     };
 
     List<CompletableFuture<HttpResponse>> futureResponses = httpRequests.stream()
-      .map(req -> http.singleRequest(req, materializer)
+      .map(req -> http.singleRequest(req)
         .thenApply(decodeResponse))
       .map(CompletionStage::toCompletableFuture)
       .collect(Collectors.toList());

--- a/docs/src/test/java/docs/http/javadsl/server/HttpServerExampleDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpServerExampleDocTest.java
@@ -45,7 +45,7 @@ public class HttpServerExampleDocTest {
     Materializer materializer = ActorMaterializer.create(system);
 
     Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-      Http.get(system).bind(ConnectHttp.toHost("localhost", 8080), materializer);
+      Http.get(system).bind(ConnectHttp.toHost("localhost", 8080));
 
     CompletionStage<ServerBinding> serverBindingFuture =
       serverSource.to(Sink.foreach(connection -> {
@@ -63,7 +63,7 @@ public class HttpServerExampleDocTest {
     Materializer materializer = ActorMaterializer.create(system);
 
     Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-      Http.get(system).bind(ConnectHttp.toHost("localhost", 80), materializer);
+      Http.get(system).bind(ConnectHttp.toHost("localhost", 80));
 
     CompletionStage<ServerBinding> serverBindingFuture =
       serverSource.to(Sink.foreach(connection -> {
@@ -85,7 +85,7 @@ public class HttpServerExampleDocTest {
     Materializer materializer = ActorMaterializer.create(system);
 
     Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-      Http.get(system).bind(ConnectHttp.toHost("localhost", 8080), materializer);
+      Http.get(system).bind(ConnectHttp.toHost("localhost", 8080));
 
     Flow<IncomingConnection, IncomingConnection, NotUsed> failureDetection =
       Flow.of(IncomingConnection.class).watchTermination((notUsed, termination) -> {
@@ -115,7 +115,7 @@ public class HttpServerExampleDocTest {
     Materializer materializer = ActorMaterializer.create(system);
 
     Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-      Http.get(system).bind(ConnectHttp.toHost("localhost", 8080), materializer);
+      Http.get(system).bind(ConnectHttp.toHost("localhost", 8080));
 
     Flow<HttpRequest, HttpRequest, NotUsed> failureDetection =
       Flow.of(HttpRequest.class)
@@ -158,7 +158,7 @@ public class HttpServerExampleDocTest {
       final Materializer materializer = ActorMaterializer.create(system);
 
       Source<IncomingConnection, CompletionStage<ServerBinding>> serverSource =
-        Http.get(system).bind(ConnectHttp.toHost("localhost", 8080), materializer);
+        Http.get(system).bind(ConnectHttp.toHost("localhost", 8080));
 
       //#request-handler
       final Function<HttpRequest, HttpResponse> requestHandler =

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
@@ -78,7 +78,7 @@ public class CustomHttpMethodExamplesTest extends JUnitRouteTest {
       .withMethod(BOLT)
       .withProtocol(HTTP_1_1);
 
-    CompletionStage<HttpResponse> response = http.singleRequest(request, materializer);
+    CompletionStage<HttpResponse> response = http.singleRequest(request);
     //#customHttpMethod
 
     assertEquals(StatusCodes.OK, response.toCompletableFuture().get(3, TimeUnit.SECONDS).status());

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MethodDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MethodDirectivesExamplesTest.java
@@ -152,7 +152,7 @@ public class MethodDirectivesExamplesTest extends JUnitRouteTest {
     //#extractMethod
 
     final Route route = concat(
-        get(() -> 
+        get(() ->
             complete("This is a GET request.")
         ),
         extractMethod(method ->
@@ -170,13 +170,13 @@ public class MethodDirectivesExamplesTest extends JUnitRouteTest {
         "This HEAD request, clearly is not a GET!");
     //#extractMethod
   }
-  
+
   @Test
   public void testOverrideMethodWithParameter() {
     //#overrideMethodWithParameter
 
     final Route route = concat(
-        overrideMethodWithParameter("method", () -> 
+        overrideMethodWithParameter("method", () ->
           concat(
             get(() -> complete("This looks like a GET request.")),
             post(() -> complete("This looks like a POST request."))
@@ -184,7 +184,7 @@ public class MethodDirectivesExamplesTest extends JUnitRouteTest {
         )
     );
 
-    
+
     // tests:
     testRoute(route).run(HttpRequest.GET("/?method=POST")).assertEntity(
         "This looks like a POST request.");
@@ -194,7 +194,7 @@ public class MethodDirectivesExamplesTest extends JUnitRouteTest {
 
     testRoute(route).run(HttpRequest.GET("/?method=hallo")).assertEntity(
         "The server either does not recognize the request method, or it lacks the ability to fulfill the request.");
-    
+
     //#overrideMethodWithParameter
   }
 }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
@@ -31,7 +31,7 @@ public class SchemeDirectivesExamplesTest extends JUnitRouteTest {
   @Test
   public void testScheme() {
     //#extractScheme
-    final Route route = extractScheme((scheme) -> 
+    final Route route = extractScheme((scheme) ->
                                       complete(String.format("The scheme is '%s'", scheme)));
     testRoute(route).run(HttpRequest.GET("https://www.example.com/"))
       .assertEntity("The scheme is 'https'");

--- a/docs/src/test/java/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/TimeoutDirectivesExamplesTest.java
@@ -43,7 +43,7 @@ public class TimeoutDirectivesExamplesTest extends AllDirectives {
             + "akka.http.server.request-timeout = 1000s");
     // large timeout - 1000s (please note - setting to infinite will disable Timeout-Access header
     // and withRequestTimeout will not work)
-    
+
     private final ActorSystem system = ActorSystem.create("TimeoutDirectivesExamplesTest", testConf);
 
     private final ActorMaterializer materializer = ActorMaterializer.create(system);
@@ -73,7 +73,7 @@ public class TimeoutDirectivesExamplesTest extends AllDirectives {
         final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = route.flow(system, materializer);
         final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost(hostAndPort._1(), hostAndPort._2()), materializer);
 
-        final CompletionStage<HttpResponse> responseCompletionStage = http.singleRequest(HttpRequest.create("http://" + hostAndPort._1() + ":" + hostAndPort._2() + "/" + routePath), materializer);
+        final CompletionStage<HttpResponse> responseCompletionStage = http.singleRequest(HttpRequest.create("http://" + hostAndPort._1() + ":" + hostAndPort._2() + "/" + routePath));
 
         CompletableFuture<HttpResponse> responseFuture = responseCompletionStage.toCompletableFuture();
 


### PR DESCRIPTION
These have been deprecated for a while. Unfortunately, it seems we never
enabled deprecation warnings for Java files in docs so we missed out on
removing those usages from the docs earlier.