### PR TITLE
http2: ignore unexpected DATA frames in state closed

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -242,7 +242,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with StageLoggi
     def handle(event: StreamFrameEvent): IncomingStreamState = event match {
       // https://http2.github.io/http2-spec/#StreamStates
       // Endpoints MUST ignore WINDOW_UPDATE or RST_STREAM frames received in this state,
-      case _: RstStreamFrame | _: WindowUpdateFrame =>
+      case _: RstStreamFrame | _: WindowUpdateFrame | _: DataFrame =>
         this
       case _ =>
         receivedUnexpectedFrame(event)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -331,6 +331,13 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         sendRST_STREAM(TheStreamId, ErrorCode.STREAM_CLOSED)
         expectNoBytes(100.millis)
       }
+      "not fail the whole connection when data frames are received after stream was cancelled" in new WaitingForRequestData {
+        entityDataIn.cancel()
+        expectRST_STREAM(TheStreamId)
+        sendDATA(TheStreamId, endStream = false, ByteString("test"))
+        // should just be ignored, especially no GOAWAY frame should be sent in response
+        expectNoBytes(100.millis)
+      }
       "send RST_STREAM if entity stream is canceled" in new WaitingForRequestData {
         val data1 = ByteString("abcdef")
         sendDATA(TheStreamId, endStream = false, data1)


### PR DESCRIPTION
Fixes #3461

Those frames are somewhat expected at least in the case where we just sent a
RST_STREAM frame and the peer might not have yet processed it.

Of course, it might also be an indication of a misbehaving peer but as long
as there's no indication that this can lead to a non-negligible overhead on
our side, we might be fine with this simple solution.