### PR TITLE
Http2SubStream cleanup

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -29,18 +29,15 @@ import scala.util.control.NoStackTrace
  */
 @InternalApi
 private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper =>
-  type T
-
   // required API from demux
   def isServer: Boolean
   def multiplexer: Http2Multiplexer
   def settings: Http2CommonSettings
   def pushGOAWAY(errorCode: ErrorCode, debug: String): Unit
-  def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Source[T, Any], correlationAttributes: Map[AttributeKey[_], _]): Unit
+  def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Source[Any, Any], correlationAttributes: Map[AttributeKey[_], _]): Unit
   def isUpgraded: Boolean
 
-  def wrapData(bytes: ByteString): T
-  def wrapTrailingHeaders(headers: ParsedHeadersFrame): Option[T]
+  def wrapTrailingHeaders(headers: ParsedHeadersFrame): Option[HttpEntity.ChunkStreamPart]
 
   def flowController: IncomingFlowController = IncomingFlowController.default(settings)
 
@@ -244,7 +241,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
             if (endStream)
               (Source.empty, nextStateEmpty)
             else {
-              val subSource = new SubSourceOutlet[T](s"substream-out-$streamId")
+              val subSource = new SubSourceOutlet[Any](s"substream-out-$streamId")
               (Source.fromGraph(subSource.source), nextStateStream(new IncomingStreamBuffer(streamId, subSource)))
             }
 
@@ -460,9 +457,9 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
     }
   }
 
-  class IncomingStreamBuffer(streamId: Int, outlet: SubSourceOutlet[T]) extends OutHandler {
+  class IncomingStreamBuffer(streamId: Int, outlet: SubSourceOutlet[Any]) extends OutHandler {
     private var buffer: ByteString = ByteString.empty
-    private var trailingHeaders: Option[T] = None
+    private var trailingHeaders: Option[HttpEntity.ChunkStreamPart] = None
     private var wasClosed: Boolean = false
     private var outstandingStreamWindow: Int = Http2Protocol.InitialWindowSize // adapt if we negotiate greater sizes by settings
     outlet.setHandler(this)
@@ -510,7 +507,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
     private def dispatchNextChunk(): Unit = {
       if (buffer.nonEmpty && outlet.isAvailable) {
         val dataSize = buffer.size min settings.requestEntityChunkSize
-        outlet.push(wrapData(buffer.take(dataSize)))
+        outlet.push(buffer.take(dataSize))
         buffer = buffer.drop(dataSize)
 
         totalBufferedData -= dataSize

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -74,7 +74,8 @@ private[http2] object RequestParsing {
 
           if (tlsSessionInfoHeader.isDefined) headers += tlsSessionInfoHeader.get
 
-          val entity = subStream.createRequestEntity(contentLength, contentType.getOrElse(ContentTypes.`application/octet-stream`))
+          val entity = subStream.createEntity(contentLength, contentType)
+
           val (path, rawQueryString) = pathAndRawQuery
           val authorityOrDefault: Uri.Authority = if (authority == null) Uri.Authority.Empty else authority
           val uri = Uri(scheme, authorityOrDefault, path, rawQueryString)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ResponseRendering.scala
@@ -51,7 +51,7 @@ private[http2] object ResponseRendering {
       renderHeaders(response.headers, headerPairs, serverHeader, log, isServer = true)
 
       val headers = ParsedHeadersFrame(streamId, endStream = response.entity.isKnownEmpty, headerPairs.result(), None)
-      substreamFor(response.entity, headers)
+      Http2SubStream(response.entity, headers)
     }
   }
 
@@ -59,13 +59,6 @@ private[http2] object ResponseRendering {
     if (entity.contentType != ContentTypes.NoContentType)
       headerPairs += "content-type" -> entity.contentType.toString
     entity.contentLengthOption.foreach(headerPairs += "content-length" -> _.toString)
-  }
-
-  private[http2] def substreamFor(entity: HttpEntity, headers: ParsedHeadersFrame): Http2SubStream = entity match {
-    case HttpEntity.Chunked(_, chunks) =>
-      ChunkedHttp2SubStream(headers, chunks, Map.empty)
-    case _ =>
-      ByteHttp2SubStream(headers, entity.dataBytes)
   }
 
   private[http2] def renderHeaders(

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/RequestRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/RequestRendering.scala
@@ -31,8 +31,7 @@ private[http2] object RequestRendering {
 
       val headersFrame = ParsedHeadersFrame(streamId.getAndAdd(2), endStream = request.entity.isKnownEmpty, headerPairs.result(), None)
 
-      val substream = ResponseRendering.substreamFor(request.entity, headersFrame)
-      substream.withCorrelationAttributes(request.attributes.filter(_._2.isInstanceOf[RequestResponseAssociation]))
+      Http2SubStream(request.entity, headersFrame, request.attributes.filter(_._2.isInstanceOf[RequestResponseAssociation]))
     }
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
@@ -30,7 +30,7 @@ private[http2] object ResponseParsing {
         // https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.4: these pseudo header fields are mandatory for a response
         checkRequiredPseudoHeader(":status", status)
 
-        val entity = subStream.createResponseEntity(contentLength, contentType.getOrElse(ContentTypes.`application/octet-stream`))
+        val entity = subStream.createEntity(contentLength, contentType)
 
         HttpResponse(
           status = status,

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -13,7 +13,7 @@ import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.http.impl.util.{ AkkaSpecWithMaterializer, LogByteStringTools }
 import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk, Strict }
+import akka.http.scaladsl.model.HttpEntity.{ Chunk, Chunked, LastChunk }
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.settings.ClientConnectionSettings
@@ -81,9 +81,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
             // TODO shouldn't this produce an error since stream '1' is already the outgoing stream?
             HeadersFrame(streamId = 1, endStream = true, endHeaders = true, HPackSpecExamples.C61FirstResponseWithHuffman, None)
           ),
-          expectedResponse =
-            HPackSpecExamples.FirstResponse
-              .withEntity(Chunked(ContentTypes.`application/octet-stream`, Source.empty))
+          expectedResponse = HPackSpecExamples.FirstResponse
         )
       }
 
@@ -115,9 +113,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
           response = Seq(
             HeadersFrame(streamId = 1, endStream = true, endHeaders = true, HPackSpecExamples.C61FirstResponseWithHuffman, None)
           ),
-          expectedResponse =
-            HPackSpecExamples.FirstResponse
-              .withEntity(Strict(ContentTypes.`application/octet-stream`, ByteString.empty))
+          expectedResponse = HPackSpecExamples.FirstResponse
         )
 
         emitRequest(3, HttpRequest(uri = "https://www.example.com/"))
@@ -148,7 +144,6 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
             HeadersFrame(streamId = 1, endStream = true, endHeaders = true, HPackSpecExamples.C61FirstResponseWithHuffman, None)
           ),
           expectedResponse = HPackSpecExamples.FirstResponse
-            .withEntity(Strict(ContentTypes.`application/octet-stream`, ByteString.empty))
         )
         requestResponseRoundtrip(
           streamId = 3,
@@ -158,7 +153,6 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
             HeadersFrame(streamId = 3, endStream = true, endHeaders = true, HPackSpecExamples.C62SecondResponseWithHuffman, None)
           ),
           expectedResponse = HPackSpecExamples.SecondResponse
-            .withEntity(Strict(ContentTypes.`application/octet-stream`, ByteString.empty))
         )
         requestResponseRoundtrip(
           streamId = 5,
@@ -168,7 +162,6 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
             HeadersFrame(streamId = 5, endStream = true, endHeaders = true, HPackSpecExamples.C63ThirdResponseWithHuffman, None)
           ),
           expectedResponse = HPackSpecExamples.ThirdResponseModeled
-            .withEntity(Strict(ContentTypes.`application/octet-stream`, ByteString.empty))
         )
       }
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -27,14 +27,15 @@ class RequestParsingSpec extends AkkaSpec() with Inside with Inspectors {
       uriParsingMode: Uri.ParsingMode         = Uri.ParsingMode.Relaxed
     ): HttpRequest = {
       // Stream containing the request
-      val subStream = ByteHttp2SubStream(
+      val subStream = Http2SubStream(
         initialHeaders = ParsedHeadersFrame(
           streamId = 1,
-          endStream = true,
+          endStream = data == Source.empty,
           keyValuePairs = keyValuePairs,
           priorityInfo = None
         ),
-        data = data
+        data = data,
+        correlationAttributes = Map.empty
       )
       // Create the parsing function
       val parseRequest: Http2SubStream => HttpRequest = {


### PR DESCRIPTION
Now we are back to a single version of Http2SubStream that can either be supplied by `ByteString` or `ChunkStreamPart` as it fits.

I also put all of the substream <=> entity conversions into that class so that it will be more easily reused from parsing / rendering.