### PR TITLE
core: allow illegal header keys to be ignored #3133

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.2.1.backwards.excludes/issue-3133-ignore-illegal-header-names.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.1.backwards.excludes/issue-3133-ignore-illegal-header-names.excludes
@@ -1,0 +1,6 @@
+ProblemFilters.exclude[Problem]("akka.http.impl.settings.ParserSettingsImpl*")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.model.parser.HeaderParser.Settings")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.engine.parsing.HttpHeaderParser#Settings.illegalResponseHeaderNameProcessingMode")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.model.parser.HeaderParser#Settings.illegalResponseHeaderNameProcessingMode")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ParserSettings.getIllegalResponseHeaderNameProcessingMode")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ParserSettings.illegalResponseHeaderNameProcessingMode")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -668,7 +668,7 @@ akka.http {
     # header name of response.
     #
     # Supported mode:
-    # `error`  : default mode, throw an ParsingException and terminate the processing
+    # `error`  : default mode, reject the request
     # `warn`   : ignore the illegal characters in response header value and log a warning message
     # `ignore` : just ignore the illegal characters in response header value
     illegal-response-header-name-processing-mode = error

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -665,6 +665,15 @@ akka.http {
     error-logging-verbosity = full
 
     # Configures the processing mode when encountering illegal characters in
+    # header name of response.
+    #
+    # Supported mode:
+    # `error`  : default mode, throw an ParsingException and terminate the processing
+    # `warn`   : ignore the illegal characters in response header value and log a warning message
+    # `ignore` : just ignore the illegal characters in response header value
+    illegal-response-header-name-processing-mode = error
+
+    # Configures the processing mode when encountering illegal characters in
     # header value of response.
     #
     # Supported mode:

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -7,7 +7,7 @@ package akka.http.impl.model.parser
 import akka.annotation.InternalApi
 import akka.http.scaladsl.settings.ParserSettings
 import akka.http.scaladsl.settings.ParserSettings.CookieParsingMode
-import akka.http.scaladsl.settings.ParserSettings.IllegalResponseHeaderValueProcessingMode
+import akka.http.scaladsl.settings.ParserSettings.{ IllegalResponseHeaderValueProcessingMode, IllegalResponseHeaderNameProcessingMode }
 import akka.http.scaladsl.model.headers.HttpCookiePair
 import akka.util.ConstantFun
 
@@ -191,18 +191,21 @@ private[http] object HeaderParser {
     def uriParsingMode: Uri.ParsingMode
     def cookieParsingMode: ParserSettings.CookieParsingMode
     def customMediaTypes: MediaTypes.FindCustom
+    def illegalResponseHeaderNameProcessingMode: IllegalResponseHeaderNameProcessingMode
     def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode
   }
   def Settings(
     uriParsingMode:    Uri.ParsingMode                          = Uri.ParsingMode.Relaxed,
     cookieParsingMode: ParserSettings.CookieParsingMode         = ParserSettings.CookieParsingMode.RFC6265,
     customMediaTypes:  MediaTypes.FindCustom                    = ConstantFun.scalaAnyTwoToNone,
-    mode:              IllegalResponseHeaderValueProcessingMode = ParserSettings.IllegalResponseHeaderValueProcessingMode.Error): Settings = {
+    modeValue:         IllegalResponseHeaderValueProcessingMode = ParserSettings.IllegalResponseHeaderValueProcessingMode.Error,
+    modeName:          IllegalResponseHeaderNameProcessingMode  = ParserSettings.IllegalResponseHeaderNameProcessingMode.Error): Settings = {
 
     val _uriParsingMode = uriParsingMode
     val _cookieParsingMode = cookieParsingMode
     val _customMediaTypes = customMediaTypes
-    val _illegalResponseHeaderValueProcessingMode = mode
+    val _illegalResponseHeaderValueProcessingMode = modeValue
+    val _illegalResponseHeaderNameProcessingMode = modeName
 
     new Settings {
       def uriParsingMode: Uri.ParsingMode = _uriParsingMode
@@ -211,6 +214,9 @@ private[http] object HeaderParser {
 
       def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode =
         _illegalResponseHeaderValueProcessingMode
+
+      def illegalResponseHeaderNameProcessingMode: IllegalResponseHeaderNameProcessingMode =
+        _illegalResponseHeaderNameProcessingMode
     }
   }
   val DefaultSettings: Settings = Settings()

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -5,7 +5,7 @@
 package akka.http.impl.settings
 
 import akka.annotation.InternalApi
-import akka.http.scaladsl.settings.ParserSettings.{ CookieParsingMode, ErrorLoggingVerbosity, IllegalResponseHeaderValueProcessingMode }
+import akka.http.scaladsl.settings.ParserSettings.{ CookieParsingMode, ErrorLoggingVerbosity, IllegalResponseHeaderValueProcessingMode, IllegalResponseHeaderNameProcessingMode }
 import akka.util.ConstantFun
 import com.typesafe.config.Config
 
@@ -32,6 +32,7 @@ private[akka] final case class ParserSettingsImpl(
   illegalHeaderWarnings:                    Boolean,
   ignoreIllegalHeaderFor:                   Set[String],
   errorLoggingVerbosity:                    ErrorLoggingVerbosity,
+  illegalResponseHeaderNameProcessingMode:  IllegalResponseHeaderNameProcessingMode,
   illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode,
   headerValueCacheLimits:                   Map[String, Int],
   includeTlsSessionInfoHeader:              Boolean,
@@ -95,6 +96,7 @@ object ParserSettingsImpl extends SettingsCompanionImpl[ParserSettingsImpl]("akk
       c.getBoolean("illegal-header-warnings"),
       c.getStringList("ignore-illegal-header-for").asScala.map(_.toLowerCase).toSet,
       ErrorLoggingVerbosity(c.getString("error-logging-verbosity")),
+      IllegalResponseHeaderNameProcessingMode(c.getString("illegal-response-header-name-processing-mode")),
       IllegalResponseHeaderValueProcessingMode(c.getString("illegal-response-header-value-processing-mode")),
       cacheConfig.entrySet.asScala.iterator.map(kvp => kvp.getKey -> cacheConfig.getInt(kvp.getKey)).toMap,
       c.getBoolean("tls-session-info-header"),

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
@@ -40,6 +40,7 @@ abstract class ParserSettings private[akka] () extends BodyPartParser.Settings {
   def getIllegalHeaderWarnings: Boolean
   def getIgnoreIllegalHeaderFor: Set[String]
   def getErrorLoggingVerbosity: ParserSettings.ErrorLoggingVerbosity
+  def getIllegalResponseHeaderNameProcessingMode: ParserSettings.IllegalResponseHeaderNameProcessingMode
   def getIllegalResponseHeaderValueProcessingMode: ParserSettings.IllegalResponseHeaderValueProcessingMode
   def getHeaderValueCacheLimits: ju.Map[String, Int]
   def getIncludeTlsSessionInfoHeader: Boolean
@@ -95,6 +96,7 @@ abstract class ParserSettings private[akka] () extends BodyPartParser.Settings {
 object ParserSettings extends SettingsCompanion[ParserSettings] {
   trait CookieParsingMode
   trait ErrorLoggingVerbosity
+  trait IllegalResponseHeaderNameProcessingMode
   trait IllegalResponseHeaderValueProcessingMode
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -40,6 +40,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   def illegalHeaderWarnings: Boolean
   def ignoreIllegalHeaderFor: Set[String]
   def errorLoggingVerbosity: ParserSettings.ErrorLoggingVerbosity
+  def illegalResponseHeaderNameProcessingMode: ParserSettings.IllegalResponseHeaderNameProcessingMode
   def illegalResponseHeaderValueProcessingMode: ParserSettings.IllegalResponseHeaderValueProcessingMode
   def headerValueCacheLimits: Map[String, Int]
   def includeTlsSessionInfoHeader: Boolean
@@ -68,6 +69,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   override def getMaxUriLength = maxUriLength
   override def getMaxMethodLength = maxMethodLength
   override def getErrorLoggingVerbosity: js.ParserSettings.ErrorLoggingVerbosity = errorLoggingVerbosity
+  override def getIllegalResponseHeaderNameProcessingMode = illegalResponseHeaderNameProcessingMode
   override def getIllegalResponseHeaderValueProcessingMode = illegalResponseHeaderValueProcessingMode
 
   override def getCustomMethods = new Function[String, Optional[akka.http.javadsl.model.HttpMethod]] {
@@ -116,6 +118,8 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
     val map = types.map(c => (c.mainType, c.subType) -> c).toMap
     self.copy(customMediaTypes = (main, sub) => map.get((main, sub)))
   }
+  def withIllegalResponseHeaderNameProcessingMode(newValue: ParserSettings.IllegalResponseHeaderNameProcessingMode): ParserSettings =
+    self.copy(illegalResponseHeaderNameProcessingMode = newValue)
   def withIllegalResponseHeaderValueProcessingMode(newValue: ParserSettings.IllegalResponseHeaderValueProcessingMode): ParserSettings =
     self.copy(illegalResponseHeaderValueProcessingMode = newValue)
 }
@@ -159,6 +163,21 @@ object ParserSettings extends SettingsCompanion[ParserSettings] {
         case "warn"   => Warn
         case "ignore" => Ignore
         case x        => throw new IllegalArgumentException(s"[$x] is not a legal `illegal-response-header-value-processing-mode` setting")
+      }
+  }
+
+  sealed trait IllegalResponseHeaderNameProcessingMode extends akka.http.javadsl.settings.ParserSettings.IllegalResponseHeaderNameProcessingMode
+  object IllegalResponseHeaderNameProcessingMode {
+    case object Error extends IllegalResponseHeaderNameProcessingMode
+    case object Warn extends IllegalResponseHeaderNameProcessingMode
+    case object Ignore extends IllegalResponseHeaderNameProcessingMode
+
+    def apply(string: String): IllegalResponseHeaderNameProcessingMode =
+      string.toRootLowerCase match {
+        case "error"  => Error
+        case "warn"   => Warn
+        case "ignore" => Ignore
+        case x        => throw new IllegalArgumentException(s"[$x] is not a legal `illegal-response-header-name-processing-mode` setting")
       }
   }
 


### PR DESCRIPTION
* reuse ignore illegal header value configuration
* configuration now applies to both, header and key
* BREAKING: name of configuration key changed

https://github.com/akka/akka-http/issues/3133

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #3133
