### PR TITLE
core: disable server-side HTTP pipelining by default

### DIFF
--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -95,7 +95,7 @@ akka.http {
     # connection can be "open" (i.e. being processed by the application) at any
     # time. Set to higher values to enable HTTP pipelining.
     # This value must be > 0 and <= 1024.
-    pipelining-limit = 16
+    pipelining-limit = 1
 
     # Enables/disables the addition of a `Remote-Address` header
     # holding the clients (remote) IP address.
@@ -535,7 +535,7 @@ akka.http {
 
     # Allows overriding settings per host. The setting must be a list in which each entry
     # is an object with a `host-pattern` entry that specifies for which hosts the overrides
-    # should take effect. All other entries have the same syntax as entries in the 
+    # should take effect. All other entries have the same syntax as entries in the
     # `host-connection-pool` section.
     #
     # The `host-pattern` can have these forms:

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -73,12 +73,23 @@ abstract class HttpServerTestSetupBase {
 
   def closeNetworkInput(): Unit = netIn.sendComplete()
 
+  def simpleResponse(): Unit = {
+    responses.sendNext(HttpResponse())
+    expectResponseWithWipedDate(
+      """HTTP/1.1 200 OK
+        |Server: akka-http/test
+        |Date: XXXX
+        |Content-Length: 0
+        |
+        |"""
+    )
+  }
+
   def shutdownBlueprint(): Unit = {
     netIn.sendComplete()
     requests.expectComplete()
 
     responses.sendComplete()
-    netOut.expectBytes(ByteString("HTT")) // ???
-    netOut.expectComplete()
+    netOut.cancel()
   }
 }

--- a/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
+++ b/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
@@ -55,6 +55,13 @@ This can save bandwidth in some cases, but is also counter-intuitive when you ac
  and may increase resource usage in cases where the logic behind the `GET` request is heavy. For this reason we have changed
  the default value of `akka.http.server.transparent-head-requests` to `off`, making this feature opt-in.
 
+### Server-side HTTP pipelining now disabled by default
+
+HTTP pipelining is now disabled by default. It is not used commonly by clients because it suffers from
+head-of-line blocking. It is recommended to use pooled connections or HTTP/2 instead.
+
+HTTP pipelining is still supported and can be re-enabled by setting `pipelining-limit = n` with a value of `n > 1`.
+
 ### X-Real-Ip now takes precedence over Remote-Address in extractClientIP
 
 The @ref[extractClientIP](../routing-dsl/directives/misc-directives/extractClientIP.md) now returns the value of the


### PR DESCRIPTION
It's somewhat of an obscure feature which doesn't seem to be tested well.