### PR TITLE
[backport #3206] tests: increase timeout in FileUploadDirectivesSpec once again

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
 
   // tests touches filesystem, so reqs may take longer than the default of 1.second to complete
-  implicit val routeTimeout = RouteTestTimeout(3.seconds.dilated)
+  implicit val routeTimeout = RouteTestTimeout(6.seconds.dilated)
 
   "the uploadedFile directive" should {
 


### PR DESCRIPTION
Backport of #3206

As commented those tests touch the filesystem (which is known to have some
issues on the `johannes` jenkins node).

Refs #3244 (same as #2733)
