### PR TITLE
http2: run handler code in its own task on the server

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -180,12 +180,17 @@ private[http] object Http2Blueprint {
   def handleWithStreamIdHeader(parallelism: Int)(handler: HttpRequest => Future[HttpResponse])(implicit ec: ExecutionContext): Flow[HttpRequest, HttpResponse, NotUsed] =
     Flow[HttpRequest]
       .mapAsyncUnordered(parallelism) { req =>
-        val response = handler(req)
+        // The handler itself may do significant work so make sure to schedule it separately. This is especially important for HTTP/2 where it is expected that
+        // multiple requests are handled concurrently on the same connection. The complete stream including `mapAsyncUnordered` shares one GraphInterpreter, so
+        // that this extra indirection will guard the GraphInterpreter from being starved by user code.
+        Future {
+          val response = handler(req)
 
-        req.attribute(Http2.streamId) match {
-          case Some(streamIdHeader) => response.map(_.addAttribute(Http2.streamId, streamIdHeader)) // add stream id attribute when request had it
-          case None                 => response
-        }
+          req.attribute(Http2.streamId) match {
+            case Some(streamIdHeader) => response.map(_.addAttribute(Http2.streamId, streamIdHeader)) // add stream id attribute when request had it
+            case None                 => response
+          }
+        }.flatten
       }
 
   private[http2] def logParsingError(info: ErrorInfo, log: LoggingAdapter,


### PR DESCRIPTION
I tested the current server implementation on some real projects and noticed some unexpected slowness which was caused by routing DSL code being run directly in the handler and blocking progress of the HTTP/2 infrastructure and sibling requests.