### PR TITLE
Updates HttpEntity.withSizeLimit, HttpEntity.withoutSizeLimit JavaDoc

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpEntity.java
@@ -113,11 +113,6 @@ public interface HttpEntity {
      * Content-Length and then another limit is applied then this new limit will be evaluated against the new
      * Content-Length. If the entity is transformed in a way that changes the Content-Length and no new limit is applied
      * then the previous limit will be applied against the previous Content-Length.
-     *
-     * Note that the size limit applied via this method will only have any effect if the `Source` instance contained
-     * in this entity has been appropriately modified via the `HttpEntity.limitable` method. For all entities created
-     * by the HTTP layer itself this is always the case, but if you create entities yourself and would like them to
-     * properly respect limits defined via this method you need to make sure to apply `HttpEntity.limitable` yourself.
      */
     HttpEntity withSizeLimit(long maxBytes);
 
@@ -127,11 +122,6 @@ public interface HttpEntity {
      * By default all message entities produced by the HTTP layer automatically carry the limit that is defined in the
      * application's `max-content-length` config setting. It is recommended to always keep an upper limit on accepted
      * entities to avoid potential attackers flooding you with too large requests/responses, so use this method with caution.
-     *
-     * Note that the size limit applied via this method will only have any effect if the `Source` instance contained
-     * in this entity has been appropriately modified via the `HttpEntity.limitable` method. For all entities created
-     * by the HTTP layer itself this is always the case, but if you create entities yourself and would like them to
-     * properly respect limits defined via this method you need to make sure to apply `HttpEntity.limitable` yourself.
      *
      * See [[withSizeLimit]] for more details.
      */


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
If I am not mistaken, since akka-http 10.1.5, we don't need to apply `HttpEntity.limitable` ourself for the entities that are not created via HTTP layer in order for them to respect the size limit. Thanks to #2185
