### PR TITLE
Make sure to fail binding promise if binding fails in MinimalHttpApp

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
@@ -36,6 +36,12 @@ public class MinimalHttpApp extends HttpApp {
   }
 
   @Override
+  protected void postHttpBindingFailure(Throwable cause) {
+    super.postHttpBindingFailure(cause);
+    bindingPromise.completeExceptionally(cause);
+  }
+
+  @Override
   protected CompletionStage<Done> waitForShutdownSignal(ActorSystem system) {
     return shutdownTrigger;
   }


### PR DESCRIPTION
Not sure this is the issue making it fail, because I'd expect that failure showing up in logs anyway, but it could provide more info if an exception is what is going on making the promise never complete.

References #3588
