### PR TITLE
Only show unmarshalling error details when 'verbose-error-messages' is on

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
@@ -69,7 +69,9 @@ object ErrorInfo {
 }
 
 /** Marker for exceptions that provide an ErrorInfo */
-abstract class ExceptionWithErrorInfo(val info: ErrorInfo) extends RuntimeException(info.formatPretty)
+abstract class ExceptionWithErrorInfo(val info: ErrorInfo, cause: Throwable) extends RuntimeException(info.formatPretty, cause) {
+  def this(info: ErrorInfo) = this(info, null)
+}
 
 case class IllegalUriException(override val info: ErrorInfo) extends ExceptionWithErrorInfo(info)
 object IllegalUriException {

--- a/akka-http-marshallers-java/akka-http-jackson/src/main/java/akka/http/javadsl/marshallers/jackson/Jackson.java
+++ b/akka-http-marshallers-java/akka-http-jackson/src/main/java/akka/http/javadsl/marshallers/jackson/Jackson.java
@@ -12,6 +12,9 @@ import akka.http.javadsl.model.RequestEntity;
 import akka.http.javadsl.marshalling.Marshaller;
 import akka.http.javadsl.unmarshalling.Unmarshaller;
 
+import akka.http.scaladsl.model.ExceptionWithErrorInfo;
+import akka.http.scaladsl.model.ErrorInfo;
+
 import akka.util.ByteString;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -20,6 +23,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class Jackson {
   private static final ObjectMapper defaultObjectMapper =
     new ObjectMapper().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
+
+  /**
+   * INTERNAL API
+   */
+  public static class JacksonUnmarshallingException extends ExceptionWithErrorInfo {
+    public JacksonUnmarshallingException(Class<?> expectedType, IOException cause) {
+      super(new ErrorInfo("Cannot unmarshal JSON as " + expectedType.getSimpleName(), cause.getMessage()), cause);
+    }
+  }
 
   public static <T> Marshaller<T, RequestEntity> marshaller() {
     return marshaller(defaultObjectMapper);
@@ -62,7 +74,7 @@ public class Jackson {
     try {
       return mapper.readerFor(expectedType).readValue(json);
     } catch (IOException e) {
-      throw new IllegalArgumentException("Cannot unmarshal JSON as " + expectedType.getSimpleName() + ": " + e.getMessage(), e);
+      throw new JacksonUnmarshallingException(expectedType, e);
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -281,6 +281,8 @@ lazy val httpJackson =
   httpMarshallersJavaSubproject("jackson")
     .settings(AutomaticModuleName.settings("akka.http.marshallers.jackson"))
     .addAkkaModuleDependency("akka-stream", "provided")
+    .addAkkaModuleDependency("akka-stream-testkit", "test")
+    .dependsOn(httpTestkit % "test")
     .settings(Dependencies.httpJackson)
     .enablePlugins(ScaladocNoVerificationOfDiagrams)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -118,7 +118,7 @@ object Dependencies {
     libraryDependencies += Test.scalatest
   )
 
-  lazy val httpJackson = l ++= Seq(jacksonDatabind, Test.scalatestplusJUnit, Test.junit)
+  lazy val httpJackson = l ++= Seq(jacksonDatabind, Test.scalatestplusJUnit, Test.junit, Test.junitIntf)
 
   lazy val docs = l ++= Seq(Docs.sprayJson, Docs.gson, Docs.jacksonXml, Docs.reflections)
 }


### PR DESCRIPTION
Only include the unmarshalling error details (like 'unrecognized field xyz')
when 'verbose-error-messages' is enabled.

When 'verbose-error-messages' is disabled the error messages are still shown
in the logs, but no longer in the response body.