### PR TITLE
HTTP/2 client test coverage (and support for) tls session info

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -103,7 +103,7 @@ private[http] object Http2Blueprint {
     // HttpHeaderParser is not thread safe and should not be called concurrently,
     // the internal trie, however, has built-in protection and will do copy-on-write
     val masterHttpHeaderParser = HttpHeaderParser(settings.parserSettings, log)
-    httpLayerClient(masterHttpHeaderParser, log) atop
+    httpLayerClient(masterHttpHeaderParser, settings.parserSettings, log) atop
       clientDemux(settings.http2Settings, masterHttpHeaderParser) atop
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
       hpackCoding() atop
@@ -111,15 +111,15 @@ private[http] object Http2Blueprint {
       idleTimeoutIfConfigured(settings.idleTimeout)
   }
 
-  def httpLayerClient(masterHttpHeaderParser: HttpHeaderParser, log: LoggingAdapter): BidiFlow[HttpRequest, Http2SubStream, Http2SubStream, HttpResponse, NotUsed] = {
+  def httpLayerClient(masterHttpHeaderParser: HttpHeaderParser, settings: ParserSettings, log: LoggingAdapter): BidiFlow[HttpRequest, Http2SubStream, Http2SubStream, HttpResponse, NotUsed] = {
     BidiFlow.fromFlows(
       Flow[HttpRequest].statefulMapConcat { () =>
         val renderer = RequestRendering.createRenderer(log)
         request => renderer(request) :: Nil
       },
-      Flow[Http2SubStream].statefulMapConcat { () =>
+      StreamUtils.statefulAttrsMap[Http2SubStream, HttpResponse] { attrs =>
         val headerParser = masterHttpHeaderParser.createShallowCopy()
-        stream => ResponseParsing.parseResponse(headerParser)(stream) :: Nil
+        stream => ResponseParsing.parseResponse(headerParser, settings, attrs)(stream)
       }
     )
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
@@ -8,7 +8,12 @@ package client
 import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.RequestParsing._
 import akka.http.impl.engine.parsing.HttpHeaderParser
+import akka.http.impl.engine.server.HttpAttributes
+import akka.http.scaladsl.model
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.`Tls-Session-Info`
+import akka.http.scaladsl.settings.ParserSettings
+import akka.stream.Attributes
 import akka.util.OptionVal
 
 import scala.annotation.tailrec
@@ -16,7 +21,19 @@ import scala.collection.immutable.VectorBuilder
 
 @InternalApi
 private[http2] object ResponseParsing {
-  def parseResponse(httpHeaderParser: HttpHeaderParser): Http2SubStream => HttpResponse = { subStream =>
+  def parseResponse(httpHeaderParser: HttpHeaderParser, settings: ParserSettings, attributes: Attributes): Http2SubStream => HttpResponse = { subStream =>
+
+    val tlsSessionInfoHeader: Option[`Tls-Session-Info`] =
+      if (settings.includeTlsSessionInfoHeader) {
+        attributes.get[HttpAttributes.TLSSessionInfo].map(sslSessionInfo =>
+          model.headers.`Tls-Session-Info`(sslSessionInfo.session))
+      } else None
+
+    val tlsSessionAttribute: Option[(AttributeKey[SslSessionInfo], SslSessionInfo)] =
+      if (settings.includeSslSessionAttribute) {
+        attributes.get[HttpAttributes.TLSSessionInfo].map(sslAttr => AttributeKeys.sslSession -> SslSessionInfo(sslAttr.session))
+      } else None
+
     @tailrec
     def rec(
       remainingHeaders:  Seq[(String, String)],
@@ -32,12 +49,17 @@ private[http2] object ResponseParsing {
 
         val entity = subStream.createEntity(contentLength, contentType)
 
+        // user access to tls session info
+        if (tlsSessionInfoHeader.isDefined) headers += tlsSessionInfoHeader.get
+        var attributes = subStream.correlationAttributes
+        if (tlsSessionAttribute.isDefined) attributes += tlsSessionAttribute.get
+
         HttpResponse(
           status = status,
           headers = headers.result(),
           entity = entity,
           HttpProtocols.`HTTP/2.0`
-        ).withAttributes(subStream.correlationAttributes)
+        ).withAttributes(attributes)
       } else remainingHeaders.head match {
         case (":status", statusCodeValue) =>
           checkUniquePseudoHeader(":status", status)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -96,6 +96,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   override def withMaxChunkSize(newValue: Int): ParserSettings = self.copy(maxChunkSize = newValue)
   override def withIllegalHeaderWarnings(newValue: Boolean): ParserSettings = self.copy(illegalHeaderWarnings = newValue)
   override def withIncludeTlsSessionInfoHeader(newValue: Boolean): ParserSettings = self.copy(includeTlsSessionInfoHeader = newValue)
+  override def withIncludeSslSessionAttribute(newValue: Boolean): ParserSettings = self.copy(includeSslSessionAttribute = newValue)
   override def withModeledHeaderParsing(newValue: Boolean): ParserSettings = self.copy(modeledHeaderParsing = newValue)
   override def withIgnoreIllegalHeaderFor(newValue: List[String]): ParserSettings = self.copy(ignoreIllegalHeaderFor = newValue.map(_.toLowerCase).toSet)
 


### PR DESCRIPTION
Started out as added HTTP/2 client test coverage but perhaps better with this as an isolated PR since it basically was about adding a feature in the end.