### PR TITLE
Deprecate UpgradeToWebSocket

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/UpgradeToWebSocket.scala
@@ -13,7 +13,13 @@ import akka.stream._
 /**
  * A virtual header that WebSocket requests will contain. Use [[UpgradeToWebSocket.handleMessagesWith]] to
  * create a WebSocket handshake response and handle the WebSocket message stream with the given handler.
+ *
+ * This low-level API is expected to be replaced by an Attribute in the future.
+ *
+ * In any case, you might want to use `handleWebSocketMessages` instead as documented
+ * at https://doc.akka.io/docs/akka-http/current/server-side/websocket-support.html#routing-support
  */
+@deprecated("This low-level API is expected to be replaced by an attribute.", since = "10.2.0")
 trait UpgradeToWebSocket extends sm.HttpHeader {
   /**
    * Returns the sequence of protocols the client accepts.

--- a/docs/src/main/paradox/server-side/websocket-support.md
+++ b/docs/src/main/paradox/server-side/websocket-support.md
@@ -126,7 +126,7 @@ is a WebSocket request. Otherwise, the directive rejects the request.
 Let's look at how the above example can be rewritten using the high-level routing DSL.
 
 Instead of writing the request handler manually, the routing behavior of the app is defined by a route that
-uses the `handleWebSocketRequests` directive in place of the `WebSocket.handleWebSocketRequestWith`:
+uses the @ref[handleWebSocketMessages](../routing-dsl/directives/websocket-directives/handleWebSocketMessages.md) directive instead of `WebSocket.handleWebSocketRequestWith`:
 
 Scala
 :  @@snip [WebSocketDirectivesExamplesSpec.scala]($test$/scala/docs/http/scaladsl/server/directives/WebSocketDirectivesExamplesSpec.scala) { #greeter-service }


### PR DESCRIPTION
Refs #3278

Recommend using the higher-level handleWebSocketMessages, or the
(yet to be implemented) attributes-based approach.