### PR TITLE
docs: add example for Get request with query parameters

### DIFF
--- a/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java
@@ -65,6 +65,14 @@ public class UriTest extends JUnitSuite {
     //#dont-double-decode
   }
 
+  @Test
+  public void testAddingQueryParams() {
+    //#create-uri-with-query
+    Uri uri = Uri.create("http://foo.com").query(Query.create(Pair.create("foo","bar")));
+    //#create-uri-with-query
+    assertEquals(Optional.of("foo=bar"),uri.rawQueryString());
+  }
+
   //#illegal-scheme
   @Test(expected = IllegalUriException.class)
   public void testIllegalScheme() {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -779,7 +779,11 @@ class UriSpec extends AnyWordSpec with Matchers {
       uri.withUserInfo("someInfo") shouldEqual Uri("http://someInfo@host/path?query#fragment")
       explicitDefault.withUserInfo("someInfo") shouldEqual Uri("http://someInfo@host:80/path?query#fragment")
 
-      uri.withQuery(Query("param1" -> "value1")) shouldEqual Uri("http://host/path?param1=value1#fragment")
+      //#create-uri-with-query
+      val uriWithQuery = uri.withQuery(Query("param1" -> "value1"))
+      //#create-uri-with-query
+
+      uriWithQuery shouldEqual Uri("http://host/path?param1=value1#fragment")
       uri.withQuery(Query(Map("param1" -> "value1"))) shouldEqual Uri("http://host/path?param1=value1#fragment")
       uri.withRawQueryString("param1=value1") shouldEqual Uri("http://host/path?param1=value1#fragment")
 

--- a/docs/src/main/paradox/client-side/request-and-response.md
+++ b/docs/src/main/paradox/client-side/request-and-response.md
@@ -12,6 +12,11 @@ Scala
 Java
 :  @@snip[ClientSingleRequestExample.java](/docs/src/test/java/docs/http/javadsl/ClientSingleRequestExample.java){ #create-simple-request }
 
+@@@ note
+@scala[@apidoc[HttpRequest](HttpRequest) also]@java[@apidoc[HttpRequest]'s method `HttpRequest::withUri()`] takes @apidoc[Uri] as a parameter.
+@ref[Query String in URI](../common/uri-model.md#query-string-in-uri) section describes a fluent API for building URIs with query parameters.
+@@@ 
+
 Or more complicated ones, like this `POST`:
 
 Scala

--- a/docs/src/main/paradox/common/uri-model.md
+++ b/docs/src/main/paradox/common/uri-model.md
@@ -93,6 +93,14 @@ which are typically [percent encoded](https://en.wikipedia.org/wiki/Percent-enco
 When you instantiate a @apidoc[Uri] class by passing a URI string, the query string is stored in its raw string form.
 Then, when you call the `query()` method, the query string is parsed from the raw string.
 
+You can add query parameters with @apidoc[Uri] class's @scala[`withQuery()` method]@java[`Uri::query()` method]
+
+Scala
+:   @@snip [UriSpec.scala](/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala) { #create-uri-with-query }
+
+Java
+:   @@snip [UriTest.java](/akka-http-core/src/test/java/akka/http/javadsl/model/UriTest.java) { #create-uri-with-query }
+
 The below code illustrates how valid query strings are parsed.
 Especially, you can check how percent encoding is used and how special characters like `+` and `;` are parsed.
 

--- a/docs/src/test/java/docs/http/javadsl/ClientSingleRequestExample.java
+++ b/docs/src/test/java/docs/http/javadsl/ClientSingleRequestExample.java
@@ -35,8 +35,10 @@ class OtherRequestResponseExamples {
   public void request() {
     //#create-simple-request
     HttpRequest.create("https://akka.io");
-    //#create-simple-request
 
+    // with query params
+    HttpRequest.create("https://akka.io?foo=bar");
+    //#create-simple-request
     //#create-post-request
     HttpRequest.POST("https://userservice.example/users")
       .withEntity(HttpEntities.create(ContentTypes.TEXT_PLAIN_UTF8, "data"));

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -276,16 +276,10 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     // or:
     import akka.http.scaladsl.client.RequestBuilding.Get
     Get("https://akka.io")
-    
+
     // with query params
-    import akka.http.scaladsl.model.Uri
-    import akka.http.scaladsl.model.Uri.Query
-    Get(Uri("https://akka.io")
-        .withQuery(
-            Query("foo" -> "bar")
-          )
-       )
-    
+    Get("https://akka.io?foo=bar")
+
     //#create-simple-request
 
     implicit val ec: ExecutionContext = null

--- a/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpClientExampleSpec.scala
@@ -276,6 +276,16 @@ class HttpClientExampleSpec extends AnyWordSpec with Matchers with CompileOnlySp
     // or:
     import akka.http.scaladsl.client.RequestBuilding.Get
     Get("https://akka.io")
+    
+    // with query params
+    import akka.http.scaladsl.model.Uri
+    import akka.http.scaladsl.model.Uri.Query
+    Get(Uri("https://akka.io")
+        .withQuery(
+            Query("foo" -> "bar")
+          )
+       )
+    
     //#create-simple-request
 
     implicit val ec: ExecutionContext = null


### PR DESCRIPTION
This is quite a common requirement and nowhere mentioned in the docs explicitely. A question on stackoverflow (with 11k views) has an [answer](https://stackoverflow.com/a/31939776/154325) to this. But I believe inclusion of a simple example in official documentation will help developers a great deal.


<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
