### PR TITLE
Fail if trying to bind flow/source with HTTP2 

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -180,6 +180,9 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
            connectionContext: ConnectionContext = defaultServerHttpContext,
            settings:          ServerSettings    = ServerSettings(system),
            log:               LoggingAdapter    = system.log): Source[Http.IncomingConnection, Future[ServerBinding]] = {
+    if (settings.previewServerSettings.enableHttp2)
+      throw new IllegalStateException("Binding with a connection source not supported with HTTP/2")
+
     val fullLayer: ServerLayerBidiFlow = fuseServerBidiFlow(settings, connectionContext, log)
 
     val masterTerminator = new MasterServerTerminator(log)
@@ -226,6 +229,9 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
     connectionContext: ConnectionContext = defaultServerHttpContext,
     settings:          ServerSettings    = ServerSettings(system),
     log:               LoggingAdapter    = system.log)(implicit fm: Materializer = systemMaterializer): Future[ServerBinding] = {
+    if (settings.previewServerSettings.enableHttp2)
+      throw new IllegalStateException("Binding with a Flow based handler not supported with HTTP/2")
+
     val fullLayer: Flow[ByteString, ByteString, (Future[Done], ServerTerminator)] =
 
       fuseServerFlow(fuseServerBidiFlow(settings, connectionContext, log), handler)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -181,7 +181,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
            settings:          ServerSettings    = ServerSettings(system),
            log:               LoggingAdapter    = system.log): Source[Http.IncomingConnection, Future[ServerBinding]] = {
     if (settings.previewServerSettings.enableHttp2)
-      throw new IllegalStateException("Binding with a connection source not supported with HTTP/2")
+      log.warning("Binding with a connection source not supported with HTTP/2. Falling back to HTTP/1.1.")
 
     val fullLayer: ServerLayerBidiFlow = fuseServerBidiFlow(settings, connectionContext, log)
 
@@ -230,7 +230,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
     settings:          ServerSettings    = ServerSettings(system),
     log:               LoggingAdapter    = system.log)(implicit fm: Materializer = systemMaterializer): Future[ServerBinding] = {
     if (settings.previewServerSettings.enableHttp2)
-      throw new IllegalStateException("Binding with a Flow based handler not supported with HTTP/2")
+      log.warning("Binding with a connection source not supported with HTTP/2. Falling back to HTTP/1.1.")
 
     val fullLayer: Flow[ByteString, ByteString, (Future[Done], ServerTerminator)] =
 


### PR DESCRIPTION
Instead of silently ignoring and binding HTTP/1.1 

Refs #3677
