### PR TITLE
tests: any exception is fine in "close substreams" test

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -775,7 +775,9 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         fromNet.sendError(new RuntimeException("Connection broke"))
 
         // now all stream stages should be closed
-        reqProbe.expectError().getMessage shouldBe "The HTTP/2 connection was shut down while the request was still ongoing"
+        // up to Akka 2.6.10: "The HTTP/2 connection was shut down while the request was still ongoing"
+        // later: "Connection broke" (in 10.2.x, we will make sure only the first error is ever thrown)
+        reqProbe.expectError()
         responseEntityProbe.expectCancellation()
       })
     }


### PR DESCRIPTION
To fix nightly failure here: https://jenkins.akka.io:8498/view/Akka-http/job/akka-http-nightly-release-10.1/AKKA_VERSION=master,Node=akka-http-nightly-node,SCALA_VERSION=2.12.10,jdk=AdoptOpenJDK%208/1089/testReport/junit/akka.http.impl.engine.http2/Http2ServerSpec/The_Http_2_server_implementation_should_support_multiple_concurrent_substreams_should_close_substreams_when_connection_is_shutting_down/

(Behavior will be slightly different between latest Akka 2.6 and previous versions but we don't care to much there.)