### PR TITLE
docs: exclude testing projects from unidoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ lazy val root = Project(
   .disablePlugins(BintrayPlugin, MimaPlugin)
   .settings(
     // Unidoc doesn't like macro definitions
-    unidocProjectExcludes := Seq(parsing),
+    unidocProjectExcludes := Seq(parsing, compatibilityTests, docs, httpTests, httpJmhBench),
     // Support applying macros in unidoc:
     scalaMacroSupport,
     unmanagedSources in (Compile, headerCreate) := (baseDirectory.value / "project").**("*.scala").get,


### PR DESCRIPTION
akka-http-docs [just failed](https://jenkins.akka.io:8498/job/akka-http-docs/448/consoleFull) because it tried to include the compatibility tests into unidoc.

Fixes #3284.