### PR TITLE
build: exclude akka-http-bench-jmh from whitesource

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,7 +255,7 @@ lazy val httpJmhBench = project("akka-http-bench-jmh")
   .addAkkaModuleDependency("akka-stream")
   .enablePlugins(JmhPlugin)
   .enablePlugins(NoPublish).disablePlugins(BintrayPlugin) // don't release benchs
-  .disablePlugins(MimaPlugin)
+  .disablePlugins(MimaPlugin, Whitesource)
 
 lazy val httpMarshallersScala = project("akka-http-marshallers-scala")
   .settings(commonSettings)


### PR DESCRIPTION
Since no artifacts are published from this module.