### PR TITLE
docs: add section about how to configure snapshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,6 +336,11 @@ Integration:
 The [Jenkins server farm](https://jenkins.akka.io/), sometimes referred to as "the Lausanne cluster", is sponsored by Lightbend.
 The cluster is made out of real bare-metal boxes, and maintained by the Akka team (and other very helpful people at Lightbend).
 
+## Snapshots
+
+Snapshots are published to a snapshot repository. See the latest information about how to use snapshots in the
+[documentation](https://doc.akka.io/docs/akka-http/snapshot/contributing.html#snapshots).
+
 ## Related links
 
 * [Akka Contributor License Agreement](https://www.lightbend.com/contribute/cla)

--- a/docs/src/main/paradox/contributing.md
+++ b/docs/src/main/paradox/contributing.md
@@ -1,7 +1,47 @@
 # 9. Contributing
 
-# Welcome!
+## Welcome!
 
 We follow the standard GitHub [fork & pull](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#fork--pull) approach to pull requests. Just fork the official repo, develop in a branch, and submit a PR!
 
 For a more detailed description of our process, please refer to the [CONTRIBUTING.md](https://github.com/akka/akka-http/blob/master/CONTRIBUTING.md) page on the github project.
+
+## Snapshots
+
+Testing snapshot versions can help us find bugs before a release. We publish snapshot versions for every master commit.
+
+The latest published snapshot version is [![bintray-badge][]][bintray].
+
+### Configure repository
+
+sbt
+:   ```scala
+    resolvers += Resolver.bintrayRepo("akka", "snapshots")
+    ```
+
+Maven
+:   ```xml
+    <project>
+    ...
+      <repositories>
+        <repository>
+          <id>akka-http-snapshots</id>
+          <name>Akka HTTP Snapshots</name>
+          <url>https://dl.bintray.com/akka/snapshots</url>
+        </repository>
+      </repositories>
+    ...
+    </project>
+    ```
+
+Gradle
+:   ```gradle
+    repositories {
+      maven {
+        url  "https://dl.bintray.com/akka/snapshots"
+      }
+    }
+    ```
+
+[bintray-badge]:  https://api.bintray.com/packages/akka/snapshots/akka-http/images/download.svg
+[bintray]:        https://bintray.com/akka/snapshots/akka-http/_latestVersion


### PR DESCRIPTION
To have an easy page that you can refer people to when you want them to test snapshots.

Based on a page in the alpakka documentation at https://github.com/akka/alpakka/blob/master/docs/src/main/paradox/other-docs/snapshots.md.