### PR TITLE
[h2 client] 'connecting' phase for persistent connections

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
@@ -187,19 +187,13 @@ class Http2PersistentClientSpec extends AkkaSpecWithMaterializer(
           var first = true
           override def clientSettings = super.clientSettings.withTransport(ClientTransport.withCustomResolver((host, port) => {
             if (first) {
-              log.warning("first resolve (to invalid host)")
-
               first = false
               // First request returns an address where we are not listening::
               Future.successful(new InetSocketAddress("example.invalid", 80))
-            } else {
-              log.warning("second resolve (to valid host)")
-
+            } else
               Future.successful(server.binding.localAddress)
-            }
           }))
 
-          log.warning("sending request")
           client.sendRequest(
             HttpRequest(
               method = HttpMethods.POST,
@@ -211,7 +205,6 @@ class Http2PersistentClientSpec extends AkkaSpecWithMaterializer(
           // need some demand on response side, otherwise, no requests will be pulled in
           client.responsesIn.request(1)
           client.requestsOut.ensureSubscription()
-          log.warning("subscription ensured")
 
           val serverRequest = server.expectRequest()
           serverRequest.request.attribute(Http2.streamId) should not be empty

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
@@ -22,6 +22,7 @@ import akka.testkit.TestProbe
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 
+import java.net.InetSocketAddress
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Future, Promise }
@@ -182,6 +183,42 @@ class Http2PersistentClientSpec extends AkkaSpecWithMaterializer(
           // request should have come in through another connection
           serverRequest2.clientPort should not be (clientPort)
         }
+        "when the first connection fails to materialize" inAssertAllStagesStopped new TestSetup(tls) {
+          var first = true
+          override def clientSettings = super.clientSettings.withTransport(ClientTransport.withCustomResolver((host, port) => {
+            if (first) {
+              first = false
+              // First request returns an address where we are not listening::
+              Future.successful(new InetSocketAddress("localhost", 1337))
+            } else {
+              Future.successful(server.binding.localAddress)
+            }
+          }))
+
+          client.sendRequest(
+            HttpRequest(
+              method = HttpMethods.POST,
+              entity = "ping",
+              headers = headers.`Accept-Encoding`(HttpEncodings.gzip) :: Nil
+            )
+              .addAttribute(requestIdAttr, RequestId("request-1"))
+          )
+          // need some demand on response side, otherwise, no requests will be pulled in
+          client.responsesIn.request(1)
+
+          val serverRequest = server.expectRequest()
+          serverRequest.request.attribute(Http2.streamId) should not be empty
+          serverRequest.request.method shouldBe HttpMethods.POST
+          serverRequest.request.header[headers.`Accept-Encoding`] should not be empty
+          serverRequest.entityAsString shouldBe "ping"
+
+          // now respond
+          server.sendResponseFor(serverRequest, HttpResponse(entity = "pong"))
+
+          val response = client.expectResponse()
+          Unmarshal(response.entity).to[String].futureValue shouldBe "pong"
+          response.attribute(requestIdAttr).get.id shouldBe "request-1"
+        }
       }
       "not leak any stages if completed" should {
         "when waiting for a response" inAssertAllStagesStopped new TestSetup(tls) {
@@ -228,7 +265,15 @@ class Http2PersistentClientSpec extends AkkaSpecWithMaterializer(
 
   class TestSetup(tls: Boolean) {
     def serverSettings: ServerSettings = ServerSettings(system)
-    def clientSettings: ClientConnectionSettings = ClientConnectionSettings(system)
+    def clientSettings: ClientConnectionSettings =
+      ClientConnectionSettings(system).withTransport(new ClientTransport {
+        override def connectTo(host: String, port: Int, settings: ClientConnectionSettings)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[Http.OutgoingConnection]] =
+          Flow.fromGraph(KillSwitches.single[ByteString])
+            .mapMaterializedValue { killer =>
+              killProbe.ref ! killer
+            }
+            .viaMat(ClientTransport.TCP.connectTo(server.binding.localAddress.getHostString, server.binding.localAddress.getPort, settings)(system))(Keep.right)
+      })
 
     val killProbe = TestProbe()
     def killConnection(): Unit = killProbe.expectMsgType[UniqueKillSwitch].abort(new RuntimeException("connection was killed"))
@@ -254,19 +299,11 @@ class Http2PersistentClientSpec extends AkkaSpecWithMaterializer(
         request.sendResponse(response)
     }
     object client {
-      val transport = new ClientTransport {
-        override def connectTo(host: String, port: Int, settings: ClientConnectionSettings)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[Http.OutgoingConnection]] =
-          Flow.fromGraph(KillSwitches.single[ByteString])
-            .mapMaterializedValue { killer =>
-              killProbe.ref ! killer
-            }
-            .viaMat(ClientTransport.TCP.connectTo(server.binding.localAddress.getHostString, server.binding.localAddress.getPort, settings)(system))(Keep.right)
-      }
 
       lazy val clientFlow = {
         val builder = Http().connectionTo("akka.example.org")
           .withCustomHttpsConnectionContext(ExampleHttpContexts.exampleClientContext)
-          .withClientConnectionSettings(clientSettings.withTransport(transport))
+          .withClientConnectionSettings(clientSettings)
 
         if (tls) builder.managedPersistentHttp2()
         else builder.managedPersistentHttp2WithPriorKnowledge()


### PR DESCRIPTION
Avoids responding with 502 responses when we fail to connect to a host at all, so we can retry (possibly to a different endpoint).

Test still fails: the reconnection seems to happen, but no request is/becomes available on `requestIn` - I can't explain that yet...