### PR TITLE
tests: use copy of SocketUtil that does not use 127.x.y.255 addresses

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -536,7 +536,7 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
   "The superPool client infrastructure" should {
 
     "route incoming requests to the right cached host connection pool" in new TestSetup(autoAccept = true) {
-      val (serverHostName2, serverPort2) = SocketUtil.temporaryServerHostnameAndPort()
+      val (serverHostName2, serverPort2) = SocketUtil2.temporaryServerHostnameAndPort()
       Http().newServerAt(serverHostName2, serverPort2).bindSync(testServerHandler(0))
 
       val (requestIn, responseOut, responseOutSub, _) = superPool[Int]()

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -82,7 +82,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
     }
 
     "report failure if bind fails" in EventFilter[BindException](occurrences = 2).intercept {
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
       val binding = Http().newServerAt(hostname, port).connectionSource()
       val probe1 = TestSubscriber.manualProbe[Http.IncomingConnection]()
       // Bind succeeded, we have a local address
@@ -124,7 +124,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
     }
 
     "run with bindSync" in {
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
       val binding = Http().newServerAt(hostname, port).bindSync(_ => HttpResponse())
       val b1 = Await.result(binding, 3.seconds.dilated)
 
@@ -136,7 +136,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
     }
 
     "prevent more than the configured number of max-connections with bind" in {
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
       val settings = ServerSettings(system).withMaxConnections(1)
 
       val receivedSlow = Promise[Long]()
@@ -203,7 +203,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
       }
 
       abstract class RemoteAddressTestScenario {
-        val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+        val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
 
         val settings = ServerSettings(system).withRemoteAddressHeader(true)
         def createBinding(): Future[ServerBinding]
@@ -245,7 +245,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
       "support server timeouts" should {
         "close connection with idle client after idleTimeout" in {
           val serverIdleTimeout = 300.millis
-          val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+          val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
           val (receivedRequest: Promise[Long], b1: ServerBinding) = bindServer(hostname, port, serverIdleTimeout)
 
           try {
@@ -311,7 +311,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
           val clientTimeout = 345.millis.dilated
           val clientPoolSettings = cs.withIdleTimeout(clientTimeout)
 
-          val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+          val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
           val (receivedRequest: Promise[Long], b1: ServerBinding) = bindServer(hostname, port, serverTimeout)
 
           try {
@@ -346,7 +346,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
           val clientTimeout = 345.millis.dilated
           val clientPoolSettings = cs.withIdleTimeout(clientTimeout)
 
-          val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+          val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
           val (receivedRequest: Promise[Long], b1: ServerBinding) = bindServer(hostname, port, serverTimeout)
 
           try {
@@ -376,7 +376,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
       "are triggered in `mapMaterialized`" in Utils.assertAllStagesStopped {
         // FIXME racy feature, needs https://github.com/akka/akka/issues/17849 to be fixed
         pending
-        val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+        val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
         val flow = Flow[HttpRequest].map(_ => HttpResponse()).mapMaterializedValue(_ => sys.error("BOOM"))
         val binding = Http(system2).newServerAt(hostname, port).bindFlow(flow)
         val b1 = Await.result(binding, 1.seconds.dilated)
@@ -608,7 +608,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
       val serverToClientNetworkBufferSize = 1000
       val responseSize = 200000
 
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
       def request(i: Int) = HttpRequest(uri = s"http://$hostname:$port/$i", headers = headers.Connection("close") :: Nil)
       def response(req: HttpRequest) = HttpResponse(entity = HttpEntity.Strict(ContentTypes.`text/plain(UTF-8)`, ByteString(req.uri.path.toString.takeRight(1) * responseSize)))
 
@@ -701,7 +701,7 @@ Host: example.com
     "complete a request/response over https when request has `Connection: close` set" in Utils.assertAllStagesStopped {
       // akka/akka-http#1219
       val serverToClientNetworkBufferSize = 1000
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
       val request = HttpRequest(uri = s"https://akka.example.org", headers = headers.Connection("close") :: Nil)
 
       // settings adapting network buffer sizes
@@ -899,7 +899,7 @@ Host: example.com
   }
 
   class TestSetup {
-    val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+    val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
     def configOverrides = ""
 
     // automatically bind a server

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
@@ -32,7 +32,7 @@ class ClientSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   "HTTP Client" should {
 
     "reuse connection pool" in {
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
       val bindingFuture = Http().newServerAt(hostname, port).bindSync(_ => HttpResponse())
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
@@ -26,7 +26,7 @@ class ClientTransportWithCustomResolverSpec extends AkkaSpecWithMaterializer("ak
     "change to the desired destination" in {
       val hostnameToFind = "some-name-out-there"
       val portToFind = 21345
-      val (hostnameToUse, portToUse) = SocketUtil.temporaryServerHostnameAndPort()
+      val (hostnameToUse, portToUse) = SocketUtil2.temporaryServerHostnameAndPort()
       val bindingFuture = Http().newServerAt(hostnameToUse, portToUse).bindSync(_ => HttpResponse())
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
 
@@ -50,7 +50,7 @@ class ClientTransportWithCustomResolverSpec extends AkkaSpecWithMaterializer("ak
     "resolve not before a connection is needed" in {
       val hostnameToFind = "some-name-out-there"
       val portToFind = 21345
-      val (hostnameToUse, portToUse) = SocketUtil.temporaryServerHostnameAndPort()
+      val (hostnameToUse, portToUse) = SocketUtil2.temporaryServerHostnameAndPort()
       val bindingFuture = Http().newServerAt(hostnameToUse, portToUse).bindSync(_ => HttpResponse())
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
@@ -54,7 +54,7 @@ class EntityDiscardingSpec extends AkkaSpecWithMaterializer {
     // TODO consider improving this by storing a mutable "already materialized" flag somewhere
     // TODO likely this is going to inter-op with the auto-draining as described in #18716
     "should not allow draining a second time" in {
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (host, port) = SocketUtil2.temporaryServerHostnameAndPort()
       val bound = Http().newServerAt(host, port).bindSync(req =>
         HttpResponse(entity = HttpEntity(
           ContentTypes.`text/csv(UTF-8)`, Source.fromIterator[ByteString](() => testData.iterator)))).futureValue

--- a/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
@@ -82,6 +82,8 @@ object SocketUtil2 {
 
         val address = hostname match {
           case RANDOM_LOOPBACK_ADDRESS =>
+            // JDK limitation? You cannot bind on addresses matching the pattern 127.x.y.255,
+            // that's why the last component must be < 255
             if (canBindOnAlternativeLoopbackAddresses) s"127.20.${Random.nextInt(256)}.${Random.nextInt(255)}"
             else "127.0.0.1"
           case other =>

--- a/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
@@ -82,7 +82,7 @@ object SocketUtil2 {
 
         val address = hostname match {
           case RANDOM_LOOPBACK_ADDRESS =>
-            if (canBindOnAlternativeLoopbackAddresses) s"127.20.${Random.nextInt(256)}.${Random.nextInt(256)}"
+            if (canBindOnAlternativeLoopbackAddresses) s"127.20.${Random.nextInt(256)}.${Random.nextInt(255)}"
             else "127.0.0.1"
           case other =>
             other

--- a/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.testkit
+
+import scala.collection.immutable
+import scala.util.Random
+import java.net.{ DatagramSocket, InetSocketAddress, NetworkInterface, StandardProtocolFamily }
+import java.nio.channels.DatagramChannel
+import java.nio.channels.ServerSocketChannel
+
+import scala.util.control.NonFatal
+
+/**
+ * Utilities to get free socket address.
+ */
+object SocketUtil22 {
+
+  val RANDOM_LOOPBACK_ADDRESS = "RANDOM_LOOPBACK_ADDRESS"
+
+  private val canBindOnAlternativeLoopbackAddresses = {
+    try {
+      SocketUtil2.temporaryServerAddress(address = "127.20.0.0")
+      true
+    } catch {
+      case _: java.net.BindException =>
+        false
+    }
+  }
+
+  sealed trait Protocol
+  final case object Tcp extends Protocol
+  final case object Udp extends Protocol
+  final case object Both extends Protocol
+
+  /** @return A port on 'localhost' that is currently available */
+  def temporaryLocalPort(udp: Boolean = false): Int = temporaryServerAddress("localhost", udp).getPort
+
+  /**
+   * Find a free local post on 'localhost' that is available on the given protocol
+   * If both UDP and TCP need to be free specify `Both`
+   */
+  def temporaryLocalPort(protocol: Protocol): Int = {
+    def findBoth(tries: Int): Int = {
+      if (tries == 0) {
+        throw new RuntimeException("Unable to find a port that is free for tcp and udp")
+      }
+      val tcpPort = SocketUtil2.temporaryLocalPort(udp = false)
+      val ds: DatagramSocket = DatagramChannel.open().socket()
+      try {
+        ds.bind(new InetSocketAddress("localhost", tcpPort))
+        tcpPort
+      } catch {
+        case NonFatal(_) => findBoth(tries - 1)
+      } finally {
+        ds.close()
+      }
+    }
+
+    protocol match {
+      case Tcp  => temporaryLocalPort(udp = false)
+      case Udp  => temporaryLocalPort(udp = true)
+      case Both => findBoth(5)
+    }
+  }
+
+  /**
+   * @param address host address. If not set, a loopback IP from the 127.20.0.0/16 range is picked
+   * @param udp     if true, select a port that is free for running a UDP server. Otherwise TCP.
+   * @return an address (host+port) that is currently available to bind on
+   */
+  def temporaryServerAddress(address: String = RANDOM_LOOPBACK_ADDRESS, udp: Boolean = false): InetSocketAddress =
+    temporaryServerAddresses(1, address, udp).head
+
+  def temporaryServerAddresses(
+    numberOfAddresses: Int,
+    hostname:          String  = RANDOM_LOOPBACK_ADDRESS,
+    udp:               Boolean = false): immutable.IndexedSeq[InetSocketAddress] = {
+    Vector
+      .fill(numberOfAddresses) {
+
+        val address = hostname match {
+          case RANDOM_LOOPBACK_ADDRESS =>
+            if (canBindOnAlternativeLoopbackAddresses) s"127.20.${Random.nextInt(256)}.${Random.nextInt(256)}"
+            else "127.0.0.1"
+          case other =>
+            other
+        }
+
+        val addr = new InetSocketAddress(address, 0)
+        try
+          if (udp) {
+            val ds = DatagramChannel.open().socket()
+            ds.bind(addr)
+            (ds, new InetSocketAddress(address, ds.getLocalPort))
+          } else {
+            val ss = ServerSocketChannel.open().socket()
+            ss.bind(addr)
+            (ss, new InetSocketAddress(address, ss.getLocalPort))
+          }
+        catch {
+          case NonFatal(ex) =>
+            throw new RuntimeException(s"Binding to $addr failed with ${ex.getMessage}", ex)
+        }
+      }
+      .collect { case (socket, address) => socket.close(); address }
+  }
+
+  def temporaryServerHostnameAndPort(interface: String = RANDOM_LOOPBACK_ADDRESS): (String, Int) = {
+    val socketAddress = temporaryServerAddress(interface)
+    socketAddress.getHostString -> socketAddress.getPort
+  }
+
+  def temporaryUdpIpv6Port(iface: NetworkInterface) = {
+    val serverSocket = DatagramChannel.open(StandardProtocolFamily.INET6).socket()
+    serverSocket.bind(new InetSocketAddress(iface.getInetAddresses.nextElement(), 0))
+    val port = serverSocket.getLocalPort
+    serverSocket.close()
+    port
+  }
+
+  def notBoundServerAddress(address: String): InetSocketAddress = new InetSocketAddress(address, 0)
+
+  def notBoundServerAddress(): InetSocketAddress = notBoundServerAddress("127.0.0.1")
+}

--- a/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
 /**
  * Utilities to get free socket address.
  */
-object SocketUtil22 {
+object SocketUtil2 {
 
   val RANDOM_LOOPBACK_ADDRESS = "RANDOM_LOOPBACK_ADDRESS"
 

--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -14,7 +14,7 @@ import akka.http.scaladsl.server.{ Directives, Route }
 import akka.http.scaladsl.Http
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
 import akka.stream.scaladsl.Source
-import akka.testkit.{ ImplicitSender, LongRunningTest, SocketUtil }
+import akka.testkit.{ ImplicitSender, LongRunningTest, SocketUtil2 }
 import akka.util.{ ByteString, Timeout }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
@@ -176,7 +176,7 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
         enterBarrier("load-gen-ready")
 
         runOn(server) {
-          val (_, port) = SocketUtil.temporaryServerHostnameAndPort()
+          val (_, port) = SocketUtil2.temporaryServerHostnameAndPort()
           info(s"Binding Akka HTTP Server to port: $port @ ${myself}")
           val futureBinding = Http().newServerAt("0.0.0.0", port).bind(routes)
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -37,7 +37,7 @@ class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
 
     "allow registering custom media type" in {
       import system.dispatcher
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (host, port) = SocketUtil2.temporaryServerHostnameAndPort()
 
       //#application-custom
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.HttpProtocols._
 import akka.http.scaladsl.model.RequestEntityAcceptance.Expected
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives
-import akka.testkit.{ AkkaSpec, SocketUtil }
+import akka.testkit.{ AkkaSpec, SocketUtil2 }
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.duration._
@@ -20,7 +20,7 @@ class CustomHttpMethodSpec extends AkkaSpec with ScalaFutures
   "Http" should {
     "allow registering custom method" in {
       import system.dispatcher
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (host, port) = SocketUtil2.temporaryServerHostnameAndPort()
 
       //#application-custom
       import akka.http.scaladsl.settings.{ ParserSettings, ServerSettings }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -17,7 +17,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future, Promise }
-import akka.testkit.{ AkkaSpec, SocketUtil }
+import akka.testkit.{ AkkaSpec, SocketUtil2 }
 
 class TimeoutDirectivesExamplesSpec extends RoutingSpec
   with ScalaFutures with CompileOnlySpec {


### PR DESCRIPTION
It recently failed various times with this stack trace:

```
java.net.BindException: Cannot assign requested address
	at java.base/sun.nio.ch.Net.bind0(Native Method)
	at java.base/sun.nio.ch.Net.bind(Net.java:455)
	at java.base/sun.nio.ch.Net.bind(Net.java:447)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
	at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:80)
	at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:73)
	at akka.testkit.SocketUtil$.$anonfun$temporaryServerAddresses$1(SocketUtil.scala:97)
	at scala.collection.StrictOptimizedSeqFactory.fill(Factory.scala:330)
	at scala.collection.StrictOptimizedSeqFactory.fill$(Factory.scala:325)
	at scala.collection.immutable.Vector$.fill(Vector.scala:34)
	at akka.testkit.SocketUtil$.temporaryServerAddresses(SocketUtil.scala:81)
	at akka.testkit.SocketUtil$.temporaryServerAddress(SocketUtil.scala:74)
	at akka.testkit.SocketUtil$.temporaryServerHostnameAndPort(SocketUtil.scala:106)
```

It's unclear why this could fail, so we add this for a round of builds to find out what the address is when it fails.