### PR TITLE
core: don't dispatch onResponseEntity... events for entities that don't have to be subscribed

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -398,8 +398,10 @@ object HttpEntity {
     def withContentType(contentType: ContentType): HttpEntity.Default =
       if (contentType == this.contentType) this else copy(contentType = contentType)
 
-    override def withSizeLimit(maxBytes: Long): HttpEntity.Default =
-      copy(data = Limitable.applyForByteStrings(data, SizeLimit(maxBytes, Some(contentLength))))
+    override def withSizeLimit(maxBytes: Long): HttpEntity.Default = {
+      if (data ne Source.empty) copy(data = Limitable.applyForByteStrings(data, SizeLimit(maxBytes, Some(contentLength))))
+      else this
+    }
 
     override def withoutSizeLimit: HttpEntity.Default =
       withSizeLimit(SizeLimit.Disabled)


### PR DESCRIPTION
For example, for HEAD requests.

Fixes #3530