### PR TITLE
Accepting trailing headers in the HTTP/2 client

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -15,7 +15,9 @@ import akka.http.impl.engine.http2.hpack.{ HeaderCompression, HeaderDecompressio
 import akka.http.impl.engine.parsing.HttpHeaderParser
 import akka.http.impl.util.LogByteStringTools.logTLSBidiBySetting
 import akka.http.impl.util.StreamUtils
+import akka.http.scaladsl.model.HttpEntity.LastChunk
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, Http2CommonSettings, ParserSettings, ServerSettings }
 import akka.stream.TLSProtocol._
 import akka.stream.scaladsl.{ BidiFlow, Flow, Source }
@@ -59,13 +61,16 @@ private[http2] final case class ByteHttp2SubStream(
 private[http2] final case class ChunkedHttp2SubStream(
   initialHeaders:        ParsedHeadersFrame,
   data:                  Source[HttpEntity.ChunkStreamPart, Any],
+  trailingHeaders:       Future[ParsedHeadersFrame],
   correlationAttributes: Map[AttributeKey[_], _]                 = Map.empty
 ) extends Http2SubStream {
   override def withCorrelationAttributes(attributes: Map[AttributeKey[_], _]): Http2SubStream =
     copy(correlationAttributes = attributes)
 
-  def createResponseEntity(contentType: ContentType): RequestEntity =
-    HttpEntity.Chunked(contentType, data)
+  def createResponseEntity(contentType: ContentType)(implicit ec: ExecutionContext): RequestEntity =
+    HttpEntity.Chunked(contentType, data.concat(Source.lazilyAsync(() => trailingHeaders.map(frame => LastChunk(extension = "", frame.keyValuePairs.map {
+      case (k, v) => RawHeader(k, v)
+    })))))
 }
 
 /** INTERNAL API */

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -15,9 +15,7 @@ import akka.http.impl.engine.http2.hpack.{ HeaderCompression, HeaderDecompressio
 import akka.http.impl.engine.parsing.HttpHeaderParser
 import akka.http.impl.util.LogByteStringTools.logTLSBidiBySetting
 import akka.http.impl.util.StreamUtils
-import akka.http.scaladsl.model.HttpEntity.LastChunk
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, Http2CommonSettings, ParserSettings, ServerSettings }
 import akka.stream.TLSProtocol._
 import akka.stream.scaladsl.{ BidiFlow, Flow, Source }
@@ -61,16 +59,13 @@ private[http2] final case class ByteHttp2SubStream(
 private[http2] final case class ChunkedHttp2SubStream(
   initialHeaders:        ParsedHeadersFrame,
   data:                  Source[HttpEntity.ChunkStreamPart, Any],
-  trailingHeaders:       Future[ParsedHeadersFrame],
   correlationAttributes: Map[AttributeKey[_], _]                 = Map.empty
 ) extends Http2SubStream {
   override def withCorrelationAttributes(attributes: Map[AttributeKey[_], _]): Http2SubStream =
     copy(correlationAttributes = attributes)
 
-  def createResponseEntity(contentType: ContentType)(implicit ec: ExecutionContext): RequestEntity =
-    HttpEntity.Chunked(contentType, data.concat(Source.lazilyAsync(() => trailingHeaders.map(frame => LastChunk(extension = "", frame.keyValuePairs.map {
-      case (k, v) => RawHeader(k, v)
-    })))))
+  def createResponseEntity(contentType: ContentType): RequestEntity =
+    HttpEntity.Chunked(contentType, data)
 }
 
 /** INTERNAL API */

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -38,7 +38,7 @@ private[http2] class Http2ClientDemux(http2Settings: Http2CommonSettings, initia
   override def createSubstream(initialHeaders: ParsedHeadersFrame, data: Source[ByteString, Any], trailingHeaders: Future[ParsedHeadersFrame], correlationAttributes: Map[AttributeKey[_], _])(implicit ec: ExecutionContext): ChunkedHttp2SubStream =
     ChunkedHttp2SubStream(initialHeaders, data.map(ChunkStreamPart(_)).concat(Source.lazilyAsync(() => trailingHeaders.map(frame => LastChunk(extension = "", frame.keyValuePairs.map {
       case (k, v) => RawHeader(k, v)
-    })))), correlationAttributes)
+    }.toList)))), correlationAttributes)
 }
 
 private[http2] class Http2ServerDemux(http2Settings: Http2CommonSettings, initialRemoteSettings: immutable.Seq[Setting], upgraded: Boolean)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -487,11 +487,10 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
       }
     }
     def onTrailingHeaders(headers: ParsedHeadersFrame): Unit = {
+      trailer.success(headers)
       if (headers.endStream) {
         onDataFrame(DataFrame(headers.streamId, endStream = true, ByteString.empty)) // simulate end stream by empty dataframe
       } else pushGOAWAY(Http2Protocol.ErrorCode.PROTOCOL_ERROR, "Got unexpected mid-stream HEADERS frame")
-
-      trailer.success(headers)
     }
     def onRstStreamFrame(rst: RstStreamFrame): Unit = {
       outlet.fail(new PeerClosedStreamException(rst.streamId, rst.errorCode))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -16,6 +16,7 @@ import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler }
 import akka.util.ByteString
 
 import scala.collection.immutable
+import scala.concurrent.{ Future, Promise }
 import scala.util.control.NoStackTrace
 
 /**
@@ -34,7 +35,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
   def multiplexer: Http2Multiplexer
   def settings: Http2CommonSettings
   def pushGOAWAY(errorCode: ErrorCode, debug: String): Unit
-  def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Source[ByteString, Any], correlationAttributes: Map[AttributeKey[_], _]): Unit
+  def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Source[ByteString, Any], trailingHeaders: Future[ParsedHeadersFrame], correlationAttributes: Map[AttributeKey[_], _]): Unit
   def isUpgraded: Boolean
 
   def flowController: IncomingFlowController = IncomingFlowController.default(settings)
@@ -235,17 +236,18 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
       correlationAttributes: Map[AttributeKey[_], _]             = Map.empty): StreamState =
       event match {
         case frame @ ParsedHeadersFrame(streamId, endStream, _, _) =>
-          val (data, nextState) =
+          val (data, nextState, trailingHeaders) =
             if (endStream)
-              (Source.empty, nextStateEmpty)
+              (Source.empty, nextStateEmpty, Future.successful(ParsedHeadersFrame(streamId, endStream = true, Seq.empty, None)))
             else {
+              val trailingHeadersPromise = Promise[ParsedHeadersFrame]()
               val subSource = new SubSourceOutlet[ByteString](s"substream-out-$streamId")
-              (Source.fromGraph(subSource.source), nextStateStream(new IncomingStreamBuffer(streamId, subSource)))
+              (Source.fromGraph(subSource.source), nextStateStream(new IncomingStreamBuffer(streamId, subSource, trailingHeadersPromise)), trailingHeadersPromise.future)
             }
 
           // FIXME: after multiplexer PR is merged
           // prioInfo.foreach(multiplexer.updatePriority)
-          dispatchSubstream(frame, data, correlationAttributes)
+          dispatchSubstream(frame, data, trailingHeaders, correlationAttributes)
           nextState
 
         case x => receivedUnexpectedFrame(x)
@@ -356,12 +358,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
         Closed
 
       case h: ParsedHeadersFrame =>
-        buffer.onTrailingHeaders(h.keyValuePairs)
-
-        if (h.endStream) {
-          buffer.onDataFrame(DataFrame(h.streamId, endStream = true, ByteString.empty)) // simulate end stream by empty dataframe
-          debug(s"Ignored trailing HEADERS frame: $h")
-        } else pushGOAWAY(Http2Protocol.ErrorCode.PROTOCOL_ERROR, "Got unexpected mid-stream HEADERS frame")
+        buffer.onTrailingHeaders(h)
 
         maybeFinishStream(h.endStream)
 
@@ -459,7 +456,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
     }
   }
 
-  class IncomingStreamBuffer(streamId: Int, outlet: SubSourceOutlet[ByteString]) extends OutHandler {
+  class IncomingStreamBuffer(streamId: Int, outlet: SubSourceOutlet[ByteString], trailer: Promise[ParsedHeadersFrame]) extends OutHandler {
     private var buffer: ByteString = ByteString.empty
     private var wasClosed: Boolean = false
     private var outstandingStreamWindow: Int = Http2Protocol.InitialWindowSize // adapt if we negotiate greater sizes by settings
@@ -488,6 +485,13 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
         dispatchNextChunk()
         None // don't change state
       }
+    }
+    def onTrailingHeaders(headers: ParsedHeadersFrame): Unit = {
+      if (headers.endStream) {
+        onDataFrame(DataFrame(headers.streamId, endStream = true, ByteString.empty)) // simulate end stream by empty dataframe
+      } else pushGOAWAY(Http2Protocol.ErrorCode.PROTOCOL_ERROR, "Got unexpected mid-stream HEADERS frame")
+
+      trailer.success(headers)
     }
     def onRstStreamFrame(rst: RstStreamFrame): Unit = {
       outlet.fail(new PeerClosedStreamException(rst.streamId, rst.errorCode))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -356,7 +356,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
         Closed
 
       case h: ParsedHeadersFrame =>
-        // ignored
+        buffer.onTrailingHeaders(h.keyValuePairs)
 
         if (h.endStream) {
           buffer.onDataFrame(DataFrame(h.streamId, endStream = true, ByteString.empty)) // simulate end stream by empty dataframe

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -510,7 +510,10 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
         debug(s"Dispatched chunk of $dataSize for stream [$streamId], remaining window space now $outstandingStreamWindow, buffered: ${buffer.size}")
         updateWindows()
       }
-      if (buffer.isEmpty && wasClosed) outlet.complete()
+      if (buffer.isEmpty && wasClosed) {
+        trailer.trySuccess(ParsedHeadersFrame(streamId, endStream = true, Seq.empty, None))
+        outlet.complete()
+      }
     }
 
     private def updateWindows(): Unit = {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -74,7 +74,7 @@ private[http2] object RequestParsing {
 
           if (tlsSessionInfoHeader.isDefined) headers += tlsSessionInfoHeader.get
 
-          val entity = subStream.createEntity(contentLength, contentType)
+          val entity = subStream.createRequestEntity(contentLength, contentType)
           val (path, rawQueryString) = pathAndRawQuery
           val authorityOrDefault: Uri.Authority = if (authority == null) Uri.Authority.Empty else authority
           val uri = Uri(scheme, authorityOrDefault, path, rawQueryString)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
@@ -63,7 +63,7 @@ private[http2] object ResponseRendering {
 
   private[http2] def substreamFor(entity: HttpEntity, headers: ParsedHeadersFrame): Http2SubStream = entity match {
     case HttpEntity.Chunked(_, chunks) =>
-      ChunkedHttp2SubStream(headers, chunks)
+      ChunkedHttp2SubStream(headers, chunks, Map.empty)
     case _ =>
       ByteHttp2SubStream(headers, entity.dataBytes)
   }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -58,7 +58,11 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
           expectDecodedResponseHEADERSPairs(streamId) should contain theSameElementsAs (expectedHeaders.filter(_._1 != "date"))
           response.foreach(sendFrame)
 
-          expectResponse() shouldBe expectedResponse
+          val receivedResponse = expectResponse()
+          receivedResponse.status shouldBe expectedResponse.status
+          receivedResponse.headers shouldBe expectedResponse.headers
+          receivedResponse.entity.contentType shouldBe expectedResponse.entity.contentType
+          receivedResponse.entity.dataBytes.runFold(ByteString())(_ ++ _).futureValue shouldBe expectedResponse.entity.dataBytes.runFold(ByteString())(_ ++ _).futureValue
         }
       }
 
@@ -113,7 +117,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
           ),
           expectedResponse =
             HPackSpecExamples.FirstResponse
-              .withEntity(Strict(ContentTypes.NoContentType, ByteString.empty))
+              .withEntity(Strict(ContentTypes.`application/octet-stream`, ByteString.empty))
         )
 
         emitRequest(3, HttpRequest(uri = "https://www.example.com/"))
@@ -144,7 +148,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
             HeadersFrame(streamId = 1, endStream = true, endHeaders = true, HPackSpecExamples.C61FirstResponseWithHuffman, None)
           ),
           expectedResponse = HPackSpecExamples.FirstResponse
-            .withEntity(Strict(ContentTypes.NoContentType, ByteString.empty))
+            .withEntity(Strict(ContentTypes.`application/octet-stream`, ByteString.empty))
         )
         requestResponseRoundtrip(
           streamId = 3,
@@ -154,7 +158,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
             HeadersFrame(streamId = 3, endStream = true, endHeaders = true, HPackSpecExamples.C62SecondResponseWithHuffman, None)
           ),
           expectedResponse = HPackSpecExamples.SecondResponse
-            .withEntity(Strict(ContentTypes.NoContentType, ByteString.empty))
+            .withEntity(Strict(ContentTypes.`application/octet-stream`, ByteString.empty))
         )
         requestResponseRoundtrip(
           streamId = 5,
@@ -164,7 +168,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
             HeadersFrame(streamId = 5, endStream = true, endHeaders = true, HPackSpecExamples.C63ThirdResponseWithHuffman, None)
           ),
           expectedResponse = HPackSpecExamples.ThirdResponseModeled
-            .withEntity(Strict(ContentTypes.NoContentType, ByteString.empty))
+            .withEntity(Strict(ContentTypes.`application/octet-stream`, ByteString.empty))
         )
       }
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -79,7 +79,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
           ),
           expectedResponse =
             HPackSpecExamples.FirstResponse
-              .withEntity(Strict(ContentTypes.NoContentType, ByteString.empty))
+              .withEntity(Chunked(ContentTypes.`application/octet-stream`, Source.empty))
         )
       }
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -300,7 +300,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
 
         val chunks = response.entity.asInstanceOf[Chunked].chunks.runWith(Sink.seq).futureValue
         chunks(0) should be(Chunk("asdf"))
-        chunks(1) should be(LastChunk(extension = "", Seq(RawHeader("grpc-status", "0"))))
+        chunks(1) should be(LastChunk(extension = "", List(RawHeader("grpc-status", "0"))))
       }
 
     }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -11,9 +11,10 @@ import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2.Http2Protocol.FrameType
 import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
 import akka.http.impl.engine.ws.ByteStringSinkProbe
-import akka.http.impl.util.{ AkkaSpecWithMaterializer, LogByteStringTools }
+import akka.http.impl.util.{ AkkaSpecWithMaterializer, LogByteStringTools, StringRendering }
+import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.HttpEntity.Strict
+import akka.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk, Strict }
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.settings.ClientConnectionSettings
@@ -273,6 +274,30 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         emitRequest(9, request)
         expectNoBytes(100.millis)
 
+      }
+    }
+
+    "support stream support for receiveing response entity data" should {
+      abstract class WaitingForResponseSetup extends TestSetup with NetProbes with Http2FrameHpackSupport {
+        val streamId = 0x1
+        emitRequest(streamId, Get("/"))
+        expectDecodedHEADERS(streamId, endStream = true)
+      }
+      "support trailing headers for responses" in new WaitingForResponseSetup {
+        sendHEADERS(streamId, endStream = false, Seq(
+          RawHeader(":status", "200"),
+          RawHeader("content-type", "application/octet-stream")
+        ))
+
+        val response = expectResponse()
+        response.entity shouldBe a[Chunked]
+
+        sendDATA(streamId, endStream = false, ByteString("asdf"))
+        sendHEADERS(streamId, endStream = true, Seq(RawHeader("grpc-status", "0")))
+
+        val chunks = response.entity.asInstanceOf[Chunked].chunks.runWith(Sink.seq).futureValue
+        chunks(0) should be(Chunk("asdf"))
+        chunks(1) should be(LastChunk(extension = "", Seq(RawHeader("grpc-status", "0"))))
       }
     }
   }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -8,10 +8,9 @@ import akka.NotUsed
 import akka.event.Logging
 import akka.http.impl.engine.http2.FrameEvent._
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
-import akka.http.impl.engine.http2.Http2Protocol.FrameType
 import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
 import akka.http.impl.engine.ws.ByteStringSinkProbe
-import akka.http.impl.util.{ AkkaSpecWithMaterializer, LogByteStringTools, StringRendering }
+import akka.http.impl.util.{ AkkaSpecWithMaterializer, LogByteStringTools }
 import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk, Strict }
@@ -197,9 +196,9 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         emitRequest(7, request) // this emit succeeds but is buffered
 
         // expect frames for 1 3 and 5
-        expect[HeadersFrame].streamId shouldBe (1)
-        expect[HeadersFrame].streamId shouldBe (3)
-        expect[HeadersFrame].streamId shouldBe (5)
+        expect[HeadersFrame]().streamId shouldBe (1)
+        expect[HeadersFrame]().streamId shouldBe (3)
+        expect[HeadersFrame]().streamId shouldBe (5)
         // expect silence on the line
         expectNoBytes(100.millis)
 
@@ -209,8 +208,8 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         emitRequest(9, request)
         emitRequest(11, request)
         // expect 7 and 9 on the line
-        expect[HeadersFrame].streamId shouldBe (7)
-        expect[HeadersFrame].streamId shouldBe (9)
+        expect[HeadersFrame]().streamId shouldBe (7)
+        expect[HeadersFrame]().streamId shouldBe (9)
         expectNoBytes(100.millis)
 
         // close 5 7 9
@@ -219,8 +218,8 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         sendFrame(HeadersFrame(streamId = 9, endStream = true, endHeaders = true, HPackSpecExamples.C61FirstResponseWithHuffman, None))
         emitRequest(13, request)
         // expect 11 the line
-        expect[HeadersFrame].streamId shouldBe (11)
-        expect[HeadersFrame].streamId shouldBe (13)
+        expect[HeadersFrame]().streamId shouldBe (11)
+        expect[HeadersFrame]().streamId shouldBe (13)
       }
       "increasing SETTINGS_MAX_CONCURRENT_STREAMS should flush backpressured outgoing streams" in new TestSetup(
         Setting(SettingIdentifier.SETTINGS_MAX_CONCURRENT_STREAMS, 2)
@@ -231,8 +230,8 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         emitRequest(5, request) // this emit succeeds but is buffered
 
         // expect frames for 1 and 3
-        expect[HeadersFrame].streamId shouldBe (1)
-        expect[HeadersFrame].streamId shouldBe (3)
+        expect[HeadersFrame]().streamId shouldBe (1)
+        expect[HeadersFrame]().streamId shouldBe (3)
         // expect silence on the line
         expectNoBytes(100.millis)
 
@@ -241,7 +240,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         expectSettingsAck()
 
         // ... should let frame 5 pass
-        expect[HeadersFrame].streamId shouldBe (5)
+        expect[HeadersFrame]().streamId shouldBe (5)
       }
       "decreasing SETTINGS_MAX_CONCURRENT_STREAMS should keep backpressure outgoing streams until limit is respected" in new TestSetup(
         Setting(SettingIdentifier.SETTINGS_MAX_CONCURRENT_STREAMS, 3)
@@ -253,9 +252,9 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         emitRequest(7, request) // this emit succeeds but is buffered
 
         // expect frames for 1 3 and 5
-        expect[HeadersFrame].streamId shouldBe (1)
-        expect[HeadersFrame].streamId shouldBe (3)
-        expect[HeadersFrame].streamId shouldBe (5)
+        expect[HeadersFrame]().streamId shouldBe (1)
+        expect[HeadersFrame]().streamId shouldBe (3)
+        expect[HeadersFrame]().streamId shouldBe (5)
         expectNoBytes(100.millis)
 
         // Decreasing the capacity...
@@ -269,7 +268,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
 
         // Once 1 and 3 are closed, there'll be capacity for 7 to go through
         sendFrame(HeadersFrame(streamId = 3, endStream = true, endHeaders = true, HPackSpecExamples.C61FirstResponseWithHuffman, None))
-        expect[HeadersFrame].streamId shouldBe (7)
+        expect[HeadersFrame]().streamId shouldBe (7)
         // .. but not enough capacity for 9
         emitRequest(9, request)
         expectNoBytes(100.millis)
@@ -299,6 +298,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         chunks(0) should be(Chunk("asdf"))
         chunks(1) should be(LastChunk(extension = "", Seq(RawHeader("grpc-status", "0"))))
       }
+
     }
   }
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -17,6 +17,7 @@ import akka.http.impl.engine.server.HttpAttributes
 import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.http.impl.util.AkkaSpecWithMaterializer
 import akka.http.impl.util.LogByteStringTools
+import akka.http.scaladsl.model.HttpEntity.{ Chunked, LastChunk }
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.CacheDirectives
 import akka.http.scaladsl.model.headers.RawHeader
@@ -1143,10 +1144,12 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
 
       "reject all other frames while waiting for CONTINUATION frames" in pending
 
-      "ignore mid-stream HEADERS with endStream = true (potential trailers)" in new SimpleRequestResponseRoundtripSetup {
+      "accept trailing request HEADERS" in new SimpleRequestResponseRoundtripSetup with Http2FrameHpackSupport {
         sendHEADERS(1, endStream = false, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman)
-        sendHEADERS(1, endStream = true, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman)
-        expectNoBytes(100.millis)
+        sendHEADERS(1, endStream = true, Seq(RawHeader("grpc-status", "0")))
+
+        // On the server side we read the entity as bytes, so the trailing headers are not available.
+        expectRequest()
       }
 
       "reject HEADERS for already closed streams" in new SimpleRequestResponseRoundtripSetup {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -415,7 +415,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
 
         val response = HttpResponse(entity = HttpEntity(ContentTypes.`application/octet-stream`, Source.fromPublisher(entityDataOut)))
         emitResponse(TheStreamId, response)
-        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = false) shouldBe response.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
+        expectDecodedHEADERS(streamId = TheStreamId, endStream = false) shouldBe response.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
       }
 
       "encode Content-Length and Content-Type headers" in new WaitingForResponseSetup {
@@ -477,7 +477,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
 
         val response = HttpResponse(entity = HttpEntity(ContentTypes.`application/octet-stream`, Source.fromPublisher(entityDataOut)))
         emitResponse(TheStreamId, response)
-        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = false) shouldBe response.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
+        expectDecodedHEADERS(streamId = TheStreamId, endStream = false) shouldBe response.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
         entityDataOut.sendNext(bytes(bytesToSend, 0x23))
 
         expectDATA(TheStreamId, false, bytesToSend)
@@ -498,7 +498,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
 
         val response = HttpResponse(entity = HttpEntity(ContentTypes.`application/octet-stream`, Source.fromPublisher(entityDataOut)))
         emitResponse(TheStreamId, response)
-        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = false) shouldBe response.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
+        expectDecodedHEADERS(streamId = TheStreamId, endStream = false) shouldBe response.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
         entityDataOut.sendNext(bytes(bytesToSend, 0x23))
 
         expectDATA(TheStreamId, false, bytesToSend)
@@ -673,9 +673,9 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
           ))
         ))
         emitResponse(TheStreamId, response)
-        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = false)
+        expectDecodedHEADERS(streamId = TheStreamId, endStream = false)
         expectDATA(TheStreamId, endStream = false, ByteString("foobar"))
-        expectDecodedResponseHEADERS(streamId = TheStreamId).headers should be(immutable.Seq(RawHeader("status", "grpc-status 10")))
+        expectDecodedHEADERS(streamId = TheStreamId).headers should be(immutable.Seq(RawHeader("status", "grpc-status 10")))
       }
       "include the trailing headers even when the buffer is emptied before sending the last chunk" in new WaitingForResponseSetup {
         val queuePromise = Promise[SourceQueueWithComplete[HttpEntity.ChunkStreamPart]]()
@@ -691,12 +691,12 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         chunkQueue.offer(HttpEntity.Chunk("foo"))
         chunkQueue.offer(HttpEntity.Chunk("bar"))
 
-        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = false)
+        expectDecodedHEADERS(streamId = TheStreamId, endStream = false)
         expectDATA(TheStreamId, endStream = false, ByteString("foobar"))
 
         chunkQueue.offer(HttpEntity.LastChunk(trailer = immutable.Seq[HttpHeader](RawHeader("Status", "grpc-status 10"))))
         chunkQueue.complete()
-        expectDecodedResponseHEADERS(streamId = TheStreamId).headers should be(immutable.Seq(RawHeader("status", "grpc-status 10")))
+        expectDecodedHEADERS(streamId = TheStreamId).headers should be(immutable.Seq(RawHeader("status", "grpc-status 10")))
       }
       "send the trailing headers immediately, even when the stream window is depleted" in new WaitingForResponseSetup {
         val queuePromise = Promise[SourceQueueWithComplete[HttpEntity.ChunkStreamPart]]()
@@ -720,12 +720,12 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
           }
         }
 
-        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = false)
+        expectDecodedHEADERS(streamId = TheStreamId, endStream = false)
         depleteWindow()
 
         chunkQueue.offer(HttpEntity.LastChunk(trailer = immutable.Seq[HttpHeader](RawHeader("grpc-status", "10"))))
         chunkQueue.complete()
-        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = true).headers should be(immutable.Seq(RawHeader("grpc-status", "10")))
+        expectDecodedHEADERS(streamId = TheStreamId, endStream = true).headers should be(immutable.Seq(RawHeader("grpc-status", "10")))
       }
       "send the trailing headers even when last data chunk was delayed by window depletion" in new WaitingForResponseSetup {
         val queuePromise = Promise[SourceQueueWithComplete[HttpEntity.ChunkStreamPart]]()
@@ -749,7 +749,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
           }
         }
 
-        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = false)
+        expectDecodedHEADERS(streamId = TheStreamId, endStream = false)
         depleteWindow()
 
         val lastData = ByteString("y" * 500)
@@ -768,7 +768,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         sendWINDOW_UPDATE(0, 1000)
         expectDATA(TheStreamId, endStream = false, lastData.drop(100))
 
-        expectDecodedResponseHEADERS(streamId = TheStreamId, endStream = true).headers should be(immutable.Seq(RawHeader("grpc-status", "10")))
+        expectDecodedHEADERS(streamId = TheStreamId, endStream = true).headers should be(immutable.Seq(RawHeader("grpc-status", "10")))
       }
     }
 
@@ -821,7 +821,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         val entity1DataOut = TestPublisher.probe[ByteString]()
         val response1 = HttpResponse(entity = HttpEntity(ContentTypes.`application/octet-stream`, Source.fromPublisher(entity1DataOut)))
         emitResponse(1, response1)
-        expectDecodedResponseHEADERS(streamId = 1, endStream = false) shouldBe response1.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
+        expectDecodedHEADERS(streamId = 1, endStream = false) shouldBe response1.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
 
         def sendDataAndExpectOnNet(outStream: TestPublisher.Probe[ByteString], streamId: Int, dataString: String, endStream: Boolean = false): Unit = {
           val data = ByteString(dataString)
@@ -839,7 +839,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         val entity2DataOut = TestPublisher.probe[ByteString]()
         val response2 = HttpResponse(entity = HttpEntity(ContentTypes.`application/octet-stream`, Source.fromPublisher(entity2DataOut)))
         emitResponse(3, response2)
-        expectDecodedResponseHEADERS(streamId = 3, endStream = false) shouldBe response2.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
+        expectDecodedHEADERS(streamId = 3, endStream = false) shouldBe response2.withEntity(HttpEntity.Empty.withContentType(ContentTypes.`application/octet-stream`))
 
         // send again on stream 1
         sendDataAndExpectOnNet(entity1DataOut, 1, "zyx")
@@ -876,7 +876,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         val response = HttpResponse(200, entity = responseEntity)
 
         emitResponse(1, response)
-        expectDecodedResponseHEADERS(1, false)
+        expectDecodedHEADERS(1, false)
 
         // check data flow for request entity
         sendDATA(1, false, ByteString("ping"))


### PR DESCRIPTION
A first stab at #3563.

I'm not too fond of the use of the promise/future here, but the obvious alternative (to make the data substream a stream of `ChunkStreamPart` instead of `ByteString`) seems invasive and inelegant as well... thoughts?