### PR TITLE
http2: use scheme portion of target URI in :scheme pseudo-header

### DIFF
--- a/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/client/RequestRendering.scala
+++ b/akka-http2-support/src/main/scala/akka/http/impl/engine/http2/client/RequestRendering.scala
@@ -23,7 +23,7 @@ private[http2] object RequestRendering {
     { request =>
       val headerPairs = new VectorBuilder[(String, String)]()
       headerPairs += ":method" -> request.method.value
-      headerPairs += ":scheme" -> "https" // FIXME: should that be the real scheme?
+      headerPairs += ":scheme" -> request.uri.scheme
       headerPairs += ":authority" -> request.uri.authority.toString
       headerPairs += ":path" -> request.uri.toHttpRequestTargetOriginForm.toString
 


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7540#section-8.1.2.3

Tests for this are already in #3532