### PR TITLE
core: make HttpRequest/HttpResponse.hashCode depend on attributes

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -387,11 +387,12 @@ final class HttpRequest(
 
   override def hashCode(): Int = {
     var result = HashCode.SEED
-    result = HashCode.hash(result, _1)
-    result = HashCode.hash(result, _2)
-    result = HashCode.hash(result, _3)
-    result = HashCode.hash(result, _4)
-    result = HashCode.hash(result, _5)
+    result = HashCode.hash(result, method)
+    result = HashCode.hash(result, uri)
+    result = HashCode.hash(result, headers)
+    result = HashCode.hash(result, attributes)
+    result = HashCode.hash(result, entity)
+    result = HashCode.hash(result, protocol)
     result
   }
 
@@ -564,10 +565,11 @@ final class HttpResponse(
 
   override def hashCode: Int = {
     var result = HashCode.SEED
-    result = HashCode.hash(result, _1)
-    result = HashCode.hash(result, _2)
-    result = HashCode.hash(result, _3)
-    result = HashCode.hash(result, _4)
+    result = HashCode.hash(result, status)
+    result = HashCode.hash(result, headers)
+    result = HashCode.hash(result, attributes)
+    result = HashCode.hash(result, entity)
+    result = HashCode.hash(result, protocol)
     result
   }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpMessageSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.http.scaladsl.model
 
+import java.net.InetAddress
+
 import akka.util.ByteString
 import headers._
 import org.scalatest.matchers.should.Matchers
@@ -58,6 +60,23 @@ class HttpMessageSpec extends AnyWordSpec with Matchers {
     "throw IllegalUriException for empty URI" in {
       an[IllegalUriException] should be thrownBy
         HttpRequest(uri = Uri())
+    }
+
+    "take attributes into account for hashCode calculation" in {
+      val orig = HttpRequest()
+      val changed = orig.addAttribute(AttributeKeys.remoteAddress, RemoteAddress(InetAddress.getLocalHost))
+
+      orig should not equal (changed)
+      orig.hashCode() should not equal (changed.hashCode())
+    }
+  }
+  "HttpResponse" should {
+    "take attributes into account for hashCode calculation" in {
+      val orig = HttpResponse()
+      val changed = orig.addAttribute(AttributeKeys.remoteAddress, RemoteAddress(InetAddress.getLocalHost))
+
+      orig should not equal (changed)
+      orig.hashCode() should not equal (changed.hashCode())
     }
   }
 


### PR DESCRIPTION
Not super important since hashCode by definition doesn't give a guarantee that different objects in terms of equals will have a different hashCode. Might still be better to take everything into account so that you don't have any surprises when putting things into a HashMap.