### PR TITLE
http2: use reflection for `setApplicationProtocols`

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2AlpnSupport.scala
@@ -67,4 +67,14 @@ private[http] object Http2AlpnSupport {
     else None
 
   def applySessionParameters(engine: SSLEngine, sessionParameters: NegotiateNewSession): Unit = TlsUtils.applySessionParameters(engine, sessionParameters)
+
+  private type SSLParametersWithALPNSupport = {
+    def setApplicationProtocols(protocols: Array[String]): Unit
+  }
+  def clientSetApplicationProtocols(engine: SSLEngine, protocols: Array[String]): Unit = {
+    val params = engine.getSSLParameters
+    params.asInstanceOf[SSLParametersWithALPNSupport].setApplicationProtocols(Array("h2"))
+    engine.setSSLParameters(params)
+  }
+
 }

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -191,9 +191,7 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
       val engine = connectionContext.sslContext.createSSLEngine(host, port)
       engine.setUseClientMode(true)
       Http2AlpnSupport.applySessionParameters(engine, connectionContext.firstSession)
-      val params = engine.getSSLParameters
-      params.setApplicationProtocols(Array("h2"))
-      engine.setSSLParameters(params)
+      Http2AlpnSupport.clientSetApplicationProtocols(engine, Array("h2"))
       engine
     }
 


### PR DESCRIPTION
That's necessary because JDK11 with `-release 8` does not yet know about
the backported JDK 8 APIs.

refs #3251