### PR TITLE
Document HTTP/2 client API

### DIFF
--- a/docs/src/main/paradox/client-side/connection-level.md
+++ b/docs/src/main/paradox/client-side/connection-level.md
@@ -24,7 +24,8 @@ Java
 
 In addition to the host name and port the builder @apidoc[OutgoingConnectionBuilder] returned by @scala[`Http().connectionTo(...)`]@java[`Http.get(system).connectionTo(...)`]
 method also allows you to specify additional properties and as the final step deciding which protocol to use 
-(HTTP/1, HTTP/1 over TLS, HTTP/2 over TLS or HTTP/2 with prior knowledge over a plaintext connection).
+(HTTP/1, HTTP/1 over TLS, HTTP/2 over TLS or HTTP/2 with prior knowledge over a plaintext connection). For details on 
+using HTTP/2 see @ref[Client-Side HTTP/2](./http2.md).
 
 No connection is attempted until the returned flow is actually materialized! If the flow is materialized
 several times then several independent connections will be opened (one per materialization).
@@ -41,25 +42,6 @@ eventually be slowed down in sending requests.
 
 Any errors occurring on the underlying connection are surfaced as exceptions terminating the response stream (and
 canceling the request source).
-
-## Request-response ordering for HTTP/2
-
-For HTTP/2 connections the responses are not guaranteed to arrive in the same order that the requests were emitted to
-the server, for example a request with a quickly available response may outrun a previous request that the server is 
-slower to respond to. For HTTP/2 it is therefore often important to have a way to correlate the response with what request
-it was made for. This can be achieved through a @apidoc[RequestResponseAssociation] set on the request, Akka HTTP will pass
-such association objects on to the response.
-
-In this sample the built in @scala[`akka.http.scaladsl.model.ResponsePromise`]@java[`akka.http.javadsl.model.ResponseFuture`] `RequestResponseAssociation`  is used to return 
-a @scala[`Future`]@java[`CompletionStage`] for the response:
-
-Scala
-:  @@snip [HttpClientOutgoingConnection.scala](/docs/src/test/scala/docs/http/scaladsl/Http2ClientApp.scala) { #response-future-association }
-
-Java
-
-:  @@snip [HttpClientExampleDocTest.java](/docs/src/test/java/docs/http/javadsl/Http2ClientApp.java) { #response-future-association }
-
 
 ## Closing Connections
 

--- a/docs/src/main/paradox/client-side/http2.md
+++ b/docs/src/main/paradox/client-side/http2.md
@@ -41,7 +41,7 @@ Akka HTTP does not currently support protocol negotiation to fall back to HTTP/1
 ### h2c with prior knowledge
 
 The other option is to connect and start communicating in HTTP/2 immediately. You must know beforehand the target server
-supports HTTP/2 over plaintext. For this reason this approach is known as h2c with
+supports HTTP/2 over a plain TCP connection. For this reason this approach is known as h2c with
 [Prior Knowledge](https://httpwg.org/specs/rfc7540.html#known-http) of HTTP/2 support.
 
 To create a client, use the `Http()` fluent API to connect and use the `http2WithPriorKnowledge()` creator:

--- a/docs/src/main/paradox/client-side/http2.md
+++ b/docs/src/main/paradox/client-side/http2.md
@@ -14,7 +14,7 @@ unexpected when coming from a background with non-"streaming first" HTTP Clients
 
 ## Create the client 
 
-There are three mechanisms for a client to establish an HTTP/2 connection. The Akka HTTP supports:
+There are three mechanisms for a client to establish an HTTP/2 connection. Akka HTTP supports:
 
  - HTTP/2 over TLS 
  - h2c with prior knowledge (which is plaintext)
@@ -72,5 +72,4 @@ Scala
 Java
 
 :  @@snip [HttpClientExampleDocTest.java](/docs/src/test/java/docs/http/javadsl/Http2ClientApp.java) { #response-future-association }
-
 

--- a/docs/src/main/paradox/client-side/http2.md
+++ b/docs/src/main/paradox/client-side/http2.md
@@ -37,6 +37,7 @@ HTTP/2 over TLS needs [Application-Layer Protocol Negotiation (ALPN)](https://en
 to negotiate whether both client and server support HTTP/2. The JVM provides ALPN support starting from JDK 8u252.
 Make sure to use at least that version.
 
+Akka HTTP does not currently support protocol negotiation to fall back to HTTP/1.1 for this API. When the server does not support HTTP/2, the stream will fail.
 ### h2c with prior knowledge
 
 The other option is to connect and start communicating in HTTP/2 immediately. You must know beforehand the target server

--- a/docs/src/main/paradox/client-side/http2.md
+++ b/docs/src/main/paradox/client-side/http2.md
@@ -12,18 +12,16 @@ concepts, tuning the client settings and HTTPS context and how to handle the Req
 unexpected when coming from a background with non-"streaming first" HTTP Clients.
 @@@
 
-## Enable HTTP/2 support
-
-HTTP/2 can then be enabled through configuration:
-
-```
-akka.http.server.preview.enable-http2 = on
-```
-
 ## Create the client 
 
-The Akka HTTP client supports HTTP/2 over TLS, and h2c with prior knowledge (plaintext), but not 
-the HTTP Upgrade mechanism.
+There are three mechanisms for a client to establish an HTTP/2 connection. The Akka HTTP supports:
+
+ - HTTP/2 over TLS 
+ - h2c with prior knowledge (which is plaintext)
+
+The Akka HTTP doesn't support:
+
+ - HTTP Upgrade mechanism (which is plaintext)
 
 ### HTTP/2 over TLS
 
@@ -37,7 +35,7 @@ Java
 
 HTTP/2 over TLS needs [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)
 to negotiate whether both client and server support HTTP/2. The JVM provides ALPN support starting from JDK 8u252.
-Make sure you run a JVM version greater than that.
+Make sure to use at least that version.
 
 ### h2c with prior knowledge
 
@@ -53,6 +51,10 @@ Scala
 Java
 :   @@snip[Http2Test.java](/docs/src/test/java/docs/http/javadsl/Http2Test.java) { #http2ClientWithPriorKnowledge }
 
+### HTTP Upgrade mechanism
+
+The Akka HTTP client doesn't support HTTP/1 to HTTP/2 negotiation over plaintext using the `Upgrade` mechanism.
+
 ## Request-response ordering
 
 For HTTP/2 connections the responses are not guaranteed to arrive in the same order that the requests were emitted to
@@ -61,7 +63,7 @@ slower to respond to. For HTTP/2 it is therefore often important to have a way t
 it was made for. This can be achieved through a @apidoc[RequestResponseAssociation] set on the request, Akka HTTP will pass
 such association objects on to the response.
 
-In this sample the built in @scala[`akka.http.scaladsl.model.ResponsePromise`]@java[`akka.http.javadsl.model.ResponseFuture`] `RequestResponseAssociation`  is used to return
+In this sample the built-in @scala[`akka.http.scaladsl.model.ResponsePromise`]@java[`akka.http.javadsl.model.ResponseFuture`] `RequestResponseAssociation`  is used to return
 a @scala[`Future`]@java[`CompletionStage`] for the response:
 
 Scala

--- a/docs/src/main/paradox/client-side/http2.md
+++ b/docs/src/main/paradox/client-side/http2.md
@@ -19,7 +19,7 @@ There are three mechanisms for a client to establish an HTTP/2 connection. Akka 
  - HTTP/2 over TLS 
  - HTTP/2 over a plain TCP connection ("h2c with prior knowledge")
 
-The Akka HTTP doesn't support:
+Akka HTTP doesn't support:
 
  - HTTP `Upgrade` mechanism
 

--- a/docs/src/main/paradox/client-side/http2.md
+++ b/docs/src/main/paradox/client-side/http2.md
@@ -60,7 +60,7 @@ The Akka HTTP client doesn't support HTTP/1 to HTTP/2 negotiation over plaintext
 
 For HTTP/2 connections the responses are not guaranteed to arrive in the same order that the requests were emitted to
 the server, for example a request with a quickly available response may outrun a previous request that the server is
-slower to respond to. For HTTP/2 it is therefore often important to have a way to correlate the response with what request
+slower to respond to. For HTTP/2 it is therefore important to have a way to correlate the response with the request
 it was made for. This can be achieved through a @apidoc[RequestResponseAssociation] set on the request, Akka HTTP will pass
 such association objects on to the response.
 

--- a/docs/src/main/paradox/client-side/http2.md
+++ b/docs/src/main/paradox/client-side/http2.md
@@ -21,7 +21,7 @@ There are three mechanisms for a client to establish an HTTP/2 connection. Akka 
 
 The Akka HTTP doesn't support:
 
- - HTTP Upgrade mechanism (which is plaintext)
+ - HTTP `Upgrade` mechanism
 
 ### HTTP/2 over TLS
 

--- a/docs/src/main/paradox/client-side/http2.md
+++ b/docs/src/main/paradox/client-side/http2.md
@@ -1,0 +1,74 @@
+# Client-Side HTTP/2 (Preview)
+
+@@@ warning
+Client-Side HTTP/2 support in akka-http is currently available as a preview.
+This means it is ready to be evaluated, but the APIs and behavior are likely to change.
+@@@
+
+@@@ note
+It is recommended to first read the @ref[Implications of the streaming nature of Request/Response Entities](../implications-of-streaming-http-entity.md) 
+and @ref[Host-Level Client-Side API](./host-level.md) sections, as they explain the underlying full-stack streaming 
+concepts, tuning the client settings and HTTPS context and how to handle the Request-Response Cycle, which may be 
+unexpected when coming from a background with non-"streaming first" HTTP Clients.
+@@@
+
+## Enable HTTP/2 support
+
+HTTP/2 can then be enabled through configuration:
+
+```
+akka.http.server.preview.enable-http2 = on
+```
+
+## Create the client 
+
+The Akka HTTP client supports HTTP/2 over TLS, and h2c with prior knowledge (plaintext), but not 
+the HTTP Upgrade mechanism.
+
+### HTTP/2 over TLS
+
+To create a client, use the `Http()` fluent API to connect and use the `http2()` creator:
+
+Scala
+:   @@snip[Http2Spec.scala](/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala) { #http2Client }
+
+Java
+:   @@snip[Http2Test.java](/docs/src/test/java/docs/http/javadsl/Http2Test.java) { #http2Client }
+
+HTTP/2 over TLS needs [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)
+to negotiate whether both client and server support HTTP/2. The JVM provides ALPN support starting from JDK 8u252.
+Make sure you run a JVM version greater than that.
+
+### h2c with prior knowledge
+
+The other option is to connect and start communicating in HTTP/2 immediately. You must know beforehand the target server
+supports HTTP/2 over plaintext. For this reason this approach is known as h2c with
+[Prior Knowledge](https://httpwg.org/specs/rfc7540.html#known-http) of HTTP/2 support.
+
+To create a client, use the `Http()` fluent API to connect and use the `http2WithPriorKnowledge()` creator:
+
+Scala
+:   @@snip[Http2Spec.scala](/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala) { #http2ClientWithPriorKnowledge }
+
+Java
+:   @@snip[Http2Test.java](/docs/src/test/java/docs/http/javadsl/Http2Test.java) { #http2ClientWithPriorKnowledge }
+
+## Request-response ordering
+
+For HTTP/2 connections the responses are not guaranteed to arrive in the same order that the requests were emitted to
+the server, for example a request with a quickly available response may outrun a previous request that the server is
+slower to respond to. For HTTP/2 it is therefore often important to have a way to correlate the response with what request
+it was made for. This can be achieved through a @apidoc[RequestResponseAssociation] set on the request, Akka HTTP will pass
+such association objects on to the response.
+
+In this sample the built in @scala[`akka.http.scaladsl.model.ResponsePromise`]@java[`akka.http.javadsl.model.ResponseFuture`] `RequestResponseAssociation`  is used to return
+a @scala[`Future`]@java[`CompletionStage`] for the response:
+
+Scala
+:  @@snip [HttpClientOutgoingConnection.scala](/docs/src/test/scala/docs/http/scaladsl/Http2ClientApp.scala) { #response-future-association }
+
+Java
+
+:  @@snip [HttpClientExampleDocTest.java](/docs/src/test/java/docs/http/javadsl/Http2ClientApp.java) { #response-future-association }
+
+

--- a/docs/src/main/paradox/client-side/http2.md
+++ b/docs/src/main/paradox/client-side/http2.md
@@ -17,7 +17,7 @@ unexpected when coming from a background with non-"streaming first" HTTP Clients
 There are three mechanisms for a client to establish an HTTP/2 connection. Akka HTTP supports:
 
  - HTTP/2 over TLS 
- - h2c with prior knowledge (which is plaintext)
+ - HTTP/2 over a plain TCP connection ("h2c with prior knowledge")
 
 The Akka HTTP doesn't support:
 
@@ -72,4 +72,3 @@ Scala
 Java
 
 :  @@snip [HttpClientExampleDocTest.java](/docs/src/test/java/docs/http/javadsl/Http2ClientApp.java) { #response-future-association }
-

--- a/docs/src/main/paradox/client-side/index.md
+++ b/docs/src/main/paradox/client-side/index.md
@@ -39,5 +39,6 @@ Akka HTTP will happily handle many thousand concurrent connections to a single o
 * [client-https-support](client-https-support.md)
 * [client-transport](client-transport.md)
 * [websocket-support](websocket-support.md)
+* [http2](http2.md)
 
 @@@

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -33,7 +33,7 @@ support HTTP/2 but not `bindFlow` or `connectionSource(): Source`.
 
 HTTP/2 over TLS needs [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)
 to negotiate whether both client and server support HTTP/2. The JVM provides ALPN support starting from JDK 8u252.
-Make sure you run a JVM version greater than that.
+Make sure to use at least that version.
 
 ### HTTP/2 without HTTPS
 

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -7,23 +7,6 @@ This means it is ready to be evaluated, but the APIs and behavior are likely to 
 
 @@@
 
-## Dependency
-
-To use Akka HTTP2 Support, add the module to your project:
-
-@@dependency [sbt,Gradle,Maven] {
-  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
-  symbol="AkkaHttpVersion"
-  value="$project.version$"
-  group="com.typesafe.akka"
-  artifact="akka-http2-support_$scala.binary.version$"
-  version="AkkaHttpVersion"
-}
-
-HTTP/2 needs support in TLS for [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)
-to negotiate whether both client and server support HTTP/2. The JVM provides ALPN support starting from JDK 8u252.
-Make sure you run a JVM greater than that.
-
 ## Enable HTTP/2 support
 
 HTTP/2 can then be enabled through configuration:
@@ -48,6 +31,9 @@ Java
 Note that currently only `newServerAt(...).bind` and `newServerAt(...).bindSync`
 support HTTP/2 but not `bindFlow` or `connectionSource(): Source`.
 
+HTTP/2 over TLS needs [Application-Layer Protocol Negotiation (ALPN)](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)
+to negotiate whether both client and server support HTTP/2. The JVM provides ALPN support starting from JDK 8u252.
+Make sure you run a JVM version greater than that.
 
 ### HTTP/2 without HTTPS
 
@@ -93,7 +79,7 @@ support.
 
 At this point you should be able to connect, but HTTP/2 may still not be available.
 
-You'll need a recent version of [cURL](https://curl.haxx.se/) compiled with HTTP/2 support (for OSX see [this article](https://simonecarletti.com/blog/2016/01/http2-curl-macosx/)). You can check whether your version supports HTTP2 with `curl --version`, look for the nghttp2 extension and the HTTP2 feature:
+You'll need a recent version of [cURL](https://curl.haxx.se/) compiled with HTTP/2 support (for OSX see [this article](https://simonecarletti.com/blog/2016/01/http2-curl-macosx/)). You can check whether your version supports HTTP2 with `curl  --version`, look for the nghttp2 extension and the HTTP2 feature:
 
 ```
 curl 7.52.1 (x86_64-pc-linux-gnu) libcurl/7.52.1 OpenSSL/1.0.2l zlib/1.2.8 libidn2/0.16 libpsl/0.17.0 (+libidn2/0.16) libssh2/1.8.0 nghttp2/1.23.1 librtmp/2.3

--- a/docs/src/main/paradox/troubleshooting/unsupported-http-method-pri.md
+++ b/docs/src/main/paradox/troubleshooting/unsupported-http-method-pri.md
@@ -7,7 +7,6 @@ Illegal request, responding with status '501 Not Implemented': Unsupported HTTP 
 This indicates that a HTTP/2 request was received, but the server was not
 correctly set up to handle those. You may have to:
 
-* Add the @ref[`akka-http2-support` dependency](../server-side/http2.md#dependency) to the classpath
 * Make sure the @ref[`akka.http.server.preview.enable-http2` option](../server-side/http2.md#enable-http-2-support) is enabled
-* Make sure you are running @ref[at least JDK version 8u252](../server-side/http2.md#dependency)
+* Make sure you are running @ref[at least JDK version 8u252](../server-side/http2.md)
 * Make sure you are not using @apidoc[Http().bindAndHandle()](Http$) or @apidoc[Http().newServerAt().bindFlow()](ServerBuilder), but @apidoc[Http().newServerAt().bind()](ServerBuilder).

--- a/docs/src/test/java/docs/http/javadsl/Http2Test.java
+++ b/docs/src/test/java/docs/http/javadsl/Http2Test.java
@@ -16,15 +16,15 @@ import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 //#bindAndHandleSecure
+//#bindAndHandlePlain
+//#http2Client
+//#http2ClientWithPriorKnowledge
 import akka.http.javadsl.Http;
-import static akka.http.javadsl.ConnectHttp.toHostHttps;
 
+//#http2ClientWithPriorKnowledge
+//#http2Client
+//#bindAndHandlePlain
 //#bindAndHandleSecure
-
-//#bindAndHandlePlain
-import static akka.http.javadsl.ConnectHttp.toHost;
-
-//#bindAndHandlePlain
 
 class Http2Test {
   void testBindAndHandleAsync() {
@@ -45,5 +45,21 @@ class Http2Test {
       .newServerAt("127.0.0.1", 8443)
       .bind(asyncHandler);
     //#bindAndHandlePlain
+
+    //#http2Client
+    Http.get(system)
+            .connectionTo("127.0.0.1")
+            .toPort(8080)
+            .http2();
+    //#http2Client
+
+    //#http2ClientWithPriorKnowledge
+    Http.get(system)
+            .connectionTo("127.0.0.1")
+            .toPort(8080)
+            .http2WithPriorKnowledge();
+    //#http2ClientWithPriorKnowledge
+
+
   }
 }

--- a/docs/src/test/java/docs/http/javadsl/Http2Test.java
+++ b/docs/src/test/java/docs/http/javadsl/Http2Test.java
@@ -49,7 +49,7 @@ class Http2Test {
     //#http2Client
     Http.get(system)
             .connectionTo("127.0.0.1")
-            .toPort(8080)
+            .toPort(8443)
             .http2();
     //#http2Client
 

--- a/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
@@ -28,7 +28,6 @@ import akka.http.scaladsl.HttpConnectionContext
 
 //#bindAndHandlePlain
 
-
 import akka.actor.ActorSystem
 
 object Http2Spec {

--- a/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
@@ -55,7 +55,7 @@ object Http2Spec {
 
   {
     //#http2Client
-    Http().connectionTo("localhost").toPort(8080).http2()
+    Http().connectionTo("localhost").toPort(8443).http2()
     //#http2Client
     //#http2ClientWithPriorKnowledge
     Http().connectionTo("localhost").toPort(8080).http2WithPriorKnowledge()

--- a/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
@@ -13,20 +13,23 @@ import scala.concurrent.Future
 import akka.http.scaladsl.HttpsConnectionContext
 //#bindAndHandleSecure
 
+//#http2ClientWithPriorKnowledge
+//#http2Client
 //#bindAndHandleSecure
 //#bindAndHandlePlain
 import akka.http.scaladsl.Http
 //#bindAndHandlePlain
-
 //#bindAndHandleSecure
+//#http2Client
+//#http2ClientWithPriorKnowledge
 
 //#bindAndHandlePlain
 import akka.http.scaladsl.HttpConnectionContext
 
 //#bindAndHandlePlain
 
+
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 
 object Http2Spec {
   implicit val system: ActorSystem = ActorSystem()
@@ -49,5 +52,14 @@ object Http2Spec {
     //#bindAndHandlePlain
     Http().newServerAt("localhost", 8080).bind(handler)
     //#bindAndHandlePlain
+  }
+
+  {
+    //#http2Client
+    Http().connectionTo("localhost").toPort(8080).http2()
+    //#http2Client
+    //#http2ClientWithPriorKnowledge
+    Http().connectionTo("localhost").toPort(8080).http2WithPriorKnowledge()
+    //#http2ClientWithPriorKnowledge
   }
 }


### PR DESCRIPTION
Introduces the `client-side/http2.md` extracting any HTTP/2-specific there. The new page references the connection-level client-side API as extra content.

Also did a bit of cleanup on the imports of the snips.