### PR TITLE
core: introduce bindServer as an alias for bindAndHandleAsync

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -322,10 +322,9 @@ class GracefulTerminationSpec
       }
     }
 
-    val routes: Flow[HttpRequest, HttpResponse, Any] = Flow[HttpRequest].mapAsync(1)(handler)
     val serverBinding =
       Http()
-        .bindAndHandle(routes, "localhost", 0, connectionContext = serverConnectionContext, settings = serverSettings)
+        .bindServer(handler, interface = "localhost", port = 0, parallelism = 1, connectionContext = serverConnectionContext, settings = serverSettings)
         .futureValue
 
     def basePoolSettings = ConnectionPoolSettings(system)

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -201,7 +201,7 @@ private[http] object RouteTest {
   def runRouteClientServer(request: HttpRequest, route: Route, serverSettings: ServerSettings)(implicit system: ActorSystem): Future[HttpResponse] = {
     import system.dispatcher
     for {
-      binding <- Http().bindAndHandle(route, "127.0.0.1", 0, settings = serverSettings)
+      binding <- Http().bindServer(route, "127.0.0.1", 0, settings = serverSettings)
       port = binding.localAddress.getPort
       targetUri = request.uri.withHost("127.0.0.1").withPort(port).withScheme("http")
 

--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -178,7 +178,7 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
         runOn(server) {
           val (_, port) = SocketUtil.temporaryServerHostnameAndPort()
           info(s"Binding Akka HTTP Server to port: $port @ ${myself}")
-          val futureBinding = Http().bindAndHandle(routes, "0.0.0.0", port)
+          val futureBinding = Http().bindServer(routes, "0.0.0.0", port)
 
           _binding = Some(futureBinding.futureValue)
           setServerPort(port)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -57,7 +57,7 @@ class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
       val routes = extractRequest { r =>
         complete(r.entity.contentType.toString + " = " + r.entity.contentType.getClass)
       }
-      Http().bindAndHandle(routes, host, port, settings = serverSettings)
+      Http().bindServer(routes, host, port, settings = serverSettings)
       //#application-custom
 
       val request = Get(s"http://$host:$port/").withEntity(HttpEntity(`application/custom`, "~~example~=~value~~"))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
@@ -41,7 +41,7 @@ class CustomStatusCodesSpec extends AkkaSpec with ScalaFutures
         complete(HttpResponse(status = LeetCode))
 
       // use serverSettings in server:
-      val binding = Http().bindAndHandle(routes, host, port, settings = serverSettings)
+      val binding = Http().bindServer(routes, host, port, settings = serverSettings)
 
       // use clientSettings in client:
       val request = HttpRequest(uri = s"http://$host:$port/")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -57,7 +57,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().bindServer(route, "localhost", port = 0).futureValue
 
     "accept small POST requests" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength)))
@@ -81,7 +81,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().bindServer(route, "localhost", port = 0).futureValue
 
     "accept a small request" in {
       val response = Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength))).futureValue
@@ -119,7 +119,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().bindServer(route, "localhost", port = 0).futureValue
 
     "reject a small request that decodes into a large chunked entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
@@ -141,7 +141,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().bindServer(route, "localhost", port = 0).futureValue
 
     "reject a small request that decodes into a large non-chunked streaming entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
@@ -163,7 +163,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().bindServer(route, "localhost", port = 0).futureValue
 
     "accept a small request" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength)))
@@ -216,7 +216,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       }
     }
 
-    val binding = Http().bindAndHandle(route, "localhost", port = 0).futureValue
+    val binding = Http().bindServer(route, "localhost", port = 0).futureValue
 
     "accept entities bigger than configured with akka.http.parsing.max-content-length" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/withoutSizeLimit", entityOfSize(maxContentLength + 1)))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -95,7 +95,7 @@ object TestServer extends App {
   }
   // format: ON
 
-  val bindingFuture = Http().bindAndHandle(routes, interface = "0.0.0.0", port = 8080)
+  val bindingFuture = Http().bindServer(routes, interface = "0.0.0.0", port = 8080)
 
   println(s"Server online at http://0.0.0.0:8080/\nPress RETURN to stop...")
   StdIn.readLine()

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -89,7 +89,7 @@ abstract class HttpApp extends Directives {
     implicit val materializer = ActorMaterializer()
     implicit val executionContext: ExecutionContextExecutor = theSystem.dispatcher
 
-    val bindingFuture = Http().bindAndHandle(
+    val bindingFuture = Http().bindServer(
       handler = routes,
       interface = host,
       port = port,

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerBindingFailure.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerBindingFailure.scala
@@ -17,14 +17,14 @@ object HttpServerBindingFailure {
     // needed for the future foreach in the end
     implicit val executionContext = system.dispatcher
 
-    val handler = get {
+    val route = get {
       complete("Hello world!")
     }
 
     // let's say the OS won't allow us to bind to 80.
     val (host, port) = ("localhost", 80)
     val bindingFuture: Future[ServerBinding] =
-      Http().bindAndHandle(handler, host, port)
+      Http().bindServer(route, host, port)
 
     bindingFuture.failed.foreach { ex =>
       system.log.error(ex, "Failed to bind to {}:{}!", host, port)

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -464,7 +464,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     }
 
     val binding: Future[Http.ServerBinding] =
-      Http().bindAndHandle(routes, "127.0.0.1", 8080)
+      Http().bindServer(routes, "127.0.0.1", 8080)
 
     // ...
     // once ready to terminate the server, invoke terminate:

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerHighLevel.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerHighLevel.scala
@@ -32,7 +32,7 @@ object HttpServerHighLevel {
       }
 
     // `route` will be implicitly converted to `Flow` using `RouteResult.route2HandlerFlow`
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().bindServer(route, "localhost", 8080)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerRoutingMinimal.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerRoutingMinimal.scala
@@ -26,7 +26,7 @@ object HttpServerRoutingMinimal {
         }
       }
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().bindServer(route, "localhost", 8080)
 
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerStreamingRandomNumbers.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerStreamingRandomNumbers.scala
@@ -40,7 +40,7 @@ object HttpServerStreamingRandomNumbers {
         }
       }
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().bindServer(route, "localhost", 8080)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorInteraction.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorInteraction.scala
@@ -75,7 +75,7 @@ object HttpServerWithActorInteraction {
         )
       }
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().bindServer(route, "localhost", 8080)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorsSample.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerWithActorsSample.scala
@@ -158,7 +158,7 @@ object HttpServerWithActorsSample {
       val routes = new JobRoutes(buildJobRepository)
 
       val serverBinding: Future[Http.ServerBinding] =
-        Http.apply().bindAndHandle(routes.theJobRoutes, host, port)
+        Http.apply().bindServer(routes.theJobRoutes, host, port)
       ctx.pipeToSelf(serverBinding) {
         case Success(binding) => Started(binding)
         case Failure(ex)      => StartFailed(ex)

--- a/docs/src/test/scala/docs/http/scaladsl/SprayJsonExample2.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SprayJsonExample2.scala
@@ -76,7 +76,7 @@ object SprayJsonExample2 {
         }
       )
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().bindServer(route, "localhost", 8080)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture

--- a/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ExceptionHandlerExamplesSpec.scala
@@ -39,7 +39,7 @@ object MyExplicitExceptionHandler {
         null // #hide
       }
 
-    Http().bindAndHandle(route, "localhost", 8080)
+    Http().bindServer(route, "localhost", 8080)
   }
 
   //#explicit-handler-example
@@ -72,7 +72,7 @@ object MyImplicitExceptionHandler {
     // ... some route structure
       null // #hide
 
-    Http().bindAndHandle(route, "localhost", 8080)
+    Http().bindServer(route, "localhost", 8080)
   }
 
   //#implicit-handler-example
@@ -152,7 +152,7 @@ object RespondWithHeaderExceptionHandlerExample {
   object MyApp extends App {
     implicit val system = ActorSystem()
 
-    Http().bindAndHandle(route, "localhost", 8080)
+    Http().bindServer(route, "localhost", 8080)
   }
   //#respond-with-header-exceptionhandler-example
 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -61,8 +61,8 @@ abstract class HttpsServerExampleSpec extends AnyWordSpec with Matchers
     //#both-https-and-http
     // you can run both HTTP and HTTPS in the same application as follows:
     val commonRoutes: Route = get { complete("Hello world!") }
-    Http().bindAndHandle(commonRoutes, "127.0.0.1", 443, connectionContext = https)
-    Http().bindAndHandle(commonRoutes, "127.0.0.1", 80)
+    Http().bindServer(commonRoutes, "127.0.0.1", 443, connectionContext = https)
+    Http().bindServer(commonRoutes, "127.0.0.1", 80)
     //#both-https-and-http
 
     //#bind-low-level-context
@@ -70,13 +70,13 @@ abstract class HttpsServerExampleSpec extends AnyWordSpec with Matchers
 
     // or using the high level routing DSL:
     val routes: Route = get { complete("Hello world!") }
-    Http().bindAndHandle(routes, "127.0.0.1", 8080, connectionContext = https)
+    Http().bindServer(routes, "127.0.0.1", 8080, connectionContext = https)
     //#bind-low-level-context
 
     //#set-low-level-context-default
     // sets default context to HTTPS – all Http() bound servers for this ActorSystem will use HTTPS from now on
     Http().setDefaultServerHttpContext(https)
-    Http().bindAndHandle(routes, "127.0.0.1", 9090, connectionContext = https)
+    Http().bindServer(routes, "127.0.0.1", 9090, connectionContext = https)
     //#set-low-level-context-default
 
     system.terminate()

--- a/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/RejectionHandlerExamplesSpec.scala
@@ -47,7 +47,7 @@ object MyRejectionHandler {
       // ... some route structure
       null // #hide
 
-    Http().bindAndHandle(route, "localhost", 8080)
+    Http().bindServer(route, "localhost", 8080)
   }
   //#custom-handler-example
 }

--- a/docs/src/test/scala/docs/http/scaladsl/server/ServerShutdownExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/ServerShutdownExampleSpec.scala
@@ -28,7 +28,7 @@ class ServerShutdownExampleSpec extends AnyWordSpec with Matchers
 
     // #suggested
     val bindingFuture = Http()
-      .bindAndHandle(handler = routes, interface = "localhost", port = 8080)
+      .bindServer(handler = routes, interface = "localhost", port = 8080)
       .map(_.addToCoordinatedShutdown(hardTerminationDeadline = 10.seconds))
     // #suggested
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
@@ -105,7 +105,7 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
       }
     //#websocket-routing
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().bindServer(route, "localhost", 8080)
 
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine()
@@ -130,7 +130,7 @@ class WebSocketExampleSpec extends AnyWordSpec with Matchers with CompileOnlySpe
     val customServerSettings =
       defaultSettings.withWebsocketSettings(customWebsocketSettings)
 
-    Http().bindAndHandle(route, "127.0.0.1", settings = customServerSettings)
+    Http().bindServer(route, "127.0.0.1", settings = customServerSettings)
     //#websocket-ping-payload-server
   }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
@@ -36,7 +36,7 @@ class CustomHttpMethodSpec extends AkkaSpec with ScalaFutures
       val routes = extractMethod { method =>
         complete(s"This is a ${method.name} method request.")
       }
-      val binding = Http().bindAndHandle(routes, host, port, settings = serverSettings)
+      val binding = Http().bindServer(routes, host, port, settings = serverSettings)
 
       val request = HttpRequest(BOLT, s"http://$host:$port/", protocol = `HTTP/1.1`)
       //#application-custom

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/JsonStreamingFullExamples.scala
@@ -66,7 +66,7 @@ class JsonStreamingFullExamples extends AnyWordSpec {
         }
       }
 
-    val bindingFuture = Http().bindAndHandle(route, "localhost", 8080)
+    val bindingFuture = Http().bindServer(route, "localhost", 8080)
 
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine()

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -36,7 +36,7 @@ class TimeoutDirectivesExamplesSpec extends AkkaSpec(TimeoutDirectivesInfiniteTi
 
   def runRoute(route: Route, routePath: String): HttpResponse = {
     val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
-    val binding = Http().bindAndHandle(route, hostname, port)
+    val binding = Http().bindServer(route, hostname, port)
 
     val response = Http().singleRequest(HttpRequest(uri = s"http://$hostname:$port/$routePath")).futureValue
 
@@ -165,7 +165,7 @@ class TimeoutDirectivesFiniteTimeoutExamplesSpec extends AkkaSpec(TimeoutDirecti
 
   def runRoute(route: Route, routePath: String): HttpResponse = {
     val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
-    val binding = Http().bindAndHandle(route, hostname, port)
+    val binding = Http().bindServer(route, hostname, port)
 
     val response = Http().singleRequest(HttpRequest(uri = s"http://$hostname:$port/$routePath")).futureValue
 


### PR DESCRIPTION
And change usages with routes to use the new method.

Refs #3271

We still have the opportunity for bike-shedding to find better names for `bindServer` as suggested in https://github.com/akka/akka-http/issues/3271#issuecomment-648124081.