### PR TITLE
[10.1 backport] server-side streamCancellationDelay

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.12.backwards.excludes/3022-fix-server-side-cancellation-races.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.12.backwards.excludes/3022-fix-server-side-cancellation-races.excludes
@@ -1,0 +1,15 @@
+# New config settings in @DoNotInherit public classes
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ServerSettings.getStreamCancellationDelay")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ServerSettings.streamCancellationDelay")
+
+# Internal changes
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.util.StreamUtils.delayCancellation")
+ProblemFilters.exclude[MissingClassProblem]("akka.http.impl.util.StreamUtils$DelayCancellationStage")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.util.StreamUtils.delayCancellation")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.settings.ServerSettingsImpl.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.http.impl.settings.ServerSettingsImpl.copy$default$20")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.settings.ServerSettingsImpl.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.settings.ServerSettingsImpl.unapply")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -187,6 +187,16 @@ akka.http {
     # Int   : determines how many bytes should be logged per data chunk
     log-unencrypted-network-bytes = off
 
+    # Cancellation in the HTTP streams is delayed by this duration to prevent race conditions between cancellation
+    # and stream completion / failure. In most cases, the value chosen here should make no difference because
+    # HTTP streams are loops where completion and failures should propagate immediately and make the handling of
+    # cancellations redundant.
+    #
+    # In most cases, there should be no reason to change this setting.
+    #
+    # Set to 0 to disable the delay.
+    stream-cancellation-delay = 100 millis
+
     http2 {
       # The maximum number of request per connection concurrently dispatched to the request handler.
       max-concurrent-streams = 256

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -721,6 +721,15 @@ private[http] object HttpServerBluePrint {
             override def onDownstreamFinish(): Unit = cancel(fromNet)
           })
 
+          // disable the old handlers, at this point we might still get something due to cancellation delay which we need to ignore
+          setHandlers(fromHttp, toHttp, new InHandler with OutHandler {
+            override def onPush(): Unit = ()
+            override def onPull(): Unit = ()
+            override def onUpstreamFinish(): Unit = ()
+            override def onUpstreamFailure(ex: Throwable): Unit = ()
+            override def onDownstreamFinish(): Unit = ()
+          })
+
           newFlow.runWith(sourceOut.source, sinkIn.sink)(subFusingMaterializer)
         }
       }

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
@@ -43,7 +43,8 @@ private[akka] final case class ServerSettingsImpl(
   http2Settings:                       Http2ServerSettings,
   defaultHttpPort:                     Int,
   defaultHttpsPort:                    Int,
-  terminationDeadlineExceededResponse: HttpResponse) extends ServerSettings {
+  terminationDeadlineExceededResponse: HttpResponse,
+  streamCancellationDelay:             FiniteDuration) extends ServerSettings {
 
   require(0 < maxConnections, "max-connections must be > 0")
   require(0 < pipeliningLimit && pipeliningLimit <= 1024, "pipelining-limit must be > 0 and <= 1024")
@@ -102,7 +103,8 @@ private[http] object ServerSettingsImpl extends SettingsCompanionImpl[ServerSett
     Http2ServerSettings.Http2ServerSettingsImpl.fromSubConfig(root, c.getConfig("http2")),
     c.getInt("default-http-port"),
     c.getInt("default-https-port"),
-    terminationDeadlineExceededResponseFrom(c)
+    terminationDeadlineExceededResponseFrom(c),
+    c.getFiniteDuration("stream-cancellation-delay")
   )
 
   private def terminationDeadlineExceededResponseFrom(c: Config): HttpResponse = {

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -14,9 +14,9 @@ import akka.stream.impl.fusing.GraphInterpreter
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import akka.stream.scaladsl._
 import akka.stream.stage._
-import akka.util.{ ByteString, OptionVal }
+import akka.util.ByteString
 
-import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.Failure
 import scala.util.Success
@@ -187,56 +187,6 @@ private[http] object StreamUtils {
 
       def source[T]: Source[T, NotUsed] = _source.asInstanceOf[Source[T, NotUsed]] // safe, because source won't generate any elements
       def open(): Unit = promise.success(())
-    }
-  }
-
-  /**
-   * INTERNAL API
-   *
-   * Returns a flow that is almost identity but delays propagation of cancellation from downstream to upstream.
-   */
-  def delayCancellation[T](cancelAfter: Duration): Flow[T, T, NotUsed] = Flow.fromGraph(new DelayCancellationStage(cancelAfter))
-  final class DelayCancellationStage[T](cancelAfter: Duration) extends SimpleLinearGraphStage[T] {
-    def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with ScheduleSupport with InHandler with OutHandler with StageLogging {
-      setHandlers(in, out, this)
-
-      def onPush(): Unit = push(out, grab(in)) // using `passAlong` was considered but it seems to need some boilerplate to make it work
-      def onPull(): Unit = pull(in)
-
-      var timeout: OptionVal[Cancellable] = OptionVal.None
-
-      override def onDownstreamFinish(): Unit = {
-        cancelAfter match {
-          case finite: FiniteDuration =>
-            log.debug(s"Delaying cancellation for $finite")
-            timeout = OptionVal.Some {
-              scheduleOnce(finite) {
-                log.debug(s"Stage was canceled after delay of $cancelAfter")
-                timeout = OptionVal.None
-                completeStage()
-              }
-            }
-          case _ => // do nothing
-        }
-
-        // don't pass cancellation to upstream but keep pulling until we get completion or failure
-        setHandler(
-          in,
-          new InHandler {
-            if (!hasBeenPulled(in)) pull(in)
-
-            def onPush(): Unit = {
-              grab(in) // ignore further elements
-              pull(in)
-            }
-          }
-        )
-      }
-
-      override def postStop(): Unit = timeout match {
-        case OptionVal.Some(x) => x.cancel()
-        case OptionVal.None    => // do nothing
-      }
     }
   }
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
@@ -46,6 +46,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def getDefaultHttpPort: Int
   def getDefaultHttpsPort: Int
   def getTerminationDeadlineExceededResponse: akka.http.javadsl.model.HttpResponse
+  def getStreamCancellationDelay: FiniteDuration
 
   // ---
 
@@ -73,7 +74,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   def withDefaultHttpsPort(newValue: Int): ServerSettings = self.copy(defaultHttpPort = newValue)
   def withTerminationDeadlineExceededResponse(response: akka.http.javadsl.model.HttpResponse): ServerSettings =
     self.copy(terminationDeadlineExceededResponse = response.asScala)
-
+  def withStreamCancellationDelay(newValue: FiniteDuration): ServerSettings = self.copy(streamCancellationDelay = newValue)
 }
 
 object ServerSettings extends SettingsCompanion[ServerSettings] {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -51,6 +51,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def defaultHttpPort: Int
   def defaultHttpsPort: Int
   def terminationDeadlineExceededResponse: HttpResponse
+  def streamCancellationDelay: FiniteDuration
 
   /* Java APIs */
 
@@ -76,6 +77,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   override def getDefaultHttpsPort: Int = defaultHttpsPort
   override def getTerminationDeadlineExceededResponse: akka.http.javadsl.model.HttpResponse =
     terminationDeadlineExceededResponse
+  override def getStreamCancellationDelay: FiniteDuration = streamCancellationDelay
   // ---
 
   // override for more specific return type
@@ -97,6 +99,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   override def withDefaultHttpsPort(newValue: Int): ServerSettings = self.copy(defaultHttpsPort = newValue)
   override def withTerminationDeadlineExceededResponse(response: akka.http.javadsl.model.HttpResponse): ServerSettings =
     self.copy(terminationDeadlineExceededResponse = response.asScala)
+  override def withStreamCancellationDelay(newValue: FiniteDuration): ServerSettings = self.copy(streamCancellationDelay = newValue)
 
   // overloads for Scala idiomatic use
   def withTimeouts(newValue: ServerSettings.Timeouts): ServerSettings = self.copy(timeouts = newValue)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -38,7 +38,6 @@ class HttpServerSpec extends AkkaSpec(
      akka.loglevel = DEBUG
      akka.http.server.log-unencrypted-network-bytes = 100
      akka.http.server.request-timeout = infinite
-     akka.scheduler.implementation = "akka.testkit.ExplicitlyTriggeredScheduler"
   """) with Inside with WithLogCapturing { spec =>
   implicit val materializer = ActorMaterializer()
 
@@ -359,8 +358,6 @@ class HttpServerSpec extends AkkaSpec(
     })
 
     "close the connection if request entity stream has been cancelled" in assertAllStagesStopped(new TestSetup {
-      override def settings: ServerSettings = super.settings.mapTimeouts(_.withLingerTimeout(10.millis))
-
       // two chunks sent by client
       send("""POST / HTTP/1.1
              |Host: example.com
@@ -374,6 +371,8 @@ class HttpServerSpec extends AkkaSpec(
              |
              |""")
 
+      netOut.ensureSubscription()
+
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Chunked(_, data), _) =>
           val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
@@ -383,8 +382,6 @@ class HttpServerSpec extends AkkaSpec(
           sub.request(1)
           dataProbe.expectNext(Chunk(ByteString("abcdef")))
           dataProbe.expectComplete()
-          // connection closes once requested elements are consumed
-          scheduler.timePasses(100.millis) // > lingerTimeout to trigger delay cancellation
           netIn.expectCancellation()
       }
       shutdownBlueprint()
@@ -698,8 +695,8 @@ class HttpServerSpec extends AkkaSpec(
 
       // client then closes the connection
       netIn.sendComplete()
-      requests.expectComplete()
       netOut.expectComplete()
+      requests.expectError()
     })
 
     "not fail with 'Cannot pull port (ControllerStage.requestParsingIn) twice' for early response to `100 Continue` request (after 100-Continue has been sent)" in assertAllStagesStopped(new TestSetup {
@@ -811,8 +808,8 @@ class HttpServerSpec extends AkkaSpec(
       netIn.sendComplete()
       netOut.expectComplete()
     })
+
     "log error and reset connection when the response stream fails" in assertAllStagesStopped(new TestSetup {
-      override def settings: ServerSettings = super.settings.mapTimeouts(_.withLingerTimeout(10.millis))
 
       send("""POST /inject-meteor HTTP/1.1
              |Host: example.com
@@ -841,12 +838,10 @@ class HttpServerSpec extends AkkaSpec(
       }
 
       netOut.expectError()
-      scheduler.timePasses(100.millis) // > lingerTimeout to trigger delay cancellation
       netIn.expectCancellation()
     })
-    "log error and reset connection when the response stream materialization fails" in assertAllStagesStopped(new TestSetup {
-      override def settings: ServerSettings = super.settings.mapTimeouts(_.withLingerTimeout(10.millis))
 
+    "log error and reset connection when the response stream materialization fails" in assertAllStagesStopped(new TestSetup {
       send("""POST /recharge-banana HTTP/1.1
              |Host: example.com
              |
@@ -877,7 +872,6 @@ class HttpServerSpec extends AkkaSpec(
           |
           |There was an internal server error.""")
 
-      scheduler.timePasses(100.millis) // > lingerTimeout to trigger delay cancellation
       netIn.sendComplete()
       netOut.expectComplete()
     })
@@ -1038,7 +1032,7 @@ class HttpServerSpec extends AkkaSpec(
         netIn.sendComplete()
         netOut.cancel()
 
-        requests.expectComplete()
+        requests.expectError()
       })
 
       "uses GET request with an unread truncated chunked entity" in assertAllStagesStopped(new TestSetup {
@@ -1059,7 +1053,7 @@ class HttpServerSpec extends AkkaSpec(
         netIn.sendComplete()
         netOut.cancel()
 
-        requests.expectComplete()
+        requests.expectError()
       })
 
       "uses GET request with a truncated default entity" in assertAllStagesStopped(new TestSetup {
@@ -1078,111 +1072,7 @@ class HttpServerSpec extends AkkaSpec(
         netIn.sendComplete()
         netOut.cancel()
 
-        requests.expectComplete()
-      })
-    }
-
-    "support request timeouts" which {
-
-      "are defined via the config" in assertAllStagesStopped(new RequestTimeoutTestSetup(10.millis) {
-        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
-        expectRequest().header[`Timeout-Access`] shouldBe defined
-
-        scheduler.timePasses(20.millis)
-        expectResponseWithWipedDate(
-          """HTTP/1.1 503 Service Unavailable
-            |Server: akka-http/test
-            |Date: XXXX
-            |Content-Type: text/plain; charset=UTF-8
-            |Content-Length: 105
-            |
-            |The server was not able to produce a timely response to your request.
-            |Please try again in a short while!""")
-
-        netIn.sendComplete()
-        netOut.expectComplete()
-      })
-
-      "are programmatically increased (not expiring)" in assertAllStagesStopped(new RequestTimeoutTestSetup(50.millis) {
-        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
-        expectRequest().header[`Timeout-Access`].foreach(_.timeoutAccess.updateTimeout(250.millis))
-        netOut.expectNoBytes()
-        responses.sendNext(HttpResponse())
-        expectResponseWithWipedDate(
-          """HTTP/1.1 200 OK
-            |Server: akka-http/test
-            |Date: XXXX
-            |Content-Length: 0
-            |
-            |""")
-
-        netIn.sendComplete()
-        netOut.expectComplete()
-      })
-
-      "are programmatically increased (expiring)" in assertAllStagesStopped(new RequestTimeoutTestSetup(50.millis) {
-        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
-
-        scheduler.timePasses(25.millis)
-        expectRequest().header[`Timeout-Access`].foreach(_.timeoutAccess.updateTimeout(250.millis))
-
-        scheduler.timePasses(150.millis)
-        netOut.expectNoBytes(Duration.Zero)
-
-        scheduler.timePasses(100.millis)
-        expectResponseWithWipedDate(
-          """HTTP/1.1 503 Service Unavailable
-            |Server: akka-http/test
-            |Date: XXXX
-            |Content-Type: text/plain; charset=UTF-8
-            |Content-Length: 105
-            |
-            |The server was not able to produce a timely response to your request.
-            |Please try again in a short while!""")
-
-        netIn.sendComplete()
-        netOut.expectComplete()
-      })
-
-      "are programmatically decreased" in assertAllStagesStopped(new RequestTimeoutTestSetup(250.millis) {
-        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
-        expectRequest().header[`Timeout-Access`].foreach(_.timeoutAccess.updateTimeout(50.millis))
-
-        scheduler.timePasses(40.millis)
-        netOut.expectNoBytes(Duration.Zero)
-
-        scheduler.timePasses(10.millis)
-        expectResponseWithWipedDate(
-          """HTTP/1.1 503 Service Unavailable
-            |Server: akka-http/test
-            |Date: XXXX
-            |Content-Type: text/plain; charset=UTF-8
-            |Content-Length: 105
-            |
-            |The server was not able to produce a timely response to your request.
-            |Please try again in a short while!""")
-
-        netIn.sendComplete()
-        netOut.expectComplete()
-      })
-
-      "have a programmatically set timeout handler" in assertAllStagesStopped(new RequestTimeoutTestSetup(400.millis) {
-        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
-        val timeoutResponse = HttpResponse(StatusCodes.InternalServerError, entity = "OOPS!")
-        expectRequest().header[`Timeout-Access`].foreach(_.timeoutAccess.updateHandler((_: HttpRequest) => timeoutResponse))
-
-        scheduler.timePasses(500.millis)
-        expectResponseWithWipedDate(
-          """HTTP/1.1 500 Internal Server Error
-            |Server: akka-http/test
-            |Date: XXXX
-            |Content-Type: text/plain; charset=UTF-8
-            |Content-Length: 5
-            |
-            |OOPS!""")
-
-        netIn.sendComplete()
-        netOut.expectComplete()
+        requests.expectError()
       })
     }
 
@@ -1206,7 +1096,7 @@ class HttpServerSpec extends AkkaSpec(
           |
           |""")
 
-      requests.expectComplete()
+      requests.expectError()
       netOut.expectComplete()
       netIn.sendComplete()
     })
@@ -1231,7 +1121,7 @@ class HttpServerSpec extends AkkaSpec(
           |
           |""")
 
-      requests.expectComplete()
+      requests.expectError()
       netOut.expectComplete()
       netIn.sendComplete()
     })
@@ -1491,18 +1381,11 @@ class HttpServerSpec extends AkkaSpec(
   class TestSetup(maxContentLength: Int = -1) extends HttpServerTestSetupBase {
     implicit def system = spec.system
     implicit def materializer = spec.materializer
-    val scheduler = spec.system.scheduler.asInstanceOf[ExplicitlyTriggeredScheduler]
 
     override def settings = {
       val s = super.settings
       if (maxContentLength < 0) s
       else s.withParserSettings(s.parserSettings.withMaxContentLength(maxContentLength))
-    }
-  }
-  class RequestTimeoutTestSetup(requestTimeout: FiniteDuration) extends TestSetup {
-    override def settings = {
-      val s = super.settings
-      s.withTimeouts(s.timeouts.withRequestTimeout(requestTimeout))
     }
   }
 }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerWithExplicitSchedulerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerWithExplicitSchedulerSpec.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.server
+
+import akka.http.impl.util._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{ Connection, `Timeout-Access` }
+import akka.stream.testkit.Utils.assertAllStagesStopped
+import akka.testkit.ExplicitlyTriggeredScheduler
+import org.scalatest.Inside
+
+import scala.concurrent.duration._
+
+/** Tests similar to HttpServerSpec that need ExplicitlyTriggeredScheduler */
+class HttpServerWithExplicitSchedulerSpec extends AkkaSpecWithMaterializer(
+  """
+     akka.http.server.log-unencrypted-network-bytes = 100
+     akka.http.server.request-timeout = infinite
+     akka.scheduler.implementation = "akka.testkit.ExplicitlyTriggeredScheduler"
+  """
+) with Inside { spec =>
+  "The server implementation" should {
+    "support request timeouts" which {
+
+      "are defined via the config" in assertAllStagesStopped(new RequestTimeoutTestSetup(10.millis) {
+        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        expectRequest().header[`Timeout-Access`] shouldBe defined
+
+        scheduler.timePasses(20.millis)
+        expectResponseWithWipedDate(
+          """HTTP/1.1 503 Service Unavailable
+            |Server: akka-http/test
+            |Date: XXXX
+            |Content-Type: text/plain; charset=UTF-8
+            |Content-Length: 105
+            |
+            |The server was not able to produce a timely response to your request.
+            |Please try again in a short while!""")
+
+        // FIXME: it seems the request side of the user handler is just completed
+        // and the response side is still working on a response.
+        // It would be better if the request side would be failed so that error could be propagated
+        // see #3072
+        requests.expectComplete()
+        responses.sendError(new RuntimeException)
+
+        netOut.expectComplete()
+        netIn.sendComplete()
+      })
+
+      "are programmatically increased (not expiring)" in assertAllStagesStopped(new RequestTimeoutTestSetup(50.millis) {
+        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        expectRequest().header[`Timeout-Access`].foreach(_.timeoutAccess.updateTimeout(250.millis))
+        netOut.expectNoBytes()
+        responses.sendNext(HttpResponse(headers = Connection("close") :: Nil))
+        expectResponseWithWipedDate(
+          """HTTP/1.1 200 OK
+            |Server: akka-http/test
+            |Date: XXXX
+            |Connection: close
+            |Content-Length: 0
+            |
+            |""")
+
+        // FIXME: why is the network handler only completed after the network?
+        // requests.expectComplete()
+
+        netOut.expectComplete()
+        netIn.sendComplete()
+
+        requests.expectComplete()
+        responses.sendComplete()
+      })
+
+      "are programmatically increased (expiring)" in assertAllStagesStopped(new RequestTimeoutTestSetup(50.millis) {
+        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+
+        scheduler.timePasses(25.millis)
+        expectRequest().header[`Timeout-Access`].foreach(_.timeoutAccess.updateTimeout(250.millis))
+
+        scheduler.timePasses(150.millis)
+        netOut.expectNoBytes(Duration.Zero)
+
+        scheduler.timePasses(100.millis)
+        expectResponseWithWipedDate(
+          """HTTP/1.1 503 Service Unavailable
+            |Server: akka-http/test
+            |Date: XXXX
+            |Content-Type: text/plain; charset=UTF-8
+            |Content-Length: 105
+            |
+            |The server was not able to produce a timely response to your request.
+            |Please try again in a short while!""")
+
+        // FIXME: it seems the request side of the user handler is just completed
+        // and the response side is still working on a response.
+        // It would be better if the request side would be failed so that error could be propagated
+        // see #3072
+        requests.expectComplete()
+        responses.sendError(new RuntimeException)
+
+        netOut.expectComplete()
+        netIn.sendComplete()
+      })
+
+      "are programmatically decreased" in assertAllStagesStopped(new RequestTimeoutTestSetup(250.millis) {
+        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        expectRequest().header[`Timeout-Access`].foreach(_.timeoutAccess.updateTimeout(50.millis))
+
+        scheduler.timePasses(40.millis)
+        netOut.expectNoBytes(Duration.Zero)
+
+        scheduler.timePasses(10.millis)
+        expectResponseWithWipedDate(
+          """HTTP/1.1 503 Service Unavailable
+            |Server: akka-http/test
+            |Date: XXXX
+            |Content-Type: text/plain; charset=UTF-8
+            |Content-Length: 105
+            |
+            |The server was not able to produce a timely response to your request.
+            |Please try again in a short while!""")
+
+        // FIXME: it seems the request side of the user handler is just completed
+        // and the response side is still working on a response.
+        // It would be better if the request side would be failed so that error could be propagated
+        // see #3072
+        requests.expectComplete()
+        responses.sendError(new RuntimeException)
+
+        netOut.expectComplete()
+        netIn.sendComplete()
+      })
+
+      "have a programmatically set timeout handler" in assertAllStagesStopped(new RequestTimeoutTestSetup(400.millis) {
+        send("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+        val timeoutResponse = HttpResponse(StatusCodes.InternalServerError, entity = "OOPS!")
+        expectRequest().header[`Timeout-Access`].foreach(_.timeoutAccess.updateHandler((_: HttpRequest) => timeoutResponse))
+
+        scheduler.timePasses(500.millis)
+        expectResponseWithWipedDate(
+          """HTTP/1.1 500 Internal Server Error
+            |Server: akka-http/test
+            |Date: XXXX
+            |Content-Type: text/plain; charset=UTF-8
+            |Content-Length: 5
+            |
+            |OOPS!""")
+
+        // FIXME: it seems the request side of the user handler is just completed
+        // and the response side is still working on a response.
+        // It would be better if the request side would be failed so that error could be propagated
+        // see #3072
+        requests.expectComplete()
+        responses.sendError(new RuntimeException)
+
+        netOut.expectComplete()
+        netIn.sendComplete()
+      })
+    }
+  }
+
+  class TestSetup(maxContentLength: Int = -1) extends HttpServerTestSetupBase {
+    implicit def system = spec.system
+    implicit def materializer = spec.materializer
+    lazy val scheduler = spec.system.scheduler.asInstanceOf[ExplicitlyTriggeredScheduler]
+
+    override def settings = {
+      val s = super.settings
+      if (maxContentLength < 0) s
+      else s.withParserSettings(s.parserSettings.withMaxContentLength(maxContentLength))
+    }
+  }
+  class RequestTimeoutTestSetup(requestTimeout: FiniteDuration) extends TestSetup {
+    override def settings = {
+      val s = super.settings
+      s.withTimeouts(s.timeouts.withRequestTimeout(requestTimeout))
+    }
+  }
+}

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -16,6 +16,7 @@ import scala.util.{ Success, Try }
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.event.Logging.LogEvent
+import akka.http.impl.engine.HttpIdleTimeoutException
 import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.http.impl.util._
 import akka.http.scaladsl.Http.ServerBinding
@@ -395,7 +396,6 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll wit
       "stop stages on failure" in Utils.assertAllStagesStopped {
         val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
         val stageCounter = new AtomicLong(0)
-        val cancelCounter = new AtomicLong(0)
         val stage: GraphStage[FlowShape[HttpRequest, HttpResponse]] = new GraphStage[FlowShape[HttpRequest, HttpResponse]] {
           val in = Inlet[HttpRequest]("request.in")
           val out = Outlet[HttpResponse]("response.out")
@@ -407,7 +407,6 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll wit
             override def postStop(): Unit = stageCounter.decrementAndGet()
             override def onPush(): Unit = push(out, HttpResponse(entity = stageCounter.get().toString))
             override def onPull(): Unit = pull(in)
-            override def onDownstreamFinish(): Unit = cancelCounter.incrementAndGet()
 
             setHandlers(in, out, this)
           }
@@ -425,23 +424,23 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll wit
 
         def performValidRequest() = Http().outgoingConnection(hostname, port).runWith(Source.single(HttpRequest()), Sink.ignore)
 
-        def assertCounters(stage: Int, cancel: Int) = eventually(timeout(1.second.dilated)) {
-          stageCounter.get shouldEqual stage
-          cancelCounter.get shouldEqual cancel
-        }
+        def assertCounters(stage: Int) =
+          eventually(timeout(3.second.dilated)) {
+            stageCounter.get shouldEqual stage
+          }
 
         val bind = Await.result(Http().bindAndHandle(Flow.fromGraph(stage), hostname, port)(materializer2), 1.seconds.dilated)
 
         performValidRequest()
-        assertCounters(0, 1)
+        assertCounters(0)
 
         EventFilter.warning(pattern = "Illegal HTTP message start", occurrences = 1) intercept {
           performFaultyRequest()
-          assertCounters(0, 2)
+          assertCounters(0)
         }
 
         performValidRequest()
-        assertCounters(0, 3)
+        assertCounters(0)
 
         Await.result(bind.unbind(), 1.second.dilated)
       }(materializer2)
@@ -782,6 +781,29 @@ Host: example.com
         // Test with a POST so auto-retry isn't triggered:
         Await.ready(Http().singleRequest(HttpRequest(uri = uri, method = HttpMethods.POST)), 30.seconds)
       }
+
+      Await.result(binding.unbind(), 10.seconds)
+    }
+
+    "report idle timeout on request entity stream for stalled client" in Utils.assertAllStagesStopped {
+      val dataProbe = ByteStringSinkProbe()
+
+      def handler(request: HttpRequest): Future[HttpResponse] = {
+        request.entity.dataBytes.runWith(dataProbe.sink)
+        Promise[HttpResponse].future // just let it hanging until idle timeout triggers
+      }
+
+      val settings = ServerSettings(system).mapTimeouts(_.withIdleTimeout(1.second))
+      val binding = Http().bindAndHandleAsync(handler, "127.0.0.1", port = 0, settings = settings).futureValue
+      val uri = "http://" + binding.localAddress.getHostString + ":" + binding.localAddress.getPort
+
+      val dataOutProbe = TestPublisher.probe[ByteString]()
+      Http().singleRequest(HttpRequest(uri = uri, entity = HttpEntity(ContentTypes.`application/octet-stream`, Source.fromPublisher(dataOutProbe))))
+
+      dataProbe.ensureSubscription()
+      dataOutProbe.sendNext(ByteString("test"))
+      dataProbe.expectUtf8EncodedString("test")
+      dataProbe.expectError() should be(an[HttpIdleTimeoutException])
 
       Await.result(binding.unbind(), 10.seconds)
     }


### PR DESCRIPTION
Backport of #3022

The client-side part was backported as part of the big bunch of backports but this one came afterwards and was missed.

I looked at #3022 to find out whether a backport was intended or not but I couldn't find one. It's a rather intrusive change so there's certainly an argument to be made to not go there for 10.1.x (on the other hand, we did already change client-side behavior for 10.1.12)

Refs #3247