### PR TITLE
Remove sbt-javaagent

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -213,7 +213,7 @@ lazy val http2Support = project("akka-http2-support")
       }
     )
   }
-  .enablePlugins(JavaAgent, BootstrapGenjavadoc)
+  .enablePlugins(BootstrapGenjavadoc)
   .enablePlugins(ReproducibleBuildsPlugin)
   .disablePlugins(MimaPlugin) // experimental module still
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,6 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1") // for advanced PR validation features
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.0")
-addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.5")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.35")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")


### PR DESCRIPTION
This was needed until JDK 8u252 to use the Jetty ALPN agent for HTTP2.