### PR TITLE
Fix for ScalatestRouteSpec on Scala 2.12 

### DIFF
--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/ScalatestRouteTestSpec.scala
@@ -63,7 +63,7 @@ class ScalatestRouteTestSpec extends AnyFreeSpec with Matchers with ScalatestRou
     "a test checking a route that returns infinite chunks" in {
       Get() ~> {
         val infiniteSource =
-          Source.cycle(() => (0 to Int.MaxValue).iterator)
+          Source.unfold(0L)((acc) => Some((acc + 1, acc)))
             .throttle(1, 20.millis)
             .map(i => ByteString(i.toString))
         complete(HttpEntity(ContentTypes.`application/octet-stream`, infiniteSource))


### PR DESCRIPTION
References #3728
