### PR TITLE
build: run mima on travis only for master builds or releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ jobs:
 
 stages:
   - name: mima
+    if: repo=akka/akka-http AND ( ( branch = master AND type = push ) OR tag =~ ^v )
 
   - name: whitesource
     if: repo=akka/akka-http AND ( ( branch = master AND type = push ) OR tag =~ ^v )


### PR DESCRIPTION
Instead, PR validation on Jenkins was changed to run mima for 2.12 as well