### PR TITLE
tests: proxy transport instead of disabling hostname verification

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -612,21 +612,38 @@ Host: example.com
       }
     }
 
-    "complete a request/response over https when request has `Connection: close` set" in Utils.assertAllStagesStopped {
-      // akka/akka-http#1219
-      val serverToClientNetworkBufferSize = 1000
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
-      val request = HttpRequest(uri = s"https://$hostname:$port", headers = headers.Connection("close") :: Nil)
-
-      // settings adapting network buffer sizes
-      val serverSettings = ServerSettings(system).withSocketOptions(SO.SendBufferSize(serverToClientNetworkBufferSize) :: Nil)
-      val clientSettings = ConnectionPoolSettings(system).withConnectionSettings(ClientConnectionSettings(system).withSocketOptions(SO.ReceiveBufferSize(serverToClientNetworkBufferSize) :: Nil))
-
+    "complete a request/response over https, disabling hostname verification with SSLConfigSettings" in Utils.assertAllStagesStopped {
       val serverConnectionContext = ExampleHttpContexts.exampleServerContext
+      val routes: Flow[HttpRequest, HttpResponse, Any] = Flow[HttpRequest].map { _ => HttpResponse(entity = "Okay") }
+      val serverBinding =
+        Http()
+          .bindAndHandle(routes, "localhost", 0, connectionContext = serverConnectionContext)
+          .futureValue
+
       // Disable hostname verification as ExampleHttpContexts.exampleClientContext sets hostname as akka.example.org
       val sslConfigSettings = SSLConfigSettings().withLoose(SSLLooseConfig().withDisableHostnameVerification(true))
       val sslConfig = AkkaSSLConfig().withSettings(sslConfigSettings)
       val clientConnectionContext = ConnectionContext.https(ExampleHttpContexts.exampleClientContext.sslContext, Some(sslConfig))
+
+      val request = HttpRequest(uri = s"https:/${serverBinding.localAddress}")
+      Http()
+        .singleRequest(request, connectionContext = clientConnectionContext)
+        .futureValue
+        .entity.dataBytes.runFold(ByteString.empty)(_ ++ _).futureValue.utf8String shouldEqual "Okay"
+
+      serverBinding.unbind().futureValue
+      Http().shutdownAllConnectionPools().futureValue
+    }
+
+    "complete a request/response over https when request has `Connection: close` set" in Utils.assertAllStagesStopped {
+      // akka/akka-http#1219
+      val serverToClientNetworkBufferSize = 1000
+      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val request = HttpRequest(uri = s"https://akka.example.org", headers = headers.Connection("close") :: Nil)
+
+      // settings adapting network buffer sizes
+      val serverSettings = ServerSettings(system).withSocketOptions(SO.SendBufferSize(serverToClientNetworkBufferSize) :: Nil)
+      val serverConnectionContext = ExampleHttpContexts.exampleServerContext
 
       val entity = Array.fill[Char](999999)('0').mkString + "x"
       val routes: Flow[HttpRequest, HttpResponse, Any] = Flow[HttpRequest].map { _ => HttpResponse(entity = entity) }
@@ -634,6 +651,13 @@ Host: example.com
         Http()
           .bindAndHandle(routes, hostname, port, connectionContext = serverConnectionContext, settings = serverSettings)
           .futureValue
+
+      // settings adapting network buffer sizes, and connecting to the spun-up server regardless of the URI address
+      val clientSettings = ConnectionPoolSettings(system)
+        .withConnectionSettings(ClientConnectionSettings(system)
+          .withSocketOptions(SO.ReceiveBufferSize(serverToClientNetworkBufferSize) :: Nil))
+        .withTransport(ExampleHttpContexts.proxyTransport(serverBinding.localAddress))
+      val clientConnectionContext = ConnectionContext.https(ExampleHttpContexts.exampleClientContext.sslContext)
 
       Http()
         .singleRequest(request, connectionContext = clientConnectionContext, settings = clientSettings)

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -21,8 +21,6 @@ import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.{ Server => _, _ }
 import akka.testkit._
 import akka.util.ByteString
-import com.typesafe.sslconfig.akka.AkkaSSLConfig
-import com.typesafe.sslconfig.ssl.{ SSLConfigSettings, SSLLooseConfig }
 import org.scalactic.Tolerance
 import org.scalatest.concurrent.Eventually
 import org.scalatest.Assertion
@@ -34,6 +32,7 @@ import scala.util.Success
 
 class GracefulTerminationSpec
   extends AkkaSpecWithMaterializer("""
+    akka.loglevel = debug
     windows-connection-abort-workaround-enabled = auto
     akka.http.server.request-timeout = infinite
     akka.http.server.log-unencrypted-network-bytes = 200
@@ -80,7 +79,7 @@ class GracefulTerminationSpec
     "fail chunked response streams" in new TestSetup {
       val clientSystem = ActorSystem("client")
       val r1 =
-        Http()(clientSystem).singleRequest(nextRequest, connectionContext = clientConnectionContext, settings = basePoolSettings)
+        Http()(clientSystem).singleRequest(nextRequest(), connectionContext = clientConnectionContext, settings = basePoolSettings)
 
       // reply with an infinite entity stream
       val chunks = Source
@@ -199,7 +198,8 @@ class GracefulTerminationSpec
         super.basePoolSettings
           .withTransport(new ClientTransport {
             override def connectTo(host: String, port: Int, settings: ClientConnectionSettings)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[Http.OutgoingConnection]] = {
-              ClientTransport.TCP.connectTo(host, port, settings)
+              ExampleHttpContexts.proxyTransport(serverBinding.localAddress)
+                .connectTo(host, port, settings)
                 .mapMaterializedValue { conn =>
                   val result = Promise[Http.OutgoingConnection]()
                   conn.onComplete {
@@ -283,17 +283,13 @@ class GracefulTerminationSpec
     (the[StreamTcpException] thrownBy Await.result(r, 1.second)).getMessage should endWith("Connection refused")
 
   class TestSetup(overrideResponse: Option[HttpResponse] = None) {
-    val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
     val counter = new AtomicInteger()
     var idleTimeoutBaseForUniqueness = 10
 
-    def nextRequest = HttpRequest(uri = s"https://$hostname:$port/${counter.incrementAndGet()}", entity = "hello-from-client")
+    def nextRequest() = HttpRequest(uri = s"https://akka.example.org/${counter.incrementAndGet()}", entity = "hello-from-client")
 
     val serverConnectionContext = ExampleHttpContexts.exampleServerContext
-    // Disable hostname verification as ExampleHttpContexts.exampleClientContext sets hostname as akka.example.org
-    val sslConfigSettings = SSLConfigSettings().withLoose(SSLLooseConfig().withDisableHostnameVerification(true))
-    val sslConfig = AkkaSSLConfig().withSettings(sslConfigSettings)
-    val clientConnectionContext = ConnectionContext.https(ExampleHttpContexts.exampleClientContext.sslContext, Some(sslConfig))
+    val clientConnectionContext = ConnectionContext.https(ExampleHttpContexts.exampleClientContext.sslContext)
 
     val serverQueue = new ArrayBlockingQueue[(HttpRequest, Promise[HttpResponse])](16)
 
@@ -331,10 +327,12 @@ class GracefulTerminationSpec
     val routes: Flow[HttpRequest, HttpResponse, Any] = Flow[HttpRequest].mapAsync(1)(handler)
     val serverBinding =
       Http()
-        .bindAndHandle(routes, hostname, port, connectionContext = serverConnectionContext, settings = serverSettings)
+        .bindAndHandle(routes, "localhost", 0, connectionContext = serverConnectionContext, settings = serverSettings)
         .futureValue
 
-    def basePoolSettings = ConnectionPoolSettings(system).withBaseConnectionBackoff(Duration.Zero)
+    def basePoolSettings = ConnectionPoolSettings(system)
+      .withBaseConnectionBackoff(Duration.Zero)
+      .withTransport(ExampleHttpContexts.proxyTransport(serverBinding.localAddress))
 
     def makeRequest(ensureNewConnection: Boolean = false): Future[HttpResponse] = {
       if (ensureNewConnection) {
@@ -342,9 +340,9 @@ class GracefulTerminationSpec
         idleTimeoutBaseForUniqueness += 1
         val clientSettings = basePoolSettings.withIdleTimeout(idleTimeoutBaseForUniqueness.seconds)
 
-        Http().singleRequest(nextRequest, connectionContext = clientConnectionContext, settings = clientSettings)
+        Http().singleRequest(nextRequest(), connectionContext = clientConnectionContext, settings = clientSettings)
       } else {
-        Http().singleRequest(nextRequest, connectionContext = clientConnectionContext, settings = basePoolSettings)
+        Http().singleRequest(nextRequest(), connectionContext = clientConnectionContext, settings = basePoolSettings)
       }
     }
   }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -32,7 +32,6 @@ import scala.util.Success
 
 class GracefulTerminationSpec
   extends AkkaSpecWithMaterializer("""
-    akka.loglevel = debug
     windows-connection-abort-workaround-enabled = auto
     akka.http.server.request-timeout = infinite
     akka.http.server.log-unencrypted-network-bytes = 200
@@ -198,8 +197,7 @@ class GracefulTerminationSpec
         super.basePoolSettings
           .withTransport(new ClientTransport {
             override def connectTo(host: String, port: Int, settings: ClientConnectionSettings)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[Http.OutgoingConnection]] = {
-              ExampleHttpContexts.proxyTransport(serverBinding.localAddress)
-                .connectTo(host, port, settings)
+              ClientTransport.TCP.connectTo(serverBinding.localAddress.getHostName, serverBinding.localAddress.getPort, settings)
                 .mapMaterializedValue { conn =>
                   val result = Promise[Http.OutgoingConnection]()
                   conn.onComplete {


### PR DESCRIPTION
Keep one test explicitly testing disabling hostname verification