### PR TITLE
testkit: fail noisily if trying to use `~>` together with transparent-head-requests

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -155,6 +155,10 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
       new TildeArrow[RequestContext, Future[RouteResult]] {
         type Out = RouteTestResult
         def apply(request: HttpRequest, route: Route): Out = {
+          if (request.method == HttpMethods.HEAD && ServerSettings(system).transparentHeadRequests)
+            failTest("`akka.http.server.transparent-head-requests = on` not supported in RouteTest using `~>`. Use `~!>` instead " +
+              "for a full-stack test, e.g. `req ~!> route ~> check {...}`")
+
           implicit val executionContext: ExecutionContext = system.classicSystem.dispatcher
           val routingSettings = RoutingSettings(system)
           val routingLog = RoutingLog(system.classicSystem.log)

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRouteTest {
+  override def testConfigSource: String = "akka.http.server.transparent-head-requests = on" // see test below
 
   "The ScalatestRouteTest should support" - {
 
@@ -132,6 +133,15 @@ class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRou
       Get() ~> route ~> check {
         status shouldEqual InternalServerError
       }
+    }
+
+    "fail if testing a HEAD request with ~> and `transparent-head-request = on`" in {
+      def runTest(): Unit = Head() ~> complete("Ok") ~> check {}
+
+      val ex = the[Exception] thrownBy (runTest())
+      ex.getMessage shouldEqual
+        "`akka.http.server.transparent-head-requests = on` not supported in RouteTest using `~>`. " +
+        "Use `~!>` instead for a full-stack test, e.g. `req ~!> route ~> check {...}`"
     }
   }
 }


### PR DESCRIPTION
Fixes #3568
