### PR TITLE
tests: set a more reasonable PatienceConfig for RoutingSpecs

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RoutingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RoutingSpec.scala
@@ -5,9 +5,11 @@
 package akka.http.scaladsl.server
 
 import akka.http.impl.util.WithLogCapturing
-import org.scalatest.Suite
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.testkit.TestKitBase
+import org.scalatest.Suite
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -19,10 +21,13 @@ trait GenericRoutingSpec extends Matchers with Directives with ScalatestRouteTes
   def echoComplete2[T, U]: (T, U) => Route = { (x, y) => complete(s"$x $y") }
 }
 
-abstract class RoutingSpec extends AnyWordSpec with GenericRoutingSpec with WithLogCapturing {
+// FIXME: currently cannot use `AkkaSpec` or `AkkaSpecWithMaterializer`, see https://github.com/akka/akka-http/issues/3313
+abstract class RoutingSpec extends AnyWordSpec with GenericRoutingSpec with WithLogCapturing with TestKitBase with ScalaFutures {
   override def testConfigSource: String =
     """
        akka.loglevel = DEBUG
        akka.loggers = ["akka.http.impl.util.SilenceAllTestEventListener"]
     """
+
+  implicit val patience: PatienceConfig = PatienceConfig(testKitSettings.DefaultTimeout.duration)
 }


### PR DESCRIPTION
Otherwise, it will use the scalatest default of 150 millis.

Refs #2405.
