### PR TITLE
Revert "build: update silencer-lib, silencer-plugin from 1.6.0 to 1.7.0"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v${h2specVersion}/${h2specName}.zip"
-  val silencerVersion = "1.7.0"
+  val silencerVersion = "1.6.0"
 
   val scalaTestVersion = "3.1.2"
   val specs2Version = "4.9.4"


### PR DESCRIPTION
Reverts akka/akka-http#3252

Isn't accessible from Maven currently:

https://jenkins.akka.io:8498/job/akka-http-nightly/162/AKKA_VERSION=default,Node=akka-http-nightly-node,SCALA_VERSION=2.13.1,jdk=AdoptOpenJDK%2011/console

```
[error]   Not found
[error]   Not found
[error]   not found: /localhome/jenkinsakka/.ivy2/local/com.github.ghik/silencer-lib_2.13.1/1.7.0/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/com/github/ghik/silencer-lib_2.13.1/1.7.0/silencer-lib_2.13.1-1.7.0.pom
[error] (akka-http-marshallers-java / update) sbt.librarymanagement.ResolveException: Error downloading com.github.ghik:silencer-lib_2.13.1:1.7.0
[error]   Not found
```