### PR TITLE
Increase patience in Http2ClientSpec

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -23,6 +23,7 @@ import akka.stream.scaladsl.{ BidiFlow, Flow, Sink, Source }
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
 import akka.util.ByteString
 import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.PatienceConfiguration
 
 import scala.collection.immutable
 import scala.concurrent.duration._
@@ -41,6 +42,8 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
     akka.http.client.http2.log-frames = on
   """)
   with WithInPendingUntilFixed with Eventually {
+
+  override implicit val patience = PatienceConfig(5.seconds, 5.seconds)
   override def failOnSevereMessages: Boolean = true
 
   "The Http/2 client implementation" should {


### PR DESCRIPTION
To reduce timing-sensitivity of tests on CI. Might (or might
not) help for #3625.