### PR TITLE
core: don't leak internal limits to the clients for EntityStreamSizeException

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -473,13 +473,8 @@ private[http] object HttpServerBluePrint {
               // the application has forwarded a request entity stream error to the response stream
               finishWithIllegalRequestError(StatusCodes.BadRequest, errorInfo)
 
-            case EntityStreamSizeException(limit, contentLength) =>
-              val summary = contentLength match {
-                case Some(cl) => s"Request Content-Length of $cl bytes exceeds the configured limit of $limit bytes"
-                case None     => s"Aggregated data length of request entity exceeds the configured limit of $limit bytes"
-              }
-              val info = ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-              finishWithIllegalRequestError(StatusCodes.PayloadTooLarge, info)
+            case e: EntityStreamSizeException =>
+              finishWithIllegalRequestError(StatusCodes.PayloadTooLarge, e.info)
 
             case IllegalUriException(errorInfo) =>
               finishWithIllegalRequestError(StatusCodes.BadRequest, errorInfo)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
@@ -7,6 +7,8 @@ package akka.http.scaladsl.model
 import StatusCodes.ClientError
 import akka.annotation.InternalApi
 
+import scala.runtime.AbstractFunction2
+
 /**
  * Two-level model of error information.
  * The summary should explain what is wrong with the request or response *without* directly
@@ -69,7 +71,7 @@ object ErrorInfo {
 }
 
 /** Marker for exceptions that provide an ErrorInfo */
-abstract class ExceptionWithErrorInfo(val info: ErrorInfo, cause: Throwable) extends RuntimeException(info.formatPretty, cause) {
+abstract class ExceptionWithErrorInfo(val info: ErrorInfo, cause: Throwable) extends RuntimeException(info.format(withDetail = true), cause) {
   def this(info: ErrorInfo) = this(info, null)
 }
 
@@ -118,16 +120,19 @@ object EntityStreamException {
  * The limit can also be configured in code, by calling [[HttpEntity#withSizeLimit]]
  * on the entity before materializing its `dataBytes` stream.
  */
-final case class EntityStreamSizeException(limit: Long, actualSize: Option[Long] = None) extends RuntimeException {
-
-  override def getMessage = toString
-
-  override def toString = {
-    s"EntityStreamSizeException: incoming entity size (${actualSize.getOrElse("while streaming")}) exceeded size limit ($limit bytes)! " +
-      "This may have been a parser limit (set via `akka.http.[server|client].parsing.max-content-length`), " +
-      "a decoder limit (set via `akka.http.routing.decode-max-size`), " +
-      "or a custom limit set with `withSizeLimit`."
-  }
+final case class EntityStreamSizeException(limit: Long, actualSize: Option[Long] = None)
+  extends ExceptionWithErrorInfo(EntityStreamSizeException.errorInfo(limit, actualSize)) {
+  override def getMessage: String = super.getMessage // for bin compat
+}
+object EntityStreamSizeException /* for bin compat */ extends AbstractFunction2[Long, Option[Long], EntityStreamSizeException] {
+  private[EntityStreamSizeException] def errorInfo(limit: Long, actualSize: Option[Long]): ErrorInfo =
+    ErrorInfo(
+      "The incoming entity size exceeded the size limit of the server.",
+      s"Incoming entity size (${actualSize.getOrElse("while streaming")}) exceeded size limit ($limit bytes)! " +
+        "This may have been a parser limit (set via `akka.http.[server|client].parsing.max-content-length`), " +
+        "a decoder limit (set via `akka.http.routing.decode-max-size`), " +
+        "or a custom limit set with `withSizeLimit`."
+    )
 }
 
 case class RequestTimeoutException(request: HttpRequest, message: String) extends RuntimeException(message)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -1225,7 +1225,7 @@ class HttpServerSpec extends AkkaSpec(
                 val error = origError.getCause
 
                 error shouldEqual EntityStreamSizeException(limit, Some(actualSize))
-                error.getMessage should include("exceeded size limit")
+                error.getMessage should include("exceeded the size limit")
 
                 responses.sendError(error.asInstanceOf[Exception])
 
@@ -1237,7 +1237,7 @@ class HttpServerSpec extends AkkaSpec(
                       |Content-Type: text/plain; charset=UTF-8
                       |Content-Length: 75
                       |
-                  |Request Content-Length of $actualSize bytes exceeds the configured limit of $limit bytes""")
+                      |Request Content-Length of $actualSize bytes exceeds the configured limit of $limit bytes""")
             }
 
           def expectChunkedEntityWithSizeError(limit: Int) =
@@ -1249,7 +1249,7 @@ class HttpServerSpec extends AkkaSpec(
                 log.error(origError, "Original Error")
                 val error = origError.getCause
                 error shouldEqual EntityStreamSizeException(limit, None)
-                error.getMessage should include("exceeded size limit")
+                error.getMessage should include("exceeded the size limit")
 
                 responses.sendError(error.asInstanceOf[Exception])
 

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
@@ -90,10 +90,7 @@ public class RouteDirectivesTest extends JUnitRouteTest {
     route
       .run(HttpRequest.create("/limit-5").withEntity("1234567890"))
       .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE)
-      .assertEntity("EntityStreamSizeException: incoming entity size (10) exceeded size limit (5 bytes)! " +
-              "This may have been a parser limit (set via `akka.http.[server|client].parsing.max-content-length`), " +
-	      "a decoder limit (set via `akka.http.routing.decode-max-size`), " +
-              "or a custom limit set with `withSizeLimit`.");
+      .assertEntity("The incoming entity size exceeded the size limit of the server.");
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -8,7 +8,6 @@ import scala.util.control.NonFatal
 import akka.http.scaladsl.settings.RoutingSettings
 import akka.http.scaladsl.model._
 import StatusCodes._
-import scala.language.implicitConversions
 
 trait ExceptionHandler extends ExceptionHandler.PF {
 
@@ -53,9 +52,9 @@ object ExceptionHandler {
         ctx.complete((status, info.format(settings.verboseErrorMessages)))
       }
       case e: EntityStreamSizeException => ctx => {
-        ctx.log.error(e, ErrorMessageTemplate, e, PayloadTooLarge)
+        ctx.log.error(e, ErrorMessageTemplate, e.info.formatPretty, PayloadTooLarge)
         ctx.request.discardEntityBytes(ctx.materializer)
-        ctx.complete((PayloadTooLarge, e.getMessage))
+        ctx.complete((PayloadTooLarge, e.info.format(settings.verboseErrorMessages)))
       }
       case e: ExceptionWithErrorInfo => ctx => {
         ctx.log.error(e, ErrorMessageTemplate, e.info.formatPretty, InternalServerError)


### PR DESCRIPTION
Fixes #1015.

~Also never include details from ErrorInfo in the exception message to avoid
accidental leakage.~

~This is now a rather big change because it's now much more likely that details will be missing also from log messages in many instances. To retain the old behavior we might want to review error logging to make sure they use `info.formatPretty` to log the problem.~