### PR TITLE
tests: get rid of SocketUtils.temporaryHostnameAndPort in some tests

### DIFF
--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -82,7 +82,8 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
     }
 
     "report failure if bind fails" in EventFilter[BindException](occurrences = 2).intercept {
-      val binding = Http().newServerAt("localhost", 0).connectionSource()
+      val port = 1025 // non-root users typically can't bind to port numbers below 1024
+      val binding = Http().newServerAt("localhost", port).connectionSource()
       val probe1 = TestSubscriber.manualProbe[Http.IncomingConnection]()
       // Bind succeeded, we have a local address
       val b1 = Await.result(binding.to(Sink.fromSubscriber(probe1)).run(), 3.seconds.dilated)

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -82,8 +82,7 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
     }
 
     "report failure if bind fails" in EventFilter[BindException](occurrences = 2).intercept {
-      val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
-      val binding = Http().newServerAt(hostname, port).connectionSource()
+      val binding = Http().newServerAt("localhost", 0).connectionSource()
       val probe1 = TestSubscriber.manualProbe[Http.IncomingConnection]()
       // Bind succeeded, we have a local address
       val b1 = Await.result(binding.to(Sink.fromSubscriber(probe1)).run(), 3.seconds.dilated)
@@ -903,7 +902,6 @@ Host: example.com
 
   class TestSetup {
     val hostname = "localhost"
-    //val (hostname, port) = SocketUtil.temporaryServerHostnameAndPort()
     def configOverrides = ""
 
     // automatically bind a server

--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -14,7 +14,7 @@ import akka.http.scaladsl.server.{ Directives, Route }
 import akka.http.scaladsl.Http
 import akka.remote.testkit.{ MultiNodeConfig, MultiNodeSpec }
 import akka.stream.scaladsl.Source
-import akka.testkit.{ ImplicitSender, LongRunningTest, SocketUtil }
+import akka.testkit.{ ImplicitSender, LongRunningTest }
 import akka.util.{ ByteString, Timeout }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
@@ -176,7 +176,7 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
         enterBarrier("load-gen-ready")
 
         runOn(server) {
-          val (_, port) = SocketUtil.temporaryServerHostnameAndPort()
+          val port = 0
           info(s"Binding Akka HTTP Server to port: $port @ ${myself}")
           val futureBinding = Http().newServerAt("0.0.0.0", port).bind(routes)
 

--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -178,10 +178,10 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
         runOn(server) {
           val port = 0
           info(s"Binding Akka HTTP Server to port: $port @ ${myself}")
-          val futureBinding = Http().newServerAt("0.0.0.0", port).bind(routes)
+          val binding = Http().newServerAt("0.0.0.0", port).bind(routes).futureValue
 
-          _binding = Some(futureBinding.futureValue)
-          setServerPort(port)
+          _binding = Some(binding)
+          setServerPort(binding.localAddress.getPort)
         }
 
         enterBarrier("http-server-running")


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #2947
Relates to https://github.com/akka/akka-http/pull/3691
