### PR TITLE
docs: Link project info to snapshots

### DIFF
--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -4,7 +4,11 @@ project-info {
   javadoc: "https://doc.akka.io/japi/akka-http/"${project-info.version}
   shared-info {
     jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
-    // snapshots: { }
+    snapshots: {
+      url: "contributing.html#snapshots"
+      text: "Snapshots are available"
+      new-tab: false
+    }
     issues: {
       url: "https://github.com/akka/akka-http/issues"
       text: "Github issues"


### PR DESCRIPTION
The link shows in the standardised project info section:
![image](https://user-images.githubusercontent.com/458526/101015942-67d7d100-3568-11eb-951d-3cbe7f4eef3d.png)

References #3642 