### PR TITLE
tests: more reliable waiting for WINDOW_UPDATES

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -788,7 +788,9 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         sendDATA(1, false, ByteString("ping"))
         reqProbe.expectUtf8EncodedString("ping")
 
-        pollForWindowUpdates(10.millis)
+        // default settings will schedule a connection and a stream-level window update
+        expectWindowUpdate()
+        expectWindowUpdate()
 
         // check data flow for response entity
         responseEntityProbe.sendNext(ByteString("pong"))


### PR DESCRIPTION
The 10.millis might otherwise just be too short. In this case, sending out `WINDOW_UPDATE`s should be deterministic.

Refs #2882