### PR TITLE
[backport] build: more reliable detection of last snapshot 

### DIFF
--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -97,7 +97,8 @@ object AkkaDependency {
     import scala.concurrent.Await
     import scala.concurrent.duration._
 
-    val body = Await.result(http.run(url("https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/")), 10.seconds).bodyAsString
+    // akka-cluster-sharding-typed_2.13 seems to be the last nightly published by `akka-publish-nightly` so if that's there then it's likely the rest also made it
+    val body = Await.result(http.run(url("https://repo.akka.io/snapshots/com/typesafe/akka/akka-cluster-sharding-typed_2.13/")), 10.seconds).bodyAsString
     """href="([^?/].*?)/"""".r.findAllMatchIn(body).map(_.group(1)).filter(_.startsWith(prefix)).toList.last
   }
 }


### PR DESCRIPTION
release-10.1 backport of #3421

akka-actor_2.12 is one of the first artifacts published by akka-publish-nightly,
so it often happened that Akka snapshots has been published only partly and
akka http nightlies failing for that reason. By using the last artifact published
for detecting the snapshot version we try to avoid that issue.