### PR TITLE
Added support to fetch chunks in the testkit without waiting for the whole response to finish

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -7,6 +7,7 @@ package akka.http.scaladsl.testkit
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding
+import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{ Host, Upgrade, `Sec-WebSocket-Protocol` }
 import akka.http.scaladsl.server._
@@ -16,6 +17,7 @@ import akka.http.scaladsl.settings.ServerSettings
 import akka.http.scaladsl.unmarshalling._
 import akka.http.scaladsl.util.FastFuture._
 import akka.stream.SystemMaterializer
+import akka.stream.scaladsl.Source
 import akka.testkit.TestKit
 import akka.util.ConstantFun
 import com.typesafe.config.{ Config, ConfigFactory }
@@ -64,6 +66,7 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
   def response: HttpResponse = result.response
   def responseEntity: HttpEntity = result.entity
   def chunks: immutable.Seq[HttpEntity.ChunkStreamPart] = result.chunks
+  def chunksStream: Source[ChunkStreamPart, Any] = result.chunksStream
   def entityAs[T: FromEntityUnmarshaller: ClassTag](implicit timeout: Duration = 1.second): T = {
     def msg(e: Throwable) = s"Could not unmarshal entity to type '${implicitly[ClassTag[T]]}' for `entityAs` assertion: $e\n\nResponse was: $responseSafe"
     Await.result(Unmarshal(responseEntity).to[T].fast.recover[T] { case error => failTest(msg(error)) }, timeout)

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
@@ -47,6 +47,12 @@ trait RouteTestResultComponent {
         case _                             => Nil
       }
 
+    def chunksStream: Source[ChunkStreamPart, Any] =
+      rawResponse.entity match {
+        case HttpEntity.Chunked(_, data) => data
+        case _                           => Source.empty
+      }
+
     def ~>[T](f: RouteTestResult => T): T = f(this)
 
     private def rawResponse: HttpResponse = synchronized {

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestResultComponent.scala
@@ -55,7 +55,7 @@ trait RouteTestResultComponent {
 
     def ~>[T](f: RouteTestResult => T): T = f(this)
 
-    private def rawResponse: HttpResponse = synchronized {
+    private[testkit] def rawResponse: HttpResponse = synchronized {
       result match {
         case Some(Right(response))        => response
         case Some(Left(Nil))              => failTest("Request was rejected")

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -68,8 +68,11 @@ class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRou
             .map(i => ByteString(i.toString))
         complete(HttpEntity(ContentTypes.`application/octet-stream`, infiniteSource))
       } ~> check {
+        status shouldEqual OK
+        contentType shouldEqual ContentTypes.`application/octet-stream`
         val future = chunksStream.take(5).runFold(Vector.empty[Int])(_ :+ _.data.utf8String.toInt)
         future.futureValue shouldEqual (0 until 5).toVector
+
       }
     }
 


### PR DESCRIPTION
It is useful using `ScalatestRouteTest` but anything inside the body of `check` method ends up calling some sort of `awaitAllElements`, effectively blocking until the whole response has been retrieved.

There are cases where we might have an infinite stream (i.e. [SSE](https://doc.akka.io/docs/akka-http/10.0/sse-support.html)) and we want to verify that part of the stream is returned as expected.

I've added `chunksStream` method for this.