### PR TITLE
core: polishing and docs for ServerBuilder API

### DIFF
--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -21,11 +21,11 @@ akka.http {
     # "PREVIEW" features that are not yet fully production ready.
     # These flags can change or be removed between patch releases.
     preview {
-      # ONLY WORKS WITH `bindAndHandleAsync` (currently)
-      #
       # If this setting is enabled AND the akka-http2-support is found
-      # on the classpath the usual Http().bind... method calls will bind
-      # using HTTP/2. Please note that you must configure HTTPS while doing so.
+      # on the classpath, `Http().newServerAt(...).bind` and `bindSync`
+      # will be enabled to use HTTP/2. Please note that you must configure HTTPS while doing so.
+      #
+      # `Http().newServerAt(...).bindFlow` and `connectionSource(): Source` are not supported.
       enable-http2 = off
     }
 
@@ -71,8 +71,8 @@ akka.http {
     # Set to 'infinite' to disable automatic connection closure (which will risk to leak connections).
     linger-timeout = 1 min
 
-    # The maximum number of concurrently accepted connections when using the
-    # `Http().bindAndHandle` methods.
+    # The maximum number of concurrently accepted connections when binding a server using
+    # `Http().newServerAt().bindXYZ()` methods.
     #
     # This setting doesn't apply to the `Http().bind` method which will still
     # deliver an unlimited backpressured stream of incoming connections.

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -23,7 +23,7 @@ akka.http {
     preview {
       # If this setting is enabled AND the akka-http2-support is found
       # on the classpath, `Http().newServerAt(...).bind` and `bindSync`
-      # will be enabled to use HTTP/2. Please note that you must configure HTTPS while doing so.
+      # will be enabled to use HTTP/2.
       #
       # `Http().newServerAt(...).bindFlow` and `connectionSource()` are not supported.
       enable-http2 = off

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -25,7 +25,7 @@ akka.http {
       # on the classpath, `Http().newServerAt(...).bind` and `bindSync`
       # will be enabled to use HTTP/2. Please note that you must configure HTTPS while doing so.
       #
-      # `Http().newServerAt(...).bindFlow` and `connectionSource(): Source` are not supported.
+      # `Http().newServerAt(...).bindFlow` and `connectionSource()` are not supported.
       enable-http2 = off
     }
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -25,9 +25,8 @@ import akka.http.scaladsl.{ model => sm }
 import akka.http.javadsl.model.ws._
 import akka.http.javadsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings, ServerSettings }
 import akka.japi.Pair
-import akka.japi.function.Function
 import akka.stream.TLSProtocol._
-import akka.stream.{ Materializer, SystemMaterializer }
+import akka.stream.Materializer
 import akka.stream.javadsl.{ BidiFlow, Flow, Source }
 import akka.stream.scaladsl.Keep
 
@@ -105,7 +104,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    *
-   * @deprecated since 10.2.0: Use Http.get(system).newServerAt(interface, port).bind() instead
+   * @deprecated since 10.2.0: Use Http.get(system).newServerAt(interface, port).connectionSource() instead
    */
   @Deprecated
   @deprecated("Use newServerAt instead", since = "10.2.0")
@@ -131,7 +130,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    *
-   * @deprecated since 10.2.0: Use Http.get(system).newServerAt(interface, port).withSettings(settings).bind() instead
+   * @deprecated since 10.2.0: Use Http.get(system).newServerAt(interface, port).withSettings(settings).connectionSource() instead
    */
   @Deprecated
   @deprecated("Use newServerAt instead", since = "10.2.0")
@@ -159,7 +158,7 @@ class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
    * The server will be bound using HTTPS if the [[ConnectHttp]] object is configured with an [[HttpsConnectionContext]],
    * or the [[defaultServerHttpContext]] has been configured to be an [[HttpsConnectionContext]].
    *
-   * @deprecated since 10.2.0: Use Http.get(system).newServerAt(interface, port).withSettings(settings).logTo(log).bind() instead
+   * @deprecated since 10.2.0: Use Http.get(system).newServerAt(interface, port).withSettings(settings).logTo(log).connectionSource() instead
    */
   @Deprecated
   @deprecated("Use newServerAt instead", since = "10.2.0")

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -171,7 +171,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
    * To configure additional settings for a server started using this method,
    * use the `akka.http.server` config section or pass in a [[akka.http.scaladsl.settings.ServerSettings]] explicitly.
    */
-  @deprecated("Use Http.newServerAt(...)...bind() to create server bindings.", since = "10.2.0")
+  @deprecated("Use Http.newServerAt(...)...connectionSource() to create a source that can be materialized to a binding.", since = "10.2.0")
   def bind(interface: String, port: Int = DefaultPortForProtocol,
            connectionContext: ConnectionContext = defaultServerHttpContext,
            settings:          ServerSettings    = ServerSettings(system),

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ServerBuilder.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ServerBuilder.scala
@@ -86,18 +86,17 @@ trait ServerBuilder {
    * Creates a [[akka.stream.scaladsl.Source]] of [[akka.http.scaladsl.Http.IncomingConnection]] instances which represents a prospective HTTP server binding
    * on the given `endpoint`.
    *
-   * If the configured  port is 0 the resulting source can be materialized several times. Each materialization will
+   * Note that each materialization will create a new binding, so
+   *
+   *  * if the configured  port is 0 the resulting source can be materialized several times. Each materialization will
    * then be assigned a new local port by the operating system, which can then be retrieved by the materialized
    * [[akka.http.scaladsl.Http.ServerBinding]].
    *
-   * If the configured  port is non-zero subsequent materialization attempts of the produced source will immediately
+   *  * if the configured  port is non-zero subsequent materialization attempts of the produced source will immediately
    * fail, unless the first materialization has already been unbound. Unbinding can be triggered via the materialized
    * [[akka.http.scaladsl.Http.ServerBinding]].
-   *
-   * If no `port` is explicitly given (or the port value is negative) the protocol's default port will be used,
-   * which is 80 for HTTP and 443 for HTTPS.
    */
-  def bind(): Source[Http.IncomingConnection, Future[ServerBinding]]
+  def connectionSource(): Source[Http.IncomingConnection, Future[ServerBinding]]
 }
 
 /**
@@ -128,7 +127,7 @@ private[http] object ServerBuilder {
     def adaptSettings(f: ServerSettings => ServerSettings): ServerBuilder = copy(settings = f(settings))
     def enableHttps(newContext: HttpsConnectionContext): ServerBuilder = copy(context = newContext)
 
-    def bind(): Source[Http.IncomingConnection, Future[ServerBinding]] =
+    def connectionSource(): Source[Http.IncomingConnection, Future[ServerBinding]] =
       http.bindImpl(interface, port, context, settings, log)
 
     def bindFlow(handlerFlow: Flow[HttpRequest, HttpResponse, _]): Future[ServerBinding] =

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -725,7 +725,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
 
   /** Transport that uses actual top-level Http APIs to establish a plaintext HTTP connection */
   case object AkkaHttpEngineTCP extends TopLevelApiClientServerImplementation {
-    protected override def bindServerSource = Http().newServerAt("localhost", 0).bind()
+    protected override def bindServerSource = Http().newServerAt("localhost", 0).connectionSource()
     protected def clientConnectionFlow(serverBinding: ServerBinding, connectionKillSwitch: SharedKillSwitch): Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] = {
       val clientConnectionSettings = ClientConnectionSettings(system).withTransport(new KillSwitchedClientTransport(connectionKillSwitch))
       Http().outgoingConnectionUsingContext(host = "localhost", port = serverBinding.localAddress.getPort, connectionContext = ConnectionContext.noEncryption(), settings = clientConnectionSettings)
@@ -738,7 +738,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
    * Currently requires an /etc/hosts entry that points akka.example.org to a locally bindable address.
    */
   case object AkkaHttpEngineTLS extends TopLevelApiClientServerImplementation {
-    protected override def bindServerSource = Http().newServerAt("akka.example.org", 0).enableHttps(ExampleHttpContexts.exampleServerContext).bind()
+    protected override def bindServerSource = Http().newServerAt("akka.example.org", 0).enableHttps(ExampleHttpContexts.exampleServerContext).connectionSource()
     protected def clientConnectionFlow(serverBinding: ServerBinding, connectionKillSwitch: SharedKillSwitch): Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] = {
       val clientConnectionSettings = ClientConnectionSettings(system).withTransport(new KillSwitchedClientTransport(connectionKillSwitch))
       Http().outgoingConnectionUsingContext(host = "akka.example.org", port = serverBinding.localAddress.getPort, connectionContext = ExampleHttpContexts.exampleClientContext, settings = clientConnectionSettings)

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -201,7 +201,7 @@ private[http] object RouteTest {
   def runRouteClientServer(request: HttpRequest, route: Route, serverSettings: ServerSettings)(implicit system: ActorSystem): Future[HttpResponse] = {
     import system.dispatcher
     for {
-      binding <- Http().bindAndHandle(route, "127.0.0.1", 0, settings = serverSettings)
+      binding <- Http().newServerAt("127.0.0.1", 0).withSettings(settings = serverSettings).bind(route)
       port = binding.localAddress.getPort
       targetUri = request.uri.withHost("127.0.0.1").withPort(port).withScheme("http")
 

--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -178,7 +178,7 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
         runOn(server) {
           val (_, port) = SocketUtil.temporaryServerHostnameAndPort()
           info(s"Binding Akka HTTP Server to port: $port @ ${myself}")
-          val futureBinding = Http().bindAndHandle(routes, "0.0.0.0", port)
+          val futureBinding = Http().newServerAt("0.0.0.0", port).bind(routes)
 
           _binding = Some(futureBinding.futureValue)
           setServerPort(port)

--- a/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
@@ -40,8 +40,8 @@ public class HttpAPIsTest extends JUnitRouteTest {
     ConnectionPoolSettings conSettings = null;
     LoggingAdapter log = null;
 
-    http.newServerAt("127.0.0.1", 8080).bind();
-    http.newServerAt("127.0.0.1", 8080).enableHttps(httpsContext).bind();
+    http.newServerAt("127.0.0.1", 8080).connectionSource();
+    http.newServerAt("127.0.0.1", 8080).enableHttps(httpsContext).connectionSource();
 
     final Flow<HttpRequest, HttpResponse, ?> handler = null;
     http.newServerAt("127.0.0.1", 8080).bindFlow(handler);

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/HttpApp.scala
@@ -89,11 +89,10 @@ abstract class HttpApp extends Directives {
     implicit val materializer = ActorMaterializer()
     implicit val executionContext: ExecutionContextExecutor = theSystem.dispatcher
 
-    val bindingFuture = Http().bindAndHandle(
-      handler = routes,
-      interface = host,
-      port = port,
-      settings = settings)
+    val bindingFuture =
+      Http().newServerAt(host, port)
+        .withSettings(settings)
+        .bind(routes)
 
     bindingFuture.onComplete {
       case Success(binding) =>

--- a/docs/src/main/paradox/migration-guide/migration-from-spray.md
+++ b/docs/src/main/paradox/migration-guide/migration-from-spray.md
@@ -268,7 +268,7 @@ IO(Http)(system) ! Http.Bind(service, "0.0.0.0", port = 8080)
 needs to be changed into:
 
 ```scala
-Http().bindAndHandle(routes, "0.0.0.0", port = 8080)
+Http().newServerAt("0.0.0.0", port = 8080).bind(routes)
 ```
 
 ### Other removed features

--- a/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
+++ b/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
@@ -12,6 +12,31 @@ If you find an unexpected incompatibility please let us know, so we can check wh
 
 ## Akka HTTP 10.1.11 -> 10.2.0
 
+### Hiding Materializer
+
+Recent Akka versions introduced a singleton system materializer that can be summoned from an ActorSystem automatically. In many cases,
+`Materializer` arguments are now optional and APIs have been simplified to require materializers in fewer places. In fact, most common
+uses do not require a materializer any more at all.
+
+### New ServerBuilder API to create server bindings
+
+To simplify binding servers (and making it more consistent between Java and Scala), a new @apidoc[ServerBuilder] API has been introduced.
+The most common change needed to bind a server to handle routes will be from:
+
+Scala
+:   @@snip [AkkaHttp1020MigrationSpec.scala]($test$/scala/docs/http/scaladsl/server/AkkaHttp1020MigrationSpec.scala) { #old-binding }
+
+Java
+:   @@snip [AkkaHttp1020MigrationExample.java]($test$/java/docs/http/javadsl/server/AkkaHttp1020MigrationExample.java) { #old-binding }
+
+to:
+
+Scala
+:   @@snip [AkkaHttp1020MigrationSpec.scala]($test$/scala/docs/http/scaladsl/server/AkkaHttp1020MigrationSpec.scala) { #new-binding }
+
+Java
+:   @@snip [AkkaHttp1020MigrationExample.java]($test$/java/docs/http/javadsl/server/AkkaHttp1020MigrationExample.java) { #new-binding }
+
 ### HTTP/2 support requires JDK 8 update 252 or later
 
 JVM support for ALPN has been backported to JDK 8u252 which is now widely available. Support for using the Jetty ALPN

--- a/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
+++ b/docs/src/main/paradox/migration-guide/migration-guide-10.2.x.md
@@ -20,7 +20,7 @@ uses do not require a materializer any more at all.
 
 ### New ServerBuilder API to create server bindings
 
-To simplify binding servers (and making it more consistent between Java and Scala), a new @apidoc[ServerBuilder] API has been introduced.
+To simplify binding servers (and to make it more consistent between Java and Scala), a new @apidoc[ServerBuilder] API has been introduced.
 The most common change needed to bind a server to handle routes will be from:
 
 Scala

--- a/docs/src/main/paradox/release-notes/10.2.x.md
+++ b/docs/src/main/paradox/release-notes/10.2.x.md
@@ -1,8 +1,9 @@
 # 10.2.x Release Notes
 
-Among other things, 10.2.0-RC1 contains:
+Among other things, 10.2.0-RC2 contains:
 
 * APIs and documentation now provide a seamless experience with Akka 2.6 and the new Actor APIs. Akka HTTP 10.2.x will still be supporting Akka 2.5 to ease incremental updating.
+* A new @ref[ServerBuilder API](../migration-guide/migration-guide-10.2.x.md#new-serverbuilder-api-to-create-server-bindings) to simplify and streamline binding servers.
 * Some new features, including the ability to [attach attributes to requests and responses](https://doc.akka.io/docs/akka-http/10.2.0-M1/common/http-model.html#attributes).
 * Allow client setting overrides for target hosts @ref[via configuration](../client-side/configuration.md#per-host-overrides) [#2574](https://github.com/akka/akka-http/pull/2574)
 * Improved default configuration, such as [disabling transparent HEAD support by default](https://github.com/akka/akka-http/issues/2088).

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -31,12 +31,12 @@ HTTP/2 can then be enabled through configuration:
 akka.http.server.preview.enable-http2 = on
 ```
 
-## Use `bindAndHandleAsync` and HTTPS
+## Use `newServerAt(...).bind()` and HTTPS
 
-HTTP/2 is primarily used over a secure connection (known as "over HTTPS" or "with TLS"), which also takes care of protocol negotiation and falling back to plain HTTPS when the client does not support HTTP/2.
+HTTP/2 is primarily used over a secure HTTPS connection which takes care of protocol negotiation and falling back to HTTP/1.1 over TLS when the client does not support HTTP/2.
 See the @ref[HTTPS section](server-https-support.md) for how to set up HTTPS.
 
-You can use @scala[@scaladoc[Http().bindAndHandleAsync](akka.http.scaladsl.HttpExt)]@java[@javadoc[Http().get(system).bindAndHandleAsync()](akka.http.javadsl.HttpExt)] as long as you followed the above steps:
+You can use @scala[@scaladoc[Http().newServerAt(...).bind()](akka.http.scaladsl.ServerBuilder)]@java[@javadoc[Http().get(system).newServerAt(...).bind()](akka.http.javadsl.ServerBuilder)] as long as you followed the above steps:
 
 Scala
 :   @@snip[Http2Spec.scala]($test$/scala/docs/http/scaladsl/Http2Spec.scala) { #bindAndHandleSecure }
@@ -44,7 +44,9 @@ Scala
 Java
 :   @@snip[Http2Test.java]($test$/java/docs/http/javadsl/Http2Test.java) { #bindAndHandleSecure }
 
-Note that `bindAndHandle` currently does not support HTTP/2, you must use `bindAndHandleAsync`.
+Note that currently only `newServerAt(...).bind` and `newServerAt(...).bindSync`
+support HTTP/2 but not `bindFlow` or `connectionSource(): Source`.
+
 
 ### HTTP/2 without HTTPS
 

--- a/docs/src/test/java/docs/http/javadsl/server/AkkaHttp1020MigrationExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/AkkaHttp1020MigrationExample.java
@@ -1,0 +1,39 @@
+package docs.http.javadsl.server;
+
+import akka.actor.typed.javadsl.Behaviors;
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import static akka.http.javadsl.server.Directives.*;
+import akka.http.javadsl.server.Route;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+
+@SuppressWarnings("deprecation")
+public class AkkaHttp1020MigrationExample {
+    public static void main(String[] args) {
+        {
+            //#old-binding
+            // only worked with classic actor system
+            akka.actor.ActorSystem system = akka.actor.ActorSystem.create("TheSystem");
+            Materializer mat = ActorMaterializer.create(system);
+            Route route = get(() -> complete("Hello World!"));
+            Http.get(system).bindAndHandle(route.flow(system), ConnectHttp.toHost("localhost", 8080), mat);
+            //#old-binding
+        }
+
+        {
+            //#new-binding
+            // works with classic or typed actor system
+            akka.actor.typed.ActorSystem system = akka.actor.typed.ActorSystem.create(Behaviors.empty(), "TheSystem");
+            // or
+            // akka.actor.ActorSystem system = akka.actor.ActorSystem.create("TheSystem");
+
+            // materializer not needed any more
+
+            Route route = get(() -> complete("Hello World!"));
+            Http.get(system).newServerAt("localhost", 8080).bind(route);
+            //#new-binding
+        }
+    }
+
+}

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerExampleSpec.scala
@@ -33,7 +33,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     implicit val executionContext = system.dispatcher
 
     val serverSource: Source[Http.IncomingConnection, Future[Http.ServerBinding]] =
-      Http().newServerAt("localhost", 8080).bind()
+      Http().newServerAt("localhost", 8080).connectionSource()
     val bindingFuture: Future[Http.ServerBinding] =
       serverSource.to(Sink.foreach { connection => // foreach materializes the source
         println("Accepted new connection from " + connection.remoteAddress)
@@ -62,7 +62,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
 
     // let's say the OS won't allow us to bind to 80.
     val (host, port) = ("localhost", 80)
-    val serverSource = Http().newServerAt(host, port).bind()
+    val serverSource = Http().newServerAt(host, port).connectionSource()
 
     val bindingFuture: Future[ServerBinding] = serverSource
       .to(handleConnections) // Sink[Http.IncomingConnection, _]
@@ -90,7 +90,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
 
     import Http._
     val (host, port) = ("localhost", 8080)
-    val serverSource = Http().newServerAt(host, port).bind()
+    val serverSource = Http().newServerAt(host, port).connectionSource()
 
     val failureMonitor: ActorRef = system.actorOf(MyExampleMonitoringActor.props)
 
@@ -117,7 +117,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     implicit val executionContext = system.dispatcher
 
     val (host, port) = ("localhost", 8080)
-    val serverSource = Http().newServerAt(host, port).bind()
+    val serverSource = Http().newServerAt(host, port).connectionSource()
 
     val reactToConnectionFailure = Flow[HttpRequest]
       .recover[HttpRequest] {
@@ -151,7 +151,7 @@ class HttpServerExampleSpec extends AnyWordSpec with Matchers
     implicit val system = ActorSystem()
     implicit val executionContext = system.dispatcher
 
-    val serverSource = Http().newServerAt("localhost", 8080).bind()
+    val serverSource = Http().newServerAt("localhost", 8080).connectionSource()
 
     val requestHandler: HttpRequest => HttpResponse = {
       case HttpRequest(GET, Uri.Path("/"), _, _, _) =>

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerHighLevel.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerHighLevel.scala
@@ -31,7 +31,7 @@ object HttpServerHighLevel {
         )
       }
 
-    // `route` will be implicitly converted to `Flow` using `RouteResult.route2HandlerFlow`
+    // `route` will be implicitly converted to an async handler
     val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
     println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return

--- a/docs/src/test/scala/docs/http/scaladsl/server/AkkaHttp1020MigrationSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/AkkaHttp1020MigrationSpec.scala
@@ -1,0 +1,43 @@
+package docs.http.scaladsl.server
+
+import akka.actor.typed.scaladsl.Behaviors
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Route
+import akka.stream.{ ActorMaterializer, Materializer }
+import com.github.ghik.silencer.silent
+
+@silent("since 10.2.0")
+@silent("method apply in object ActorMaterializer is deprecated")
+class AkkaHttp1020MigrationSpec {
+  import akka.http.scaladsl.server.Directives._
+
+  {
+    //#old-binding
+    // only worked with classic actor system
+    implicit val system = akka.actor.ActorSystem("TheSystem")
+    implicit val mat: Materializer = ActorMaterializer()
+    val route: Route =
+      get {
+        complete("Hello world")
+      }
+    Http().bindAndHandle(route, "localhost", 8080)
+    //#old-binding
+  }
+
+  {
+    //#new-binding
+    // works with both classic and typed ActorSystem
+    implicit val system = akka.actor.typed.ActorSystem(Behaviors.empty, "TheSystem")
+    // or
+    // implicit val system = akka.actor.ActorSystem("TheSystem")
+
+    // materializer not needed any more
+
+    val route: Route =
+      get {
+        complete("Hello world")
+      }
+    Http().newServerAt("localhost", 8080).bind(route)
+    //#new-binding
+  }
+}

--- a/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -66,7 +66,7 @@ abstract class HttpsServerExampleSpec extends AnyWordSpec with Matchers
     //#both-https-and-http
 
     //#bind-low-level-context
-    Http().newServerAt("127.0.0.1", 0).enableHttps(https).bind()
+    Http().newServerAt("127.0.0.1", 0).enableHttps(https).connectionSource()
 
     // or using the high level routing DSL:
     val routes: Route = get { complete("Hello world!") }

--- a/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/HttpsServerExampleSpec.scala
@@ -61,8 +61,8 @@ abstract class HttpsServerExampleSpec extends AnyWordSpec with Matchers
     //#both-https-and-http
     // you can run both HTTP and HTTPS in the same application as follows:
     val commonRoutes: Route = get { complete("Hello world!") }
-    Http().newServerAt("127.0.0.1", 443).enableHttps(https).bindFlow(commonRoutes)
-    Http().newServerAt("127.0.0.1", 80).bindFlow(commonRoutes)
+    Http().newServerAt("127.0.0.1", 443).enableHttps(https).bind(commonRoutes)
+    Http().newServerAt("127.0.0.1", 80).bind(commonRoutes)
     //#both-https-and-http
 
     //#bind-low-level-context


### PR DESCRIPTION
 * One significant change over #3362: I renamed `bind()` to `connectionSource` to make it clear that calling the method will not immediately create a binding and also to avoid overloading `bind()` (which became awkward in docs)
 * Converted remaining internal and docs usages of `Http().bindXYZ` usages
 * Brief release notes and migration notes entry