### PR TITLE
Update formFields example

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
@@ -13,7 +13,7 @@ class FormFieldDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "formFields" in {
     //#formFields
     val route =
-      formFields("direction" ! "up", "color", "age".as[Int]) { (_, color, age) =>
+      formFields("color", "age".as[Int], "direction" ! "up") { (color, age, _) =>
         complete(s"The color is '$color' and the age ten years ago was ${age - 10}")
       }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FormFieldDirectivesExamplesSpec.scala
@@ -13,12 +13,12 @@ class FormFieldDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
   "formFields" in {
     //#formFields
     val route =
-      formFields("color", "age".as[Int]) { (color, age) =>
+      formFields("direction" ! "up", "color", "age".as[Int]) { (_, color, age) =>
         complete(s"The color is '$color' and the age ten years ago was ${age - 10}")
       }
 
     // tests:
-    Post("/", FormData("color" -> "blue", "age" -> "68")) ~> route ~> check {
+    Post("/", FormData("direction" -> "up", "color" -> "blue", "age" -> "68")) ~> route ~> check {
       responseAs[String] shouldEqual "The color is 'blue' and the age ten years ago was 58"
     }
 


### PR DESCRIPTION
With the new `formFields` signature, parameters that extract nothing still need to be accounted for in the output. Code example is updated demonstrating that.
The discussion on magnets and signatures at the top of https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/form-field-directives/formFields.html also probably needs to be updated, but I'm not sure what to replace it with.