### PR TITLE
docs: release notes for 10.1.13

### DIFF
--- a/docs/src/main/paradox/release-notes/10.1.x.md
+++ b/docs/src/main/paradox/release-notes/10.1.x.md
@@ -1,5 +1,14 @@
 # 10.1.x Release Notes
 
+## 10.1.13
+
+### Changes since 10.1.12
+
+#### akka-http-core
+
+* Don't fail pool slot after previous connection failed in special condition [#3021](https://github.com/akka/akka-http/pull/3021)
+* Make HttpEntity.Strict.discardBytes a no-op [#3329](https://github.com/akka/akka-http/pull/3329)
+
 ## 10.1.12
 
 ### ALPN support in JDK >= 8u252


### PR DESCRIPTION
After I reverted the big backport of fixing server-side cancellation races (88a6a75f3e59d11ef8bb03c73b0193b5ad4e78d6) because of it breaking the `lingerTimeout` there's actually not much left but a fix for the connection pool and an performance optimization for strict entities.

I'm seeing this as a good sign that maintenance on 10.1.x has naturally wound down.