### PR TITLE
core: Uri.collapseDotSegments fails on some relative paths #2507

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -866,6 +866,7 @@ object Uri {
   }
 
   private[http] def collapseDotSegments(path: Path): Path = {
+    import Path._
     @tailrec def hasDotOrDotDotSegment(p: Path): Boolean = p match {
       case Path.Empty => false
       case Path.Segment(".", _) | Path.Segment("..", _) => true
@@ -873,7 +874,6 @@ object Uri {
     }
     // http://tools.ietf.org/html/rfc3986#section-5.2.4
     @tailrec def process(input: Path, output: Path = Path.Empty): Path = {
-      import Path._
       input match {
         case Path.Empty                       => output.reverse
         case Segment("." | "..", Slash(tail)) => process(tail, output)
@@ -889,7 +889,9 @@ object Uri {
         case Segment(string, tail)     => process(tail, string :: output)
       }
     }
-    if (hasDotOrDotDotSegment(path)) process(path) else path
+    if (hasDotOrDotDotSegment(path))
+      if (path.startsWithSlash) process(path) else process(Slash(path)).tail
+    else path
   }
 
   private[http] def fail(summary: String, detail: String = "") = throw IllegalUriException(summary, detail)

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -857,5 +857,13 @@ class UriSpec extends AnyWordSpec with Matchers {
       query.head._2 shouldEqual "1"
       query.last._2 shouldEqual "2000"
     }
+
+    "collapsing dot segments correctly in relative paths" in {
+      Uri.from(scheme = "file", path = "aa/bb/../../cc") shouldEqual
+        Uri.from(scheme = "file", path = "cc")
+      Uri.from(scheme = "file", path = "aa/../cc") shouldEqual
+        Uri.from(scheme = "file", path = "cc")
+    }
+
   }
 }


### PR DESCRIPTION
Uri.collapseDotSegments fails on some relative paths #2507
Description:
the conclusion is that the 'collapseDotSegments' doesnt work as described in 'http://tools.ietf.org/html/rfc3986#section-5.2.4' when relative path doent start with a '/'. the easy solution is to check whether the given Uri starts with a '/' or not. and call 'process' accordingly. 