### PR TITLE
Added unusedParameters to RequestContext

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
@@ -25,7 +25,7 @@ import akka.http.scaladsl.server.{ Directives => D }
 import akka.http.scaladsl
 import akka.stream.Materializer
 import java.util.function.Supplier
-import java.util.{ List => JList }
+import java.util.{ List => JList, Set => JSet }
 
 import akka.http.javadsl.model.HttpResponse
 import akka.http.javadsl.model.ResponseEntity
@@ -41,6 +41,7 @@ import akka.http.javadsl.server
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
 
 abstract class BasicDirectives {
   import akka.http.impl.util.JavaMapping.Implicits._
@@ -173,6 +174,15 @@ abstract class BasicDirectives {
   def extractMatchedPath(inner: JFunction[String, Route]) = RouteAdapter {
     D.extractMatchedPath { path =>
       inner.apply(path.toString).delegate
+    }
+  }
+
+  /**
+   * Extracts the yet unused query parameters from the RequestContext.
+   */
+  def extractUnusedParameters(inner: JFunction[JSet[String], Route]) = RouteAdapter {
+    D.extractUnusedParameters { parameters =>
+      inner.apply(parameters.asJava).delegate
     }
   }
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RequestContext.scala
@@ -30,6 +30,11 @@ trait RequestContext {
   val unmatchedPath: Uri.Path
 
   /**
+   * The unused query parameter names of this context.
+   */
+  val unusedParameters: Set[String]
+
+  /**
    * The default ExecutionContext to be used for scheduling asynchronous logic related to this request.
    */
   implicit def executionContext: ExecutionContextExecutor
@@ -132,7 +137,18 @@ trait RequestContext {
   def mapUnmatchedPath(f: Uri.Path => Uri.Path): RequestContext
 
   /**
+   * Returns a copy of this context with the unused query parameters updated to the given one.
+   */
+  def withUnusedParameters(parameters: Set[String]): RequestContext
+
+  /**
+   * Returns a copy of this context with the unused query parameters transformed by the given function.
+   */
+  def mapUnusedParameters(f: Set[String] => Set[String]): RequestContext
+
+  /**
    * Removes a potentially existing Accept header from the request headers.
    */
   def withAcceptAll: RequestContext
+
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
@@ -211,6 +211,8 @@ trait BasicDirectives {
 
   /**
    * Extracts the yet unused query parameters from the RequestContext.
+   *
+   * @group basic
    */
   def extractUnusedParameters: Directive1[Set[String]] = BasicDirectives._extractUnusedParameters
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
@@ -210,6 +210,11 @@ trait BasicDirectives {
   def extractMatchedPath: Directive1[Uri.Path] = BasicDirectives._extractMatchedPath
 
   /**
+   * Extracts the yet unused query parameters from the RequestContext.
+   */
+  def extractUnusedParameters: Directive1[Set[String]] = BasicDirectives._extractUnusedParameters
+
+  /**
    * Extracts the current [[HttpRequest]] instance.
    *
    * @group basic
@@ -412,6 +417,7 @@ trait BasicDirectives {
 object BasicDirectives extends BasicDirectives {
   private val _extractUnmatchedPath: Directive1[Uri.Path] = extract(_.unmatchedPath)
   private val _extractMatchedPath: Directive1[Uri.Path] = extract(extractMatched)
+  private val _extractUnusedParameters: Directive1[Set[String]] = extract(_.unusedParameters)
   private val _extractRequest: Directive1[HttpRequest] = extract(_.request)
   private val _extractUri: Directive1[Uri] = extract(_.request.uri)
   private val _extractExecutionContext: Directive1[ExecutionContextExecutor] = extract(_.executionContext)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/ParameterDirectives.scala
@@ -209,7 +209,7 @@ object ParameterDirectives extends ParameterDirectives {
         import ctx.executionContext
         import ctx.materializer
         onComplete(fsou(ctx.request.uri.query().get(paramName))) flatMap {
-          case Success(value) if value == requiredValue => pass
+          case Success(value) if value == requiredValue => pass & mapRequestContext(_ mapUnusedParameters (_ - paramName))
           case Success(value)                           => reject(InvalidRequiredValueForQueryParamRejection(paramName, requiredValue.toString, value.toString))
           case _                                        => reject(MissingQueryParamRejection(paramName))
         }
@@ -224,7 +224,7 @@ object ParameterDirectives extends ParameterDirectives {
 
     def handleParamResult[T](paramName: String, result: Future[T]): Directive1[T] =
       onComplete(result).flatMap {
-        case Success(x)                               => provide(x)
+        case Success(x)                               => provide(x) & mapRequestContext(_ mapUnusedParameters (_ - paramName))
         case Failure(Unmarshaller.NoContentException) => reject(MissingQueryParamRejection(paramName))
         case Failure(x)                               => reject(MalformedQueryParamRejection(paramName, x.getMessage.nullAsEmpty, Option(x.getCause)))
       }


### PR DESCRIPTION
Fixes https://github.com/akka/akka-http/issues/3566

It is probably better than the solution I pushed on the PR https://github.com/akka/akka-http/pull/3567

The usefulness of adding this field is the ability to easily create the following Directive:

```scala
  val rejectOnUnusedParameters: Directive0 =
   extractUnusedParameters flatMap { 
      case unused if unused.isEmpty => pass
      case unused => reject(validationRejection(s"query parameters not valid: '${invalid.mkString(", ")}'"))
    }
```