### PR TITLE
docs: fix typo in deprecation message

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/FormData.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/FormData.scala
@@ -15,7 +15,7 @@ final case class FormData(fields: Uri.Query) {
   def toEntity: akka.http.scaladsl.model.RequestEntity =
     toEntityWithCharset(`application/x-www-form-urlencoded`.charset)
 
-  @deprecated("FormData always uses charset UTF-8 without appending the charset to 'Content-Type: application/x-www-form-urlencoded', use toEntity() instead.", "10.1.7")
+  @deprecated("FormData always uses charset UTF-8 without appending the charset to 'Content-Type: application/x-www-form-urlencoded', use toEntity instead.", "10.1.7")
   def toEntity(charset: HttpCharset): akka.http.scaladsl.model.RequestEntity =
     toEntityWithCharset(charset)
 


### PR DESCRIPTION
```
overloaded method value toEntity with alternatives:
[error]   (charset: akka.http.scaladsl.model.HttpCharset)akka.http.scaladsl.model.RequestEntity <and>
[error]   => akka.http.scaladsl.model.RequestEntity
[error]  cannot be applied to ()
[error]           ).toEntity()
[error]             ^
[error] one error found
```