### PR TITLE
Updated Scala style guide example to match the Java one (removed duplication)

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/StyleGuideExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/StyleGuideExamplesSpec.scala
@@ -75,7 +75,7 @@ class StyleGuideExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
       val customerRoutes: Route =
         concat(
-          path("customer" / IntNumber) { customerId =>
+          path(IntNumber) { customerId =>
             complete("")
           }
         // ...
@@ -107,7 +107,7 @@ class StyleGuideExamplesSpec extends RoutingSpec with CompileOnlySpec {
           },
           pathPrefix("customer") {
             concat(
-              path("customer" / IntNumber) { cosumerId =>
+              path(IntNumber) { customerId =>
                 complete("")
               }
             // ...


### PR DESCRIPTION
The Java example for `path-compose` already does the right thing but the Scala example duplicates the `customer` path.
I also fixed the name of the extracted `customerId` value.

