### PR TITLE
Avoid expensive logging in NewHostConnectionPool

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ConnectionPoolBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ConnectionPoolBenchmark.scala
@@ -8,16 +8,16 @@ import akka.dispatch.ExecutionContexts
 import akka.http.CommonBenchmark
 import akka.http.impl.util.enhanceString_
 import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
-import akka.http.scaladsl.{ClientTransport, Http}
+import akka.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
+import akka.http.scaladsl.{ ClientTransport, Http }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
 
 /**
  * A benchmark that tries to stress the pool and the client infrastructure (but nothing else)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -118,7 +118,7 @@ private[client] object NewHostConnectionPool {
             slots.find(_.isIdle)
               .getOrElse(throw new IllegalStateException("Tried to dispatch request when no slot is idle"))
 
-          slot.debug("Dispatching request [{}]", req.request.debugString)
+          slot.debug(s"Dispatching request [${req.request.debugString}]")
           slot.onNewRequest(req)
         }
 
@@ -351,29 +351,8 @@ private[client] object NewHostConnectionPool {
             loop(event, arg, 10)
           }
 
-          def debug(msg: String): Unit =
-            if (log.isDebugEnabled)
-              log.debug("[{} ({})] {}", slotId, state.productPrefix, msg)
-
-          def debug(msg: String, arg1: AnyRef): Unit =
-            if (log.isDebugEnabled)
-              log.debug(s"[{} ({})] $msg", slotId, state.productPrefix, arg1)
-
-          def debug(msg: String, arg1: AnyRef, arg2: AnyRef): Unit =
-            if (log.isDebugEnabled)
-              log.debug(s"[{} ({})] $msg", slotId, state.productPrefix, arg1, arg2)
-
-          def debug(msg: String, arg1: AnyRef, arg2: AnyRef, arg3: AnyRef): Unit =
-            if (log.isDebugEnabled)
-              log.debug(log.format(s"[{} ({})] $msg", slotId, state.productPrefix, arg1, arg2, arg3))
-
-          def warning(msg: String): Unit =
-            if (log.isWarningEnabled)
-              log.warning("[{} ({})] {}", slotId, state.productPrefix, msg)
-
-          def warning(msg: String, arg1: AnyRef): Unit =
-            if (log.isWarningEnabled)
-              log.warning(s"[{} ({})] $msg", slotId, state.productPrefix, arg1)
+          override def log: LoggingAdapter = _log
+          override def prefixString: String = s"[$slotId (${state.productPrefix})]"
 
           def error(cause: Throwable, msg: String): Unit =
             if (log.isErrorEnabled)
@@ -569,7 +548,7 @@ private[client] object NewHostConnectionPool {
               }
             case Failure(cause) =>
               slotCon.withSlot { sl =>
-                slot.debug("Connection attempt failed with {}", cause.getMessage)
+                slot.debug(s"Connection attempt failed with ${cause.getMessage}")
                 onConnectionAttemptFailed(currentEmbargoLevel)
                 sl.onConnectionAttemptFailed(cause)
               }

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
@@ -156,7 +156,8 @@ class SlotStateSpec extends AkkaSpec {
     }
   }
 
-  class MockSlotContext(log: LoggingAdapter, val settings: ConnectionPoolSettings = ConnectionPoolSettings("")) extends SlotContext {
+  class MockSlotContext(_log: LoggingAdapter, val settings: ConnectionPoolSettings = ConnectionPoolSettings("")) extends SlotContext {
+    override def log: LoggingAdapter = _log
 
     var connectionClosed = true
     var connectionOpenRequested = false
@@ -175,24 +176,6 @@ class SlotStateSpec extends AkkaSpec {
 
     override def willCloseAfter(response: HttpResponse): Boolean =
       response.header[headers.Connection].exists(_.hasClose)
-
-    override def debug(message: String): Unit =
-      log.debug(message)
-
-    override def debug(message: String, arg1: AnyRef): Unit =
-      log.debug(message, arg1)
-
-    override def debug(message: String, arg1: AnyRef, arg2: AnyRef): Unit =
-      log.debug(message, arg1, arg2)
-
-    override def debug(message: String, arg1: AnyRef, arg2: AnyRef, arg3: AnyRef): Unit =
-      log.debug(message, arg1, arg2, arg3)
-
-    override def warning(message: String): Unit =
-      log.warning(message)
-
-    override def warning(message: String, arg1: AnyRef): Unit =
-      log.warning(message, arg1)
 
     def expectOpenConnection[T](cb: => T) = {
       connectionClosed should be(true)

--- a/akka-parsing/src/main/scala/akka/macros/LogHelper.scala
+++ b/akka-parsing/src/main/scala/akka/macros/LogHelper.scala
@@ -20,7 +20,7 @@ private[akka] trait LogHelper {
   def log: LoggingAdapter
 
   /** Override to prefix every log message with a user-defined context string */
-  protected def prefixString: String = ""
+  def prefixString: String = ""
 
   def debug(msg: String): Unit = macro LogHelper.debugMacro
   def info(msg: String): Unit = macro LogHelper.infoMacro


### PR DESCRIPTION
By using the existing log macro that avoids logging code if not enabled.

Refs #3324 