### PR TITLE
Stream window test fail fix

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -409,8 +409,10 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         // trigger a connection-level WINDOW_UPDATE
         sendDATA(TheStreamId, endStream = false, ByteString("0000"))
         expectWindowUpdate()
+        entityDataIn.expectUtf8EncodedString("0000")
+        expectWindowUpdate() // window resize/update triggered
 
-        sendFrame(DataFrame(TheStreamId, endStream = false, ByteString("0" * 100000)))
+        sendFrame(DataFrame(TheStreamId, endStream = false, ByteString("0" * 512001)))
         expectRST_STREAM(TheStreamId, ErrorCode.FLOW_CONTROL_ERROR)
       }
       "fail entity stream if advertised content-length doesn't match" in pending


### PR DESCRIPTION
Make sure the stream window resize always happens.
Previously it would only be triggered in Akka 2.6 by a earlier pull causing the test to fail
while with Akka 2.5 would pass. This adds an explicit pull to trigger the same behavior on both.

Credits for fix mostly goes to jrudolph who helped me a lot.

References #3606
