### PR TITLE
fix 3589

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -24,6 +24,7 @@ import akka.stream.testkit.{ TestPublisher, TestSubscriber }
 import akka.util.ByteString
 import org.scalatest.concurrent.Eventually
 
+import scala.collection.immutable
 import scala.concurrent.duration._
 
 /**
@@ -312,7 +313,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
     toNet.expectBytes(Http2Protocol.ClientConnectionPreface)
     expectSETTINGS()
 
-    sendFrame(SettingsFrame(initialServerSettings))
+    sendFrame(SettingsFrame(immutable.Seq.empty ++ initialServerSettings))
     expectSettingsAck()
   }
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -1296,7 +1296,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
     sendBytes(Http2Protocol.ClientConnectionPreface)
     expectSETTINGS()
 
-    sendFrame(SettingsFrame(initialClientSettings))
+    sendFrame(SettingsFrame(immutable.Seq.empty ++ initialClientSettings))
     expectSettingsAck()
   }
 


### PR DESCRIPTION
Fix for #3589 
this encoding is cross-compatible across 2.12/2.13, since those are tests I assume we do not care about performance.
