### PR TITLE
build: setup mima for 10.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -450,7 +450,7 @@ lazy val compatibilityTests = Project("akka-http-compatibility-tests", file("akk
   .addAkkaModuleDependency("akka-stream", "provided")
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-http" % MiMa.latestVersion % "provided",
+      "com.typesafe.akka" %% "akka-http" % MiMa.latest101Version % "provided",
     ),
     (dependencyClasspath in Test) := {
       // HACK: We'd like to use `dependsOn(http % "test->compile")` to upgrade the explicit dependency above to the

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -23,27 +23,12 @@ object MiMa extends AutoPlugin {
   )
 
   // A fork is a branch of the project where new releases are created that are not ancestors of the current release line
-  val forks = Seq("10.0.")
-  val currentFork = "10.1."
+  val forks = Seq("10.0.", "10.1.")
+  val currentFork = "10.2."
 
   // manually maintained list of previous versions to make sure all incompatibilities are found
   // even if so far no files have been been created in this project's mima-filters directory
   val pre213Versions = Set(
-    "10.0.0",
-    "10.0.1",
-    "10.0.2",
-    "10.0.3",
-    "10.0.4",
-    "10.0.5",
-    "10.0.6",
-    "10.0.7",
-    "10.0.8",
-    "10.0.9",
-    "10.0.10",
-    "10.0.11",
-    "10.0.12",
-    "10.0.13",
-    "10.0.14",
     "10.0.15",
     "10.1.0",
     "10.1.1",
@@ -60,6 +45,7 @@ object MiMa extends AutoPlugin {
     "10.1.10",
     "10.1.11",
     "10.1.12",
+    "10.2.0",
   )
 
   lazy val latestVersion = post213Versions.max(versionOrdering)

--- a/project/MiMa.scala
+++ b/project/MiMa.scala
@@ -39,16 +39,22 @@ object MiMa extends AutoPlugin {
     "10.1.6",
     "10.1.7",
   )
-  val post213Versions = Set(
+
+  val `10.1-post-2.13-versions` = Set(
     "10.1.8",
     "10.1.9",
     "10.1.10",
     "10.1.11",
     "10.1.12",
+  )
+  val `10.2-versions` = Set(
     "10.2.0",
   )
 
+  val post213Versions = `10.1-post-2.13-versions` ++ `10.2-versions`
+
   lazy val latestVersion = post213Versions.max(versionOrdering)
+  lazy val latest101Version = `10.1-post-2.13-versions`.max(versionOrdering)
 
   override val projectSettings = Seq(
     mimaPreviousArtifacts := {


### PR DESCRIPTION
 * create new "fork" for 10.1 and set current to 10.2
 * remove mima testing for old 10.0 versions (but keep 10.0.15 around for a while)

I guess it makes sense to wait with merging after 10.2.0 is released.