### PR TITLE
h2: close down connections after sending or receiving GOAWAY

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -137,6 +137,7 @@ private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with Stage
         def connectionWindowAvailable(): MultiplexerState
         def enqueueOutStream(streamId: Int): MultiplexerState
         def closeStream(streamId: Int): MultiplexerState
+        //def complete(maxStreamId: Int): MultiplexerState
 
         protected def sendDataFrame(streamId: Int, sendableOutstreams: immutable.Set[Int]): MultiplexerState = {
           val maxBytesToSend = currentMaxFrameSize min connectionWindowLeft

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -188,8 +188,8 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
   private def shutdownIfReady(): Unit = {
     lastPossiblePeerProcessedStreamId match {
       case None =>
-        // We have not determined a final stream id yet,
-        // which means we are not yet shutting down.
+      // We have not determined a final stream id yet,
+      // which means we are not yet shutting down.
       case Some(lastStreamId) =>
         if (!activeStreamsUpTo(lastStreamId)) {
           multiplexer.complete(lastStreamId)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -730,7 +730,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
 
     // https://tools.ietf.org/html/rfc7540#section-6.8
     "support gracefully shutting down the connection" should {
-      "when the connection is idle" in new TestSetup {
+      "when the connection is idle" inAssertAllStagesStopped new TestSetup {
         // A server that is attempting to gracefully shut down a connection SHOULD
         // send an initial GOAWAY frame with the last stream identifier set to 2^31-1
         // and a NO_ERROR code.
@@ -746,7 +746,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         network.sendGOAWAY(0x0, ErrorCode.NO_ERROR)
       }
 
-      "while a request is still in flight" in new WaitingForResponseData {
+      "while a request is still in flight" inAssertAllStagesStopped new WaitingForResponseData {
         // This signals to the client that a shutdown is imminent
         // and that initiating further requests is prohibited
         network.sendGOAWAY(Int.MaxValue, ErrorCode.NO_ERROR)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -758,8 +758,10 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         entityDataIn.expectBytes(ByteString("asdf"))
         entityDataIn.expectComplete()
 
-        // not really relevant, could be there or not...
+        // window updates are not really relevant for this test, could be there or not...
         network.expectWindowUpdate()
+        network.expectWindowUpdate()
+
         network.toNet.expectComplete()
 
         network.sendGOAWAY(0x0, ErrorCode.NO_ERROR)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -499,9 +499,8 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         network.sendWINDOW_UPDATE(0, 10000)
         network.expectNoBytes(100.millis) // don't expect anything, stream has been cancelled in the meantime
 
-        // TODO the client stack should not accept new connections anymore
-        // TODO what to do with requests that are already in the queue at this point?
-        // user.requestOut.expectCancellation()
+        // the client stack should not accept new connections anymore
+        user.requestOut.expectCancellation()
 
         // Check finishing old requests is still allowed
         network.sendHEADERS(otherRequestStreamId, true, Seq(RawHeader(":status", "200")))

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameProbe.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameProbe.scala
@@ -179,7 +179,7 @@ private[http] object Http2FrameProbe extends Matchers {
         val reader = new ByteReader(payload)
         val incomingLastStreamId = reader.readIntBE()
         if (lastStreamId > 0) incomingLastStreamId should ===(lastStreamId)
-        (lastStreamId, ErrorCode.byId(reader.readIntBE()))
+        (incomingLastStreamId, ErrorCode.byId(reader.readIntBE()))
       }
 
       override def expectSETTINGS(): SettingsFrame = {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameSending.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameSending.scala
@@ -6,7 +6,7 @@ package akka.http.impl.engine.http2
 
 import java.nio.ByteOrder
 
-import akka.http.impl.engine.http2.FrameEvent.{ ContinuationFrame, HeadersFrame, PriorityFrame, Setting, SettingsFrame, WindowUpdateFrame }
+import akka.http.impl.engine.http2.FrameEvent.{ ContinuationFrame, GoAwayFrame, HeadersFrame, PriorityFrame, Setting, SettingsFrame, WindowUpdateFrame }
 import akka.http.impl.engine.http2.Http2Protocol.{ ErrorCode, Flags, FrameType, SettingIdentifier }
 import akka.http.impl.engine.http2.framing.FrameRenderer
 import akka.util.{ ByteString, ByteStringBuilder }
@@ -24,14 +24,8 @@ private[http2] trait Http2FrameSending {
   def sendDATA(streamId: Int, endStream: Boolean, data: ByteString): Unit =
     sendFrame(FrameType.DATA, Flags.END_STREAM.ifSet(endStream), streamId, data)
 
-  def sendSETTING(identifier: SettingIdentifier, value: Int): Unit =
-    sendFrame(SettingsFrame(Setting(identifier, value) :: Nil))
-
   def sendHEADERS(streamId: Int, endStream: Boolean, endHeaders: Boolean, headerBlockFragment: ByteString): Unit =
     sendBytes(FrameRenderer.render(HeadersFrame(streamId, endStream, endHeaders, headerBlockFragment, None)))
-
-  def sendCONTINUATION(streamId: Int, endHeaders: Boolean, headerBlockFragment: ByteString): Unit =
-    sendBytes(FrameRenderer.render(ContinuationFrame(streamId, endHeaders, headerBlockFragment)))
 
   def sendPRIORITY(streamId: Int, exclusiveFlag: Boolean, streamDependency: Int, weight: Int): Unit =
     sendBytes(FrameRenderer.render(PriorityFrame(streamId, exclusiveFlag, streamDependency, weight)))
@@ -43,8 +37,16 @@ private[http2] trait Http2FrameSending {
     sendFrame(FrameType.RST_STREAM, ByteFlag.Zero, streamId, bb.result())
   }
 
+  def sendSETTING(identifier: SettingIdentifier, value: Int): Unit =
+    sendFrame(SettingsFrame(Setting(identifier, value) :: Nil))
+
+  def sendGOAWAY(lastStreamId: Int, errorCode: ErrorCode, debug: ByteString = ByteString.empty): Unit =
+    sendFrame(GoAwayFrame(lastStreamId, errorCode, debug))
+
   /** Can be overridden to also update windows */
   def sendWINDOW_UPDATE(streamId: Int, windowSizeIncrement: Int): Unit =
     sendBytes(FrameRenderer.render(WindowUpdateFrame(streamId, windowSizeIncrement)))
 
+  def sendCONTINUATION(streamId: Int, endHeaders: Boolean, headerBlockFragment: ByteString): Unit =
+    sendBytes(FrameRenderer.render(ContinuationFrame(streamId, endHeaders, headerBlockFragment)))
 }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -1186,7 +1186,9 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
       "reject other frame than HEADERS/PUSH_PROMISE in idle state with connection-level PROTOCOL_ERROR (5.1)" inAssertAllStagesStopped new SimpleRequestResponseRoundtripSetup {
         network.sendDATA(9, endStream = true, HPackSpecExamples.C41FirstRequestWithHuffman)
         val (lastStreamId, error) = network.expectGOAWAY()
-        lastStreamId should be(0x0)
+        // We are over-estimating the last stream for which 'data may have been processed' here.
+        // That is allowed. Returning '0' would be better here, since the stream is not actually processed.
+        lastStreamId should be(0x9)
         error should be(ErrorCode.PROTOCOL_ERROR)
       }
       "reject incoming frames on already half-closed substream" in pending

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -1185,7 +1185,9 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
 
       "reject other frame than HEADERS/PUSH_PROMISE in idle state with connection-level PROTOCOL_ERROR (5.1)" inAssertAllStagesStopped new SimpleRequestResponseRoundtripSetup {
         network.sendDATA(9, endStream = true, HPackSpecExamples.C41FirstRequestWithHuffman)
-        network.expectGOAWAY()
+        val (lastStreamId, error) = network.expectGOAWAY()
+        lastStreamId should be(0x0)
+        error should be(ErrorCode.PROTOCOL_ERROR)
       }
       "reject incoming frames on already half-closed substream" in pending
 


### PR DESCRIPTION
But not before processing remaining in-flight requests.