### PR TITLE
Fix compiler warnings

### DIFF
--- a/akka-http-caching/src/main/scala/akka/http/caching/scaladsl/Cache.scala
+++ b/akka-http-caching/src/main/scala/akka/http/caching/scaladsl/Cache.scala
@@ -99,7 +99,7 @@ abstract class Cache[K, V] extends akka.http.caching.javadsl.Cache[K, V] {
    * Returns either the cached CompletionStage for the given key or the given value as a CompletionStage
    */
   override def getOrCreateStrict(key: K, block: Creator[V]): CompletionStage[V] =
-    futureToJava(get(key, () => block.create))
+    futureToJava(get(key, () => block.create()))
 
   /**
    * Returns the upper bound for the number of currently cached entries.

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolMasterActor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolMasterActor.scala
@@ -224,7 +224,7 @@ private[http] final class PoolMasterActor extends Actor with ActorLogging {
 
 private[http] object PoolMasterActor {
 
-  val props = Props[PoolMasterActor].withDeploy(Deploy.local)
+  val props = Props[PoolMasterActor]().withDeploy(Deploy.local)
 
   sealed trait PoolInterfaceStatus
   final case class PoolInterfaceRunning(interface: PoolInterface) extends PoolInterfaceStatus

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -118,10 +118,10 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
       protocol = c(7) match {
         case '0' => `HTTP/1.0`
         case '1' => `HTTP/1.1`
-        case _   => onBadProtocol
+        case _   => onBadProtocol()
       }
       cursor + 8
-    } else onBadProtocol
+    } else onBadProtocol()
   }
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpResponseParser.scala
@@ -114,7 +114,7 @@ private[http] class HttpResponseParser(protected val settings: ParserSettings, p
       // Status format with no reason phrase and no trailing space accepted, diverging from the spec
       // See https://github.com/akka/akka-http/pull/989
       skipNewLine(cursor + 3)
-    } else badStatusCode
+    } else badStatusCode()
   }
 
   def handleInformationalResponses: Boolean = true

--- a/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
@@ -307,7 +307,7 @@ private[http] class ByteStringRendering(sizeHint: Int) extends Rendering {
   private[this] val builder = new ByteStringBuilder
   builder.sizeHint(sizeHint)
 
-  def get: ByteString = builder.result
+  def get: ByteString = builder.result()
 
   def ~~(char: Char): this.type = {
     builder += char.toByte

--- a/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/package.scala
@@ -71,7 +71,7 @@ package object util {
     if (bytes >= unit) {
       val exp = (math.log(bytes.toDouble) / math.log(unit)).toInt
       val pre = if (si) "kMGTPE".charAt(exp - 1).toString else "KMGTPE".charAt(exp - 1).toString + 'i'
-      "%.1f %sB" format (bytes / math.pow(unit, exp), pre)
+      "%.1f %sB".format(bytes / math.pow(unit, exp), pre)
     } else bytes.toString + "  B"
   }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -481,7 +481,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
   private[akka] def newHostConnectionPool[T](setup: HostConnectionPoolSetup)(
     implicit
     fm: Materializer): Flow[(HttpRequest, T), (Try[HttpResponse], T), HostConnectionPool] = {
-    val poolId = new PoolId(setup, PoolId.newUniquePool)
+    val poolId = new PoolId(setup, PoolId.newUniquePool())
     poolMaster.startPool(poolId)
     poolClientFlow(poolId)
   }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala
@@ -99,7 +99,7 @@ sealed trait BinaryMessage extends akka.http.javadsl.model.ws.BinaryMessage with
       case BinaryMessage.Streamed(binaryStream) => binaryStream
         .completionTimeout(timeout)
         .runFold(new ByteStringBuilder())((b, e) => b.append(e))
-        .map(b => b.result)(fm.executionContext)
+        .map(b => b.result())(fm.executionContext)
         .map(binary => BinaryMessage.Strict(binary))(fm.executionContext)
     }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -105,7 +105,7 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
         case (Success(x), 43) => requestUri(x) should endWith("/b")
         case x                => fail(x.toString)
       }
-      Seq(r1, r2).map(t => connNr(t._1.get)) should contain allOf (1, 2)
+      Seq(r1, r2).map(t => connNr(t._1.get)) should contain(allOf(1, 2))
     }
 
     "open a second connection if the request on the first one is dispatch but not yet completed" in new TestSetup {
@@ -642,7 +642,7 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
     def mapServerSideOutboundRawBytes(bytes: ByteString): ByteString = bytes
 
     val incomingConnectionCounter = new AtomicInteger
-    val incomingConnections = TestSubscriber.manualProbe[Http.IncomingConnection]
+    val incomingConnections = TestSubscriber.manualProbe[Http.IncomingConnection]()
     val (incomingConnectionsSub, serverHostName: String, serverPort: Int) = {
       val rawBytesInjection = BidiFlow.fromFlows(
         Flow[SslTlsOutbound].collect[ByteString] { case SendBytes(x) => mapServerSideOutboundRawBytes(x) }
@@ -729,7 +729,7 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
 
     def flowTestBench[T, Mat](poolFlow: Flow[(HttpRequest, T), (Try[HttpResponse], T), Mat]) = {
       val requestIn = TestPublisher.probe[(HttpRequest, T)]()
-      val responseOut = TestSubscriber.manualProbe[(Try[HttpResponse], T)]
+      val responseOut = TestSubscriber.manualProbe[(Try[HttpResponse], T)]()
       val hcp = Source.fromPublisher(requestIn).viaMat(poolFlow)(Keep.right).to(Sink.fromSubscriber(responseOut)).run()
       val responseOutSub = responseOut.expectSubscription()
       (requestIn, responseOut, responseOutSub, hcp)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -105,7 +105,7 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
         case (Success(x), 43) => requestUri(x) should endWith("/b")
         case x                => fail(x.toString)
       }
-      Seq(r1, r2).map(t => connNr(t._1.get)) should contain(allOf(1, 2))
+      Seq(r1, r2).map(t => connNr(t._1.get)) should contain allOf (1, 2)
     }
 
     "open a second connection if the request on the first one is dispatch but not yet completed" in new TestSetup {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HttpsProxyGraphStageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HttpsProxyGraphStageSpec.scala
@@ -124,7 +124,7 @@ class HttpsProxyGraphStageSpec extends AkkaSpecWithMaterializer {
 
         flowOutProbe.sendNext(ByteString("HTTP/1.0 501 Some Error\r\n\r\n"))
 
-        sink.expectError match {
+        sink.expectError() match {
           case _: ProxyConnectionFailedException =>
           case e =>
             fail(s"should be ProxyConnectionFailedException, caught ${e.getClass.getName} instead")

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/LowLevelOutgoingConnectionSpec.scala
@@ -279,7 +279,7 @@ class LowLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer with Insid
 
       inside(expectResponse()) {
         case HttpResponse(StatusCodes.OK, _, HttpEntity.Chunked(_, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
+          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]()
           // but only one consumed by server
           data.take(1).to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/PrepareResponseSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/PrepareResponseSpec.scala
@@ -49,7 +49,7 @@ class PrepareResponseSpec extends AkkaSpec {
       implicit val mat = ActorMaterializer()
 
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
-      val responseProbe = TestSubscriber.manualProbe[HttpResponse]
+      val responseProbe = TestSubscriber.manualProbe[HttpResponse]()
 
       Source.fromPublisher(inProbe)
         .via(new PrepareResponse(parserSettings))
@@ -94,7 +94,7 @@ class PrepareResponseSpec extends AkkaSpec {
       implicit val mat = ActorMaterializer()
 
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
-      val responseProbe = TestSubscriber.manualProbe[HttpResponse]
+      val responseProbe = TestSubscriber.manualProbe[HttpResponse]()
 
       Source.fromPublisher(inProbe)
         .via(new PrepareResponse(parserSettings))
@@ -130,7 +130,7 @@ class PrepareResponseSpec extends AkkaSpec {
       implicit val mat = ActorMaterializer()
 
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
-      val responseProbe = TestSubscriber.manualProbe[HttpResponse]
+      val responseProbe = TestSubscriber.manualProbe[HttpResponse]()
 
       Source.fromPublisher(inProbe)
         .via(new PrepareResponse(parserSettings))
@@ -171,7 +171,7 @@ class PrepareResponseSpec extends AkkaSpec {
       implicit val mat = ActorMaterializer()
 
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
-      val responseProbe = TestSubscriber.manualProbe[HttpResponse]
+      val responseProbe = TestSubscriber.manualProbe[HttpResponse]()
 
       Source.fromPublisher(inProbe)
         .via(new PrepareResponse(parserSettings))
@@ -199,7 +199,7 @@ class PrepareResponseSpec extends AkkaSpec {
       implicit val mat = ActorMaterializer()
 
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
-      val responseProbe = TestSubscriber.manualProbe[HttpResponse]
+      val responseProbe = TestSubscriber.manualProbe[HttpResponse]()
 
       Source.fromPublisher(inProbe)
         .via(new PrepareResponse(parserSettings))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
@@ -28,7 +28,7 @@ class ResponseParsingMergeSpec extends AkkaSpec {
 
       val inBypassProbe = TestPublisher.manualProbe[OutgoingConnectionBlueprint.BypassData]()
       val inSessionBytesProbe = TestPublisher.manualProbe[SessionBytes]()
-      val responseProbe = TestSubscriber.manualProbe[List[ParserOutput.ResponseOutput]]
+      val responseProbe = TestSubscriber.manualProbe[List[ParserOutput.ResponseOutput]]()
 
       val responseParsingMerge: ResponseParsingMerge = {
         val rootParser = new HttpResponseParser(parserSettings, HttpHeaderParser(parserSettings, log))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
@@ -31,7 +31,7 @@ class SlotStateSpec extends AkkaSpec {
     RequestContext(
       HttpRequest(
         entity = HttpEntity(ContentTypes.`application/octet-stream`, Source.single(ByteString("test")))),
-      Promise[HttpResponse], 0
+      Promise[HttpResponse](), 0
     )
 
   "The new connection pool slot state machine" should {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/HttpHeaderParserSpec.scala
@@ -207,7 +207,7 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends AkkaS
     "continue parsing raw headers even if the overall cache value capacity is reached" in new TestSetup() {
       val randomHeaders = Iterator.continually {
         val name = nextRandomString(nextRandomAlphaNumChar _, nextRandomInt(4, 16))
-        val value = nextRandomString(() => nextRandomPrintableChar, nextRandomInt(4, 16))
+        val value = nextRandomString(() => nextRandomPrintableChar(), nextRandomInt(4, 16))
         RawHeader(name, value)
       }
       randomHeaders.take(300).foldLeft(0) {
@@ -239,7 +239,7 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends AkkaS
 
     "continue parsing raw headers even if the header-specific cache capacity is reached" in new TestSetup() {
       val randomHeaders = Iterator.continually {
-        val value = nextRandomString(() => nextRandomPrintableChar, nextRandomInt(4, 16))
+        val value = nextRandomString(() => nextRandomPrintableChar(), nextRandomInt(4, 16))
         RawHeader("Fancy", value)
       }
       randomHeaders.take(20).foldLeft(0) {
@@ -311,7 +311,7 @@ abstract class HttpHeaderParserSpec(mode: String, newLine: String) extends AkkaS
         accept.mediaRanges.head.getParams.size should be(numKeys)
       }
 
-      BenchUtils.nanoRace(regular, colliding) should be < 3.0 // speed must be in same order of magnitude
+      BenchUtils.nanoRace(regular(), colliding()) should be < 3.0 // speed must be in same order of magnitude
     }
   }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -71,7 +71,7 @@ class HttpServerSpec extends AkkaSpec(
 
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Default(_, 12, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ByteString]
+          val dataProbe = TestSubscriber.manualProbe[ByteString]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -121,7 +121,7 @@ class HttpServerSpec extends AkkaSpec(
 
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Chunked(_, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
+          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -177,7 +177,7 @@ class HttpServerSpec extends AkkaSpec(
 
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Default(_, 12, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ByteString]
+          val dataProbe = TestSubscriber.manualProbe[ByteString]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -202,7 +202,7 @@ class HttpServerSpec extends AkkaSpec(
 
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Chunked(_, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
+          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -253,7 +253,7 @@ class HttpServerSpec extends AkkaSpec(
 
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Default(_, 12, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ByteString]
+          val dataProbe = TestSubscriber.manualProbe[ByteString]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -291,7 +291,7 @@ class HttpServerSpec extends AkkaSpec(
 
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Chunked(_, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
+          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -328,7 +328,7 @@ class HttpServerSpec extends AkkaSpec(
 
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Default(_, 12, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ByteString]
+          val dataProbe = TestSubscriber.manualProbe[ByteString]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -352,7 +352,7 @@ class HttpServerSpec extends AkkaSpec(
 
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Chunked(_, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
+          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -384,7 +384,7 @@ class HttpServerSpec extends AkkaSpec(
 
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Chunked(_, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
+          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]()
           // but only one consumed by server
           data.take(1).to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
@@ -424,7 +424,7 @@ class HttpServerSpec extends AkkaSpec(
              |abcdef""")
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Default(_, 12, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ByteString]
+          val dataProbe = TestSubscriber.manualProbe[ByteString]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -446,7 +446,7 @@ class HttpServerSpec extends AkkaSpec(
              |""")
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, HttpEntity.Chunked(_, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
+          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val sub = dataProbe.expectSubscription()
           sub.request(10)
@@ -609,7 +609,7 @@ class HttpServerSpec extends AkkaSpec(
              |""")
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, Default(ContentType(`application/octet-stream`, None), 16, data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ByteString]
+          val dataProbe = TestSubscriber.manualProbe[ByteString]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val dataSub = dataProbe.expectSubscription()
           netOut.expectNoBytes(50.millis.dilated)
@@ -649,7 +649,7 @@ class HttpServerSpec extends AkkaSpec(
              |""")
       inside(expectRequest()) {
         case HttpRequest(POST, _, _, Chunked(ContentType(`application/octet-stream`, None), data), _) =>
-          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]
+          val dataProbe = TestSubscriber.manualProbe[ChunkStreamPart]()
           data.to(Sink.fromSubscriber(dataProbe)).run()
           val dataSub = dataProbe.expectSubscription()
           netOut.expectNoBytes(50.millis.dilated)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -23,7 +23,7 @@ abstract class HttpServerTestSetupBase {
   implicit def system: ActorSystem
   implicit def materializer: Materializer
 
-  val requests = TestSubscriber.probe[HttpRequest]
+  val requests = TestSubscriber.probe[HttpRequest]()
   val responses = TestPublisher.probe[HttpResponse]()
 
   def settings = ServerSettings(system)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/MessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/MessageSpec.scala
@@ -983,7 +983,7 @@ class MessageSpec extends AkkaSpecWithMaterializer with Eventually {
 
     val netIn = TestPublisher.probe[ByteString]()
     val netOut = ByteStringSinkProbe()
-    val messageIn = TestSubscriber.probe[Message]
+    val messageIn = TestSubscriber.probe[Message]()
     val messageOut = TestPublisher.probe[Message]()
     val messageHandler: Flow[Message, Message, NotUsed] =
       Flow.fromSinkAndSource(

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
@@ -78,7 +78,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
             FlowShape(Inlet("completeOnlySwitch.in"), Outlet("completeOnlySwitch.out"))
 
           override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Promise[Done]) = {
-            val promise = Promise[Done]
+            val promise = Promise[Done]()
 
             val logic = new GraphStageLogic(shape) with InHandler with OutHandler {
               override def onPush(): Unit = push(shape.out, grab(shape.in))
@@ -195,7 +195,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
     }
 
     "terminate the handler flow with an error when the connection is aborted" in Utils.assertAllStagesStopped {
-      val handlerTermination = Promise[Done]
+      val handlerTermination = Promise[Done]()
 
       val handler = Flow[Message]
         .watchTermination()(Keep.right)

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
@@ -43,11 +43,11 @@ class JavaApiSpec extends AnyFreeSpec with Matchers {
       }
       "pathSegments" in {
         Uri.create("/abc/def/ghi/jkl")
-          .pathSegments().asScala.toSeq must contain inOrderOnly ("abc", "def", "ghi", "jkl")
+          .pathSegments().asScala.toSeq must contain(inOrderOnly("abc", "def", "ghi", "jkl"))
       }
       "access parameterMap" in {
         Uri.create("/abc?name=blub&age=28")
-          .query().toMap.asScala must contain allOf ("name" -> "blub", "age" -> "28")
+          .query().toMap.asScala must contain(allOf("name" -> "blub", "age" -> "28"))
       }
       "access parameters" in {
         val mutable.Seq(param1, param2, param3) =

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
@@ -43,11 +43,11 @@ class JavaApiSpec extends AnyFreeSpec with Matchers {
       }
       "pathSegments" in {
         Uri.create("/abc/def/ghi/jkl")
-          .pathSegments().asScala.toSeq must contain(inOrderOnly("abc", "def", "ghi", "jkl"))
+          .pathSegments().asScala.toSeq must contain inOrderOnly ("abc", "def", "ghi", "jkl")
       }
       "access parameterMap" in {
         Uri.create("/abc?name=blub&age=28")
-          .query().toMap.asScala must contain(allOf("name" -> "blub", "age" -> "28"))
+          .query().toMap.asScala must contain allOf ("name" -> "blub", "age" -> "28")
       }
       "access parameters" in {
         val mutable.Seq(param1, param2, param3) =

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -814,7 +814,7 @@ Host: example.com
 
       def handler(request: HttpRequest): Future[HttpResponse] = {
         request.entity.dataBytes.runWith(dataProbe.sink)
-        Promise[HttpResponse].future // just let it hanging until idle timeout triggers
+        Promise[HttpResponse]().future // just let it hanging until idle timeout triggers
       }
 
       val settings = ServerSettings(system).mapTimeouts(_.withIdleTimeout(1.second))
@@ -846,7 +846,7 @@ Host: example.com
     val (connSource, binding: Future[ServerBinding]) = {
       val settings = configOverrides.toOption.fold(ServerSettings(system))(ServerSettings(_))
       val connections = Http().bind(hostname, port, settings = settings)
-      val probe = TestSubscriber.manualProbe[Http.IncomingConnection]
+      val probe = TestSubscriber.manualProbe[Http.IncomingConnection]()
       val binding = connections.to(Sink.fromSubscriber(probe)).run()
       (probe, binding)
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -109,7 +109,7 @@ class GracefulTerminationSpec
     "fail close delimited response streams" ignore new TestSetup {
       val clientSystem = ActorSystem("client")
       val r1 =
-        Http()(clientSystem).singleRequest(nextRequest, connectionContext = clientConnectionContext, settings = basePoolSettings)
+        Http()(clientSystem).singleRequest(nextRequest(), connectionContext = clientConnectionContext, settings = basePoolSettings)
 
       // reply with an infinite entity stream
       val chunks = Source

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -155,7 +155,7 @@ class HttpEntitySpec extends AkkaSpecWithMaterializer {
       }
       "Chunked with LastChunk with trailer header keep header chunk" in {
         val entity = Chunked(tpe, source(Chunk(abc), Chunk(fgh), Chunk(ijk), LastChunk("", RawHeader("Foo", "pip apo") :: Nil)))
-        val transformed = entity.transformDataBytes(duplicateBytesTransformer())
+        val transformed = entity.transformDataBytes(duplicateBytesTransformer)
         val parts = transformed.chunks.runWith(Sink.seq).awaitResult(100.millis)
 
         parts.map(_.data).reduce(_ ++ _) shouldEqual doubleChars("abcfghijk") ++ trailer
@@ -281,7 +281,7 @@ class HttpEntitySpec extends AkkaSpecWithMaterializer {
         strict.toString + " == " + expectedRendering)
     }
 
-  def duplicateBytesTransformer(): Flow[ByteString, ByteString, NotUsed] =
+  def duplicateBytesTransformer: Flow[ByteString, ByteString, NotUsed] =
     Flow[ByteString].via(StreamUtils.byteStringTransformer(doubleChars, () => trailer))
 
   def trailer: ByteString = ByteString("--dup")

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/headers/HeaderSpec.scala
@@ -5,7 +5,6 @@
 package akka.http.scaladsl.model.headers
 
 import akka.http.impl.util._
-import org.scalatest._
 import java.net.InetAddress
 
 import akka.http.scaladsl.model.{ headers, _ }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/util/FastFutureSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/util/FastFutureSpec.scala
@@ -168,7 +168,7 @@ class FastFutureSpec extends AnyFreeSpec with Matchers {
       check(op(f.fast).value.get)
     }
     def testLazily(): Unit = {
-      val p = Promise[Int]
+      val p = Promise[Int]()
       val opped = op(p.future.fast)
       p.complete(result)
       Await.ready(opped, 500.millis)

--- a/akka-http-core/src/test/scala/akka/testkit/Coroner.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/Coroner.scala
@@ -39,7 +39,7 @@ object Coroner {
 
   private class WatchHandleImpl(startAndStopDuration: FiniteDuration)
     extends WatchHandle {
-    val cancelPromise = Promise[Boolean]
+    val cancelPromise = Promise[Boolean]()
     val startedLatch = new CountDownLatch(1)
     val finishedLatch = new CountDownLatch(1)
 

--- a/akka-http-tests/src/multi-jvm/scala/akka/remote/testkit/MultiNodeConfig.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/remote/testkit/MultiNodeConfig.scala
@@ -272,18 +272,18 @@ abstract class MultiNodeSpec(val myself: RoleName, _system: ActorSystem, _roles:
     def await: T = Await.result(w, remainingOr(testConductor.Settings.QueryTimeout.duration))
   }
 
-  final override def multiNodeSpecBeforeAll {
+  final override def multiNodeSpecBeforeAll: Unit = {
     atStartup()
   }
 
-  final override def multiNodeSpecAfterAll {
+  final override def multiNodeSpecAfterAll: Unit = {
     // wait for all nodes to remove themselves before we shut the conductor down
     if (selfIndex == 0) {
       testConductor.removeNode(myself)
       within(testConductor.Settings.BarrierTimeout.duration) {
         awaitCond {
           // Await.result(testConductor.getNodes, remaining).filterNot(_ == myself).isEmpty
-          testConductor.getNodes.await.filterNot(_ == myself).isEmpty
+          testConductor.getNodes.await.forall(_ == myself)
         }
       }
     }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -106,31 +106,31 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
     "multipartMarshaller should correctly marshal multipart content with" - {
       "no parts" in {
         marshal(Multipart.General(`multipart/mixed`)) shouldEqual HttpEntity(
-          contentType = (`multipart/mixed` withBoundary randomBoundary()).toContentType,
+          contentType = (`multipart/mixed` withBoundary randomBoundaryValue).toContentType,
           data = ByteString(s"""
-                      |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
+                      |--$randomBoundaryValue--""".stripMarginWithNewline("\r\n")))
       }
       "one empty part" in {
         marshal(Multipart.General(`multipart/mixed`, Multipart.General.BodyPart.Strict(""))) shouldEqual HttpEntity(
-          contentType = (`multipart/mixed` withBoundary randomBoundary()).toContentType,
-          data = ByteString(s"""--${randomBoundary()}
+          contentType = (`multipart/mixed` withBoundary randomBoundaryValue).toContentType,
+          data = ByteString(s"""--$randomBoundaryValue
                       |Content-Type: text/plain; charset=UTF-8
                       |
                       |
-                      |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
+                      |--$randomBoundaryValue--""".stripMarginWithNewline("\r\n")))
       }
       "one non-empty part" in {
         marshal(Multipart.General(`multipart/alternative`, Multipart.General.BodyPart.Strict(
           entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com"),
           headers = `Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" -> "email")) :: Nil))) shouldEqual
           HttpEntity(
-            contentType = (`multipart/alternative` withBoundary randomBoundary()).toContentType,
-            data = ByteString(s"""--${randomBoundary()}
+            contentType = (`multipart/alternative` withBoundary randomBoundaryValue).toContentType,
+            data = ByteString(s"""--$randomBoundaryValue
                         |Content-Type: text/plain; charset=UTF-8
                         |Content-Disposition: form-data; name="email"
                         |
                         |test@there.com
-                        |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
+                        |--$randomBoundaryValue--""".stripMarginWithNewline("\r\n")))
       }
       "two different parts" in {
         marshal(Multipart.General(
@@ -140,18 +140,18 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
             HttpEntity(`application/octet-stream`, ByteString("filecontent")),
             RawHeader("Content-Transfer-Encoding", "binary") :: Nil))) shouldEqual
           HttpEntity(
-            contentType = (`multipart/related` withBoundary randomBoundary()).toContentType,
-            data = ByteString(s"""--${randomBoundary()}
+            contentType = (`multipart/related` withBoundary randomBoundaryValue).toContentType,
+            data = ByteString(s"""--$randomBoundaryValue
                       |Content-Type: text/plain; charset=US-ASCII
                       |
                       |first part, with a trailing linebreak
                       |
-                      |--${randomBoundary()}
+                      |--$randomBoundaryValue
                       |Content-Type: application/octet-stream
                       |Content-Transfer-Encoding: binary
                       |
                       |filecontent
-                      |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
+                      |--$randomBoundaryValue--""".stripMarginWithNewline("\r\n")))
       }
     }
 
@@ -161,18 +161,18 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
           "surname" -> HttpEntity("Mike"),
           "age" -> marshal(<int>42</int>)))) shouldEqual
           HttpEntity(
-            contentType = (`multipart/form-data` withBoundary randomBoundary()).toContentType,
-            data = ByteString(s"""--${randomBoundary()}
+            contentType = (`multipart/form-data` withBoundary randomBoundaryValue).toContentType,
+            data = ByteString(s"""--$randomBoundaryValue
                       |Content-Type: text/plain; charset=UTF-8
                       |Content-Disposition: form-data; name="surname"
                       |
                       |Mike
-                      |--${randomBoundary()}
+                      |--$randomBoundaryValue
                       |Content-Type: text/xml; charset=UTF-8
                       |Content-Disposition: form-data; name="age"
                       |
                       |<int>42</int>
-                      |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
+                      |--$randomBoundaryValue--""".stripMarginWithNewline("\r\n")))
       }
 
       "two fields having a custom `Content-Disposition`" in {
@@ -182,21 +182,21 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
           Multipart.FormData.BodyPart("attachment[1]", HttpEntity("naice!".getBytes),
             Map("filename" -> "attachment2.csv"), List(RawHeader("Content-Transfer-Encoding", "binary"))))))) shouldEqual
           HttpEntity(
-            contentType = (`multipart/form-data` withBoundary randomBoundary()).toContentType,
-            data = ByteString(s"""--${randomBoundary()}
+            contentType = (`multipart/form-data` withBoundary randomBoundaryValue).toContentType,
+            data = ByteString(s"""--$randomBoundaryValue
                         |Content-Type: text/csv; charset=UTF-8
                         |Content-Disposition: form-data; filename="attachment.csv"; name="attachment[0]"
                         |
                         |name,age
                         |"John Doe",20
                         |
-                        |--${randomBoundary()}
+                        |--$randomBoundaryValue
                         |Content-Type: application/octet-stream
                         |Content-Disposition: form-data; filename="attachment2.csv"; name="attachment[1]"
                         |Content-Transfer-Encoding: binary
                         |
                         |naice!
-                        |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
+                        |--$randomBoundaryValue--""".stripMarginWithNewline("\r\n")))
       }
     }
   }
@@ -210,4 +210,5 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
     }
   }
   override protected val multipartBoundaryRandom = new FixedRandom // fix for stable value
+  val randomBoundaryValue = super.randomBoundary()
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -106,31 +106,31 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
     "multipartMarshaller should correctly marshal multipart content with" - {
       "no parts" in {
         marshal(Multipart.General(`multipart/mixed`)) shouldEqual HttpEntity(
-          contentType = (`multipart/mixed` withBoundary randomBoundary).toContentType,
+          contentType = (`multipart/mixed` withBoundary randomBoundary()).toContentType,
           data = ByteString(s"""
-                      |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
+                      |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
       }
       "one empty part" in {
         marshal(Multipart.General(`multipart/mixed`, Multipart.General.BodyPart.Strict(""))) shouldEqual HttpEntity(
-          contentType = (`multipart/mixed` withBoundary randomBoundary).toContentType,
-          data = ByteString(s"""--$randomBoundary
+          contentType = (`multipart/mixed` withBoundary randomBoundary()).toContentType,
+          data = ByteString(s"""--${randomBoundary()}
                       |Content-Type: text/plain; charset=UTF-8
                       |
                       |
-                      |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
+                      |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
       }
       "one non-empty part" in {
         marshal(Multipart.General(`multipart/alternative`, Multipart.General.BodyPart.Strict(
           entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, "test@there.com"),
           headers = `Content-Disposition`(ContentDispositionTypes.`form-data`, Map("name" -> "email")) :: Nil))) shouldEqual
           HttpEntity(
-            contentType = (`multipart/alternative` withBoundary randomBoundary).toContentType,
-            data = ByteString(s"""--$randomBoundary
+            contentType = (`multipart/alternative` withBoundary randomBoundary()).toContentType,
+            data = ByteString(s"""--${randomBoundary()}
                         |Content-Type: text/plain; charset=UTF-8
                         |Content-Disposition: form-data; name="email"
                         |
                         |test@there.com
-                        |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
+                        |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
       }
       "two different parts" in {
         marshal(Multipart.General(
@@ -140,18 +140,18 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
             HttpEntity(`application/octet-stream`, ByteString("filecontent")),
             RawHeader("Content-Transfer-Encoding", "binary") :: Nil))) shouldEqual
           HttpEntity(
-            contentType = (`multipart/related` withBoundary randomBoundary).toContentType,
-            data = ByteString(s"""--$randomBoundary
+            contentType = (`multipart/related` withBoundary randomBoundary()).toContentType,
+            data = ByteString(s"""--${randomBoundary()}
                       |Content-Type: text/plain; charset=US-ASCII
                       |
                       |first part, with a trailing linebreak
                       |
-                      |--$randomBoundary
+                      |--${randomBoundary()}
                       |Content-Type: application/octet-stream
                       |Content-Transfer-Encoding: binary
                       |
                       |filecontent
-                      |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
+                      |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
       }
     }
 
@@ -161,18 +161,18 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
           "surname" -> HttpEntity("Mike"),
           "age" -> marshal(<int>42</int>)))) shouldEqual
           HttpEntity(
-            contentType = (`multipart/form-data` withBoundary randomBoundary).toContentType,
-            data = ByteString(s"""--$randomBoundary
+            contentType = (`multipart/form-data` withBoundary randomBoundary()).toContentType,
+            data = ByteString(s"""--${randomBoundary()}
                       |Content-Type: text/plain; charset=UTF-8
                       |Content-Disposition: form-data; name="surname"
                       |
                       |Mike
-                      |--$randomBoundary
+                      |--${randomBoundary()}
                       |Content-Type: text/xml; charset=UTF-8
                       |Content-Disposition: form-data; name="age"
                       |
                       |<int>42</int>
-                      |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
+                      |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
       }
 
       "two fields having a custom `Content-Disposition`" in {
@@ -182,21 +182,21 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
           Multipart.FormData.BodyPart("attachment[1]", HttpEntity("naice!".getBytes),
             Map("filename" -> "attachment2.csv"), List(RawHeader("Content-Transfer-Encoding", "binary"))))))) shouldEqual
           HttpEntity(
-            contentType = (`multipart/form-data` withBoundary randomBoundary).toContentType,
-            data = ByteString(s"""--$randomBoundary
+            contentType = (`multipart/form-data` withBoundary randomBoundary()).toContentType,
+            data = ByteString(s"""--${randomBoundary()}
                         |Content-Type: text/csv; charset=UTF-8
                         |Content-Disposition: form-data; filename="attachment.csv"; name="attachment[0]"
                         |
                         |name,age
                         |"John Doe",20
                         |
-                        |--$randomBoundary
+                        |--${randomBoundary()}
                         |Content-Type: application/octet-stream
                         |Content-Disposition: form-data; filename="attachment2.csv"; name="attachment[1]"
                         |Content-Transfer-Encoding: binary
                         |
                         |naice!
-                        |--$randomBoundary--""".stripMarginWithNewline("\r\n")))
+                        |--${randomBoundary()}--""".stripMarginWithNewline("\r\n")))
       }
     }
   }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
@@ -43,7 +43,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))\n"
+        normalizedDebugMsg() shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))\n"
       }
     }
   }
@@ -58,7 +58,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))\n"
+        normalizedDebugMsg() shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))\n"
       }
     }
   }
@@ -73,7 +73,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg shouldEqual
+        normalizedDebugMsg() shouldEqual
           """|3: Response for
              |  Request : HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
              |  Response: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))
@@ -94,7 +94,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         handled shouldBe false
-        normalizedDebugMsg shouldEqual
+        normalizedDebugMsg() shouldEqual
           """Request: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
             |was rejected with rejections:
             |List(ValidationRejection(The request could not be validated,None))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
@@ -17,7 +17,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
 
   // Gracefully handle prefix difference for `ByteString.ByteString1C`
   // in Scala 2.12 due to https://issues.scala-lang.org/browse/SI-9019.
-  def normalizedDebugMsg(): String =
+  def normalizedDebugMsg: String =
     debugMsg.replace("ByteString.ByteString1C(", "ByteString(")
 
   val log = new LoggingAdapter {
@@ -43,7 +43,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg() shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))\n"
+        normalizedDebugMsg shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))\n"
       }
     }
   }
@@ -58,7 +58,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg() shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))\n"
+        normalizedDebugMsg shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))\n"
       }
     }
   }
@@ -73,7 +73,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg() shouldEqual
+        normalizedDebugMsg shouldEqual
           """|3: Response for
              |  Request : HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
              |  Response: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))
@@ -94,7 +94,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         handled shouldBe false
-        normalizedDebugMsg() shouldEqual
+        normalizedDebugMsg shouldEqual
           """Request: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
             |was rejected with rejections:
             |List(ValidationRejection(The request could not be validated,None))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/DebuggingDirectivesSpec.scala
@@ -17,7 +17,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
 
   // Gracefully handle prefix difference for `ByteString.ByteString1C`
   // in Scala 2.12 due to https://issues.scala-lang.org/browse/SI-9019.
-  def normalizedDebugMsg: String =
+  def normalizedDebugMsg(): String =
     debugMsg.replace("ByteString.ByteString1C(", "ByteString(")
 
   val log = new LoggingAdapter {
@@ -43,7 +43,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))\n"
+        normalizedDebugMsg() shouldEqual "1: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))\n"
       }
     }
   }
@@ -58,7 +58,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))\n"
+        normalizedDebugMsg() shouldEqual "2: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))\n"
       }
     }
   }
@@ -73,7 +73,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         response shouldEqual Ok
-        normalizedDebugMsg shouldEqual
+        normalizedDebugMsg() shouldEqual
           """|3: Response for
              |  Request : HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
              |  Response: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1)))
@@ -94,7 +94,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       resetDebugMsg()
       Get("/hello") ~> route ~> check {
         handled shouldBe false
-        normalizedDebugMsg shouldEqual
+        normalizedDebugMsg() shouldEqual
           """Request: HttpRequest(HttpMethod(GET),http://example.com/hello,List(),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
             |was rejected with rejections:
             |List(ValidationRejection(The request could not be validated,None))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
@@ -64,6 +64,6 @@ class TimeoutDirectivesSpec extends RoutingSpec {
     }
   }
 
-  def slowFuture(): Future[String] = Promise[String].future
+  def slowFuture(): Future[String] = Promise[String]().future
 
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
@@ -17,7 +17,7 @@ object RejectionHandler {
   /**
    * Creates a new [[RejectionHandler]] builder.
    */
-  def newBuilder = new RejectionHandlerBuilder(server.RejectionHandler.newBuilder)
+  def newBuilder = new RejectionHandlerBuilder(server.RejectionHandler.newBuilder())
 
   def defaultHandler = new RejectionHandler(server.RejectionHandler.default)
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -6,7 +6,6 @@ package akka.http.javadsl.server.directives
 
 import java.util.concurrent.{ CompletionException, CompletionStage }
 
-import akka.actor.ClassicActorSystemProvider
 import akka.dispatch.ExecutionContexts
 import akka.http.javadsl.marshalling.Marshaller
 
@@ -22,8 +21,6 @@ import akka.http.javadsl.server.RoutingJavaMapping._
 import akka.http.scaladsl.server.RouteResult
 import akka.http.scaladsl.server.directives.{ RouteDirectives => D }
 import akka.http.scaladsl.util.FastFuture._
-
-import scala.concurrent.ExecutionContext
 
 abstract class RouteDirectives extends RespondWithDirectives {
   import RoutingJavaMapping.Implicits._

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
@@ -54,7 +54,7 @@ trait Encoder {
     def encodeChunk(bytes: ByteString): ByteString = compressor.compressAndFlush(bytes)
     def finish(): ByteString = compressor.finish()
 
-    StreamUtils.byteStringTransformer(encodeChunk, () => finish)
+    StreamUtils.byteStringTransformer(encodeChunk, () => finish())
   }
 }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContextImpl.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.util.FastFuture._
-import akka.stream.{ ActorMaterializerHelper, Materializer }
+import akka.stream.Materializer
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
@@ -34,7 +34,7 @@ private[http2] object FrameRenderer {
           Http2Protocol.FrameType.GOAWAY,
           Http2Protocol.Flags.NO_FLAGS,
           Http2Protocol.NoStreamId,
-          bb.result
+          bb.result()
         )
 
       case DataFrame(streamId, endStream, payload) =>
@@ -118,7 +118,7 @@ private[http2] object FrameRenderer {
           Http2Protocol.FrameType.RST_STREAM,
           Http2Protocol.Flags.NO_FLAGS,
           streamId,
-          new ByteStringBuilder().putInt(errorCode.id).result
+          new ByteStringBuilder().putInt(errorCode.id).result()
         )
 
       case PushPromiseFrame(streamId, endHeaders, promisedStreamId, headerBlockFragment) =>
@@ -159,6 +159,6 @@ private[http2] object FrameRenderer {
   }
   def renderPriorityInfo(priorityFrame: PriorityFrame): ByteString = {
     val exclusiveBit: Int = if (priorityFrame.exclusiveFlag) 0x80000000 else 0
-    new ByteStringBuilder().putInt(exclusiveBit | priorityFrame.streamDependency).putByte(priorityFrame.weight.toByte).result
+    new ByteStringBuilder().putInt(exclusiveBit | priorityFrame.streamDependency).putByte(priorityFrame.weight.toByte).result()
   }
 }

--- a/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
+++ b/akka-http2-support/src/main/scala/akka/http/scaladsl/Http2.scala
@@ -175,7 +175,7 @@ final class Http2Ext(private val config: Config)(implicit val system: ActorSyste
       Http2AlpnSupport.applySessionParameters(engine, httpsContext.firstSession)
       Http2AlpnSupport.enableForServer(engine, setChosenProtocol)
     }
-    val tls = TLS(() => createEngine, _ => Success(()), IgnoreComplete)
+    val tls = TLS(() => createEngine(), _ => Success(()), IgnoreComplete)
 
     ProtocolSwitch(_ => getChosenProtocol(), http1, http2) join
       tls

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ProtocolSwitchSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ProtocolSwitchSpec.scala
@@ -52,8 +52,8 @@ class ProtocolSwitchSpec extends AkkaSpec {
         http1flowMaterialized.future.futureValue
       }
       http2flowMaterialized.future.futureValue should be(Done)
-      out.pull.futureValue should be(Some(SendBytes(Http2Protocol.ClientConnectionPreface)))
-      out.pull.futureValue should be(Some(SendBytes(payload)))
+      out.pull().futureValue should be(Some(SendBytes(Http2Protocol.ClientConnectionPreface)))
+      out.pull().futureValue should be(Some(SendBytes(payload)))
     }
 
     "switch to http2 when the connection preface arrives together with the payload" in {
@@ -79,7 +79,7 @@ class ProtocolSwitchSpec extends AkkaSpec {
         http1flowMaterialized.future.futureValue
       }
       http2flowMaterialized.future.futureValue should be(Done)
-      out.pull.futureValue should be(Some(SendBytes(Http2Protocol.ClientConnectionPreface ++ payload)))
+      out.pull().futureValue should be(Some(SendBytes(Http2Protocol.ClientConnectionPreface ++ payload)))
     }
 
     "switch to http2 when the connection preface arrives in two parts" ignore {
@@ -106,8 +106,8 @@ class ProtocolSwitchSpec extends AkkaSpec {
         http1flowMaterialized.future.futureValue
       }
       http2flowMaterialized.future.futureValue should be(Done)
-      out.pull.futureValue should be(Some(SendBytes(Http2Protocol.ClientConnectionPreface)))
-      out.pull.futureValue should be(Some(SendBytes(payload)))
+      out.pull().futureValue should be(Some(SendBytes(Http2Protocol.ClientConnectionPreface)))
+      out.pull().futureValue should be(Some(SendBytes(payload)))
     }
 
     "select http1 when receiving a short http1 request" in {
@@ -132,7 +132,7 @@ class ProtocolSwitchSpec extends AkkaSpec {
         http2flowMaterialized.future.futureValue
       }
       http1flowMaterialized.future.futureValue should be(Done)
-      out.pull.futureValue should be(Some(SendBytes(payload)))
+      out.pull().futureValue should be(Some(SendBytes(payload)))
     }
   }
 }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/package.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/package.scala
@@ -17,10 +17,10 @@ package object http2 {
     def hex(args: Any*): ByteString = {
       val strings = sc.parts.iterator
       val expressions = args.iterator
-      val buf = new StringBuffer(strings.next)
+      val buf = new StringBuffer(strings.next())
       while (strings.hasNext) {
-        buf append expressions.next
-        buf append strings.next
+        buf append expressions.next()
+        buf append strings.next()
       }
       buf.toString.parseHexByteString
     }

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
@@ -59,7 +59,7 @@ class Http2BindingViaConfigSpec extends AkkaSpec("""
     }
   }
 
-  private def fishForDebugMessage(a: TestProbe, messagePrefix: String, max: Duration = 3.seconds) {
+  private def fishForDebugMessage(a: TestProbe, messagePrefix: String, max: Duration = 3.seconds): Unit = {
     a.fishForMessage(max, hint = "expected debug message part: " + messagePrefix) {
       case Logging.Debug(_, _, msg: String) if msg contains messagePrefix => true
       case _ => false

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -110,8 +110,8 @@ object Http2ServerTest extends App {
 
   def imagesBlock = {
     def one(): String =
-      s"""<img width="80" height="60" src="/image1?cachebuster=${Random.nextInt}"></img>
-         |<img width="80" height="60" src="/image2?cachebuster=${Random.nextInt}"></img>
+      s"""<img width="80" height="60" src="/image1?cachebuster=${Random.nextInt()}"></img>
+         |<img width="80" height="60" src="/image2?cachebuster=${Random.nextInt()}"></img>
          |""".stripMargin
 
     Seq.fill(20)(one()).mkString


### PR DESCRIPTION
Most warnings were "Auto-application to `()` is deprecated."
Very few "procedure syntax is deprecated".