### PR TITLE
core: reenable lingerTimeout

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/ServerTerminator.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/ServerTerminator.scala
@@ -260,8 +260,9 @@ private[http] final class GracefulTerminatorStage(settings: ServerSettings)
       })
 
       def installTerminationHandlers(deadline: Deadline): Unit = {
-        // when no inflight requests, complete stage right away
-        if (!pendingUserHandlerResponse) completeStage()
+        // when no inflight requests, fail stage right away, could probably be a complete
+        // when https://github.com/akka/akka-http/issues/3209 is fixed
+        if (!pendingUserHandlerResponse) failStage(new ServerTerminationDeadlineReached)
 
         setHandler(fromUser, new InHandler {
           override def onPush(): Unit = {

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -15,9 +15,9 @@ import akka.stream.impl.fusing.GraphInterpreter
 import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
 import akka.stream.scaladsl._
 import akka.stream.stage._
-import akka.util.ByteString
+import akka.util.{ ByteString, OptionVal }
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.Failure
 import scala.util.Success
@@ -188,6 +188,56 @@ private[http] object StreamUtils {
 
       def source[T]: Source[T, NotUsed] = _source.asInstanceOf[Source[T, NotUsed]] // safe, because source won't generate any elements
       def open(): Unit = promise.success(())
+    }
+  }
+
+  /**
+   * INTERNAL API
+   *
+   * Returns a flow that is almost identity but delays propagation of cancellation from downstream to upstream.
+   */
+  def delayCancellation[T](cancelAfter: Duration): Flow[T, T, NotUsed] = Flow.fromGraph(new DelayCancellationStage(cancelAfter))
+  final class DelayCancellationStage[T](cancelAfter: Duration) extends SimpleLinearGraphStage[T] {
+    def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with ScheduleSupport with InHandler with OutHandler with StageLogging {
+      setHandlers(in, out, this)
+
+      def onPush(): Unit = push(out, grab(in)) // using `passAlong` was considered but it seems to need some boilerplate to make it work
+      def onPull(): Unit = pull(in)
+
+      var timeout: OptionVal[Cancellable] = OptionVal.None
+
+      override def onDownstreamFinish(): Unit = {
+        cancelAfter match {
+          case finite: FiniteDuration =>
+            log.debug(s"Delaying cancellation for $finite")
+            timeout = OptionVal.Some {
+              scheduleOnce(finite) {
+                log.debug(s"Stage was canceled after delay of $cancelAfter")
+                timeout = OptionVal.None
+                completeStage()
+              }
+            }
+          case _ => // do nothing
+        }
+
+        // don't pass cancellation to upstream but keep pulling until we get completion or failure
+        setHandler(
+          in,
+          new InHandler {
+            if (!hasBeenPulled(in)) pull(in)
+
+            def onPush(): Unit = {
+              grab(in) // ignore further elements
+              pull(in)
+            }
+          }
+        )
+      }
+
+      override def postStop(): Unit = timeout match {
+        case OptionVal.Some(x) => x.cancel()
+        case OptionVal.None    => // do nothing
+      }
     }
   }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -397,7 +397,7 @@ class HttpServerSpec extends AkkaSpec(
           sub.request(1)
           dataProbe.expectNext(Chunk(ByteString("abcdef")))
           dataProbe.expectComplete()
-          netIn.expectCancellation()
+          netOut.expectError()
       }
       shutdownBlueprint()
     })
@@ -859,8 +859,8 @@ class HttpServerSpec extends AkkaSpec(
         dataOutProbe.sendError(new RuntimeException("Meteor wiped data center"))
       }
 
-      netOut.expectError()
-      netIn.expectCancellation()
+      val error = netOut.expectError()
+      netIn.sendError(error) // close loop
     })
 
     "log error and reset connection when the response stream materialization fails" in assertAllStagesStopped(new TestSetup {


### PR DESCRIPTION
Fixes #3452, #2532

In 294df230af0e1e1b3a7aba575975a634bd017050, the stream-cancellation-delay was
introduced. However, at the same time I removed the lingerTimeout functionality.
While both features are related, they serve different purposes:

 * `streamCancellationDelay` tries to avoid cancellation races by giving a
   stream graph more time to propagate errors/completion on the forward path.
   The default is 100 millis because that suffices in most conditions.
 * `lingerTimeout` gives clients more time to read a response slowly when the
   server is finished with a connection. lingerTimeout is set to a more generous
   1 minute, because it is only a safe-guard that a connection, that isn't "managed"
   any more by the server (because the server stack was already done), is
   still ultimately closed if the client is too slow (or stuck at all).

We backported the same change on 10.1.13, so it needs to be fixed there as well.