### PR TITLE
docs: Document how to disable hostname verification without ssl-config

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.2.0.backwards.excludes/ssl-config.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.0.backwards.excludes/ssl-config.excludes
@@ -1,0 +1,2 @@
+# ApiMayChange
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.javadsl.ConnectionContext.httpsClient")

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -47,7 +47,7 @@ object ConnectionContext {
    *  are enabled as needed.
    */
   @ApiMayChange
-  def httpsClient(createEngine: akka.japi.function.Function2[String, Int, SSLEngine]): HttpsConnectionContext =
+  def httpsClient(createEngine: akka.japi.function.Function2[String, Integer, SSLEngine]): HttpsConnectionContext =
     scaladsl.ConnectionContext.httpsClient((host, port) => createEngine(host, port))
 
   // ConnectionContext

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
@@ -72,6 +72,11 @@ class TlsEndpointVerificationSpec extends AkkaSpecWithMaterializer("""
       def createInsecureSslEngine(host: String, port: Int): SSLEngine = {
         val engine = context.createSSLEngine(host, port)
         engine.setUseClientMode(true)
+
+        // WARNING: this creates an SSL Engine without enabling endpoint identification/verification procedures
+        // Disabling host name verification is a very bad idea, please don't unless you have a very good reason to.
+        // When in doubt, use the `ConnectionContext.httpsClient` that takes an `SSLContext` instead.
+
         engine
       }
       val clientConnectionContext = ConnectionContext.httpsClient(createInsecureSslEngine _)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/TlsEndpointVerificationSpec.scala
@@ -75,7 +75,12 @@ class TlsEndpointVerificationSpec extends AkkaSpecWithMaterializer("""
 
         // WARNING: this creates an SSL Engine without enabling endpoint identification/verification procedures
         // Disabling host name verification is a very bad idea, please don't unless you have a very good reason to.
-        // When in doubt, use the `ConnectionContext.httpsClient` that takes an `SSLContext` instead.
+        // When in doubt, use the `ConnectionContext.httpsClient` that takes an `SSLContext` instead, or enable with:
+        // engine.setSSLParameters({
+        //  val params = engine.getSSLParameters
+        //  params.setEndpointIdentificationAlgorithm("https")
+        //  params
+        // )
 
         engine
       }

--- a/docs/src/main/paradox/client-side/client-https-support.md
+++ b/docs/src/main/paradox/client-side/client-https-support.md
@@ -35,82 +35,36 @@ that you configure a custom `HttpsContext` instance and set it via
 @scala[`Http().setDefaultClientHttpsContext`]@java[`Http.get(system).setDefaultClientHttpsContext`].
 Afterwards you simply use `outgoingConnectionHttps`, `newHostConnectionPoolHttps`, `cachedHostConnectionPoolHttps`,
 `superPool` or `singleRequest` without a specific `httpsContext` argument, which causes encrypted connections
-to rely on the configured default client-side `HttpsContext`.
+to rely on the configured default client-side @apidoc[HttpsConnectionContext].
 
 If no custom `HttpsContext` is defined the default context uses Java's default TLS settings. Customizing the
 `HttpsContext` can make the Https client less secure. Understand what you are doing!
 
-## SSL-Config
-
-Akka HTTP heavily relies on, and delegates most configuration of any SSL/TLS related options to
-[Lightbend SSL-Config](https://lightbend.github.io/ssl-config/), which is a library specialized in providing an secure-by-default SSLContext
-and related options.
-
-Please refer to the [Lightbend SSL-Config](https://lightbend.github.io/ssl-config/) documentation for detailed documentation of all available settings.
-
-SSL Config settings used by Akka HTTP (as well as Streaming TCP) are located under the *akka.ssl-config* namespace.
-
 ## Detailed configuration and workarounds
-
-Akka HTTP relies on [Lightbend SSL-Config](https://lightbend.github.io/ssl-config/) which is a library maintained by Lightbend that makes configuring
-things related to SSL/TLS much simpler than using the raw SSL APIs provided by the JDK. Please refer to its
-documentation to learn more about it.
-
-All configuration options available to this library may be set under the `akka.ssl-config` configuration for Akka HTTP applications.
-
-@@@ note
-When encountering problems connecting to HTTPS hosts we highly encourage to reading up on the excellent ssl-config
-configuration. Especially the quick start sections about [adding certificates to the trust store](https://lightbend.github.io/ssl-config/WSQuickStart.html#connecting-to-a-remote-server-over-https) should prove
-very useful, for example to easily trust a self-signed certificate that applications might use in development mode.
-@@@
 
 @@@ warning
 
-While it is possible to disable certain checks using the so called "loose" settings in SSL Config, we **strongly recommend**
+While it is possible to disable certain checks, we **strongly recommend**
 to instead attempt to solve these issues by properly configuring TLS–for example by adding trusted keys to the keystore.
 
 If however certain checks really need to be disabled because of misconfigured (or legacy) servers that your
-application has to speak to, instead of disabling the checks globally (i.e. in `application.conf`) we suggest
+application has to speak to, instead of disabling the checks globally (by using `setDefaultClientHttpsContext`) we suggest
 configuring the loose settings for *specific connections* that are known to need them disabled (and trusted for some other reason).
 The pattern of doing so is documented in the following sub-sections.
 
 @@@
 
-### Hostname verification
+### Disabling hostname verification
 
 Hostname verification proves that the Akka HTTP client is actually communicating with the server it intended to
 communicate with. Without this check a man-in-the-middle attack is possible. In the attack scenario, an alternative
 certificate would be presented which was issued for another host name. Checking the host name in the certificate
 against the host name the connection was opened against is therefore vital.
 
-The default `HttpsContext` enables hostname verification. Akka HTTP relies on the [Lightbend SSL-Config](https://lightbend.github.io/ssl-config) library
-to implement this and security options for SSL/TLS. Hostname verification is provided by the JDK
-and used by Akka since Java 7, and on Java 6 the verification is implemented by ssl-config manually.
-
-For further recommended reading we would like to highlight the [fixing hostname verification blog post](https://tersesystems.com/2014/03/23/fixing-hostname-verification/) by blog post by Will Sargent.
-
-### Disabling TLS security features, at your own risk
-
-@@@ warning
-
-It is highly discouraged to disable any of the security features of TLS, however do acknowledge that workarounds may sometimes be needed.
-
-Before disabling any of the features one should consider if they may be solvable *within* the TLS world,
-for example by [trusting a certificate](https://lightbend.github.io/ssl-config/WSQuickStart.html), or [configuring the trusted cipher suites](https://lightbend.github.io/ssl-config/CipherSuites.html).
-There's also a very important section in the ssl-config docs titled [LooseSSL - Please read this before turning anything off!](https://lightbend.github.io/ssl-config/LooseSSL.html#please-read-this-before-turning-anything-off).
-
-If disabling features is indeed desired, we recommend doing so for *specific connections*,
-instead of globally configuring it via `application.conf`.
-
-@@@
-
-The following shows an example of disabling hostname verification for a given connection:
+When you create your @apidoc[HttpsConnectionContext] with @apidoc[] enables hostname verification. The following shows an example of disabling hostname verification for a given connection:
 
 Scala
-:  @@snip [HttpsExamplesSpec.scala]($test$/scala/docs/http/scaladsl/HttpsExamplesSpec.scala) { #disable-hostname-verification-connection }
+:  @@snip [HttpsExamplesSpec.scala](/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala) { #disable-hostname-verification-connection }
 
 Java
-:  @@snip [HttpsExamplesDocTest.java]($test$/java/docs/http/javadsl/HttpsExamplesDocTest.java) { #disable-hostname-verification-connection }
-
-The `badSslConfig` is a copy of the default `AkkaSSLConfig` with the slightly changed configuration to disable hostname verification.
-This value can be cached and used for connections which should indeed not use this feature.
+:  @@snip [HttpsExamplesDocTest.java](/docs/src/test/java/docs/http/javadsl/HttpsExamplesDocTest.java) { #disable-hostname-verification-connection }

--- a/docs/src/main/paradox/client-side/client-https-support.md
+++ b/docs/src/main/paradox/client-side/client-https-support.md
@@ -61,7 +61,7 @@ communicate with. Without this check a man-in-the-middle attack is possible. In 
 certificate would be presented which was issued for another host name. Checking the host name in the certificate
 against the host name the connection was opened against is therefore vital.
 
-When you create your @apidoc[HttpsConnectionContext] with @apidoc[] enables hostname verification. The following shows an example of disabling hostname verification for a given connection:
+When you create your @apidoc[HttpsConnectionContext] with @apidoc[ConnectionContext.httpsClient](ConnectionContext) enables hostname verification. The following shows an example of disabling hostname verification for a given connection:
 
 Scala
 :  @@snip [HttpsExamplesSpec.scala](/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala) { #disable-hostname-verification-connection }

--- a/docs/src/test/java/docs/http/javadsl/HttpsExamplesDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpsExamplesDocTest.java
@@ -12,6 +12,7 @@ import akka.http.javadsl.HttpsConnectionContext;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 
 @SuppressWarnings("unused")
 public class HttpsExamplesDocTest {
@@ -29,7 +30,11 @@ public class HttpsExamplesDocTest {
 
       // WARNING: this creates an SSL Engine without enabling endpoint identification/verification procedures
       // Disabling host name verification is a very bad idea, please don't unless you have a very good reason to.
-      // When in doubt, use the `ConnectionContext.httpsClient` that takes an `SSLContext` instead.
+      // When in doubt, use the `ConnectionContext.httpsClient` that takes an `SSLContext` instead, or enable
+      // with:
+      // SSLParameters params = engine.getSSLParameters();
+      // params.setEndpointIdentificationAlgorithm("https");
+      // engine.setSSLParameters(params);
 
       return engine;
     });

--- a/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
@@ -5,15 +5,12 @@
 package docs.http.scaladsl
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import com.github.ghik.silencer.silent
-import com.typesafe.sslconfig.akka.AkkaSSLConfig
+import akka.http.scaladsl.{ ConnectionContext, Http }
 import docs.CompileOnlySpec
+import javax.net.ssl.{ SSLContext, SSLEngine }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-// TODO https://github.com/akka/akka-http/issues/2845
-@silent("deprecated")
 class HttpsExamplesSpec extends AnyWordSpec with Matchers with CompileOnlySpec {
 
   "disable hostname verification for connection" in compileOnlySpec {
@@ -21,9 +18,17 @@ class HttpsExamplesSpec extends AnyWordSpec with Matchers with CompileOnlySpec {
     //#disable-hostname-verification-connection
     implicit val system = ActorSystem()
 
-    // WARNING: disabling host name verification is a very bad idea, please don't unless you have a very good reason to.
-    val badSslConfig = AkkaSSLConfig().mapSettings(s => s.withLoose(s.loose.withDisableHostnameVerification(true)))
-    val badCtx = Http().createClientHttpsContext(badSslConfig)
+    def createInsecureSslEngine(host: String, port: Int): SSLEngine = {
+      val engine = SSLContext.getDefault.createSSLEngine(host, port)
+      engine.setUseClientMode(true)
+
+      // WARNING: this creates an SSL Engine without enabling endpoint identification/verification procedures
+      // Disabling host name verification is a very bad idea, please don't unless you have a very good reason to.
+      // When in doubt, use the `ConnectionContext.httpsClient` that takes an `SSLContext` instead.
+
+      engine
+    }
+    val badCtx = ConnectionContext.httpsClient(createInsecureSslEngine _)
     Http().outgoingConnectionHttps(unsafeHost, connectionContext = badCtx)
     //#disable-hostname-verification-connection
   }

--- a/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpsExamplesSpec.scala
@@ -24,7 +24,12 @@ class HttpsExamplesSpec extends AnyWordSpec with Matchers with CompileOnlySpec {
 
       // WARNING: this creates an SSL Engine without enabling endpoint identification/verification procedures
       // Disabling host name verification is a very bad idea, please don't unless you have a very good reason to.
-      // When in doubt, use the `ConnectionContext.httpsClient` that takes an `SSLContext` instead.
+      // When in doubt, use the `ConnectionContext.httpsClient` that takes an `SSLContext` instead, or enable with:
+      // engine.setSSLParameters({
+      //  val params = engine.getSSLParameters
+      //  params.setEndpointIdentificationAlgorithm("https")
+      //  params
+      // )
 
       engine
     }


### PR DESCRIPTION
Somewhat related to #3477 but not resolving it yet: no documentation on how to
do futher configuration without using the deprecated methods.