### PR TITLE
core: make HttpEntity.Strict.discardBytes a no-op

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HttpEntityBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HttpEntityBenchmark.scala
@@ -1,0 +1,59 @@
+package akka.http.impl.engine
+
+import java.util.concurrent.CountDownLatch
+
+import akka.actor.ActorSystem
+import akka.dispatch.ExecutionContexts
+import akka.http.CommonBenchmark
+import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
+import akka.stream.scaladsl.Source
+import akka.stream.{ ActorMaterializer, Materializer }
+import akka.util.ByteString
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations.{ Benchmark, Param, Setup, TearDown }
+
+class HttpEntityBenchmark extends CommonBenchmark {
+  @Param(Array("strict", "default"))
+  var entityType: String = _
+
+  implicit var system: ActorSystem = _
+  implicit var mat: Materializer = _
+
+  var entity: HttpEntity = _
+
+  @Benchmark
+  def discardBytes(): Unit = {
+    val latch = new CountDownLatch(1)
+    entity.discardBytes(mat)
+      .future
+      .onComplete(_ => latch.countDown())(ExecutionContexts.parasitic)
+    latch.await()
+  }
+
+  private val chunk = ByteString(new Array[Byte](10000))
+  @Setup
+  def setup(): Unit = {
+    val config =
+      ConfigFactory.parseString(
+        """
+           akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
+        """)
+        .withFallback(ConfigFactory.load())
+    system = ActorSystem("AkkaHttpBenchmarkSystem", config)
+    mat = ActorMaterializer()
+
+    entity = entityType match {
+      case "strict" =>
+        HttpEntity.Strict(ContentTypes.`application/octet-stream`, chunk)
+      case "default" =>
+        HttpEntity.Default(
+          ContentTypes.`application/octet-stream`,
+          10 * chunk.size,
+          Source.repeat(chunk).take(10)
+        )
+    }
+  }
+
+  @TearDown
+  def tearDown(): Unit = system.terminate()
+}

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -114,7 +114,8 @@ sealed trait HttpEntity extends jm.HttpEntity {
    * In future versions, more automatic ways to warn or resolve these situations may be introduced, see issue #18716.
    */
   override def discardBytes(mat: Materializer): HttpMessage.DiscardedEntity =
-    new HttpMessage.DiscardedEntity(dataBytes.runWith(Sink.ignore)(mat))
+    if (isStrict) HttpMessage.AlreadyDiscardedEntity
+    else new HttpMessage.DiscardedEntity(dataBytes.runWith(Sink.ignore)(mat))
 
   /**
    * Returns a copy of the given entity with the ByteString chunks of this entity transformed by the given transformer.

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -258,6 +258,7 @@ object HttpMessage {
      */
     def completionStage: CompletionStage[Done] = FutureConverters.toJava(f)
   }
+  val AlreadyDiscardedEntity = new DiscardedEntity(Future.successful(Done))
 
   /** Adds Scala DSL idiomatic methods to [[HttpMessage]], e.g. versions of methods with an implicit [[Materializer]]. */
   implicit final class HttpMessageScalaDSLSugar(val httpMessage: HttpMessage) extends AnyVal {


### PR DESCRIPTION
This will be a win for lots of situations where discardBytes is called
to ensure that no streams are leaked but where it's common that the entity
is empty or small.

Fix #3323