### PR TITLE
build: simplify http-core test against akka master scenario

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,12 +137,12 @@ lazy val httpCore = project("akka-http-core")
   .settings(AutomaticModuleName.settings("akka.http.core"))
   .dependsOn(parsing)
   .addAkkaModuleDependency("akka-stream", "provided")
-  .addAkkaModuleDependency("akka-stream-testkit", "test")
   .addAkkaModuleDependency(
     "akka-stream-testkit",
     "test",
-    AkkaDependency.Sources("git://github.com/akka/akka.git#master"),
-    onlyIf = System.getProperty("akka.http.test-against-akka-master", "false") == "true"
+    akka =
+      if (System.getProperty("akka.http.test-against-akka-master", "false") == "true") AkkaDependency.masterSnapshot
+      else AkkaDependency.default
   )
   .settings(Dependencies.httpCore)
   .settings(VersionGenerator.versionSettings)


### PR DESCRIPTION
Here, we also don't build against akka master any more but use the
latest snapshot.

Also `onlyIf` is not necessary any more.