### PR TITLE
build: Set build-time jvm locale to en_US.UTF-8

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,2 +1,3 @@
 -Duser.language=en_US.UTF-8
 -Dfile.encoding=en_US.UTF-8
+-Dsun.jnu.encoding=UTF-8

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,2 @@
+-Duser.language=en_US.UTF-8
+-Dfile.encoding=en_US.UTF-8

--- a/.jvmopts-travis
+++ b/.jvmopts-travis
@@ -1,5 +1,7 @@
 # This is used to configure the sbt instance that Travis launches
 
+-Duser.language=en_US.UTF-8
+-Dfile.encoding=en_US.UTF-8
 -Xms1G
 -Xmx1G
 -Xss2M

--- a/.jvmopts-travis
+++ b/.jvmopts-travis
@@ -2,6 +2,7 @@
 
 -Duser.language=en_US.UTF-8
 -Dfile.encoding=en_US.UTF-8
+-Dsun.jnu.encoding=UTF-8
 -Xms1G
 -Xmx1G
 -Xss2M


### PR DESCRIPTION
This prevents problems with 'akka-http-tests/lib/i have sp��ces.jar' in
environments where the locale is not UTF-8