### PR TITLE
http: new ServerBuilder API

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/ServerBuilder.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ServerBuilder.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.javadsl
+
+import java.util.concurrent.CompletionStage
+
+import akka.actor.ClassicActorSystemProvider
+import akka.dispatch.ExecutionContexts
+import akka.event.LoggingAdapter
+import akka.http.impl.util.JavaMapping.Implicits._
+import akka.http.javadsl.model.{ HttpRequest, HttpResponse }
+import akka.http.javadsl.settings.ServerSettings
+import akka.http.scaladsl
+import akka.http.scaladsl.util.FastFuture
+import akka.http.scaladsl.{ HttpExt, model => sm }
+import akka.japi.function.Function
+import akka.stream.javadsl.Flow
+import akka.stream.scaladsl.Source
+import akka.stream.{ Materializer, SystemMaterializer }
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.ExecutionContext
+
+/**
+ * Builder API to create server bindings.
+ *
+ * Use [[HttpExt.newServerAt()]] to create a builder, use methods to customize settings,
+ * and then call one of the bind* methods to bind a server.
+ */
+trait ServerBuilder {
+  /** Change interface to bind to */
+  def onInterface(interface: String): ServerBuilder
+
+  /** Change port to bind to */
+  def onPort(port: Int): ServerBuilder
+
+  /** Use a custom logger */
+  def logTo(log: LoggingAdapter): ServerBuilder
+
+  /**
+   * Use custom [[ServerSettings]] for the binding.
+   */
+  def withSettings(settings: ServerSettings): ServerBuilder
+
+  /**
+   * Adapt the current configured settings with a function.
+   */
+  def adaptSettings(f: Function[ServerSettings, ServerSettings]): ServerBuilder
+
+  /**
+   * Enable HTTPS for this binding with the given context.
+   */
+  def enableHttps(context: HttpsConnectionContext): ServerBuilder
+
+  /**
+   * Bind a new HTTP server and use the given asynchronous `handler`
+   * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
+   *
+   * The number of concurrently accepted connections can be configured by overriding
+   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * information about what kind of guarantees to expect.
+   *
+   * Supports HTTP/2 on the same port if the akka-http2-support module is on the classpath and http2 support is enabled.
+   */
+  def bind(f: Function[HttpRequest, CompletionStage[HttpResponse]]): CompletionStage[ServerBinding]
+
+  /**
+   * Bind a new HTTP server and use the given handler provider to create an asynchronous `handler`
+   * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
+   *
+   * Most importantly, you can pass a Route to this method because Route implements HandlerProvider.
+   *
+   * The number of concurrently accepted connections can be configured by overriding
+   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * information about what kind of guarantees to expect.
+   *
+   * Supports HTTP/2 on the same port if the akka-http2-support module is on the classpath and http2 support is enabled.
+   */
+  def bind(handlerProvider: HandlerProvider): CompletionStage[ServerBinding]
+
+  /**
+   * Bind a new HTTP server at the given endpoint and uses the given `handler`
+   * [[akka.stream.javadsl.Flow]] for processing all incoming connections.
+   *
+   * The number of concurrently accepted connections can be configured by overriding
+   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * information about what kind of guarantees to expect.
+   *
+   * Supports HTTP/2 on the same port if the akka-http2-support module is on the classpath and http2 support is enabled.
+   */
+  def bindSync(f: Function[HttpRequest, HttpResponse]): CompletionStage[ServerBinding]
+
+  /**
+   * Binds a new HTTP server at the given endpoint and uses the given `handler`
+   * [[akka.stream.scaladsl.Flow]] for processing all incoming connections.
+   *
+   * The number of concurrently accepted connections can be configured by overriding
+   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * information about what kind of guarantees to expect.
+   */
+  def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): CompletionStage[ServerBinding]
+
+  /**
+   * Creates a [[akka.stream.javadsl.Source]] of [[akka.http.javadsl.IncomingConnection]] instances which represents a prospective HTTP server binding
+   * on the given `endpoint`.
+   *
+   * If the configured  port is 0 the resulting source can be materialized several times. Each materialization will
+   * then be assigned a new local port by the operating system, which can then be retrieved by the materialized
+   * [[akka.http.javadsl.ServerBinding]].
+   *
+   * If the configured  port is non-zero subsequent materialization attempts of the produced source will immediately
+   * fail, unless the first materialization has already been unbound. Unbinding can be triggered via the materialized
+   * [[akka.http.javadsl.ServerBinding]].
+   *
+   * If no `port` is explicitly given (or the port value is negative) the protocol's default port will be used,
+   * which is 80 for HTTP and 443 for HTTPS.
+   */
+  def bind(): Source[IncomingConnection, CompletionStage[ServerBinding]]
+}
+
+/**
+ * A HandlerProvider can provide an asynchronous request handler given an ClassicActorSystemProvider.
+ *
+ * The main use case for this class is to enable passing a Route to ServerBuilder.bind().
+ */
+trait HandlerProvider {
+  def handler(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]]
+}
+
+object ServerBuilder {
+  private[http] def apply(interface: String, port: Int, system: ClassicActorSystemProvider): ServerBuilder =
+    Impl(interface, port, scaladsl.HttpConnectionContext, system.classicSystem.log, ServerSettings.create(system.classicSystem), system)
+
+  private case class Impl(
+    interface: String,
+    port:      Int,
+    context:   ConnectionContext,
+    log:       LoggingAdapter,
+    settings:  ServerSettings,
+    system:    ClassicActorSystemProvider
+  ) extends ServerBuilder {
+    private implicit def executionContext: ExecutionContext = system.classicSystem.dispatcher
+    private implicit def materializer: Materializer = SystemMaterializer(system).materializer
+    private def http: scaladsl.HttpExt = scaladsl.Http(system)
+
+    def onInterface(newInterface: String): ServerBuilder = copy(interface = newInterface)
+    def onPort(newPort: Int): ServerBuilder = copy(port = newPort)
+    def logTo(newLog: LoggingAdapter): ServerBuilder = copy(log = newLog)
+    def withSettings(newSettings: ServerSettings): ServerBuilder = copy(settings = newSettings)
+    def adaptSettings(f: Function[ServerSettings, ServerSettings]): ServerBuilder = copy(settings = f(settings))
+    def enableHttps(newContext: HttpsConnectionContext): ServerBuilder = copy(context = newContext)
+
+    def bind(handler: Function[HttpRequest, CompletionStage[HttpResponse]]): CompletionStage[ServerBinding] =
+      http.bindAndHandleAsyncImpl(
+        handler.apply(_).asScala,
+        interface, port, context.asScala, settings.asScala, parallelism = 0, log = log)
+        .map(new ServerBinding(_)).toJava
+
+    def bind(handlerProvider: HandlerProvider): CompletionStage[ServerBinding] = bind(handlerProvider.handler(system))
+
+    def bindSync(handler: Function[HttpRequest, HttpResponse]): CompletionStage[ServerBinding] =
+      http.bindAndHandleAsyncImpl(
+        req => FastFuture.successful(handler(req).asScala),
+        interface, port, context.asScala, settings.asScala, parallelism = 0, log)
+        .map(new ServerBinding(_)).toJava
+
+    def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): CompletionStage[ServerBinding] =
+      http.bindAndHandleImpl(
+        handlerFlow.asInstanceOf[Flow[sm.HttpRequest, sm.HttpResponse, _]].asScala,
+        interface, port, context.asScala, settings.asScala, log)
+        .map(new ServerBinding(_)).toJava
+
+    def bind(): Source[IncomingConnection, CompletionStage[ServerBinding]] =
+      http.bindImpl(interface, port, context.asScala, settings.asScala, log)
+        .map(new IncomingConnection(_))
+        .mapMaterializedValue(_.map(new ServerBinding(_))(ExecutionContexts.sameThreadExecutionContext).toJava)
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ServerBuilder.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ServerBuilder.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.scaladsl
+
+import akka.actor.ClassicActorSystemProvider
+import akka.annotation.InternalApi
+import akka.event.LoggingAdapter
+import akka.http.scaladsl
+import akka.http.scaladsl.Http.ServerBinding
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.http.scaladsl.settings.ServerSettings
+import akka.http.scaladsl.util.FastFuture
+import akka.stream.{ Materializer, SystemMaterializer }
+import akka.stream.scaladsl.{ Flow, Source }
+
+import scala.concurrent.Future
+
+/**
+ * Builder API to create server bindings.
+ *
+ * Use [[HttpExt.newServerAt()]] to create a builder, use methods to customize settings,
+ * and then call one of the bind* methods to bind a server.
+ */
+trait ServerBuilder {
+  /** Change interface to bind to */
+  def onInterface(interface: String): ServerBuilder
+
+  /** Change port to bind to */
+  def onPort(port: Int): ServerBuilder
+
+  /** Use a custom logger */
+  def logTo(log: LoggingAdapter): ServerBuilder
+
+  /**
+   * Use custom [[ServerSettings]] for the binding.
+   */
+  def withSettings(settings: ServerSettings): ServerBuilder
+
+  /**
+   * Adapt the current configured settings with a function.
+   */
+  def adaptSettings(f: ServerSettings => ServerSettings): ServerBuilder
+
+  /**
+   * Enable HTTPS for this binding with the given context.
+   */
+  def enableHttps(context: HttpsConnectionContext): ServerBuilder
+
+  /**
+   * Bind a new HTTP server at the given endpoint and use the given asynchronous `handler`
+   * [[akka.stream.scaladsl.Flow]] for processing all incoming connections.
+   *
+   * The number of concurrently accepted connections can be configured by overriding
+   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * information about what kind of guarantees to expect.
+   *
+   * Supports HTTP/2 on the same port if the akka-http2-support module is on the classpath and http2 support is enabled.
+   */
+  def bind(f: HttpRequest => Future[HttpResponse]): Future[ServerBinding]
+
+  /**
+   * Bind a new HTTP server at the given endpoint and uses the given `handler`
+   * [[akka.stream.scaladsl.Flow]] for processing all incoming connections.
+   *
+   * The number of concurrently accepted connections can be configured by overriding
+   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * information about what kind of guarantees to expect.
+   *
+   * Supports HTTP/2 on the same port if the akka-http2-support module is on the classpath and http2 support is enabled.
+   */
+  def bindSync(f: HttpRequest => HttpResponse): Future[ServerBinding]
+
+  /**
+   * Binds a new HTTP server at the given endpoint and uses the given `handler`
+   * [[akka.stream.scaladsl.Flow]] for processing all incoming connections.
+   *
+   * The number of concurrently accepted connections can be configured by overriding
+   * the `akka.http.server.max-connections` setting. Please see the documentation in the reference.conf for more
+   * information about what kind of guarantees to expect.
+   */
+  def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): Future[ServerBinding]
+
+  /**
+   * Creates a [[akka.stream.scaladsl.Source]] of [[akka.http.scaladsl.Http.IncomingConnection]] instances which represents a prospective HTTP server binding
+   * on the given `endpoint`.
+   *
+   * If the configured  port is 0 the resulting source can be materialized several times. Each materialization will
+   * then be assigned a new local port by the operating system, which can then be retrieved by the materialized
+   * [[akka.http.scaladsl.Http.ServerBinding]].
+   *
+   * If the configured  port is non-zero subsequent materialization attempts of the produced source will immediately
+   * fail, unless the first materialization has already been unbound. Unbinding can be triggered via the materialized
+   * [[akka.http.scaladsl.Http.ServerBinding]].
+   *
+   * If no `port` is explicitly given (or the port value is negative) the protocol's default port will be used,
+   * which is 80 for HTTP and 443 for HTTPS.
+   */
+  def bind(): Source[Http.IncomingConnection, Future[ServerBinding]]
+}
+
+/**
+ * Internal API
+ *
+ * Use [[HttpExt.newServerAt]] to create a new server builder.
+ */
+@InternalApi
+private[http] object ServerBuilder {
+  def apply(interface: String, port: Int, system: ClassicActorSystemProvider): ServerBuilder =
+    Impl(interface, port, scaladsl.HttpConnectionContext, system.classicSystem.log, ServerSettings(system.classicSystem), system)
+
+  private case class Impl(
+    interface: String,
+    port:      Int,
+    context:   ConnectionContext,
+    log:       LoggingAdapter,
+    settings:  ServerSettings,
+    system:    ClassicActorSystemProvider
+  ) extends ServerBuilder {
+    private val http: scaladsl.HttpExt = scaladsl.Http(system)
+    private implicit val mat: Materializer = SystemMaterializer(system).materializer
+
+    def onInterface(newInterface: String): ServerBuilder = copy(interface = newInterface)
+    def onPort(newPort: Int): ServerBuilder = copy(port = newPort)
+    def logTo(newLog: LoggingAdapter): ServerBuilder = copy(log = newLog)
+    def withSettings(newSettings: ServerSettings): ServerBuilder = copy(settings = newSettings)
+    def adaptSettings(f: ServerSettings => ServerSettings): ServerBuilder = copy(settings = f(settings))
+    def enableHttps(newContext: HttpsConnectionContext): ServerBuilder = copy(context = newContext)
+
+    def bind(): Source[Http.IncomingConnection, Future[ServerBinding]] =
+      http.bindImpl(interface, port, context, settings, log)
+
+    def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): Future[ServerBinding] =
+      http.bindAndHandleImpl(handlerFlow, interface, port, context, settings, log)
+
+    def bind(handler: HttpRequest => Future[HttpResponse]): Future[ServerBinding] =
+      http.bindAndHandleAsyncImpl(handler, interface, port, context, settings, parallelism = 0, log)
+
+    def bindSync(handler: HttpRequest => HttpResponse): Future[ServerBinding] =
+      bind(req => FastFuture.successful(handler(req)))
+  }
+}

--- a/akka-http-core/src/test/java/akka/http/JavaTestServer.java
+++ b/akka-http-core/src/test/java/akka/http/JavaTestServer.java
@@ -29,20 +29,20 @@ public class JavaTestServer {
         ActorSystem system = ActorSystem.create();
 
         try {
-            final Materializer materializer = ActorMaterializer.create(system);
-
             CompletionStage<ServerBinding> serverBindingFuture =
-                    Http.get(system).bindAndHandleSync(
-                      request -> {
-                          System.out.println("Handling request to " + request.getUri());
+                    Http.get(system)
+                      .newServerAt("localhost", 8080)
+                      .bindSync(
+                          request -> {
+                              System.out.println("Handling request to " + request.getUri());
 
-                          if (request.getUri().path().equals("/"))
-                              return WebSocket.handleWebSocketRequestWith(request, echoMessages());
-                          else if (request.getUri().path().equals("/greeter"))
-                              return WebSocket.handleWebSocketRequestWith(request, greeter());
-                          else
-                              return JavaApiTestCases.handleRequest(request);
-                      }, ConnectHttp.toHost("localhost", 8080), materializer);
+                              if (request.getUri().path().equals("/"))
+                                  return WebSocket.handleWebSocketRequestWith(request, echoMessages());
+                              else if (request.getUri().path().equals("/greeter"))
+                                  return WebSocket.handleWebSocketRequestWith(request, greeter());
+                              else
+                                  return JavaApiTestCases.handleRequest(request);
+                          });
 
             serverBindingFuture.toCompletableFuture().get(1, TimeUnit.SECONDS); // will throw if binding fails
             System.out.println("Press ENTER to stop.");

--- a/akka-http-core/src/test/java/akka/http/javadsl/GracefulTerminationCompileTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/GracefulTerminationCompileTest.java
@@ -19,13 +19,12 @@ public class GracefulTerminationCompileTest {
 
     public static void main(String[] args) throws Exception {
         ActorSystem system = ActorSystem.create();
-        Materializer materializer = ActorMaterializer.create(system);
 
         Http http = Http.get(system);
 
         Function<HttpRequest, CompletionStage<HttpResponse>> handle =
                 (req) -> CompletableFuture.completedFuture(HttpResponse.create());
-        CompletionStage<ServerBinding> bound = http.bindAndHandleAsync(handle, ConnectHttp.toHost("127.0.0.1"), system);
+        CompletionStage<ServerBinding> bound = http.newServerAt("127.0.0.1", 0).bind(handle);
 
         ServerBinding serverBinding = bound.toCompletableFuture().get();
         CompletionStage<HttpTerminated> terminate = serverBinding.terminate(Duration.ofSeconds(1));

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
@@ -51,19 +51,13 @@ class ClientCancellationSpec extends AkkaSpecWithMaterializer {
 
   class TestSetup {
     lazy val binding = Await.result(
-      Http().bindAndHandleSync(
-        { _ => HttpResponse(headers = headers.Connection("close") :: Nil) },
-        "localhost", 0),
+      Http().newServerAt("localhost", 0).bindSync({ _ => HttpResponse(headers = headers.Connection("close") :: Nil) }),
       5.seconds
     )
     lazy val address = binding.localAddress
 
     lazy val bindingTls = Await.result(
-      Http().bindAndHandleSync(
-        { _ => HttpResponse() }, // TLS client does full-close, no need for the connection:close header
-        "localhost",
-        0,
-        connectionContext = ExampleHttpContexts.exampleServerContext),
+      Http().newServerAt("localhost", 0).enableHttps(ExampleHttpContexts.exampleServerContext).bindSync({ _ => HttpResponse() }),
       5.seconds
     )
     lazy val addressTls = bindingTls.localAddress

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -537,7 +537,7 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
 
     "route incoming requests to the right cached host connection pool" in new TestSetup(autoAccept = true) {
       val (serverHostName2, serverPort2) = SocketUtil.temporaryServerHostnameAndPort()
-      Http().bindAndHandleSync(testServerHandler(0), serverHostName2, serverPort2)
+      Http().newServerAt(serverHostName2, serverPort2).bindSync(testServerHandler(0))
 
       val (requestIn, responseOut, responseOutSub, _) = superPool[Int]()
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
@@ -19,9 +19,7 @@ class HighLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer {
   "The connection-level client implementation" should {
 
     "be able to handle 100 requests across one connection" in Utils.assertAllStagesStopped {
-      val binding = Http().bindAndHandleSync(
-        r => HttpResponse(entity = r.uri.toString.reverse.takeWhile(Character.isDigit).reverse),
-        "127.0.0.1", 0).futureValue
+      val binding = Http().newServerAt("127.0.0.1", 0).bindSync(r => HttpResponse(entity = r.uri.toString.reverse.takeWhile(Character.isDigit).reverse)).futureValue
 
       val N = 100
       val result = Source.fromIterator(() => Iterator.from(1))
@@ -36,9 +34,7 @@ class HighLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer {
     }
 
     "be able to handle 100 requests across 4 connections (client-flow is reusable)" in Utils.assertAllStagesStopped {
-      val binding = Http().bindAndHandleSync(
-        r => HttpResponse(entity = r.uri.toString.reverse.takeWhile(Character.isDigit).reverse),
-        "127.0.0.1", 0).futureValue
+      val binding = Http().newServerAt("127.0.0.1", 0).bindSync(r => HttpResponse(entity = r.uri.toString.reverse.takeWhile(Character.isDigit).reverse)).futureValue
 
       val connFlow = Http().outgoingConnection("127.0.0.1", binding.localAddress.getPort)
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -725,7 +725,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
 
   /** Transport that uses actual top-level Http APIs to establish a plaintext HTTP connection */
   case object AkkaHttpEngineTCP extends TopLevelApiClientServerImplementation {
-    protected override def bindServerSource = Http().bind("localhost", 0)
+    protected override def bindServerSource = Http().newServerAt("localhost", 0).bind()
     protected def clientConnectionFlow(serverBinding: ServerBinding, connectionKillSwitch: SharedKillSwitch): Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] = {
       val clientConnectionSettings = ClientConnectionSettings(system).withTransport(new KillSwitchedClientTransport(connectionKillSwitch))
       Http().outgoingConnectionUsingContext(host = "localhost", port = serverBinding.localAddress.getPort, connectionContext = ConnectionContext.noEncryption(), settings = clientConnectionSettings)
@@ -738,7 +738,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
    * Currently requires an /etc/hosts entry that points akka.example.org to a locally bindable address.
    */
   case object AkkaHttpEngineTLS extends TopLevelApiClientServerImplementation {
-    protected override def bindServerSource = Http().bind("akka.example.org", 0, connectionContext = ExampleHttpContexts.exampleServerContext)
+    protected override def bindServerSource = Http().newServerAt("akka.example.org", 0).enableHttps(ExampleHttpContexts.exampleServerContext).bind()
     protected def clientConnectionFlow(serverBinding: ServerBinding, connectionKillSwitch: SharedKillSwitch): Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] = {
       val clientConnectionSettings = ClientConnectionSettings(system).withTransport(new KillSwitchedClientTransport(connectionKillSwitch))
       Http().outgoingConnectionUsingContext(host = "akka.example.org", port = serverBinding.localAddress.getPort, connectionContext = ExampleHttpContexts.exampleClientContext, settings = clientConnectionSettings)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketIntegrationSpec.scala
@@ -35,9 +35,9 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
 
     "not reset the connection when no data are flowing" in Utils.assertAllStagesStopped {
       val source = TestPublisher.probe[Message]()
-      val bindingFuture = Http().bindAndHandleSync({
+      val bindingFuture = Http().newServerAt("localhost", 0).bindSync({
         _.attribute(webSocketUpgrade).get.handleMessages(Flow.fromSinkAndSource(Sink.ignore, Source.fromPublisher(source)), None)
-      }, interface = "localhost", port = 0)
+      })
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
       val myPort = binding.localAddress.getPort
 
@@ -62,9 +62,9 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
 
     "not reset the connection when no data are flowing and the connection is closed from the client" in Utils.assertAllStagesStopped {
       val source = TestPublisher.probe[Message]()
-      val bindingFuture = Http().bindAndHandleSync({
+      val bindingFuture = Http().newServerAt("localhost", 0).bindSync({
         _.attribute(webSocketUpgrade).get.handleMessages(Flow.fromSinkAndSource(Sink.ignore, Source.fromPublisher(source)), None)
-      }, interface = "localhost", port = 0)
+      })
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
       val myPort = binding.localAddress.getPort
 
@@ -121,9 +121,9 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
 
     "echo 100 elements and then shut down without error" in Utils.assertAllStagesStopped {
 
-      val bindingFuture = Http().bindAndHandleSync({
+      val bindingFuture = Http().newServerAt("localhost", 0).bindSync({
         _.attribute(webSocketUpgrade).get.handleMessages(Flow.apply, None)
-      }, interface = "localhost", port = 0)
+      })
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
       val myPort = binding.localAddress.getPort
 
@@ -160,9 +160,9 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
         FlowShape(mapMsgToInt.in, mapIntToMsg.out)
       })
 
-      val bindingFuture = Http().bindAndHandleSync({
+      val bindingFuture = Http().newServerAt("localhost", 0).bindSync({
         _.attribute(webSocketUpgrade).get.handleMessages(handler, None)
-      }, interface = "localhost", port = 0)
+      })
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
       val myPort = binding.localAddress.getPort
 
@@ -194,10 +194,7 @@ class WebSocketIntegrationSpec extends AkkaSpec("akka.stream.materializer.debug.
         .mapMaterializedValue(handlerTermination.completeWith(_))
         .map(m => TextMessage.Strict(s"Echo [$m]"))
 
-      val bindingFuture = Http().bindAndHandleSync(
-        _.attribute(webSocketUpgrade).get.handleMessages(handler, None),
-        interface = "localhost",
-        port = 0)
+      val bindingFuture = Http().newServerAt("localhost", 0).bindSync(_.attribute(webSocketUpgrade).get.handleMessages(handler, None))
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
       val myPort = binding.localAddress.getPort
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
@@ -33,7 +33,7 @@ class ClientSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
     "reuse connection pool" in {
       val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
-      val bindingFuture = Http().bindAndHandleSync(_ => HttpResponse(), hostname, port)
+      val bindingFuture = Http().newServerAt(hostname, port).bindSync(_ => HttpResponse())
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
 
       val respFuture = Http().singleRequest(HttpRequest(POST, s"http://$hostname:$port/"))

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
@@ -27,7 +27,7 @@ class ClientTransportWithCustomResolverSpec extends AkkaSpecWithMaterializer("ak
       val hostnameToFind = "some-name-out-there"
       val portToFind = 21345
       val (hostnameToUse, portToUse) = SocketUtil.temporaryServerHostnameAndPort()
-      val bindingFuture = Http().bindAndHandleSync(_ => HttpResponse(), hostnameToUse, portToUse)
+      val bindingFuture = Http().newServerAt(hostnameToUse, portToUse).bindSync(_ => HttpResponse())
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
 
       val otherHostAndPortTransport: ClientTransport = ClientTransport.withCustomResolver((host, port) => {
@@ -51,7 +51,7 @@ class ClientTransportWithCustomResolverSpec extends AkkaSpecWithMaterializer("ak
       val hostnameToFind = "some-name-out-there"
       val portToFind = 21345
       val (hostnameToUse, portToUse) = SocketUtil.temporaryServerHostnameAndPort()
-      val bindingFuture = Http().bindAndHandleSync(_ => HttpResponse(), hostnameToUse, portToUse)
+      val bindingFuture = Http().newServerAt(hostnameToUse, portToUse).bindSync(_ => HttpResponse())
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
 
       val resolverCalled = Promise[Done]()

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -322,10 +322,9 @@ class GracefulTerminationSpec
       }
     }
 
-    val routes: Flow[HttpRequest, HttpResponse, Any] = Flow[HttpRequest].mapAsync(1)(handler)
+    val handlerFlow: Flow[HttpRequest, HttpResponse, Any] = Flow[HttpRequest].mapAsync(1)(handler)
     val serverBinding =
-      Http()
-        .bindAndHandle(routes, "localhost", 0, connectionContext = serverConnectionContext, settings = serverSettings)
+      Http().newServerAt("localhost", 0).enableHttps(serverConnectionContext).withSettings(serverSettings).bindFlow(handlerFlow)
         .futureValue
 
     def basePoolSettings = ConnectionPoolSettings(system)

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
@@ -38,7 +38,7 @@ object TestServer extends App {
     .withInputBuffer(128, 128)
   implicit val fm = ActorMaterializer(settings)
   try {
-    val binding = Http().bindAndHandleSync({
+    val binding = Http().newServerAt("localhost", 9001).bindSync {
       case req @ HttpRequest(GET, Uri.Path("/"), _, _, _) =>
         req.attribute(webSocketUpgrade) match {
           case Some(upgrade) => upgrade.handleMessages(echoWebSocketService) // needed for running the autobahn test suite
@@ -52,7 +52,7 @@ object TestServer extends App {
           case None          => HttpResponse(400, entity = "Not a valid websocket request!")
         }
       case _: HttpRequest => HttpResponse(404, entity = "Unknown resource!")
-    }, interface = "localhost", port = 9001)
+    }
 
     Await.result(binding, 1.second) // throws if binding fails
     println("Server online at http://localhost:9001")

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
@@ -36,7 +36,7 @@ class TightRequestTimeoutSpec extends AnyWordSpec with Matchers with BeforeAndAf
 
     "not cause double push error caused by the late response attempting to push" in {
       val slowHandler = Flow[HttpRequest].map(_ => HttpResponse()).delay(500.millis.dilated, OverflowStrategy.backpressure)
-      val binding = Http().bindAndHandle(slowHandler, "localhost", 0).futureValue
+      val binding = Http().newServerAt("localhost", 0).bindFlow(slowHandler).futureValue
       val (hostname, port) = (binding.localAddress.getHostString, binding.localAddress.getPort)
 
       val p = TestProbe()

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
@@ -55,11 +55,9 @@ class EntityDiscardingSpec extends AkkaSpecWithMaterializer {
     // TODO likely this is going to inter-op with the auto-draining as described in #18716
     "should not allow draining a second time" in {
       val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
-      val bound = Http().bindAndHandleSync(
-        req =>
-          HttpResponse(entity = HttpEntity(
-            ContentTypes.`text/csv(UTF-8)`, Source.fromIterator[ByteString](() => testData.iterator))),
-        host, port).futureValue
+      val bound = Http().newServerAt(host, port).bindSync(req =>
+        HttpResponse(entity = HttpEntity(
+          ContentTypes.`text/csv(UTF-8)`, Source.fromIterator[ByteString](() => testData.iterator)))).futureValue
 
       try {
 

--- a/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
@@ -40,22 +40,20 @@ public class HttpAPIsTest extends JUnitRouteTest {
     ConnectionPoolSettings conSettings = null;
     LoggingAdapter log = null;
 
-    http.bind(toHost("127.0.0.1", 8080) );
-    http.bind(toHost("127.0.0.1", 8080));
-    http.bind(toHostHttps("127.0.0.1", 8080));
+    http.newServerAt("127.0.0.1", 8080).bind();
+    http.newServerAt("127.0.0.1", 8080).enableHttps(httpsContext).bind();
 
     final Flow<HttpRequest, HttpResponse, ?> handler = null;
-    http.bindAndHandle(handler, toHost("127.0.0.1", 8080), system());
-    http.bindAndHandle(handler, toHost("127.0.0.1", 8080), system());
-    http.bindAndHandle(handler, toHostHttps("127.0.0.1", 8080).withCustomHttpsContext(httpsContext), system());
+    http.newServerAt("127.0.0.1", 8080).bindFlow(handler);
+    http.newServerAt("127.0.0.1", 8080).enableHttps(httpsContext).bindFlow(handler);
 
     final Function<HttpRequest, CompletionStage<HttpResponse>> handler1 = null;
-    http.bindAndHandleAsync(handler1, toHost("127.0.0.1", 8080), system());
-    http.bindAndHandleAsync(handler1, toHostHttps("127.0.0.1", 8080), system());
+    http.newServerAt("127.0.0.1", 8080).bind(handler1);
+    http.newServerAt("127.0.0.1", 8080).enableHttps(httpsContext).bind(handler1);
 
     final Function<HttpRequest, HttpResponse> handler2 = null;
-    http.bindAndHandleSync(handler2, toHost("127.0.0.1", 8080), system());
-    http.bindAndHandleSync(handler2, toHostHttps("127.0.0.1", 8080), system());
+    http.newServerAt("127.0.0.1", 8080).bindSync(handler2);
+    http.newServerAt("127.0.0.1", 8080).enableHttps(httpsContext).bindSync(handler2);
 
     final HttpRequest handler3 = null;
     http.singleRequest(handler3);

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -57,7 +57,7 @@ class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
       val routes = extractRequest { r =>
         complete(r.entity.contentType.toString + " = " + r.entity.contentType.getClass)
       }
-      Http().bindAndHandle(routes, host, port, settings = serverSettings)
+      Http().newServerAt(host, port).withSettings(serverSettings).bind(routes)
       //#application-custom
 
       val request = Get(s"http://$host:$port/").withEntity(HttpEntity(`application/custom`, "~~example~=~value~~"))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
@@ -34,7 +34,7 @@ class CustomStatusCodesSpec extends AkkaSpecWithMaterializer with ScalaFutures
         complete(HttpResponse(status = LeetCode))
 
       // use serverSettings in server:
-      val binding = Http().bindAndHandle(routes, "127.0.0.1", 0, settings = serverSettings).futureValue
+      val binding = Http().newServerAt("127.0.0.1", 0).withSettings(serverSettings).bind(routes).futureValue
 
       // use clientSettings in client:
       val request = HttpRequest(uri = s"http://127.0.0.1:${binding.localAddress.getPort}/")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -57,7 +57,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().newServerAt("localhost", port = 0).bind(route).futureValue
 
     "accept small POST requests" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength)))
@@ -81,7 +81,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().newServerAt("localhost", port = 0).bind(route).futureValue
 
     "accept a small request" in {
       val response = Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength))).futureValue
@@ -119,7 +119,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().newServerAt("localhost", port = 0).bind(route).futureValue
 
     "reject a small request that decodes into a large chunked entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
@@ -141,7 +141,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().newServerAt("localhost", port = 0).bind(route).futureValue
 
     "reject a small request that decodes into a large non-chunked streaming entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
@@ -163,7 +163,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().newServerAt("localhost", port = 0).bind(route).futureValue
 
     "accept a small request" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength)))
@@ -216,7 +216,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().newServerAt("localhost", port = 0).bind(route).futureValue
 
     "accept entities bigger than configured with akka.http.parsing.max-content-length" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/withoutSizeLimit", entityOfSize(maxContentLength + 1)))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -95,7 +95,7 @@ object TestServer extends App {
   }
   // format: ON
 
-  val bindingFuture = Http().bindAndHandle(routes, interface = "0.0.0.0", port = 8080)
+  val bindingFuture = Http().newServerAt(interface = "0.0.0.0", port = 8080).bind(routes)
 
   println(s"Server online at http://0.0.0.0:8080/\nPress RETURN to stop...")
   StdIn.readLine()

--- a/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/3362-java-ServerBuilder.excludes
+++ b/akka-http/src/main/mima-filters/10.1.x.backwards.excludes/3362-java-ServerBuilder.excludes
@@ -1,0 +1,3 @@
+# New method in @DoNotInherit class
+ProblemFilters.exclude[Problem]("akka.http.javadsl.server.Route.handler")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.http.javadsl.server.Route.handler")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -10,6 +10,7 @@ import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.actor.ClassicActorSystemProvider
 import akka.annotation.{ DoNotInherit, InternalApi }
+import akka.http.javadsl.HandlerProvider
 import akka.http.javadsl.model.HttpRequest
 import akka.http.javadsl.model.HttpResponse
 import akka.http.scaladsl
@@ -40,7 +41,7 @@ import akka.japi.function.Function
  * is the actual String that was given as method argument.
  */
 @DoNotInherit
-trait Route {
+trait Route extends HandlerProvider {
 
   /** Converts to the Scala DSL form of an Route. */
   def asScala: server.Route = delegate
@@ -54,7 +55,8 @@ trait Route {
   def flow(system: ClassicActorSystemProvider): Flow[HttpRequest, HttpResponse, NotUsed] =
     flow(system.classicSystem, SystemMaterializer(system).materializer)
 
-  def function(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]]
+  def function(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]] = handler(system)
+  def handler(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]]
 
   /**
    * Seals a route by wrapping it with default exception handling and rejection conversion.

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -26,7 +26,7 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
   override def flow(system: ActorSystem, materializer: Materializer): javadsl.Flow[HttpRequest, HttpResponse, NotUsed] =
     scalaFlow(system, materializer).asJava
 
-  override def function(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]] = {
+  override def handler(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]] = {
     import scala.compat.java8.FutureConverters.toJava
     import akka.http.impl.util.JavaMapping._
     val scalaFunction = scaladsl.server.Route.toFunction(delegate)(system)

--- a/akka-http2-support/src/test/java/akka/http/javadsl/Http2JavaServerTest.java
+++ b/akka-http2-support/src/test/java/akka/http/javadsl/Http2JavaServerTest.java
@@ -38,11 +38,9 @@ public class Http2JavaServerTest {
 
     HttpsConnectionContext httpsConnectionContext = ExampleHttpContexts.getExampleServerContext();
 
-    Http.get(system).bindAndHandleAsync(
-      handler,
-      ConnectWithHttps.toHostHttps("localhost", 9001)
-        .withCustomHttpsContext(httpsConnectionContext),
-      system);
+    Http.get(system).newServerAt("localhost", 9001)
+        .enableHttps(httpsConnectionContext)
+        .bind(handler);
 
     // TODO what about unencrypted http2?
   }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
@@ -117,7 +117,7 @@ class Http2ClientServerSpec extends AkkaSpecWithMaterializer(
       p.future
     }
     lazy val binding =
-      Http().bindAndHandleAsync(handler, "localhost", 0, connectionContext = ExampleHttpContexts.exampleServerContext).futureValue
+      Http().newServerAt("localhost", 0).enableHttps(ExampleHttpContexts.exampleServerContext).bind(handler).futureValue
 
     // FIXME: use public API
     lazy val clientFlow = {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/WithPriorKnowledgeSpec.scala
@@ -21,11 +21,7 @@ class WithPriorKnowledgeSpec extends AkkaSpecWithMaterializer("""
   """) {
 
   "An HTTP server with PriorKnowledge" should {
-    val binding = Http().bindAndHandleAsync(
-      _ => Future.successful(HttpResponse(status = StatusCodes.ImATeapot)),
-      "127.0.0.1",
-      port = 0
-    ).futureValue
+    val binding = Http().newServerAt("127.0.0.1", 0).bind(_ => Future.successful(HttpResponse(status = StatusCodes.ImATeapot))).futureValue
 
     "respond to cleartext HTTP/1.1 requests with cleartext HTTP/1.1" in {
       val (host, port) = (binding.localAddress.getHostName, binding.localAddress.getPort)

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
@@ -40,9 +40,10 @@ class Http2BindingViaConfigSpec extends AkkaSpec("""
         system.eventStream.subscribe(p.ref, classOf[Logging.Debug])
 
         val connectionContext = ExampleHttpContexts.exampleServerContext
-        binding = Http().bindAndHandleAsync(
-          helloWorldHandler,
-          host, port, connectionContext)
+        binding =
+          Http().newServerAt(host, port)
+            .enableHttps(connectionContext)
+            .bind(helloWorldHandler)
 
         // TODO we currently don't verify it really bound as h2, since we don't have a client lib
         fishForDebugMessage(p, "Binding server using HTTP/2")

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2ServerTest.scala
@@ -72,8 +72,8 @@ object Http2ServerTest extends App {
   try {
     val bindings =
       for {
-        httpsBinding <- Http().bindAndHandleAsync(asyncHandler, interface = "localhost", port = 9000, ExampleHttpContexts.exampleServerContext)
-        plainBinding <- Http().bindAndHandleAsync(asyncHandler, interface = "localhost", port = 9002, HttpConnectionContext())
+        httpsBinding <- Http().newServerAt(interface = "localhost", port = 9000).enableHttps(ExampleHttpContexts.exampleServerContext).bind(asyncHandler)
+        plainBinding <- Http().newServerAt(interface = "localhost", port = 9002).bind(asyncHandler)
       } yield (httpsBinding, plainBinding)
 
     Await.result(bindings, 1.second) // throws if binding fails

--- a/docs/src/test/java/docs/http/javadsl/CustomMediaTypesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/CustomMediaTypesExampleTest.java
@@ -60,12 +60,11 @@ public class CustomMediaTypesExampleTest extends JUnitRouteTest {
         + req.entity().getContentType().getClass())
     );
 
-    final CompletionStage<ServerBinding> binding = Http.get(system)
-      .bindAndHandle(route.flow(system),
-        ConnectHttp.toHost(host, 0),
-        serverSettings,
-        system.log(),
-        system);
+    final CompletionStage<ServerBinding> binding =
+      Http.get(system)
+        .newServerAt(host, 0)
+        .withSettings(serverSettings)
+        .bind(route);
 
     //#application-custom-java
     final ServerBinding serverBinding = binding.toCompletableFuture().get();

--- a/docs/src/test/java/docs/http/javadsl/Http2Test.java
+++ b/docs/src/test/java/docs/http/javadsl/Http2Test.java
@@ -35,18 +35,15 @@ class Http2Test {
 
     //#bindAndHandleSecure
     Http.get(system)
-      .bindAndHandleAsync(
-        asyncHandler,
-        toHostHttps("127.0.0.1", 8443).withCustomHttpsContext(httpsConnectionContext),
-        system);
+      .newServerAt("127.0.0.1", 8443)
+      .enableHttps(httpsConnectionContext)
+      .bind(asyncHandler);
     //#bindAndHandleSecure
 
     //#bindAndHandlePlain
     Http.get(system)
-      .bindAndHandleAsync(
-        asyncHandler,
-        toHost("127.0.0.1", 8080),
-        system);
+      .newServerAt("127.0.0.1", 8443)
+      .bind(asyncHandler);
     //#bindAndHandlePlain
   }
 }

--- a/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerActorInteractionExample.java
@@ -47,9 +47,9 @@ public class HttpServerActorInteractionExample extends AllDirectives {
     //In order to access all directives we need an instance where the routes are define.
     HttpServerActorInteractionExample app = new HttpServerActorInteractionExample(system);
 
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system);
-    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
-      ConnectHttp.toHost("localhost", 8080), system);
+    final CompletionStage<ServerBinding> binding =
+      http.newServerAt("localhost", 8080)
+        .bind(app.createRoute());
 
     System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
     System.in.read(); // let it run until user presses return

--- a/docs/src/test/java/docs/http/javadsl/HttpServerDynamicRoutingExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerDynamicRoutingExampleTest.java
@@ -4,18 +4,12 @@
 
 package docs.http.javadsl;
 
-import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.marshallers.jackson.Jackson;
-import akka.http.javadsl.model.HttpRequest;
-import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
-import akka.stream.javadsl.Flow;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -31,14 +25,13 @@ public class HttpServerDynamicRoutingExampleTest extends AllDirectives {
     ActorSystem system = ActorSystem.create("routes");
 
     final Http http = Http.get(system);
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
     //In order to access all directives we need an instance where the routes are define.
     HttpServerDynamicRoutingExampleTest app = new HttpServerDynamicRoutingExampleTest();
 
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
-
-    http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
+    http
+      .newServerAt("localhost", 8080)
+      .bind(app.createRoute());
   }
 
   //#dynamic-routing-example

--- a/docs/src/test/java/docs/http/javadsl/HttpServerLowLevelExample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerLowLevelExample.java
@@ -25,7 +25,7 @@ public class HttpServerLowLevelExample {
 
     try {
       CompletionStage<ServerBinding> serverBindingFuture =
-        Http.get(system).bindAndHandleSync(
+        Http.get(system).newServerAt("localhost", 8080).bindSync(
           request -> {
             if (request.getUri().path().equals("/"))
               return HttpResponse.create().withEntity(ContentTypes.TEXT_HTML_UTF8,
@@ -38,7 +38,7 @@ public class HttpServerLowLevelExample {
               request.discardEntityBytes(system);
               return HttpResponse.create().withStatus(StatusCodes.NOT_FOUND).withEntity("Unknown resource!");
             }
-          }, ConnectHttp.toHost("localhost", 8080), system);
+          });
 
       System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
       System.in.read(); // let it run until user presses return

--- a/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
@@ -4,18 +4,12 @@
 
 package docs.http.javadsl;
 //#minimal-routing-example
-import akka.NotUsed;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.javadsl.Behaviors;
-import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
-import akka.http.javadsl.model.HttpRequest;
-import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
-import akka.stream.javadsl.Flow;
 
 import java.util.concurrent.CompletionStage;
 
@@ -30,9 +24,9 @@ public class HttpServerMinimalExampleTest extends AllDirectives {
     //In order to access all directives we need an instance where the routes are define.
     HttpServerMinimalExampleTest app = new HttpServerMinimalExampleTest();
 
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system);
-    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
-        ConnectHttp.toHost("localhost", 8080), system);
+    final CompletionStage<ServerBinding> binding =
+      http.newServerAt("localhost", 8080)
+          .bind(app.createRoute());
 
     System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
     System.in.read(); // let it run until user presses return

--- a/docs/src/test/java/docs/http/javadsl/HttpServerStreamRandomNumbersTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerStreamRandomNumbersTest.java
@@ -33,9 +33,9 @@ public class HttpServerStreamRandomNumbersTest extends AllDirectives {
     //In order to access all directives we need an instance where the routes are define.
     HttpServerStreamRandomNumbersTest app = new HttpServerStreamRandomNumbersTest();
 
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system);
-    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
-        ConnectHttp.toHost("localhost", 8080), system);
+    final CompletionStage<ServerBinding> binding =
+        http.newServerAt("localhost", 8080)
+                .bind(app.createRoute());
 
     System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
     System.in.read(); // let it run until user presses return

--- a/docs/src/test/java/docs/http/javadsl/HttpServerWithActorsSample.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerWithActorsSample.java
@@ -12,17 +12,16 @@ package docs.http.javadsl;
 // curl localhost:8080/jobs/42
 
 //#bootstrap
+
 import akka.actor.typed.ActorRef;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.Behavior;
 import akka.actor.typed.PostStop;
 import akka.actor.typed.javadsl.BehaviorBuilder;
 import akka.actor.typed.javadsl.Behaviors;
-import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.server.Route;
-import akka.stream.SystemMaterializer;
 
 import java.util.concurrent.CompletionStage;
 
@@ -55,11 +54,10 @@ public class HttpServerWithActorsSample {
       Route routes = new JobRoutes(buildJobRepository, ctx.getSystem()).jobRoutes();
 
       CompletionStage<ServerBinding> serverBinding =
-              Http.get(ctx.getSystem()).bindAndHandle(
-                      routes.flow(ctx.getSystem()),
-                      ConnectHttp.toHost(host, port),
-                      SystemMaterializer.get(system).materializer()
-              );
+              Http.get(system)
+                .newServerAt(host, port)
+                .bind(routes);
+
       ctx.pipeToSelf(serverBinding, (binding, failure) -> {
         if (binding != null) return new Started(binding);
         else return new StartFailed(failure);

--- a/docs/src/test/java/docs/http/javadsl/JacksonExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/JacksonExampleTest.java
@@ -39,9 +39,9 @@ public class JacksonExampleTest extends AllDirectives {
     //In order to access all directives we need an instance where the routes are define.
     JacksonExampleTest app = new JacksonExampleTest();
 
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system);
-    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
-      ConnectHttp.toHost("localhost", 8080), system);
+    final CompletionStage<ServerBinding> binding =
+        http.newServerAt("localhost", 8080)
+            .bind(app.createRoute());
 
     System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
     System.in.read(); // let it run until user presses return

--- a/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
@@ -59,12 +59,11 @@ public class WebSocketCoreExample {
     ActorSystem system = ActorSystem.create();
 
     try {
-      final Materializer materializer = ActorMaterializer.create(system);
-
       final Function<HttpRequest, HttpResponse> handler = request -> handleRequest(request);
       CompletionStage<ServerBinding> serverBindingFuture =
-        Http.get(system).bindAndHandleSync(
-          handler, ConnectHttp.toHost("localhost", 8080), system);
+          Http.get(system)
+              .newServerAt("localhost", 8080)
+              .bindSync(handler);
 
       // will throw if binding fails
       serverBindingFuture.toCompletableFuture().get(1, TimeUnit.SECONDS);
@@ -113,7 +112,6 @@ public class WebSocketCoreExample {
 
   {
     ActorSystem system = null;
-    ActorMaterializer materializer = null;
     Flow<HttpRequest, HttpResponse, NotUsed> handler = null;
     //#websocket-ping-payload-server
     ServerSettings defaultSettings = ServerSettings.create(system);
@@ -129,11 +127,9 @@ public class WebSocketCoreExample {
     ServerSettings customServerSettings = defaultSettings.withWebsocketSettings(customWebsocketSettings);
 
     Http http = Http.get(system);
-    http.bindAndHandle(handler,
-        ConnectHttp.toHost("127.0.0.1"),
-        customServerSettings, // pass the configuration
-        system.log(),
-        materializer);
+    http.newServerAt("127.0.0.1", 8080)
+        .withSettings(customServerSettings)
+        .bindFlow(handler);
     //#websocket-ping-payload-server
   }
 

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CustomHttpMethodExamplesTest.java
@@ -60,15 +60,12 @@ public class CustomHttpMethodExamplesTest extends JUnitRouteTest {
         complete( "This is a " + method.name() + " request.")
       )
     );
-    final Flow<HttpRequest, HttpResponse, NotUsed> handler = routes.flow(system);
     final Http http = Http.get(system);
     final CompletionStage<ServerBinding> binding =
-      http.bindAndHandle(
-        handler,
-        ConnectHttp.toHost(host, port),
-        serverSettings,
-        loggingAdapter,
-        system);
+      http.newServerAt(host, port)
+          .withSettings(serverSettings)
+          .logTo(loggingAdapter)
+          .bind(routes);
 
     HttpRequest request = HttpRequest.create()
       .withUri("http://" + host + ":" + Integer.toString(port))

--- a/docs/src/test/java/docs/http/javadsl/server/directives/JsonStreamingFullExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/JsonStreamingFullExample.java
@@ -7,15 +7,12 @@ package docs.http.javadsl.server.directives;
 //#custom-content-type
 import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.common.EntityStreamingSupport;
 import akka.http.javadsl.marshalling.Marshaller;
 import akka.http.javadsl.model.*;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
-import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Source;
 
 import java.util.Random;
@@ -70,10 +67,8 @@ public class JsonStreamingFullExample extends AllDirectives {
         ActorSystem system = ActorSystem.create();
         final JsonStreamingFullExample app = new JsonStreamingFullExample();
         final Http http = Http.get(system);
-        final ActorMaterializer materializer = ActorMaterializer.create(system);
 
-        final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
-        http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
+        http.newServerAt("localhost", 8080).bind(app.createRoute());
     }
 }
 //#custom-content-type

--- a/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
@@ -36,11 +36,7 @@ object Http2Spec {
     val httpsServerContext: HttpsConnectionContext = ExampleHttpContexts.exampleServerContext
 
     //#bindAndHandleSecure
-    Http().bindAndHandleAsync(
-      asyncHandler,
-      interface = "localhost",
-      port = 8443,
-      httpsServerContext)
+    Http().newServerAt(interface = "localhost", port = 8443).enableHttps(httpsServerContext).bind(asyncHandler)
     //#bindAndHandleSecure
   }
 
@@ -51,11 +47,7 @@ object Http2Spec {
     val handler: HttpRequest => Future[HttpResponse] =
       Route.toFunction(complete(StatusCodes.ImATeapot))
     //#bindAndHandlePlain
-    Http().bindAndHandleAsync(
-      handler,
-      interface = "localhost",
-      port = 8080,
-      connectionContext = HttpConnectionContext())
+    Http().newServerAt("localhost", 8080).bind(handler)
     //#bindAndHandlePlain
   }
 }

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerBindingFailure.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerBindingFailure.scala
@@ -24,7 +24,7 @@ object HttpServerBindingFailure {
     // let's say the OS won't allow us to bind to 80.
     val (host, port) = ("localhost", 80)
     val bindingFuture: Future[ServerBinding] =
-      Http().bindAndHandle(handler, host, port)
+      Http().newServerAt(host, port).bindFlow(handler)
 
     bindingFuture.failed.foreach { ex =>
       system.log.error(ex, "Failed to bind to {}:{}!", host, port)

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -33,7 +33,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     implicit val executionContext = system.dispatcher
 
     val serverSource: Source[Http.IncomingConnection, Future[Http.ServerBinding]] =
-      Http().bind(interface = "localhost", port = 8080)
+      Http().newServerAt("localhost", 8080).bind()
     val bindingFuture: Future[Http.ServerBinding] =
       serverSource.to(Sink.foreach { connection => // foreach materializes the source
         println("Accepted new connection from " + connection.remoteAddress)
@@ -62,7 +62,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
 
     // let's say the OS won't allow us to bind to 80.
     val (host, port) = ("localhost", 80)
-    val serverSource = Http().bind(host, port)
+    val serverSource = Http().newServerAt(host, port).bind()
 
     val bindingFuture: Future[ServerBinding] = serverSource
       .to(handleConnections) // Sink[Http.IncomingConnection, _]
@@ -90,7 +90,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
 
     import Http._
     val (host, port) = ("localhost", 8080)
-    val serverSource = Http().bind(host, port)
+    val serverSource = Http().newServerAt(host, port).bind()
 
     val failureMonitor: ActorRef = system.actorOf(MyExampleMonitoringActor.props)
 
@@ -117,7 +117,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     implicit val executionContext = system.dispatcher
 
     val (host, port) = ("localhost", 8080)
-    val serverSource = Http().bind(host, port)
+    val serverSource = Http().newServerAt(host, port).bind()
 
     val reactToConnectionFailure = Flow[HttpRequest]
       .recover[HttpRequest] {
@@ -151,7 +151,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     implicit val system = ActorSystem()
     implicit val executionContext = system.dispatcher
 
-    val serverSource = Http().bind(interface = "localhost", port = 8080)
+    val serverSource = Http().newServerAt("localhost", 8080).bind()
 
     val requestHandler: HttpRequest => HttpResponse = {
       case HttpRequest(GET, Uri.Path("/"), _, _, _) =>
@@ -464,7 +464,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     }
 
     val binding: Future[Http.ServerBinding] =
-      Http().bindAndHandle(routes, "127.0.0.1", 8080)
+      Http().newServerAt("127.0.0.1", 8080).bind(routes)
 
     // ...
     // once ready to terminate the server, invoke terminate:

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerHighLevel.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerHighLevel.scala
@@ -32,7 +32,7 @@ object HttpServerHighLevel {
       }
 
     // `route` will be implicitly converted to `Flow` using `RouteResult.route2HandlerFlow`
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerLowLevel.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerLowLevel.scala
@@ -37,7 +37,7 @@ object HttpServerLowLevel {
         HttpResponse(404, entity = "Unknown resource!")
     }
 
-    val bindingFuture = Http().bindAndHandleSync(requestHandler, "localhost", 8080)
+    val bindingFuture = Http().newServerAt("localhost", 8080).bindSync(requestHandler)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerRoutingMinimal.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerRoutingMinimal.scala
@@ -26,7 +26,7 @@ object HttpServerRoutingMinimal {
         }
       }
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
 
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerStreamingRandomNumbers.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerStreamingRandomNumbers.scala
@@ -40,7 +40,7 @@ object HttpServerStreamingRandomNumbers {
         }
       }
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorInteraction.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorInteraction.scala
@@ -75,7 +75,7 @@ object HttpServerWithActorInteraction {
         )
       }
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorsSample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorsSample.scala
@@ -158,7 +158,7 @@ object HttpServerWithActorsSample {
       val routes = new JobRoutes(buildJobRepository)
 
       val serverBinding: Future[Http.ServerBinding] =
-        Http.apply().bindAndHandle(routes.theJobRoutes, host, port)
+        Http().newServerAt(host, port).bind(routes.theJobRoutes)
       ctx.pipeToSelf(serverBinding) {
         case Success(binding) => Started(binding)
         case Failure(ex)      => StartFailed(ex)

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExample2.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExample2.scala
@@ -76,7 +76,7 @@ object SprayJsonExample2 {
         }
       )
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture

--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -39,7 +39,7 @@ object MyExplicitExceptionHandler {
         null // #hide
       }
 
-    Http().bindAndHandle(route, "localhost", 8080)
+    Http().newServerAt("localhost", 8080).bind(route)
   }
 
   //#explicit-handler-example
@@ -72,7 +72,7 @@ object MyImplicitExceptionHandler {
     // ... some route structure
       null // #hide
 
-    Http().bindAndHandle(route, "localhost", 8080)
+    Http().newServerAt("localhost", 8080).bind(route)
   }
 
   //#implicit-handler-example
@@ -152,7 +152,7 @@ object RespondWithHeaderExceptionHandlerExample {
   object MyApp extends App {
     implicit val system = ActorSystem()
 
-    Http().bindAndHandle(route, "localhost", 8080)
+    Http().newServerAt("localhost", 8080).bind(route)
   }
   //#respond-with-header-exceptionhandler-example
 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -61,22 +61,22 @@ abstract class HttpsServerExampleSpec extends AnyWordSpec with Matchers
     //#both-https-and-http
     // you can run both HTTP and HTTPS in the same application as follows:
     val commonRoutes: Route = get { complete("Hello world!") }
-    Http().bindAndHandle(commonRoutes, "127.0.0.1", 443, connectionContext = https)
-    Http().bindAndHandle(commonRoutes, "127.0.0.1", 80)
+    Http().newServerAt("127.0.0.1", 443).enableHttps(https).bindFlow(commonRoutes)
+    Http().newServerAt("127.0.0.1", 80).bindFlow(commonRoutes)
     //#both-https-and-http
 
     //#bind-low-level-context
-    Http().bind("127.0.0.1", connectionContext = https)
+    Http().newServerAt("127.0.0.1", 0).enableHttps(https).bind()
 
     // or using the high level routing DSL:
     val routes: Route = get { complete("Hello world!") }
-    Http().bindAndHandle(routes, "127.0.0.1", 8080, connectionContext = https)
+    Http().newServerAt("127.0.0.1", 8080).enableHttps(https).bind(routes)
     //#bind-low-level-context
 
     //#set-low-level-context-default
     // sets default context to HTTPS – all Http() bound servers for this ActorSystem will use HTTPS from now on
     Http().setDefaultServerHttpContext(https)
-    Http().bindAndHandle(routes, "127.0.0.1", 9090, connectionContext = https)
+    Http().newServerAt("127.0.0.1", 9090).enableHttps(https).bind(routes)
     //#set-low-level-context-default
 
     system.terminate()

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -47,7 +47,7 @@ object MyRejectionHandler {
       // ... some route structure
       null // #hide
 
-    Http().bindAndHandle(route, "localhost", 8080)
+    Http().newServerAt("localhost", 8080).bind(route)
   }
   //#custom-handler-example
 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/ServerShutdownExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ServerShutdownExampleSpec.scala
@@ -27,8 +27,7 @@ class ServerShutdownExampleSpec extends AnyWordSpec with Matchers
     val routes: Route = ???
 
     // #suggested
-    val bindingFuture = Http()
-      .bindAndHandle(handler = routes, interface = "localhost", port = 8080)
+    val bindingFuture = Http().newServerAt("localhost", 8080).bind(routes)
       .map(_.addToCoordinatedShutdown(hardTerminationDeadline = 10.seconds))
     // #suggested
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
@@ -64,7 +64,7 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
     //#websocket-request-handling
 
     val bindingFuture =
-      Http().bindAndHandleSync(requestHandler, interface = "localhost", port = 8080)
+      Http().newServerAt("localhost", 8080).bindSync(requestHandler)
 
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine()
@@ -104,7 +104,7 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
       }
     //#websocket-routing
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().newServerAt("localhost", port = 8080).bind(route)
 
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine()
@@ -122,14 +122,10 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
     val defaultSettings = ServerSettings(system)
 
     val pingCounter = new AtomicInteger()
-    val customWebsocketSettings =
-      defaultSettings.websocketSettings
-        .withPeriodicKeepAliveData(() => ByteString(s"debug-${pingCounter.incrementAndGet()}"))
 
-    val customServerSettings =
-      defaultSettings.withWebsocketSettings(customWebsocketSettings)
-
-    Http().bindAndHandle(route, "127.0.0.1", settings = customServerSettings)
+    Http().newServerAt("127.0.0.1", 0)
+      .adaptSettings(_.mapWebsocketSettings(_.withPeriodicKeepAliveData(() => ByteString(s"debug-${pingCounter.incrementAndGet()}"))))
+      .bind(route)
     //#websocket-ping-payload-server
   }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
@@ -36,7 +36,7 @@ class CustomHttpMethodSpec extends AkkaSpec with ScalaFutures
       val routes = extractMethod { method =>
         complete(s"This is a ${method.name} method request.")
       }
-      val binding = Http().bindAndHandle(routes, host, port, settings = serverSettings)
+      val binding = Http().newServerAt(host, port).withSettings(serverSettings).bind(routes)
 
       val request = HttpRequest(BOLT, s"http://$host:$port/", protocol = `HTTP/1.1`)
       //#application-custom

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
@@ -66,7 +66,7 @@ class JsonStreamingFullExamples extends AnyWordSpec {
         }
       }
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
 
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine()


### PR DESCRIPTION
The Javadsl-side of the Http entrypoints was always a bit unpolished. Especially the need to create a `ConnectHttp.toHost` to bind a server seemed quite wild.

In the process of finding simpler ways to bind servers on the Java-side, I created a little fluent builder to ease the creation of server and find something against the sprouting variety of overloads in javadsl.Http over time.