### PR TITLE
http: allow 'bindAndHandleAsync' to take a 'Route'

### DIFF
--- a/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/route-to-function.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/route-to-function.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.server.Route.function")

--- a/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/route-to-function.backwards.excludes
+++ b/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/route-to-function.backwards.excludes
@@ -1,1 +1,2 @@
+# New method in @DoNotInherit class
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.server.Route.function")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -4,18 +4,20 @@
 
 package akka.http.javadsl.server
 
+import java.util.concurrent.CompletionStage
+
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
 import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.http.javadsl.model.HttpRequest
 import akka.http.javadsl.model.HttpResponse
-import akka.http.javadsl.settings.{ ParserSettings, RoutingSettings }
 import akka.http.scaladsl
 import akka.http.scaladsl.server
 import akka.stream.Materializer
 import akka.stream.SystemMaterializer
 import akka.stream.javadsl.Flow
+import akka.japi.function.Function
 
 /**
  * In the Java DSL, a Route can only consist of combinations of the built-in directives. A Route can not be
@@ -51,6 +53,8 @@ trait Route {
 
   def flow(system: ClassicActorSystemProvider): Flow[HttpRequest, HttpResponse, NotUsed] =
     flow(system.classicSystem, SystemMaterializer(system).materializer)
+
+  def function(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]]
 
   /**
    * Seals a route by wrapping it with default exception handling and rejection conversion.

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -4,16 +4,18 @@
 
 package akka.http.javadsl.server.directives
 
+import java.util.concurrent.CompletionStage
+
 import akka.NotUsed
-import akka.actor.ActorSystem
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
+import akka.annotation.InternalApi
 import akka.http.javadsl.model.HttpRequest
 import akka.http.javadsl.model.HttpResponse
 import akka.http.impl.util.JavaMapping.Implicits._
 import akka.http.javadsl.server.{ ExceptionHandler, RejectionHandler, Route }
-import akka.annotation.InternalApi
-import akka.http.javadsl.settings.{ ParserSettings, RoutingSettings }
 import akka.http.scaladsl
 import akka.http.scaladsl.server.RouteConcatenation._
+import akka.japi.function.Function
 import akka.stream.{ Materializer, javadsl }
 import akka.stream.scaladsl.Flow
 
@@ -23,6 +25,13 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
 
   override def flow(system: ActorSystem, materializer: Materializer): javadsl.Flow[HttpRequest, HttpResponse, NotUsed] =
     scalaFlow(system, materializer).asJava
+
+  override def function(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]] = {
+    import scala.compat.java8.FutureConverters.toJava
+    import akka.http.impl.util.JavaMapping._
+    val scalaFunction = scaladsl.server.Route.toFunction(delegate)(system)
+    request => toJava(scalaFunction(request.asScala))
+  }
 
   private def scalaFlow(system: ActorSystem, materializer: Materializer): Flow[HttpRequest, HttpResponse, NotUsed] = {
     implicit val s: ActorSystem = system

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -51,7 +51,7 @@ object RouteResult {
    * is in that type means this implicit conversion come into scope whereever
    * a `Route` is given but a `Function[HttpRequest, Future[HttpResponse]` is expected.
    */
-  implicit def routeToFunction(route: Route)(implicit system: ClassicActorSystemProvider): Function[HttpRequest, Future[HttpResponse]] =
+  implicit def routeToFunction(route: Route)(implicit system: ClassicActorSystemProvider): HttpRequest => Future[HttpResponse] =
     Route.toFunction(route)
 
   @deprecated("Replaced by routeToFlow", "10.2.0")

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -14,7 +14,7 @@ import akka.stream.scaladsl.Flow
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor }
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future }
 
 /**
  * The result of handling a request.
@@ -42,6 +42,17 @@ object RouteResult {
    */
   implicit def routeToFlow(route: Route)(implicit system: ClassicActorSystemProvider): Flow[HttpRequest, HttpResponse, NotUsed] =
     Route.toFlow(route)
+
+  /**
+   * Turns a `Route` into a server function.
+   *
+   * This implicit conversion is defined here because `Route` is an alias for
+   * `RequestContext => Future[RouteResult]`, and the fact that `RouteResult`
+   * is in that type means this implicit conversion come into scope whereever
+   * a `Route` is given but a `Function[HttpRequest, Future[HttpResponse]` is expected.
+   */
+  implicit def routeToFunction(route: Route)(implicit system: ClassicActorSystemProvider): Function[HttpRequest, Future[HttpResponse]] =
+    Route.toFunction(route)
 
   @deprecated("Replaced by routeToFlow", "10.2.0")
   def route2HandlerFlow(route: Route)(

--- a/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/h2spec/H2SpecIntegrationSpec.scala
@@ -8,11 +8,11 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.http.impl.util.{ ExampleHttpContexts, WithLogCapturing }
-import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.Http2
 import akka.stream.ActorMaterializer
 import akka.testkit._
+import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext
@@ -39,10 +39,8 @@ class H2SpecIntegrationSpec extends AkkaSpec(
 
   override def expectedTestDuration = 5.minutes // because slow jenkins, generally finishes below 1 or 2 minutes
 
-  val echo = (req: HttpRequest) => {
-    req.entity.toStrict(5.second.dilated).map { entity =>
-      HttpResponse().withEntity(HttpEntity(entity.data))
-    }
+  val echo = entity(as[ByteString]) { data =>
+    complete(data)
   }
 
   val binding = Http2().bindAndHandleAsync(echo, "127.0.0.1", 0, ExampleHttpContexts.exampleServerContext).futureValue


### PR DESCRIPTION
Related to #2463

This makes H2Spec '6.4. RST_STREAM' emit a 'Trying to materialize stream after
materializer has been shutdown. Completing with 500 Internal Server Error
response.', but that might be a separate issue?