### PR TITLE
Avoid temporaryServerHostnameAndPort

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ConnectionPoolSpec.scala
@@ -536,8 +536,9 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
   "The superPool client infrastructure" should {
 
     "route incoming requests to the right cached host connection pool" in new TestSetup(autoAccept = true) {
-      val (serverHostName2, serverPort2) = SocketUtil.temporaryServerHostnameAndPort()
-      Http().newServerAt(serverHostName2, serverPort2).bindSync(testServerHandler(0))
+      val serverHostName2 = "localhost"
+      val binding = Http().newServerAt(serverHostName2, 0).bindSync(testServerHandler(0))
+      val serverPort2 = binding.futureValue.localAddress.getPort
 
       val (requestIn, responseOut, responseOutSub, _) = superPool[Int]()
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
@@ -32,17 +32,17 @@ class ClientSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   "HTTP Client" should {
 
     "reuse connection pool" in {
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
-      val bindingFuture = Http().newServerAt(hostname, port).bindSync(_ => HttpResponse())
+      val bindingFuture = Http().newServerAt("localhost", 0).bindSync(_ => HttpResponse())
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
+      val port = binding.localAddress.getPort
 
-      val respFuture = Http().singleRequest(HttpRequest(POST, s"http://$hostname:$port/"))
+      val respFuture = Http().singleRequest(HttpRequest(POST, s"http://localhost:$port/"))
       val resp = Await.result(respFuture, 3.seconds.dilated)
       resp.status shouldBe StatusCodes.OK
 
       Await.result(Http().poolSize, 1.second.dilated) shouldEqual 1
 
-      Http().singleRequest(HttpRequest(POST, s"http://$hostname:$port/"))
+      Http().singleRequest(HttpRequest(POST, s"http://localhost:$port/"))
       val resp2 = Await.result(respFuture, 3.seconds.dilated)
       resp2.status shouldBe StatusCodes.OK
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/EntityDiscardingSpec.scala
@@ -54,14 +54,13 @@ class EntityDiscardingSpec extends AkkaSpecWithMaterializer {
     // TODO consider improving this by storing a mutable "already materialized" flag somewhere
     // TODO likely this is going to inter-op with the auto-draining as described in #18716
     "should not allow draining a second time" in {
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
-      val bound = Http().newServerAt(host, port).bindSync(req =>
+      val bound = Http().newServerAt("localhost", 0).bindSync(req =>
         HttpResponse(entity = HttpEntity(
           ContentTypes.`text/csv(UTF-8)`, Source.fromIterator[ByteString](() => testData.iterator)))).futureValue
 
       try {
 
-        val response = Http().singleRequest(HttpRequest(uri = s"http://$host:$port/")).futureValue
+        val response = Http().singleRequest(HttpRequest(uri = s"http://localhost:${bound.localAddress.getPort}/")).futureValue
 
         val de = response.discardEntityBytes()
         de.future.futureValue should ===(Done)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -37,8 +37,6 @@ class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
 
     "allow registering custom media type" in {
       import system.dispatcher
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
-
       //#application-custom
 
       // similarly in Java: `akka.http.javadsl.settings.[...]`
@@ -57,10 +55,10 @@ class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
       val routes = extractRequest { r =>
         complete(r.entity.contentType.toString + " = " + r.entity.contentType.getClass)
       }
-      Http().newServerAt(host, port).withSettings(serverSettings).bind(routes)
+      val binding = Http().newServerAt("localhost", 0).withSettings(serverSettings).bind(routes)
       //#application-custom
 
-      val request = Get(s"http://$host:$port/").withEntity(HttpEntity(`application/custom`, "~~example~=~value~~"))
+      val request = Get(s"http://localhost:${binding.futureValue.localAddress.getPort}/").withEntity(HttpEntity(`application/custom`, "~~example~=~value~~"))
       val response = Http().singleRequest(request).futureValue
 
       response.status should ===(StatusCodes.OK)

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/CustomHttpMethodSpec.scala
@@ -20,8 +20,8 @@ class CustomHttpMethodSpec extends AkkaSpec with ScalaFutures
   "Http" should {
     "allow registering custom method" in {
       import system.dispatcher
-      val (host, port) = SocketUtil.temporaryServerHostnameAndPort()
-
+      val host = "localhost"
+      var port = 0
       //#application-custom
       import akka.http.scaladsl.settings.{ ParserSettings, ServerSettings }
 
@@ -38,11 +38,12 @@ class CustomHttpMethodSpec extends AkkaSpec with ScalaFutures
       }
       val binding = Http().newServerAt(host, port).withSettings(serverSettings).bind(routes)
 
+      //#application-custom
+      // Make sure we're bound
+      port = binding.futureValue.localAddress.getPort
+      //#application-custom
       val request = HttpRequest(BOLT, s"http://$host:$port/", protocol = `HTTP/1.1`)
       //#application-custom
-
-      // Make sure we're bound
-      binding.futureValue
 
       // Check response
       val response = Http().singleRequest(request).futureValue


### PR DESCRIPTION
Since it has an inherent race condition.

Refs #3679. I thought we had an 'umbrella ticket' for this
but can't find it right now.