### PR TITLE
core: don't send '100 Continue' if 'Content-Length' header is 0, doesn't exist or data got sent early

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -410,8 +410,16 @@ private[http] object HttpServerBluePrint {
               openRequests = openRequests.enqueue(r)
               messageEndPending = r.createEntity.isInstanceOf[StreamedEntityCreator[_, _]]
               val rs = if (r.expect100Continue) {
-                oneHundredContinueResponsePending = true
-                r.copy(createEntity = with100ContinueTrigger(r.createEntity))
+                r.createEntity match {
+                  case StrictEntityCreator(HttpEntity.Strict(_, _)) =>
+                    // This covers two cases:
+                    // - Either: The strict entity got all its data send already, so no need to wait for more data
+                    // - Or: The strict entity contains no data (Content-Length header value was 0 or it did not exist), the client will not send any data
+                    r
+                  case _ =>
+                    oneHundredContinueResponsePending = true
+                    r.copy(createEntity = with100ContinueTrigger(r.createEntity))
+                }
               } else r
               push(requestPrepOut, rs)
             case MessageEnd =>

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -648,6 +648,121 @@ class HttpServerSpec extends AkkaSpec(
       netOut.expectComplete()
     })
 
+    "produce a `100 Continue` response when requested by a `Default` entity and some data sent early" in assertAllStagesStopped(new TestSetup {
+      send("""POST / HTTP/1.1
+             |Host: example.com
+             |Expect: 100-continue
+             |Content-Length: 24
+             |
+             |0123456789ABCDEF""") // only 16 bytes get send at first
+      inside(expectRequest()) {
+        case HttpRequest(POST, _, _, Default(ContentType(`application/octet-stream`, None), 24, data), _) =>
+          val dataProbe = TestSubscriber.manualProbe[ByteString]()
+          data.to(Sink.fromSubscriber(dataProbe)).run()
+          val dataSub = dataProbe.expectSubscription()
+          netOut.expectNoBytes(50.millis.dilated)
+          dataSub.request(1) // triggers `100 Continue` response
+          expectResponseWithWipedDate(
+            """HTTP/1.1 100 Continue
+              |Server: akka-http/test
+              |Date: XXXX
+              |
+              |""")
+          dataProbe.expectNext(ByteString("0123456789ABCDEF"))
+          dataSub.request(1)
+          dataProbe.expectNoMessage(50.millis)
+          send("GHIJKLMN") // send missing 8 bytes
+          dataProbe.expectNext(ByteString("GHIJKLMN"))
+          dataSub.request(1)
+          dataProbe.expectComplete()
+          responses.sendNext(HttpResponse(entity = "Yeah"))
+          expectResponseWithWipedDate(
+            """HTTP/1.1 200 OK
+              |Server: akka-http/test
+              |Date: XXXX
+              |Content-Type: text/plain; charset=UTF-8
+              |Content-Length: 4
+              |
+              |Yeah""")
+      }
+
+      netIn.sendComplete()
+      netOut.expectComplete()
+    })
+
+    "not produce a `100 Continue` response for a `Strict` entity when all data sent early" in assertAllStagesStopped(new TestSetup {
+      send("""POST / HTTP/1.1
+             |Host: example.com
+             |Expect: 100-continue
+             |Content-Length: 16
+             |
+             |0123456789ABCDEF""")
+
+      val HttpRequest(POST, _, _, entity @ Strict(ContentType(`application/octet-stream`, None), data), _) = expectRequest()
+      data shouldEqual ByteString("0123456789ABCDEF")
+
+      responses.sendNext(HttpResponse(entity = "Yeah"))
+
+      expectResponseWithWipedDate(
+        """HTTP/1.1 200 OK
+          |Server: akka-http/test
+          |Date: XXXX
+          |Content-Type: text/plain; charset=UTF-8
+          |Content-Length: 4
+          |
+          |Yeah""")
+
+      netIn.sendComplete()
+      netOut.expectComplete()
+    })
+
+    "not produce a `100 Continue` response if `Strict` entity is empty because `Content-Length` header is 0" in assertAllStagesStopped(new TestSetup {
+      send("""POST / HTTP/1.1
+             |Host: example.com
+             |Expect: 100-continue
+             |Content-Length: 0
+             |
+             |""")
+
+      val HttpRequest(POST, _, _, entity @ Strict(ContentTypes.NoContentType, ByteString.empty), _) = expectRequest()
+      responses.sendNext(HttpResponse(entity = "Yeah"))
+
+      expectResponseWithWipedDate(
+        """HTTP/1.1 200 OK
+          |Server: akka-http/test
+          |Date: XXXX
+          |Content-Type: text/plain; charset=UTF-8
+          |Content-Length: 4
+          |
+          |Yeah""")
+
+      netIn.sendComplete()
+      netOut.expectComplete()
+    })
+
+    "not produce a `100 Continue` response if `Strict` entity is empty because `Content-Length` header is missing" in assertAllStagesStopped(new TestSetup {
+      send("""POST / HTTP/1.1
+             |Host: example.com
+             |Expect: 100-continue
+             |
+             |""")
+
+      val HttpRequest(POST, _, _, entity @ Strict(ContentTypes.NoContentType, ByteString.empty), _) = expectRequest()
+      responses.sendNext(HttpResponse(entity = "Yeah"))
+
+      expectResponseWithWipedDate(
+        """HTTP/1.1 200 OK
+          |Server: akka-http/test
+          |Date: XXXX
+          |Content-Type: text/plain; charset=UTF-8
+          |Content-Length: 4
+          |
+          |Yeah""")
+
+      netIn.sendComplete()
+      netOut.expectComplete()
+    })
+
     "produce a `100 Continue` response when requested by a `Chunked` entity" in assertAllStagesStopped(new TestSetup {
       send("""POST / HTTP/1.1
              |Host: example.com


### PR DESCRIPTION
Just have a look at the tests I addded, also the title says it all:
[If a request (which is _not_ a chunked one)](https://github.com/akka/akka-http/blob/b071bd67547714bd8bed2ccd8170fbbc6c2dbd77/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala#L202-L208) does [not have a `Content-Length` header or it is 0](https://github.com/akka/akka-http/blob/b071bd67547714bd8bed2ccd8170fbbc6c2dbd77/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala#L362-L363), it means it will not send a body/entitiy.
Therefore we do not have to send `100 Continue`, because obviously there will be nothing to continue with from the client.

Right now akka-http _does_ send `100 Continue` and then **waits/hangs indefinitely** (=until the request timeout) for data which will never be send... 

Original report: https://github.com/playframework/playframework/issues/10733

BTW: As you can see in the original report, netty does already behave correctly.