### PR TITLE
Publish docs from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
   # using jabba for custom jdk management
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.1/install.sh | bash && . ~/.jabba/jabba.sh
   - jabba install adopt@1.8-0
+  - jabba use "adopt@1.8-0"
+  - java -version
 
 addons:
   apt:
@@ -32,8 +34,6 @@ cache:
     - $HOME/.cache/coursier
 
 script:
-  - jabba use "adopt@1.8-0"
-  - java -version
   - sbt -jvm-opts .jvmopts-travis "$CMD"
 
 jobs:
@@ -44,6 +44,9 @@ jobs:
       script: git branch -f "$TRAVIS_BRANCH" && git checkout "$TRAVIS_BRANCH" && sbt whitesourceCheckPolicies whitesourceUpdate
     - stage: publish
       env: CMD="+publish"
+      name: artifacts to bintray
+    - script: eval "$(ssh-agent -s)" && echo $SCP_SECRET | base64 -d > /tmp/id_rsa && chmod 600 /tmp/id_rsa && ssh-add /tmp/id_rsa && sbt -jvm-opts .jvmopts-travis -Dakka.genjavadoc.enabled=true publishRsync
+      name: paradox and api docs to gustav
 
 stages:
   - name: mima

--- a/project/release.sh
+++ b/project/release.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-sbt -Dpublish.maven.central=true -Dakka.genjavadoc.enabled=true publishSigned
-sbt ';project docs; paradox'

--- a/scripts/release-train-issue-template.md
+++ b/scripts/release-train-issue-template.md
@@ -50,7 +50,6 @@ Wind down PR queue. There has to be enough time after the last (non-trivial) PR 
 - [ ] Notify Telemetry / Play team to check against staged artifacts
 - [ ] Run a test against the staging repository to make sure the release went well, for example by using https://github.com/akka/akka-http-quickstart-scala.g8 and adding the sonatype staging repo with `resolvers += "Staging Repo" at "https://oss.sonatype.org/content/repositories/staging"`
 - [ ] Release the staging repository to Maven Central.
-- [ ] Checkout the newly created tag and run `sbt -Dakka.genjavadoc.enabled=true ++2.12.9 publishRsync` to deploy API and reference documentation.
 
 ### Check availability
 - [ ] Check release on sonatype: https://oss.sonatype.org/content/repositories/releases/com/typesafe/akka/akka-http-core_2.13/


### PR DESCRIPTION
Automates deploying docs when releasing and removing the need for
https://jenkins.akka.io:8498/job/akka-http-docs/