### PR TITLE
Docs: show Akka HTTP as symbolic version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -355,6 +355,8 @@ lazy val docs = project("docs")
       "project.name" -> "Akka HTTP",
       "canonical.base_url" -> "https://doc.akka.io/docs/akka-http/current",
       "akka.version" -> AkkaDependency.docs.version,
+      "akka.minimum.version25" -> AkkaDependency.minimumExpectedAkkaVersion,
+      "akka.minimum.version26" -> AkkaDependency.minimumExpectedAkka26Version,
       "scala.binary_version" -> scalaBinaryVersion.value, // to be consistent with Akka build
       "scala.binaryVersion" -> scalaBinaryVersion.value,
       "scaladoc.version" -> scalaVersion.value,

--- a/docs/src/main/paradox/common/caching.md
+++ b/docs/src/main/paradox/common/caching.md
@@ -18,9 +18,11 @@ time-based entry expiration.
 To use Akka HTTP Caching, add the module to your project:
 
 @@dependency [sbt,Gradle,Maven] {
+  symbol="AkkaHttpVersion"
+  value="$project.version$"
   group="com.typesafe.akka"
   artifact="akka-http-caching_$scala.binary.version$"
-  version="$project.version$"
+  version="AkkaHttpVersion"
 }
 
 ## Basic design

--- a/docs/src/main/paradox/common/json-support.md
+++ b/docs/src/main/paradox/common/json-support.md
@@ -12,9 +12,11 @@ See [the list of current community extensions for Akka HTTP](https://akka.io/com
 To make use of the support module for (un)marshalling from and to JSON with [Jackson], add a library dependency onto:
 
 @@dependency [sbt,Gradle,Maven] {
+  symbol="AkkaHttpVersion"
+  value="$project.version$"
   group="com.typesafe.akka"
   artifact="akka-http-jackson_$scala.binary.version$"
-  version="$project.version$"
+  version="AkkaHttpVersion"
 }
 
 Use `akka.http.javadsl.marshallers.jackson.Jackson.unmarshaller(T.class)` to create an @apidoc[Unmarshaller[HttpEntity,T]] which expects the request
@@ -42,9 +44,11 @@ that an implicit `spray.json.RootJsonReader` and/or `spray.json.RootJsonWriter` 
 To enable automatic support for (un)marshalling from and to JSON with [spray-json], add a library dependency onto:
 
 @@dependency [sbt,Gradle,Maven] {
+  symbol="AkkaHttpVersion"
+  value="$project.version$"
   group="com.typesafe.akka"
   artifact="akka-http-spray-json_$scala.binary.version$"
-  version="$project.version$"
+  version="AkkaHttpVersion"
 }
 
 Next, provide a `RootJsonFormat[T]` for your type and bring it into scope. Check out the [spray-json] documentation for more info on how to do this.

--- a/docs/src/main/paradox/common/xml-support.md
+++ b/docs/src/main/paradox/common/xml-support.md
@@ -36,9 +36,11 @@ In order to enable support for (un)marshalling from and to XML with [Scala XML][
 the following dependency:
 
 @@dependency [sbt,Gradle,Maven] {
+  symbol="AkkaHttpVersion"
+  value="$project.version$"
   group="com.typesafe.akka"
   artifact="akka-http-xml_$scala.binary.version$"
-  version="$project.version$"
+  version="AkkaHttpVersion"
 }
 
 Once you have done this (un)marshalling between XML and `NodeSeq` instances should work nicely and transparently,

--- a/docs/src/main/paradox/compatibility-guidelines.md
+++ b/docs/src/main/paradox/compatibility-guidelines.md
@@ -117,69 +117,20 @@ of your libraries: `Detected java.lang.NoSuchMethodError error, which MAY be cau
 
 ### Compatibility with Akka
 
-Akka HTTP 10.1.x is (binary) compatible with Akka >= 2.5.11
-and future Akka 2.x versions that are released during the lifetime of Akka HTTP 10.1.x.
+Akka HTTP 10.2.x is (binary) compatible with Akka >= $akka.minimum.version25$ and Akka >= $akka.minimum.version26$ and future Akka 2.x versions that are released during the lifetime of Akka HTTP 10.2.x.
 To facilitate supporting multiple minor versions of Akka we do not depend on `akka-stream`
 explicitly but mark it as a `provided` dependency in our build. That means that you will *always* have to add
 a manual dependency to `akka-stream`.
 
-sbt
-:   @@@vars
-    ```
-    val akkaVersion = "$akka.version$"
-    val akkaHttpVersion = "$project.version$"
-    libraryDependencies += "com.typesafe.akka" %% "akka-http"   % akkaHttpVersion
-    libraryDependencies += "com.typesafe.akka" %% "akka-actor"  % akkaVersion
-    libraryDependencies += "com.typesafe.akka" %% "akka-stream" % akkaVersion
-    // If testkit used, explicitly declare dependency on akka-streams-testkit in same version as akka-actor
-    libraryDependencies += "com.typesafe.akka" %% "akka-http-testkit"   % akkaHttpVersion % Test
-    libraryDependencies += "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion     % Test
-    ```
-    @@@
+The same goes for `akka-http-testkit`: If the testkit is used, explicitly declare the dependency on `akka-stream-testkit` of same Akka version as `akka-stream`.
 
-Gradle
-:   @@@vars
-    ```
-    compile group: 'com.typesafe.akka', name: 'akka-http_$scala.binary_version$',   version: '$project.version$'
-    compile group: 'com.typesafe.akka', name: 'akka-actor_$scala.binary_version$',  version: '$akka.version$'
-    compile group: 'com.typesafe.akka', name: 'akka-stream_$scala.binary_version$', version: '$akka.version$'
-    // If testkit used, explicitly declare dependency on akka-streams-testkit in same version as akka-actor
-    testCompile group: 'com.typesafe.akka', name: 'akka-http-testkit_$scala.binary_version$',   version: '$project.version$'
-    testCompile group: 'com.typesafe.akka', name: 'akka-stream-testkit_$scala.binary_version$', version: '$akka.version$'
-    ```
-    @@@
-    
-Maven
-:   @@@vars
-    ```
-    <dependency>
-      <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-actor_$scala.binary_version$</artifactId>
-      <version>$akka.version$</version>
-    </dependency>
-    <!-- Explicitly depend on akka-streams in same version as akka-actor-->
-    <dependency>
-      <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-stream_$scala.binary_version$</artifactId>
-      <version>$akka.version$</version>
-    </dependency>
-    <dependency>
-      <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-http_$scala.binary_version$</artifactId>
-      <version>$project.version$</version>
-    </dependency>
-    <!-- If testkit used, explicitly declare dependency on akka-streams-testkit in same version as akka-actor-->
-    <dependency>
-      <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-http-testkit_$scala.binary_version$</artifactId>
-      <version>$project.version$</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.typesafe.akka</groupId>
-      <artifactId>akka-stream-testkit_$scala.binary_version$</artifactId>
-      <version>$akka.version$</version>
-      <scope>test</scope>
-    </dependency>
-    ```
-    @@@
+@@dependency [sbt,Gradle,Maven] {
+  symbol1=AkkaVersion
+  value1=$akka.version$
+  symbol2="AkkaHttpVersion"
+  value2="$project.version$"
+  group1="com.typesafe.akka" artifact1="akka-http_$scala.binary.version$" version1="AkkaHttpVersion"
+  group2="com.typesafe.akka" artifact2="akka-stream_$scala.binary.version$" version2=AkkaVersion
+  group3="com.typesafe.akka" artifact3="akka-http-testkit_$scala.binary.version$" version3=AkkaHttpVersion scope3=Test
+  group4="com.typesafe.akka" artifact4="akka-stream-testkit_$scala.binary.version$" version4=AkkaVersion scope4=Test
+}

--- a/docs/src/main/paradox/introduction.md
+++ b/docs/src/main/paradox/introduction.md
@@ -34,8 +34,10 @@ choose an Akka version to run against and add a manual dependency to `akka-strea
 @@dependency [sbt,Gradle,Maven] {
   symbol1=AkkaVersion
   value1=$akka.version$
+  symbol2="AkkaHttpVersion"
+  value2="$project.version$"
   group1="com.typesafe.akka" artifact1="akka-stream_$scala.binary.version$" version1=AkkaVersion
-  group2="com.typesafe.akka" artifact2="akka-http_$scala.binary.version$" version2="$project.version$"
+  group2="com.typesafe.akka" artifact2="akka-http_$scala.binary.version$" version2="AkkaHttpVersion"
 }
 
 Alternatively, you can bootstrap a new sbt project with Akka HTTP already
@@ -94,9 +96,11 @@ for JSON. An additional module provides JSON serialization using the spray-json 
 for details):
 
 @@dependency [sbt,Gradle,Maven] {
+  symbol="AkkaHttpVersion"
+  value="$project.version$"
   group="com.typesafe.akka"
   artifact="akka-http-spray-json_$scala.binary.version$"
-  version="$project.version$"
+  version="AkkaHttpVersion"
 }
 
 @@@
@@ -105,9 +109,11 @@ JSON support is possible in `akka-http` by the use of Jackson, an external artif
 for details):
 
 @@dependency [sbt,Gradle,Maven] {
+  symbol="AkkaHttpVersion"
+  value="$project.version$"
   group="com.typesafe.akka"
   artifact="akka-http-jackson_$scala.binary.version$"
-  version="$project.version$"
+  version="AkkaHttpVersion"
 }
 
 @@@

--- a/docs/src/main/paradox/routing-dsl/directives/caching-directives/index.md
+++ b/docs/src/main/paradox/routing-dsl/directives/caching-directives/index.md
@@ -11,9 +11,11 @@ caching support works.
 To use Akka HTTP Caching, add the module to your project:
 
 @@dependency[sbt,Gradle,Maven] {
+  symbol="AkkaHttpVersion"
+  value="$project.version$"
   group="com.typesafe.akka"
   artifact="akka-http-caching_$scala.binary.version$"
-  version="$project.version$"
+  version="AkkaHttpVersion"
 }
 
 ## Imports

--- a/docs/src/main/paradox/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/routing-dsl/testkit.md
@@ -11,8 +11,10 @@ To use Akka HTTP TestKit, add the module to your project:
 @@dependency [sbt,Gradle,Maven] {
   symbol1=AkkaVersion
   value1=$akka.version$
+  symbol2="AkkaHttpVersion"
+  value2="$project.version$"
   group1="com.typesafe.akka" artifact1="akka-stream-testkit_$scala.binary.version$" version1=AkkaVersion
-  group2="com.typesafe.akka" artifact2="akka-http-testkit_$scala.binary.version$" version2="$project.version$"
+  group2="com.typesafe.akka" artifact2="akka-http-testkit_$scala.binary.version$" version2="AkkaHttpVersion"
 }
 
 ## Usage

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -12,9 +12,11 @@ This means it is ready to be evaluated, but the APIs and behavior are likely to 
 To use Akka HTTP2 Support, add the module to your project:
 
 @@dependency [sbt,Gradle,Maven] {
+  symbol="AkkaHttpVersion"
+  value="$project.version$"
   group="com.typesafe.akka"
   artifact="akka-http2-support_$scala.binary.version$"
-  version="$project.version$"
+  version="AkkaHttpVersion"
 }
 
 HTTP/2 needs support in TLS for [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)

--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -44,7 +44,8 @@ object AkkaDependency {
   // Default version updated only when needed, https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
   val minimumExpectedAkkaVersion = "2.5.31"
   val default = akkaDependency(defaultVersion = minimumExpectedAkkaVersion)
-  val docs = akkaDependency(defaultVersion = "2.6.4")
+  val minimumExpectedAkka26Version = "2.6.4"
+  val docs = akkaDependency(defaultVersion = minimumExpectedAkka26Version)
 
   val akkaVersion: String = default match {
     case Artifact(version, _) => version


### PR DESCRIPTION
...and pull the minimum Akka versions from the build.