### PR TITLE
http: optimize header directives by avoiding HttpHeader.unapply

### DIFF
--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
@@ -135,7 +135,7 @@ trait HeaderDirectives {
   def optionalHeaderValueByName(headerName: String): Directive1[Option[String]] = {
     val lowerCaseName = headerName.toLowerCase
     extract(_.request.headers.collectFirst {
-      case HttpHeader(`lowerCaseName`, value) => value
+      case h: HttpHeader if h.is(lowerCaseName) => h.value
     })
   }
 


### PR DESCRIPTION
The existing implementation of `optionalHeaderValueByName` is costly for the `Authorization` header due to the `unapply` on `value` which evaluates the header value for each such call.

For `Authorization` header, for example in case of `OAuth2BearerToken` evaluating the `value` causes the `render` to execute which causes a new string to be created and discarded for each such call.
In our case, the header is a jwt header which is 1kb in size, and such frequent eager evaluation this adds to ~ 9% of the time spent in our flow.

```
final case class OAuth2BearerToken(token: String) extends jm.headers.OAuth2BearerToken {
  def render[R <: Rendering](r: R): r.type = r ~~ "Bearer " ~~ token

  override def scheme: String = "Bearer"
  override def params: Map[String, String] = Map.empty
}
```
<img width="747" alt="FlameGraph" src="https://user-images.githubusercontent.com/54163056/97821603-0e665300-1cd9-11eb-95f6-5d60088f5471.png">


**This PR avoids doing eager `value` evaluation and delays it till we have a matching header.**