### PR TITLE
docs: create actor system from a guardian instead

### DIFF
--- a/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpServerMinimalExampleTest.java
@@ -5,6 +5,7 @@
 package docs.http.javadsl;
 //#minimal-routing-example
 import akka.actor.typed.ActorSystem;
+import akka.actor.typed.Behavior;
 import akka.actor.typed.javadsl.Behaviors;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
@@ -15,32 +16,36 @@ import java.util.concurrent.CompletionStage;
 
 public class HttpServerMinimalExampleTest extends AllDirectives {
 
-  public static void main(String[] args) throws Exception {
-    // boot up server using the route as defined below
-    ActorSystem<Void> system = ActorSystem.create(Behaviors.empty(), "routes");
+    public static void main(String[] args) throws Exception {
+        Behavior<Void> guardian = Behaviors.setup(actorContext -> {
+            final ActorSystem<?> system = actorContext.getSystem();
+            final Http http = Http.get(system);
 
-    final Http http = Http.get(system);
+            //In order to access all directives we need an instance where the routes are define.
+            HttpServerMinimalExampleTest app = new HttpServerMinimalExampleTest();
 
-    //In order to access all directives we need an instance where the routes are define.
-    HttpServerMinimalExampleTest app = new HttpServerMinimalExampleTest();
+            final CompletionStage<ServerBinding> binding =
+                http.newServerAt("localhost", 8080)
+                    .bind(app.createRoute());
 
-    final CompletionStage<ServerBinding> binding =
-      http.newServerAt("localhost", 8080)
-          .bind(app.createRoute());
+            System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
+            System.in.read(); // let it run until user presses return
 
-    System.out.println("Server online at http://localhost:8080/\nPress RETURN to stop...");
-    System.in.read(); // let it run until user presses return
+            binding
+                .thenCompose(ServerBinding::unbind) // trigger unbinding from the port
+                .thenAccept(unbound -> system.terminate()); // and shutdown when done
+            return Behaviors.empty();
+        });
 
-    binding
-        .thenCompose(ServerBinding::unbind) // trigger unbinding from the port
-        .thenAccept(unbound -> system.terminate()); // and shutdown when done
-  }
+        // boot up server using the route as defined below
+        ActorSystem.create(guardian, "routes");
+    }
 
-  private Route createRoute() {
-    return concat(
-        path("hello", () ->
-            get(() ->
-                complete("<h1>Say hello to akka-http</h1>"))));
-  }
+    private Route createRoute() {
+        return concat(
+            path("hello", () ->
+                get(() ->
+                    complete("<h1>Say hello to akka-http</h1>"))));
+    }
 }
 //#minimal-routing-example

--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerRoutingMinimal.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerRoutingMinimal.scala
@@ -5,33 +5,41 @@
 package docs.http.scaladsl
 
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
+import scala.concurrent.ExecutionContext
 import scala.io.StdIn
 
 object HttpServerRoutingMinimal {
 
   def main(args: Array[String]): Unit = {
+    val guardian: Behavior[Unit] = Behaviors.setup { actorContext =>
+      implicit val system: ActorSystem[_] = actorContext.system
 
-    implicit val system = ActorSystem(Behaviors.empty, "my-system")
-    // needed for the future flatMap/onComplete in the end
-    implicit val executionContext = system.executionContext
+      // needed for the future flatMap/onComplete in the end
+      implicit val executionContext: ExecutionContext = system.executionContext
 
-    val route =
-      path("hello") {
-        get {
-          complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
+      val route =
+        path("hello") {
+          get {
+            complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
+          }
         }
-      }
 
-    val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
+      val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
 
-    println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
-    StdIn.readLine() // let it run until user presses return
-    bindingFuture
-      .flatMap(_.unbind()) // trigger unbinding from the port
-      .onComplete(_ => system.terminate()) // and shutdown when done
+      println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
+      StdIn.readLine() // let it run until user presses return
+      bindingFuture
+        .flatMap(_.unbind()) // trigger unbinding from the port
+        .onComplete(_ => system.terminate()) // and shutdown when done
+
+      Behaviors.empty
+    }
+
+    ActorSystem(guardian, "my-system")
   }
 }


### PR DESCRIPTION
Updates the minimal examples with the new actors API to create the Akka HTTP binding in a guardian actor instead.