### PR TITLE
build: more reliable detection of last snapshot

### DIFF
--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -29,7 +29,7 @@ object AkkaDependency {
       case None =>
         Option(System.getProperty("akka.http.build.akka.version")) match {
           case Some("master") => Artifact(determineLatestSnapshot(), true)
-          case Some("release-2.5") => 
+          case Some("release-2.5") =>
             // Don't 'downgrade' building even if akka.sources asks for it
             // (typically for the docs that require 2.6)
             if (defaultVersion.startsWith("2.5")) Artifact(determineLatestSnapshot("2.5"), true)
@@ -91,7 +91,8 @@ object AkkaDependency {
     import scala.concurrent.Await
     import scala.concurrent.duration._
 
-    val body = Await.result(http.run(url("https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/")), 10.seconds).bodyAsString
+    // akka-cluster-sharding-typed_2.13 seems to be the last nightly published by `akka-publish-nightly` so if that's there then it's likely the rest also made it
+    val body = Await.result(http.run(url("https://repo.akka.io/snapshots/com/typesafe/akka/akka-cluster-sharding-typed_2.13/")), 10.seconds).bodyAsString
     """href="([^?/].*?)/"""".r.findAllMatchIn(body).map(_.group(1)).filter(_.startsWith(prefix)).toList.last
   }
 }


### PR DESCRIPTION
akka-actor_2.12 is one of the first artifacts published by akka-publish-nightly,
so it often happened that Akka snapshots has been published only partly and
akka http nightlies failing for that reason. By using the last artifact published
for detecting the snapshot version we try to avoid that issue.

Tried it locally and it selected 2.6.8+15 instead of 2.6.8-20. 2.6.8+15 corresponds to the last non-failing nightly snapshot build: https://jenkins.akka.io:8498/view/Nightly%20Jobs/job/akka-publish-nightly/1428/consoleFull, so that seems like a more reasonable choice.