### PR TITLE
bench: fix http2 compilation

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
@@ -9,7 +9,6 @@ import akka.actor.ActorSystem
 import akka.http.CommonBenchmark
 import akka.http.impl.engine.http2.FrameEvent.HeadersFrame
 import akka.http.impl.engine.http2.framing.FrameRenderer
-import akka.http.scaladsl.Http2
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.ActorMaterializer


### PR DESCRIPTION
Benchmark compilation silently failed since the move of http2 into akka-http-core.

Added email notifications for akka-http-bench-nightly failures.