### PR TITLE
More accurately track the last-stream-id for GOAWAY

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -107,19 +107,8 @@ private[http2] class Http2ServerDemux(http2Settings: Http2CommonSettings, initia
         multiplexer.pushControlFrame(SettingsFrame(Nil)) // both client and server must send an settings frame as first frame
       }
 
-      /**
-       * The "last peer-initiated stream that was or might be processed on the sending endpoint in this connection"
-       * @see http://httpwg.org/specs/rfc7540.html#rfc.section.6.8
-       *
-       * We currently don't support tracking that value accurately.
-       * TODO: track more accurately
-       */
-      def lastStreamId: Int = 1
-
-      def pushGOAWAY(errorCode: ErrorCode, debug: String): Unit = {
-        // http://httpwg.org/specs/rfc7540.html#rfc.section.6.8
-        val last = lastStreamId
-        val frame = GoAwayFrame(last, errorCode, ByteString(debug))
+      override def pushGOAWAY(errorCode: ErrorCode, debug: String): Unit = {
+        val frame = GoAwayFrame(lastStreamId(), errorCode, ByteString(debug))
         multiplexer.pushControlFrame(frame)
         // FIXME: handle the connection closing according to the specification
       }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -72,6 +72,13 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
     updateState(streamId, _.handleOutgoingEnded())
   }
 
+  /**
+   * The "last peer-initiated stream that was or might be processed on the sending endpoint in this connection"
+   *
+   * @see http://httpwg.org/specs/rfc7540.html#rfc.section.6.8
+   */
+  def lastStreamId(): Int = largestIncomingStreamId
+
   private def updateState(streamId: Int, handle: IncomingStreamState => IncomingStreamState): Unit = {
     val oldState = streamFor(streamId)
     val newState = handle(oldState)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -94,7 +94,6 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
           request = HttpRequest(uri = "https://www.example.com/"),
           expectedHeaders = Seq(
             ":method" -> "GET",
-            // TODO check if this makes sense?
             ":scheme" -> "https",
             ":authority" -> "www.example.com",
             ":path" -> "/",
@@ -115,8 +114,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         val incorrectHeaderBlock = hex"00 00 01 01 05 00 00 00 01 40"
         sendHEADERS(4, endStream = true, endHeaders = true, headerBlockFragment = incorrectHeaderBlock)
 
-        // TODO shouldn't this be '3'?
-        val (_, errorCode) = expectGOAWAY(1)
+        val (_, errorCode) = expectGOAWAY(3)
         errorCode should ===(ErrorCode.COMPRESSION_ERROR)
       }
     }


### PR DESCRIPTION
Though this value is somewhat best-effort, if I'm reading the [spec](https://tools.ietf.org/html/rfc7540#section-6.8)
right we should over-estimate, not under-estimate.

This probably conflicts with the ongoing refactor in this area, I'm happy to rebase when that is done :)