### PR TITLE
[10.1 backport] tests: use copy of SocketUtil that does not use 127.x.y.255 addresses

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ClientCancellationSpec.scala
@@ -12,19 +12,19 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Sink, Source }
 import akka.stream.testkit.{ TestPublisher, TestSubscriber, Utils }
 import akka.http.scaladsl.model.headers
-import akka.testkit.SocketUtil
+import akka.testkit.SocketUtil2
 
 class ClientCancellationSpec extends AkkaSpecWithMaterializer {
   val noncheckedMaterializer = ActorMaterializer()
 
   "Http client connections" must {
-    val address = SocketUtil.temporaryServerAddress()
+    val address = SocketUtil2.temporaryServerAddress()
     Http().bindAndHandleSync(
       { req => HttpResponse(headers = headers.Connection("close") :: Nil) },
       address.getHostName,
       address.getPort)(noncheckedMaterializer)
 
-    val addressTls = SocketUtil.temporaryServerAddress()
+    val addressTls = SocketUtil2.temporaryServerAddress()
     Http().bindAndHandleSync(
       { req => HttpResponse() }, // TLS client does full-close, no need for the connection:close header
       addressTls.getHostName,

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -533,7 +533,7 @@ abstract class ConnectionPoolSpec(poolImplementation: PoolImplementation)
   "The superPool client infrastructure" should {
 
     "route incoming requests to the right cached host connection pool" in new TestSetup(autoAccept = true) {
-      val (serverHostName2, serverPort2) = SocketUtil.temporaryServerHostnameAndPort()
+      val (serverHostName2, serverPort2) = SocketUtil2.temporaryServerHostnameAndPort()
       Http().bindAndHandleSync(testServerHandler(0), serverHostName2, serverPort2)
 
       val (requestIn, responseOut, responseOutSub, _) = superPool[Int]()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HighLevelOutgoingConnectionSpec.scala
@@ -19,7 +19,7 @@ class HighLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer {
   "The connection-level client implementation" should {
 
     "be able to handle 100 requests across one connection" in Utils.assertAllStagesStopped {
-      val (serverHostName, serverPort) = SocketUtil.temporaryServerHostnameAndPort()
+      val (serverHostName, serverPort) = SocketUtil2.temporaryServerHostnameAndPort()
 
       val binding = Http().bindAndHandleSync(
         r => HttpResponse(entity = r.uri.toString.reverse.takeWhile(Character.isDigit).reverse),
@@ -38,7 +38,7 @@ class HighLevelOutgoingConnectionSpec extends AkkaSpecWithMaterializer {
     }
 
     "be able to handle 100 requests across 4 connections (client-flow is reusable)" in Utils.assertAllStagesStopped {
-      val (serverHostName, serverPort) = SocketUtil.temporaryServerHostnameAndPort()
+      val (serverHostName, serverPort) = SocketUtil2.temporaryServerHostnameAndPort()
 
       val binding = Http().bindAndHandleSync(
         r => HttpResponse(entity = r.uri.toString.reverse.takeWhile(Character.isDigit).reverse),

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
@@ -31,7 +31,7 @@ class ClientSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   "HTTP Client" should {
 
     "reuse connection pool" in {
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
       val bindingFuture = Http().bindAndHandleSync(_ => HttpResponse(), hostname, port)
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -204,7 +204,7 @@ class GracefulTerminationSpec
     (the[StreamTcpException] thrownBy Await.result(r, 1.second)).getMessage should endWith("Connection refused")
 
   class TestSetup(overrideResponse: Option[HttpResponse] = None) {
-    val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+    val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
     val counter = new AtomicInteger()
     var idleTimeoutBaseForUniqueness = 10
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
@@ -56,7 +56,7 @@ class EntityDiscardingSpec extends AkkaSpec {
     // TODO consider improving this by storing a mutable "already materialized" flag somewhere
     // TODO likely this is going to inter-op with the auto-draining as described in #18716
     "should not allow draining a second time" in {
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (host, port) = SocketUtil2.temporaryServerHostnameAndPort()
       val bound = Http().bindAndHandleSync(
         req =>
           HttpResponse(entity = HttpEntity(

--- a/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2009-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.testkit
+
+import scala.collection.immutable
+import scala.util.Random
+import java.net.{ DatagramSocket, InetSocketAddress, NetworkInterface, StandardProtocolFamily }
+import java.nio.channels.DatagramChannel
+import java.nio.channels.ServerSocketChannel
+
+import scala.util.control.NonFatal
+
+/**
+ * Utilities to get free socket address.
+ */
+object SocketUtil2 {
+
+  val RANDOM_LOOPBACK_ADDRESS = "RANDOM_LOOPBACK_ADDRESS"
+
+  private val canBindOnAlternativeLoopbackAddresses = {
+    try {
+      SocketUtil2.temporaryServerAddress(address = "127.20.0.0")
+      true
+    } catch {
+      case _: java.net.BindException =>
+        false
+    }
+  }
+
+  sealed trait Protocol
+  final case object Tcp extends Protocol
+  final case object Udp extends Protocol
+  final case object Both extends Protocol
+
+  /** @return A port on 'localhost' that is currently available */
+  def temporaryLocalPort(udp: Boolean = false): Int = temporaryServerAddress("localhost", udp).getPort
+
+  /**
+   * Find a free local post on 'localhost' that is available on the given protocol
+   * If both UDP and TCP need to be free specify `Both`
+   */
+  def temporaryLocalPort(protocol: Protocol): Int = {
+    def findBoth(tries: Int): Int = {
+      if (tries == 0) {
+        throw new RuntimeException("Unable to find a port that is free for tcp and udp")
+      }
+      val tcpPort = SocketUtil2.temporaryLocalPort(udp = false)
+      val ds: DatagramSocket = DatagramChannel.open().socket()
+      try {
+        ds.bind(new InetSocketAddress("localhost", tcpPort))
+        tcpPort
+      } catch {
+        case NonFatal(_) => findBoth(tries - 1)
+      } finally {
+        ds.close()
+      }
+    }
+
+    protocol match {
+      case Tcp  => temporaryLocalPort(udp = false)
+      case Udp  => temporaryLocalPort(udp = true)
+      case Both => findBoth(5)
+    }
+  }
+
+  /**
+   * @param address host address. If not set, a loopback IP from the 127.20.0.0/16 range is picked
+   * @param udp     if true, select a port that is free for running a UDP server. Otherwise TCP.
+   * @return an address (host+port) that is currently available to bind on
+   */
+  def temporaryServerAddress(address: String = RANDOM_LOOPBACK_ADDRESS, udp: Boolean = false): InetSocketAddress =
+    temporaryServerAddresses(1, address, udp).head
+
+  def temporaryServerAddresses(
+    numberOfAddresses: Int,
+    hostname:          String  = RANDOM_LOOPBACK_ADDRESS,
+    udp:               Boolean = false): immutable.IndexedSeq[InetSocketAddress] = {
+    Vector
+      .fill(numberOfAddresses) {
+
+        val address = hostname match {
+          case RANDOM_LOOPBACK_ADDRESS =>
+            // JDK limitation? You cannot bind on addresses matching the pattern 127.x.y.255,
+            // that's why the last component must be < 255
+            if (canBindOnAlternativeLoopbackAddresses) s"127.20.${Random.nextInt(256)}.${Random.nextInt(255)}"
+            else "127.0.0.1"
+          case other =>
+            other
+        }
+
+        val addr = new InetSocketAddress(address, 0)
+        try
+          if (udp) {
+            val ds = DatagramChannel.open().socket()
+            ds.bind(addr)
+            (ds, new InetSocketAddress(address, ds.getLocalPort))
+          } else {
+            val ss = ServerSocketChannel.open().socket()
+            ss.bind(addr)
+            (ss, new InetSocketAddress(address, ss.getLocalPort))
+          }
+        catch {
+          case NonFatal(ex) =>
+            throw new RuntimeException(s"Binding to $addr failed with ${ex.getMessage}", ex)
+        }
+      }
+      .collect { case (socket, address) => socket.close(); address }
+  }
+
+  def temporaryServerHostnameAndPort(interface: String = RANDOM_LOOPBACK_ADDRESS): (String, Int) = {
+    val socketAddress = temporaryServerAddress(interface)
+    socketAddress.getHostString -> socketAddress.getPort
+  }
+
+  def temporaryUdpIpv6Port(iface: NetworkInterface) = {
+    val serverSocket = DatagramChannel.open(StandardProtocolFamily.INET6).socket()
+    serverSocket.bind(new InetSocketAddress(iface.getInetAddresses.nextElement(), 0))
+    val port = serverSocket.getLocalPort
+    serverSocket.close()
+    port
+  }
+
+  def notBoundServerAddress(address: String): InetSocketAddress = new InetSocketAddress(address, 0)
+
+  def notBoundServerAddress(): InetSocketAddress = notBoundServerAddress("127.0.0.1")
+}

--- a/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
+++ b/akka-http-core/src/test/scala/akka/testkit/SocketUtil2.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.testkit

--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -15,7 +15,7 @@ import akka.http.scaladsl.Http
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
-import akka.testkit.{ ImplicitSender, LongRunningTest, SocketUtil }
+import akka.testkit.{ ImplicitSender, LongRunningTest, SocketUtil2 }
 import akka.util.{ ByteString, Timeout }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
@@ -180,7 +180,7 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
         enterBarrier("load-gen-ready")
 
         runOn(server) {
-          val (_, port) = SocketUtil.temporaryServerHostnameAndPort()
+          val (_, port) = SocketUtil2.temporaryServerHostnameAndPort()
           info(s"Binding Akka HTTP Server to port: $port @ ${myself}")
           val futureBinding = Http().bindAndHandle(routes, "0.0.0.0", port)
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -37,7 +37,7 @@ class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
 
     "allow registering custom media type" in {
       import system.dispatcher
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (host, port) = SocketUtil2.temporaryServerHostnameAndPort()
 
       //#application-custom
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomStatusCodesSpec.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.ActorMaterializer
-import akka.testkit.{ AkkaSpec, SocketUtil }
+import akka.testkit.{ AkkaSpec, SocketUtil2 }
 import org.scalatest.concurrent.ScalaFutures
 
 class CustomStatusCodesSpec extends AkkaSpec with ScalaFutures
@@ -21,7 +21,7 @@ class CustomStatusCodesSpec extends AkkaSpec with ScalaFutures
   "Http" should {
     "allow registering custom status code" in {
       import system.dispatcher
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (host, port) = SocketUtil2.temporaryServerHostnameAndPort()
 
       //#application-custom
       // similarly in Java: `akka.http.javadsl.settings.[...]`

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/IntegrationRoutingSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.stream.ActorMaterializer
-import akka.testkit.{ AkkaSpec, SocketUtil, TestKit }
+import akka.testkit.{ AkkaSpec, SocketUtil2, TestKit }
 import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 
@@ -31,7 +31,7 @@ private[akka] trait IntegrationRoutingSpec extends WordSpecLike with Matchers wi
 
   implicit class Checking(p: Prepped) {
     def ~!>(checking: HttpResponse => Unit) = {
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (host, port) = SocketUtil2.temporaryServerHostnameAndPort()
       val binding = Http().bindAndHandle(p.route, host, port)
 
       try {

--- a/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/scaladsl/Http2BindingViaConfigSpec.scala
@@ -8,7 +8,7 @@ import akka.event.Logging
 import akka.http.impl.util.ExampleHttpContexts
 import akka.http.scaladsl.model._
 import akka.stream._
-import akka.testkit.{ AkkaSpec, TestProbe, SocketUtil }
+import akka.testkit.{ AkkaSpec, TestProbe, SocketUtil2 }
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
@@ -23,7 +23,7 @@ class Http2BindingViaConfigSpec extends AkkaSpec("""
   implicit val mat = ActorMaterializer()
   import system.dispatcher
 
-  val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+  val (host, port) = SocketUtil2.temporaryServerHostnameAndPort()
   var binding: Future[Http.ServerBinding] = _ // initialized atStartup
 
   val helloWorldHandler: HttpRequest => Future[HttpResponse] =

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
@@ -11,7 +11,7 @@ import akka.http.scaladsl.model.RequestEntityAcceptance.Expected
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives
 import akka.stream.ActorMaterializer
-import akka.testkit.{ AkkaSpec, SocketUtil }
+import akka.testkit.{ AkkaSpec, SocketUtil2 }
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 
@@ -25,7 +25,7 @@ class CustomHttpMethodSpec extends AkkaSpec with ScalaFutures
   "Http" should {
     "allow registering custom method" in {
       import system.dispatcher
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
+      val (host, port) = SocketUtil2.temporaryServerHostnameAndPort()
 
       //#application-custom
       import akka.http.scaladsl.settings.{ ParserSettings, ServerSettings }

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/TimeoutDirectivesExamplesSpec.scala
@@ -16,7 +16,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.duration._
 import scala.concurrent.{ Future, Promise }
-import akka.testkit.{ AkkaSpec, SocketUtil }
+import akka.testkit.{ AkkaSpec, SocketUtil2 }
 
 private[this] object TimeoutDirectivesInfiniteTimeoutTestConfig {
   val testConf: Config = ConfigFactory.parseString("""
@@ -37,7 +37,7 @@ class TimeoutDirectivesExamplesSpec extends AkkaSpec(TimeoutDirectivesInfiniteTi
   def slowFuture(): Future[String] = Promise[String].future // TODO: move to Future.never in Scala 2.12
 
   def runRoute(route: Route, routePath: String): HttpResponse = {
-    val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+    val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
     val binding = Http().bindAndHandle(route, hostname, port)
 
     val response = Http().singleRequest(HttpRequest(uri = s"http://$hostname:$port/$routePath")).futureValue
@@ -167,7 +167,7 @@ class TimeoutDirectivesFiniteTimeoutExamplesSpec extends AkkaSpec(TimeoutDirecti
   def slowFuture(): Future[String] = Promise[String].future // TODO: move to Future.never in Scala 2.12
 
   def runRoute(route: Route, routePath: String): HttpResponse = {
-    val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
+    val (hostname, port) = SocketUtil2.temporaryServerHostnameAndPort()
     val binding = Http().bindAndHandle(route, hostname, port)
 
     val response = Http().singleRequest(HttpRequest(uri = s"http://$hostname:$port/$routePath")).futureValue


### PR DESCRIPTION
Backport of #3460 for the release-10.1 branch.