### PR TITLE
http: provide implicit conversion from route and materializer to flow

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RouteResultSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RouteResultSpec.scala
@@ -22,10 +22,11 @@ class RouteResultSpec extends AnyWordSpec with Matchers {
       TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
     }
 
-    "provide a conversion from Route to Flow when a Materializer is implicitily available" in {
+    "provide a conversion from Route to Flow when a Materializer is implicitly available" in {
       val system = ActorSystem("RouteResultSpec1")
       implicit val materializer: Materializer = SystemMaterializer(system).materializer
 
+      @silent("deprecated")
       val flow: Flow[HttpRequest, HttpResponse, Any] = route
 
       TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
@@ -33,7 +34,8 @@ class RouteResultSpec extends AnyWordSpec with Matchers {
 
     "provide a conversion from Route to Flow when both a Materializer and a system are implicitly  available" in {
       implicit val system = ActorSystem("RouteResultSpec1")
-      implicit val materializer: Materializer = SystemMaterializer(system).materializer
+      // implemented with ??? so it produces an error when the materializer is selected over the system
+      implicit def materializer: Materializer = ???
 
       val flow: Flow[HttpRequest, HttpResponse, Any] = route
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RouteResultSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RouteResultSpec.scala
@@ -1,0 +1,44 @@
+package akka.http.scaladsl.server
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
+import akka.http.scaladsl.server.Directives.complete
+import akka.stream.{ Materializer, SystemMaterializer }
+import akka.stream.scaladsl.Flow
+import akka.testkit.TestKit
+import com.github.ghik.silencer.silent
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+@silent("never used")
+class RouteResultSpec extends AnyWordSpec with Matchers {
+  "RouteResult" should {
+    val route: Route = complete(StatusCodes.OK)
+    "provide a conversion from Route to Flow when an ActorSystem is available" in {
+      implicit val system = ActorSystem("RouteResultSpec1")
+
+      val flow: Flow[HttpRequest, HttpResponse, Any] = route
+
+      TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    }
+
+    "provide a conversion from Route to Flow when a Materializer is implicitily available" in {
+      val system = ActorSystem("RouteResultSpec1")
+      implicit val materializer: Materializer = SystemMaterializer(system).materializer
+
+      val flow: Flow[HttpRequest, HttpResponse, Any] = route
+
+      TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    }
+
+    "provide a conversion from Route to Flow when both a Materializer and a system are implicitly  available" in {
+      implicit val system = ActorSystem("RouteResultSpec1")
+      implicit val materializer: Materializer = SystemMaterializer(system).materializer
+
+      val flow: Flow[HttpRequest, HttpResponse, Any] = route
+
+      TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    }
+  }
+
+}

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -82,6 +82,7 @@ sealed abstract class LowerPriorityRouteResultImplicits {
    * is in that type means this implicit conversion come into scope whereever
    * a `Route` is given but a `Flow` is expected.
    */
+  @deprecated("make an ActorSystem available implicitly instead", "10.2.0")
   implicit def routeToFlowViaMaterializer(route: Route)(implicit materializer: Materializer): Flow[HttpRequest, HttpResponse, NotUsed] =
     Route.toFlow(route)(ActorMaterializerHelper.downcast(materializer).system)
 


### PR DESCRIPTION
For better backwards compatibility with 10.1.x #3427

I think putting it in a superclass like this should avoid any
ambiguous import problems, but a second pair of eyes would not
hurt here.