### PR TITLE
docs: don't show `route` import in docs

### DIFF
--- a/akka-http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
+++ b/akka-http-tests/src/test/java/docs/http/javadsl/server/HandlerExampleDocTest.java
@@ -24,7 +24,6 @@ import akka.http.javadsl.testkit.TestRoute;
 
 //#simple-handler-example-full
 import static akka.http.javadsl.server.Directives.get;
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.post;
 //#simple-handler

--- a/docs/src/test/java/docs/http/javadsl/server/DirectiveExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/DirectiveExamplesTest.java
@@ -27,8 +27,6 @@ import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.put;
-import static akka.http.javadsl.server.Directives.route;
-
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 import static akka.http.javadsl.server.PathMatchers.segment;
 
@@ -39,8 +37,6 @@ import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.head;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.put;
-import static akka.http.javadsl.server.Directives.route;
-
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 import static akka.http.javadsl.server.PathMatchers.segment;
 
@@ -52,8 +48,6 @@ import static akka.http.javadsl.server.Directives.extractMethod;
 import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.put;
-import static akka.http.javadsl.server.Directives.route;
-
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 import static akka.http.javadsl.server.PathMatchers.segment;
 

--- a/docs/src/test/java/docs/http/javadsl/server/PathDirectiveExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/PathDirectiveExampleTest.java
@@ -15,8 +15,6 @@ import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathEnd;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathSingleSlash;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-examples
 
 public class PathDirectiveExampleTest extends JUnitRouteTest {

--- a/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/RejectionHandlerExamplesTest.java
@@ -26,8 +26,6 @@ import static akka.http.javadsl.server.Directives.decodeRequestWith;
 import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.post;
-import static akka.http.javadsl.server.Directives.route;
-
 //#example1
 //#custom-handler-example-java
 import static akka.http.javadsl.server.Directives.complete;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
@@ -31,7 +31,6 @@ import static akka.http.javadsl.model.RequestEntityAcceptances.Expected;
 
 //#customHttpMethod
 import static akka.http.javadsl.server.Directives.complete;
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.extractMethod;
 
 //#customHttpMethod

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MethodDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MethodDirectivesExamplesTest.java
@@ -57,7 +57,6 @@ import static akka.http.javadsl.server.Directives.extractMethod;
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.get;
 import static akka.http.javadsl.server.Directives.post;
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.overrideMethodWithParameter;
 
 //#overrideMethodWithParameter

--- a/docs/src/test/java/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/PathDirectivesExamplesTest.java
@@ -50,84 +50,60 @@ import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathEnd;
-import static akka.http.javadsl.server.Directives.route;
-
 //#pathPrefix
 
 //#path-end-or-single-slash
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathEndOrSingleSlash;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-end-or-single-slash
 //#path-prefix
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathEnd;
 import static akka.http.javadsl.server.Directives.pathPrefix;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-prefix
 //#path-prefix-test
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathEnd;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathPrefixTest;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-prefix-test
 //#path-single-slash
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathSingleSlash;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-single-slash
 //#path-suffix
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathSuffix;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-suffix
 //#path-suffix-test
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.pathSuffixTest;
-import static akka.http.javadsl.server.Directives.route;
-
 //#path-suffix-test
 //#raw-path-prefix
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.rawPathPrefix;
-import static akka.http.javadsl.server.Directives.route;
-
 //#raw-path-prefix
 //#raw-path-prefix-test
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.rawPathPrefixTest;
-import static akka.http.javadsl.server.Directives.route;
-
 //#raw-path-prefix-test
 //#redirect-notrailing-slash-missing
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.redirectToTrailingSlashIfMissing;
-import static akka.http.javadsl.server.Directives.route;
-
 //#redirect-notrailing-slash-missing
 //#redirect-notrailing-slash-present
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.redirectToNoTrailingSlashIfPresent;
-import static akka.http.javadsl.server.Directives.route;
-
 //#redirect-notrailing-slash-present
 //#ignoreTrailingSlash
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.ignoreTrailingSlash;
-import static akka.http.javadsl.server.Directives.route;
-
 //#ignoreTrailingSlash
 
 public class PathDirectivesExamplesTest extends JUnitRouteTest {

--- a/docs/src/test/java/docs/http/javadsl/server/directives/RouteDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/RouteDirectivesExamplesTest.java
@@ -30,8 +30,6 @@ import akka.http.javadsl.server.Directives;
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.path;
 import static akka.http.javadsl.server.Directives.reject;
-import static akka.http.javadsl.server.Directives.route;
-
 //#reject
 //#redirect
 import static akka.http.javadsl.server.Directives.complete;
@@ -39,8 +37,6 @@ import static akka.http.javadsl.server.Directives.pathEnd;
 import static akka.http.javadsl.server.Directives.pathPrefix;
 import static akka.http.javadsl.server.Directives.pathSingleSlash;
 import static akka.http.javadsl.server.Directives.redirect;
-import static akka.http.javadsl.server.Directives.route;
-
 //#redirect
 //#failWith
 import static akka.http.javadsl.server.Directives.failWith;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/SchemeDirectivesExamplesTest.java
@@ -21,7 +21,6 @@ import static akka.http.javadsl.server.Directives.extractScheme;
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.extract;
 import static akka.http.javadsl.server.Directives.redirect;
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.scheme;
 
 //#scheme

--- a/docs/src/test/java/docs/http/javadsl/server/directives/WebSocketDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/WebSocketDirectivesExamplesTest.java
@@ -33,19 +33,16 @@ import static akka.http.javadsl.server.Directives.handleWebSocketMessages;
 
 //#handleWebSocketMessages
 //#handleWebSocketMessagesForProtocol
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.handleWebSocketMessagesForProtocol;
 
 //#handleWebSocketMessagesForProtocol
 //#extractUpgradeToWebSocket
 import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.extractUpgradeToWebSocket;
-import static akka.http.javadsl.server.Directives.route;
 
 
 //#extractUpgradeToWebSocket
 //#extractOfferedWsProtocols
-import static akka.http.javadsl.server.Directives.route;
 import static akka.http.javadsl.server.Directives.extractOfferedWsProtocols;
 import static akka.http.javadsl.server.Directives.handleWebSocketMessagesForOptionalProtocol;
 


### PR DESCRIPTION
Less intrusive alternative to #3193.