### PR TITLE
docs: show akka-http-bom in dependencies

### DIFF
--- a/docs/src/main/paradox/common/caching.md
+++ b/docs/src/main/paradox/common/caching.md
@@ -18,6 +18,7 @@ time-based entry expiration.
 To use Akka HTTP Caching, add the module to your project:
 
 @@dependency [sbt,Gradle,Maven] {
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol="AkkaHttpVersion"
   value="$project.version$"
   group="com.typesafe.akka"

--- a/docs/src/main/paradox/common/json-support.md
+++ b/docs/src/main/paradox/common/json-support.md
@@ -12,6 +12,7 @@ See [the list of current community extensions for Akka HTTP](https://akka.io/com
 To make use of the support module for (un)marshalling from and to JSON with [Jackson], add a library dependency onto:
 
 @@dependency [sbt,Gradle,Maven] {
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol="AkkaHttpVersion"
   value="$project.version$"
   group="com.typesafe.akka"
@@ -44,6 +45,7 @@ that an implicit `spray.json.RootJsonReader` and/or `spray.json.RootJsonWriter` 
 To enable automatic support for (un)marshalling from and to JSON with [spray-json], add a library dependency onto:
 
 @@dependency [sbt,Gradle,Maven] {
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol="AkkaHttpVersion"
   value="$project.version$"
   group="com.typesafe.akka"

--- a/docs/src/main/paradox/common/xml-support.md
+++ b/docs/src/main/paradox/common/xml-support.md
@@ -36,6 +36,7 @@ In order to enable support for (un)marshalling from and to XML with [Scala XML][
 the following dependency:
 
 @@dependency [sbt,Gradle,Maven] {
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol="AkkaHttpVersion"
   value="$project.version$"
   group="com.typesafe.akka"

--- a/docs/src/main/paradox/compatibility-guidelines.md
+++ b/docs/src/main/paradox/compatibility-guidelines.md
@@ -137,6 +137,9 @@ The same goes for `akka-http-testkit`: If the testkit is used, explicitly declar
 @@dependency [sbt,Gradle,Maven] {
   symbol1=AkkaVersion
   value1=$akka.version$
+  bomGroup2=com.typesafe.akka
+  bomArtifact2=akka-http-bom_$scala.binary.version$
+  bomVersionSymbols2=AkkaHttpVersion
   symbol2="AkkaHttpVersion"
   value2="$project.version$"
   group1="com.typesafe.akka" artifact1="akka-http_$scala.binary.version$" version1="AkkaHttpVersion"

--- a/docs/src/main/paradox/introduction.md
+++ b/docs/src/main/paradox/introduction.md
@@ -35,6 +35,7 @@ choose an Akka version to run against and add a manual dependency to `akka-strea
 @@dependency [sbt,Gradle,Maven] {
   symbol1=AkkaVersion
   value1=$akka.version$
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol2="AkkaHttpVersion"
   value2="$project.version$"
   group1="com.typesafe.akka" artifact1="akka-actor-typed_$scala.binary.version$" version1=AkkaVersion
@@ -103,6 +104,7 @@ for JSON. An additional module provides JSON serialization using the spray-json 
 for details):
 
 @@dependency [sbt,Gradle,Maven] {
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol="AkkaHttpVersion"
   value="$project.version$"
   group="com.typesafe.akka"
@@ -116,6 +118,7 @@ JSON support is possible in `akka-http` by the use of Jackson, an external artif
 for details):
 
 @@dependency [sbt,Gradle,Maven] {
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol="AkkaHttpVersion"
   value="$project.version$"
   group="com.typesafe.akka"

--- a/docs/src/main/paradox/routing-dsl/directives/caching-directives/index.md
+++ b/docs/src/main/paradox/routing-dsl/directives/caching-directives/index.md
@@ -11,6 +11,7 @@ caching support works.
 To use Akka HTTP Caching, add the module to your project:
 
 @@dependency[sbt,Gradle,Maven] {
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol="AkkaHttpVersion"
   value="$project.version$"
   group="com.typesafe.akka"

--- a/docs/src/main/paradox/routing-dsl/testkit.md
+++ b/docs/src/main/paradox/routing-dsl/testkit.md
@@ -11,6 +11,7 @@ To use Akka HTTP TestKit, add the module to your project:
 @@dependency [sbt,Gradle,Maven] {
   symbol1=AkkaVersion
   value1=$akka.version$
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol2="AkkaHttpVersion"
   value2="$project.version$"
   group1="com.typesafe.akka" artifact1="akka-stream-testkit_$scala.binary.version$" version1=AkkaVersion

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -12,6 +12,7 @@ This means it is ready to be evaluated, but the APIs and behavior are likely to 
 To use Akka HTTP2 Support, add the module to your project:
 
 @@dependency [sbt,Gradle,Maven] {
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol="AkkaHttpVersion"
   value="$project.version$"
   group="com.typesafe.akka"


### PR DESCRIPTION
WIP as it lacks a Paradox release.

This uses the new notation for BOM dependencies introduced in https://github.com/lightbend/paradox/pull/462

A bit sad that it can't yet show the use of the Akka BOM as that won't be available prior to Akka 2.6.11.

References #2665, https://github.com/akka/akka/pull/29839