### PR TITLE
tests: increase timeout in FileUploadDirectivesSpec once again

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
 
   // tests touches filesystem, so reqs may take longer than the default of 1.second to complete
-  implicit val routeTimeout = RouteTestTimeout(3.seconds.dilated)
+  implicit val routeTimeout = RouteTestTimeout(6.seconds.dilated)
 
   "the storeUploadedFile directive" should {
     val data = s"<int>${"42" * 1000000}</int>" // ~2MB of data


### PR DESCRIPTION
As commented those tests touch the filesystem (which is known to have some
issues on the `johannes` jenkins node).

Refs #2733

In the [last instance](https://github.com/akka/akka-http/issues/2733#issuecomment-636641196) when it failed the log looks like it would have made progress right after shutting down after the timeout so this might help.