### PR TITLE
Track idle slots explicitly to avoid O(n^2) work for big pools

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ConnectionPoolBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ConnectionPoolBenchmark.scala
@@ -8,16 +8,16 @@ import akka.dispatch.ExecutionContexts
 import akka.http.CommonBenchmark
 import akka.http.impl.util.enhanceString_
 import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
-import akka.http.scaladsl.{ClientTransport, Http}
+import akka.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
+import akka.http.scaladsl.{ ClientTransport, Http }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
 
 /**
  * A benchmark that tries to stress the pool and the client infrastructure (but nothing else)


### PR DESCRIPTION
Before linear scanning for idle slots was the number one hot spot for pools.
In experiments that showed for pools of size > 500.

Refs #3325

```
Before:

Benchmark                              (maxConnections)   Mode  Cnt      Score      Error  Units
ConnectionPoolBenchmark.singleRequest              1000  thrpt    3  10459.168 ±  948.674  ops/s
ConnectionPoolBenchmark.singleRequest             10000  thrpt    3   4302.828 ± 1031.308  ops/s

After:

Benchmark                              (maxConnections)   Mode  Cnt      Score       Error  Units
ConnectionPoolBenchmark.singleRequest              1000  thrpt    3  28747.105 ± 44447.131  ops/s
ConnectionPoolBenchmark.singleRequest             10000  thrpt    3  29018.001 ±  2771.695  ops/s
```

I.e.
~ 3x speedup for a size of 1000 connections
~ 7x speedup for a size of 10000 connections

