### PR TITLE
Convert more javadsl doc examples from bindAndHandle to ServerBuilder

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/ServerBuilder.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ServerBuilder.scala
@@ -16,8 +16,7 @@ import akka.http.scaladsl
 import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.{ model => sm }
 import akka.japi.function.Function
-import akka.stream.javadsl.Flow
-import akka.stream.scaladsl.Source
+import akka.stream.javadsl.{ Flow, Source }
 import akka.stream.{ Materializer, SystemMaterializer }
 
 import scala.compat.java8.FutureConverters._
@@ -174,6 +173,6 @@ object ServerBuilder {
     def connectionSource(): Source[IncomingConnection, CompletionStage[ServerBinding]] =
       http.bindImpl(interface, port, context.asScala, settings.asScala, log)
         .map(new IncomingConnection(_))
-        .mapMaterializedValue(_.map(new ServerBinding(_))(ExecutionContexts.sameThreadExecutionContext).toJava)
+        .mapMaterializedValue(_.map(new ServerBinding(_))(ExecutionContexts.sameThreadExecutionContext).toJava).asJava
   }
 }

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java
@@ -59,7 +59,7 @@ public class PetStoreExample {
         path("", () ->
           getFromResource("web/index.html")
         ),
-        pathPrefix("pet", () -> 
+        pathPrefix("pet", () ->
           path(INTEGER, petId -> concat(
             // demonstrates different ways of handling requests:
 
@@ -67,18 +67,18 @@ public class PetStoreExample {
             get(() -> existingPet.apply(petId)),
 
             // 2. using a method
-            put(() -> 
-              entity(Jackson.unmarshaller(Pet.class), thePet -> 
+            put(() ->
+              entity(Jackson.unmarshaller(Pet.class), thePet ->
                 putPetHandler(pets, thePet)
               )
             ),
             // 2.1. using a method, and internally handling a Future value
             path("alternate", () ->
-              put(() -> 
-                entity(Jackson.unmarshaller(Pet.class), thePet -> 
+              put(() ->
+                entity(Jackson.unmarshaller(Pet.class), thePet ->
                   putPetHandler(pets, thePet)
                 )
-              )              
+              )
             ),
 
             // 3. calling a method of a controller instance
@@ -97,11 +97,8 @@ public class PetStoreExample {
     pets.put(1, cat);
 
     final ActorSystem system = ActorSystem.create();
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
-    final ConnectHttp host = ConnectHttp.toHost("127.0.0.1");
-
-    Http.get(system).bindAndHandle(appRoute(pets).flow(system, materializer), host, materializer);
+    Http.get(system).newServerAt("127.0.0.1", 8080).bind(appRoute(pets));
 
     System.console().readLine("Type RETURN to exit...");
     system.terminate();

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerApp.java
@@ -106,7 +106,6 @@ public class SimpleServerApp {
 
   public static void main(String[] args) throws IOException {
     final ActorSystem system = ActorSystem.create("SimpleServerApp");
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
     final Http http = Http.get(system);
 
     boolean useHttps = false; // pick value from anywhere
@@ -116,9 +115,8 @@ public class SimpleServerApp {
     }
 
     final SimpleServerApp app = new SimpleServerApp();
-    final Flow<HttpRequest, HttpResponse, NotUsed> flow = app.createRoute().flow(system, materializer);
 
-    Http.get(system).bindAndHandle(flow, ConnectHttp.toHost("localhost", 8080), materializer);
+    Http.get(system).newServerAt("localhost", 8080).bind(app.createRoute());
 
     System.out.println("Type RETURN to exit");
     System.in.read();

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerHttpHttpsApp.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/simple/SimpleServerHttpHttpsApp.java
@@ -29,15 +29,14 @@ public class SimpleServerHttpHttpsApp {
 
   public static void main(String[] args) throws IOException {
     final ActorSystem system = ActorSystem.create("SimpleServerHttpHttpsApp");
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
     final SimpleServerApp app = new SimpleServerApp();
-    final Flow<HttpRequest, HttpResponse, NotUsed> flow = app.createRoute().flow(system, materializer);
+    final Route route = app.createRoute();
 
     //#both-https-and-http
     final Http http = Http.get(system);
     //Run HTTP server firstly
-    http.bindAndHandle(flow, ConnectHttp.toHost("localhost", 80), materializer);
+    http.newServerAt("localhost", 80).bind(route);
 
     //get configured HTTPS context
     HttpsConnectionContext https = SimpleServerApp.useHttps(system);
@@ -46,7 +45,7 @@ public class SimpleServerHttpHttpsApp {
     http.setDefaultServerHttpContext(https);
 
     //Then run HTTPS server
-    http.bindAndHandle(flow, ConnectHttp.toHost("localhost", 443), materializer);
+    http.newServerAt("localhost", 443).enableHttps(https).bind(route);
     //#both-https-and-http
 
     System.out.println("Type RETURN to exit");

--- a/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
@@ -49,7 +49,7 @@ public abstract class HttpApp extends AllDirectives {
   /**
    * Start a server on the specified host and port, using the provided [[ActorSystem]]
    * Note that this method is blocking.
-   * 
+   *
    * @param system ActorSystem to use for starting the app,
    *   if null is passed in a new default ActorSystem will be created instead, which will
    *   be terminated when the server is stopped.
@@ -69,7 +69,7 @@ public abstract class HttpApp extends AllDirectives {
   /**
    * Start a server on the specified host and port, using the provided settings and [[ActorSystem]].
    * Note that this method is blocking.
-   * 
+   *
    * @param system ActorSystem to use for starting the app,
    *   if null is passed in a new default ActorSystem will be created instead, which will
    *   be terminated when the server is stopped.
@@ -82,8 +82,8 @@ public abstract class HttpApp extends AllDirectives {
    * Start a server on the specified host and port, using the provided settings and [[ActorSystem]] if present.
    * Note that this method is blocking.
    * This method may throw an {@link ExecutionException} or {@link InterruptedException} if the future that signals that
-   * the server should shutdown is interrupted or cancelled.   
-   * 
+   * the server should shutdown is interrupted or cancelled.
+   *
    * @param system ActorSystem to use for starting the app,
    *   if an empty Optional is passed in a new default ActorSystem will be created instead, which will
    *   be terminated when the server is stopped.
@@ -96,11 +96,9 @@ public abstract class HttpApp extends AllDirectives {
 
     CompletionStage<ServerBinding> bindingFuture = Http
       .get(theSystem)
-      .bindAndHandle(routes().flow(theSystem, materializer),
-        ConnectHttp.toHost(host, port),
-        settings,
-        theSystem.log(),
-        materializer);
+      .newServerAt(host, port)
+      .withSettings(settings)
+      .bind(routes());
 
     bindingFuture.handle((binding, exception) -> {
       if (exception != null) {

--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -157,8 +157,8 @@ private[http] object Http2Blueprint {
    *
    * To make use of parallelism requests and responses need to be associated (other than by ordering), suggestion
    * is to add a special (virtual) header containing the streamId (or any other kind of token) is added to the HttRequest
-   * that must be reproduced in an HttpResponse. This can be done automatically for the bindAndHandleAsync API but for
-   * bindAndHandle the user needs to take of this manually.
+   * that must be reproduced in an HttpResponse. This can be done automatically for the `bind`` API but for
+   * `bindFlow` the user needs to take of this manually.
    */
   def httpLayer(settings: ServerSettings, log: LoggingAdapter): BidiFlow[HttpResponse, Http2SubStream, Http2SubStream, HttpRequest, NotUsed] = {
     val parserSettings = settings.parserSettings

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
@@ -8,11 +8,10 @@ import akka.event.Logging
 import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model._
 import akka.stream._
-import akka.testkit.{ AkkaSpec, TestProbe, SocketUtil }
+import akka.testkit.{ AkkaSpec, TestProbe }
 
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration._
+import scala.concurrent.duration.{ Duration, _ }
 
 class Http2BindingViaConfigSpec extends AkkaSpec("""
     akka.http.server.preview.enable-http2 = on
@@ -23,7 +22,6 @@ class Http2BindingViaConfigSpec extends AkkaSpec("""
   implicit val mat = ActorMaterializer()
   import system.dispatcher
 
-  val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
   var binding: Future[Http.ServerBinding] = _ // initialized atStartup
 
   val helloWorldHandler: HttpRequest => Future[HttpResponse] =
@@ -41,7 +39,7 @@ class Http2BindingViaConfigSpec extends AkkaSpec("""
 
         val connectionContext = ExampleHttpContexts.exampleServerContext
         binding =
-          Http().newServerAt(host, port)
+          Http().newServerAt("localhost", 0)
             .enableHttps(connectionContext)
             .bind(helloWorldHandler)
 

--- a/docs/src/main/paradox/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/routing-dsl/testkit.md
@@ -108,7 +108,7 @@ Java
 :   @@snip [MyAppService.java]($test$/java/docs/http/javadsl/server/testkit/MyAppService.java) { #simple-app }
 
 `MyAppService` extends from `AllDirectives` which brings all of the directives into scope. We define a method called `createRoute`
-that provides the routes to serve to `bindAndHandle`.
+that provides the routes to serve to `bind`.
 
 Here's how you would test that service:
 

--- a/docs/src/test/java/docs/http/javadsl/ComposeDirectivesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/ComposeDirectivesExampleTest.java
@@ -33,14 +33,11 @@ public class ComposeDirectivesExampleTest extends AllDirectives {
     ActorSystem system = ActorSystem.create("routes");
 
     final Http http = Http.get(system);
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
     //In order to access all directives we need an instance where the routes are define.
     ComposeDirectivesExampleTest app = new ComposeDirectivesExampleTest();
 
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
-    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow,
-        ConnectHttp.toHost("localhost", 8080), materializer);
+    final CompletionStage<ServerBinding> binding = http.newServerAt("localhost", 8080).bind(app.createRoute());
 
     System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
     System.in.read(); // let it run until user presses return

--- a/docs/src/test/java/docs/http/javadsl/CustomStatusCodesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/CustomStatusCodesExampleTest.java
@@ -41,7 +41,6 @@ public class CustomStatusCodesExampleTest extends JUnitRouteTest {
   public void customStatusCodes() throws ExecutionException, InterruptedException, NoSuchAlgorithmException {
 
     final ActorSystem system = system();
-    final Materializer materializer = materializer();
     final String host = "127.0.0.1";
 
     //#application-custom-java
@@ -69,11 +68,9 @@ public class CustomStatusCodesExampleTest extends JUnitRouteTest {
 
     // Use serverSettings in server:
     final CompletionStage<ServerBinding> binding = Http.get(system)
-      .bindAndHandle(route.flow(system, materializer),
-        ConnectHttp.toHost(host, 0),
-        serverSettings,
-        system.log(),
-        materializer);
+      .newServerAt(host, 0)
+      .withSettings(serverSettings)
+      .bind(route);
 
     final ServerBinding serverBinding = binding.toCompletableFuture().get();
 

--- a/docs/src/test/java/docs/http/javadsl/ExceptionHandlerExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ExceptionHandlerExample.java
@@ -5,34 +5,28 @@
 package docs.http.javadsl;
 
 //#explicit-handler-example
-import akka.NotUsed;
+
 import akka.actor.ActorSystem;
-import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
-import akka.http.javadsl.model.HttpRequest;
-import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.ExceptionHandler;
 import akka.http.javadsl.server.PathMatchers;
 import akka.http.javadsl.server.Route;
-import akka.http.javadsl.Http;
-import akka.stream.ActorMaterializer;
-import akka.stream.javadsl.Flow;
 
 import java.util.concurrent.CompletionStage;
+
 import static akka.http.javadsl.server.PathMatchers.integerSegment;
 
 public class ExceptionHandlerExample extends AllDirectives {
   public static void main(String[] args) {
     final ActorSystem system = ActorSystem.create();
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
     final Http http = Http.get(system);
 
     final ExceptionHandlerExample app = new ExceptionHandlerExample();
 
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
-    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
+    final CompletionStage<ServerBinding> binding = http.newServerAt("localhost", 8080).bind(app.createRoute());
   }
 
 

--- a/docs/src/test/java/docs/http/javadsl/RespondWithHeaderHandlerExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/RespondWithHeaderHandlerExampleTest.java
@@ -5,37 +5,30 @@
 package docs.http.javadsl;
 
 //#respond-with-header-exceptionhandler-example
-import akka.NotUsed;
+
 import akka.actor.ActorSystem;
-import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.model.HttpRequest;
-import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.model.headers.RawHeader;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.ExceptionHandler;
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
-import akka.stream.javadsl.Flow;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import akka.http.javadsl.testkit.TestRoute;
+import akka.http.scaladsl.model.ErrorInfo;
+import akka.http.scaladsl.model.IllegalHeaderException;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CompletionStage;
-//#respond-with-header-exceptionhandler-example
 
-//#no-exception-details-in-response
-import static akka.http.javadsl.server.Directives.get;
-
-import akka.http.scaladsl.model.IllegalHeaderException;
-import akka.http.scaladsl.model.ErrorInfo;
-
-import akka.http.javadsl.testkit.JUnitRouteTest;
-import akka.http.javadsl.testkit.TestRoute;
 import static junit.framework.TestCase.assertTrue;
-//#no-exception-details-in-response
 
-import org.junit.Test;
+//#respond-with-header-exceptionhandler-example
+//#no-exception-details-in-response
+//#no-exception-details-in-response
 
 public class RespondWithHeaderHandlerExampleTest extends JUnitRouteTest {
 
@@ -64,13 +57,11 @@ public class RespondWithHeaderHandlerExampleTest extends JUnitRouteTest {
     class RespondWithHeaderHandlerExample extends AllDirectives {
         public static void main(String[] args) throws IOException {
             final ActorSystem system = ActorSystem.create();
-            final ActorMaterializer materializer = ActorMaterializer.create(system);
             final Http http = Http.get(system);
 
             final RespondWithHeaderHandlerExample app = new RespondWithHeaderHandlerExample();
 
-            final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
-            final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
+            final CompletionStage<ServerBinding> binding = http.newServerAt("localhost", 8080).bind(app.createRoute());
         }
 
         public Route createRoute() {
@@ -86,7 +77,7 @@ public class RespondWithHeaderHandlerExampleTest extends JUnitRouteTest {
                             respondWithHeader(RawHeader.create("X-Inner-Header", "inner"), () -> {
                                 // Will cause Internal server error,
                                 // only ArithmeticExceptions are handled by divByZeroHandler.
-                                throw new RuntimeException("Boom!");                                                                     
+                                throw new RuntimeException("Boom!");
                             })
                     ))
             );

--- a/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
+++ b/docs/src/test/java/docs/http/javadsl/RouteSealExample.java
@@ -4,33 +4,25 @@
 
 package docs.http.javadsl;
 
-import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
-import akka.http.javadsl.model.*;
 import akka.http.javadsl.model.headers.RawHeader;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
-import akka.stream.javadsl.Flow;
-
-import java.io.IOException;
 
 import java.util.concurrent.CompletionStage;
 
 //#route-seal-example
 public class RouteSealExample extends AllDirectives {
 
-  public static void main(String [] args) throws IOException {
+  public static void main(String [] args) {
     RouteSealExample app = new RouteSealExample();
     app.runServer();
   }
 
   public void runServer(){
     ActorSystem system = ActorSystem.create();
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
     Route sealedRoute = get(
       () -> pathSingleSlash( () ->
@@ -44,8 +36,7 @@ public class RouteSealExample extends AllDirectives {
     );
 
     final Http http = Http.get(system);
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = route.flow(system, materializer);
-    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
+    final CompletionStage<ServerBinding> binding = http.newServerAt("localhost", 8080).bind(route);
   }
 }
 //#route-seal-example

--- a/docs/src/test/java/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HighLevelServerBindFailureExample.java
@@ -6,16 +6,10 @@ package docs.http.javadsl.server;
 
 //#binding-failure-high-level-example
 
-import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.http.javadsl.ConnectHttp;
-import akka.http.javadsl.ServerBinding;
-import akka.http.javadsl.model.HttpRequest;
-import akka.http.javadsl.model.HttpResponse;
-import akka.http.javadsl.server.Route;
 import akka.http.javadsl.Http;
-import akka.stream.ActorMaterializer;
-import akka.stream.javadsl.Flow;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.server.Route;
 
 import java.io.IOException;
 import java.util.concurrent.CompletionStage;
@@ -24,13 +18,12 @@ public class HighLevelServerBindFailureExample {
   public static void main(String[] args) throws IOException {
     // boot up server using the route as defined below
     final ActorSystem system = ActorSystem.create();
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
     final HighLevelServerExample app = new HighLevelServerExample();
     final Route route = app.createRoute();
 
-    final Flow<HttpRequest, HttpResponse, NotUsed> handler = route.flow(system, materializer);
-    final CompletionStage<ServerBinding> binding = Http.get(system).bindAndHandle(handler, ConnectHttp.toHost("127.0.0.1", 8080), materializer);
+    final CompletionStage<ServerBinding> binding =
+        Http.get(system).newServerAt("127.0.0.1", 8080).bind(route);
 
     binding.exceptionally(failure -> {
       System.err.println("Something very bad happened! " + failure.getMessage());

--- a/docs/src/test/java/docs/http/javadsl/server/HighLevelServerExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HighLevelServerExample.java
@@ -6,19 +6,13 @@ package docs.http.javadsl.server;
 
 //#high-level-server-example
 
-import akka.NotUsed;
 import akka.actor.ActorSystem;
-import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.HttpEntities;
-import akka.http.javadsl.model.HttpRequest;
-import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
-import akka.stream.javadsl.Flow;
 
 import java.io.IOException;
 import java.util.concurrent.CompletionStage;
@@ -31,14 +25,12 @@ public class HighLevelServerExample extends AllDirectives {
     final HighLevelServerExample app = new HighLevelServerExample();
 
     final Http http = Http.get(system);
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
-    final Flow<HttpRequest, HttpResponse, NotUsed> routeFlow = app.createRoute().flow(system, materializer);
-    final CompletionStage<ServerBinding> binding = http.bindAndHandle(routeFlow, ConnectHttp.toHost("localhost", 8080), materializer);
+    final CompletionStage<ServerBinding> binding = http.newServerAt("localhost", 8080).bind(app.createRoute());
 
     System.out.println("Type RETURN to exit");
     System.in.read();
-    
+
     binding
       .thenCompose(ServerBinding::unbind)
       .thenAccept(unbound -> system.terminate());

--- a/docs/src/test/java/docs/http/javadsl/server/ServerShutdownExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/ServerShutdownExampleTest.java
@@ -7,12 +7,9 @@ package docs.http.javadsl.server;
 import akka.actor.CoordinatedShutdown;
 import akka.actor.typed.ActorSystem;
 import akka.actor.typed.javadsl.Behaviors;
-import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.server.Route;
-import akka.stream.Materializer;
-import akka.stream.SystemMaterializer;
 
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
@@ -21,14 +18,14 @@ public class ServerShutdownExampleTest {
 
     public void mountCoordinatedShutdown() {
         ActorSystem<?> system = ActorSystem.create(Behaviors.empty(), "http-server");
-        Materializer materializer = SystemMaterializer.get(system).materializer();
 
         Route routes = null;
 
         // #suggested
         CompletionStage<ServerBinding> bindingFuture = Http
             .get(system)
-            .bindAndHandle(routes.flow(system), ConnectHttp.toHost("localhost", 8080), materializer)
+            .newServerAt("localhost", 8080)
+            .bind(routes)
             .thenApply(binding -> binding.addToCoordinatedShutdown(Duration.ofSeconds(10), system));
         // #suggested
 

--- a/docs/src/test/java/docs/http/javadsl/server/testkit/MyAppService.java
+++ b/docs/src/test/java/docs/http/javadsl/server/testkit/MyAppService.java
@@ -7,13 +7,11 @@ package docs.http.javadsl.server.testkit;
 //#simple-app
 
 import akka.actor.ActorSystem;
-import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.Route;
-import akka.http.javadsl.unmarshalling.StringUnmarshallers;
 import akka.http.javadsl.server.examples.simple.SimpleServerApp;
-import akka.stream.ActorMaterializer;
+import akka.http.javadsl.unmarshalling.StringUnmarshallers;
 
 import java.io.IOException;
 
@@ -40,13 +38,10 @@ public class MyAppService extends AllDirectives {
 
   public static void main(String[] args) throws IOException {
     final ActorSystem system = ActorSystem.create();
-    final ActorMaterializer materializer = ActorMaterializer.create(system);
 
     final SimpleServerApp app = new SimpleServerApp();
 
-    final ConnectHttp host = ConnectHttp.toHost("127.0.0.1");
-
-    Http.get(system).bindAndHandle(app.createRoute().flow(system, materializer), host, materializer);
+    Http.get(system).newServerAt("127.0.0.1", 8080).bind(app.createRoute());
 
     System.console().readLine("Type RETURN to exit...");
     system.terminate();


### PR DESCRIPTION
Last time I missed Java examples that still used old `bindAndHandle` APIs and also a `scaladsl.Source` slipped into `javadsl.ServerBuilder`.