### PR TITLE
docs: use Route directly in exception handler

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FutureDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FutureDirectivesExamplesSpec.scala
@@ -22,8 +22,7 @@ class FutureDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
   implicit val myExceptionHandler =
     ExceptionHandler {
-      case TestException => ctx =>
-        ctx.complete(InternalServerError -> "Unsuccessful future!")
+      case TestException => complete(InternalServerError -> "Unsuccessful future!")
     }
 
   implicit val responseTimeout = Timeout(2, TimeUnit.SECONDS)


### PR DESCRIPTION
See https://github.com/akka/akka-http/pull/3335#issuecomment-654077375