### PR TITLE
FutureDirectivesExampleSpec fail fix

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/FutureDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/FutureDirectivesExamplesSpec.scala
@@ -91,10 +91,17 @@ class FutureDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
 
     Thread.sleep(resetTimeout.toMillis + 200)
 
+    //#onCompleteWithBreaker
+    // retry to make test more stable, since breaker reset is timer based, hidden from docs
+    // format: OFF
+    awaitAssert({
+    //#onCompleteWithBreaker
     Get("/divide/10/2") ~> route ~> check {
       responseAs[String] shouldEqual "The result was 5"
     }
     //#onCompleteWithBreaker
+    }, 500.millis)
+    // format: ON
   }
 
   "onSuccess" in {


### PR DESCRIPTION
References #3311

I think the cause is that the reset is timer based so needs to "happen" before the call, but if it is a bad JVM day those 200ms of leeway is not enough for it to complete before the sample http call expecting the breaker to have been reset/closed again.