### PR TITLE
build: really increase paradox parsing timeout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -403,7 +403,7 @@ lazy val docs = project("docs")
       // Code after ??? can be considered 'dead',  but still useful for docs
       "-Ywarn-dead-code",
     ),
-    paradoxProcessor := {
+    (paradoxProcessor in Compile) := {
       import scala.concurrent.duration._
       import com.lightbend.paradox.ParadoxProcessor
       import com.lightbend.paradox.markdown.{ Reader, Writer }

--- a/project/ParadoxSupport.scala
+++ b/project/ParadoxSupport.scala
@@ -18,13 +18,7 @@ import scala.io.{Codec, Source}
 
 object ParadoxSupport {
   val paradoxWithCustomDirectives = Seq(
-    paradoxDirectives ++= Def.taskDyn {
-      Def.task { Seq(
-        { context: Writer.Context =>
-            new SignatureDirective(context.location.tree.label, context.properties, context)
-        },
-      )}
-    }.value
+    paradoxDirectives += ((context: Writer.Context) => new SignatureDirective(context.location.tree.label, context.properties, context))
   )
 
   class SignatureDirective(page: Page, variables: Map[String, String], ctx: Writer.Context) extends LeafBlockDirective("signature") {


### PR DESCRIPTION
Fixes #3429

Previously in #3430 the wrong key was updated so that the change had no effect and the timeout was still 2 seconds which is arguably slow enough to trip over now and then.