### PR TITLE
http2: remove reflective access to alpn classes

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/3811-http2-internals.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/3811-http2-internals.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[Problem]("akka.http.impl.engine.http2.*")


### PR DESCRIPTION
Fixes #3808

The former use of structural types tried to use reflection on the concrete
type of the receiver. In this case this was an internal JDK type which cannot
be accessed reflectively in JDK16 any more.

The new pattern relies on lazy class loading for accessing a compatible JDK
only after checking for the method explicitly.