### PR TITLE
build: update to Scala 2.12.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -360,11 +360,7 @@ lazy val httpScalafixTests =
     .disablePlugins(BintrayPlugin, MimaPlugin)
     .settings(
       skip in publish := true,
-      libraryDependencies += {
-        // FIXME: temporary cludge to use old testkit until we can update to latest scala versions after 10.2.0
-        val scalafixTestkitVersion = if (scalaVersion.value == "2.12.11") "0.9.18" else Dependencies.scalafixVersion
-        "ch.epfl.scala" % "scalafix-testkit" % scalafixTestkitVersion % Test cross CrossVersion.full
-      },
+      libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % Dependencies.scalafixVersion % Test cross CrossVersion.full,
       compile.in(Compile) :=
         compile.in(Compile).dependsOn(compile.in(httpScalafixTestInput, Compile)).value,
       scalafixTestkitOutputSourceDirectories :=

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
 
   val scalafixVersion = _root_.scalafix.sbt.BuildInfo.scalafixVersion // grab from plugin
 
-  val scala212Version = "2.12.11"
+  val scala212Version = "2.12.12"
   val scala213Version = "2.13.3"
 
   val Versions = Seq(


### PR DESCRIPTION
To be merged only after #3419 and the release (too risky to do it so late before the release).