### PR TITLE
core: add pool keep-alive-timeout

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/keep-alive-timeout.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/keep-alive-timeout.excludes
@@ -1,0 +1,6 @@
+# Method added to class not meant for user extension:
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.keepAliveTimeout")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ConnectionPoolSettings.withKeepAliveTimeout")
+
+ProblemFilters.exclude[Problem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.*")
+ProblemFilters.exclude[Problem]("akka.http.impl.engine.client.pool.SlotState*")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -556,20 +556,19 @@ akka.http {
     # will automatically terminate itself. Set to `infinite` to completely disable idle timeouts.
     idle-timeout = 30 s
 
-    # The time after which an idle connection (without pending requests)
-    # will automatically terminate itself. Set to `infinite` to completely disable idle timeouts.
+    # When a server uses a `Connection: keep-alive` header to allow using the same
+    # connection to send a subsequent request, close the connection when no such
+    # request appears within the timeout.
+    # Set to `infinite` to allow the connection to remain open indefinitely
+    # (or be closed by the more general idle-timeout).
     #
-    # Note that this is different than the idle-timeout which is about the whole pool.
+    # This settings affects each single connection independently.
     #
-    # This settings afects each single connection independently.
-    # In that context, idle means the connection is sitting unused in the pool and is not associated any ongoing request.
-    #
-    # A common scenario where this setting can be useful is when a host closes a connection according to its keep-alive
-    # timeout and at the same time the client tries to sent a request on a now invalid connection.
-    # Such a call will fail with UnexpectedConnectionClosureException.
-    # This can be prevented (mitigated) by configuring this timeout with a value lower than the host keep-alive timeout.
-    # As such, you minimise the risk of using a connection that is likely to be closed by the host.
-    max-connection-idle-timeout = infinite
+    # A common scenario where this setting can be useful is when a server (or reverse-proxy) closes a connection according to its keep-alive
+    # timeout and at the same time the client tries to send a request on the now-invalid connection.
+    # Such a call will fail with `UnexpectedConnectionClosureException`.
+    # This can be avoided by configuring this timeout with a value lower than the server-side keep-alive timeout.
+    keep-alive-timeout = infinite
 
     # The pool implementation will fail a connection early and clear the slot if a response entity was not
     # subscribed during the given time period after the response was dispatched. In busy systems the timeout might be

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -562,7 +562,7 @@ akka.http {
     #
     # A common scenario where this setting is useful is to prevent a race-condition inherent in HTTP: in most cases, a server
     # or reverse-proxy closes a persistent (kept-alive) connection after some time. HTTP does not define a protocol between
-    # client and server to negotiate a graceful tear down of an idle persistent connection. Therefore, it can happen that a server decides to
+    # client and server to negotiate a graceful teardown of an idle persistent connection. Therefore, it can happen that a server decides to
     # close a connection at the same time that a client decides to send a new request. In that case, the request will fail to be processed,
     # but the client cannot determine for which reason the server closed the connection and whether the request was (partly) processed or not.
     # Such a condition can be observed when a request fails with an `UnexpectedConnectionClosureException`.

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -556,18 +556,21 @@ akka.http {
     # will automatically terminate itself. Set to `infinite` to completely disable idle timeouts.
     idle-timeout = 30 s
 
-    # When a server uses a `Connection: keep-alive` header to allow using the same
-    # connection to send a subsequent request, close the connection when no such
-    # request appears within the timeout.
-    # Set to `infinite` to allow the connection to remain open indefinitely
-    # (or be closed by the more general idle-timeout).
+    # HTTP connections are commonly used for multiple requests, that is, they are kept alive between requests. The
+    # `akka.http.host-connection-pool.keep-alive-timeout` setting configures how long a pool keeps a connection alive between
+    # requests before it closes the connection (and eventually reestablishes it).
     #
-    # This settings affects each single connection independently.
+    # A common scenario where this setting is useful is to prevent a race-condition inherent in HTTP: in most cases, a server
+    # or reverse-proxy closes a persistent (kept-alive) connection after some time. HTTP does not define a protocol between
+    # client and server to negotiate a graceful tear down of an idle persistent connection. Therefore, it can happen that a server decides to
+    # close a connection at the same time that a client decides to send a new request. In that case, the request will fail to be processed,
+    # but the client cannot determine for which reason the server closed the connection and whether the request was (partly) processed or not.
+    # Such a condition can be observed when a request fails with an `UnexpectedConnectionClosureException`.
     #
-    # A common scenario where this setting can be useful is when a server (or reverse-proxy) closes a connection according to its keep-alive
-    # timeout and at the same time the client tries to send a request on the now-invalid connection.
-    # Such a call will fail with `UnexpectedConnectionClosureException`.
-    # This can be avoided by configuring this timeout with a value lower than the server-side keep-alive timeout.
+    # To prevent this from happening, you can set the timeout to a lower value than the server-side keep-alive timeout
+    # (which you either have to know or find out experimentally).
+    #
+    # Set to `infinite` to allow the connection to remain open indefinitely (or be closed by the more general `idle-timeout`).
     keep-alive-timeout = infinite
 
     # The pool implementation will fail a connection early and clear the slot if a response entity was not

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -556,6 +556,21 @@ akka.http {
     # will automatically terminate itself. Set to `infinite` to completely disable idle timeouts.
     idle-timeout = 30 s
 
+    # The time after which an idle connection (without pending requests)
+    # will automatically terminate itself. Set to `infinite` to completely disable idle timeouts.
+    #
+    # Note that this is different than the idle-timeout which is about the whole pool.
+    #
+    # This settings afects each single connection independently.
+    # In that context, idle means the connection is sitting unused in the pool and is not associated any ongoing request.
+    #
+    # A common scenario where this setting can be useful is when a host closes a connection according to its keep-alive
+    # timeout and at the same time the client tries to sent a request on a now invalid connection.
+    # Such a call will fail with UnexpectedConnectionClosureException.
+    # This can be prevented (mitigated) by configuring this timeout with a value lower than the host keep-alive timeout.
+    # As such, you minimise the risk of using a connection that is likely to be closed by the host.
+    max-connection-idle-timeout = infinite
+
     # The pool implementation will fail a connection early and clear the slot if a response entity was not
     # subscribed during the given time period after the response was dispatched. In busy systems the timeout might be
     # too tight if a response is not picked up quick enough after it was dispatched by the pool.

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/SlotState.scala
@@ -42,6 +42,7 @@ private[pool] sealed abstract class SlotState extends Product {
   def isIdle: Boolean
   def isConnected: Boolean
 
+  def idle(ctx: SlotContext): SlotState = SlotState.Idle(ctx.settings.keepAliveTimeout)
   def onPreConnect(ctx: SlotContext): SlotState = illegalState(ctx, "onPreConnect")
   def onConnectionAttemptSucceeded(ctx: SlotContext, outgoingConnection: Http.OutgoingConnection): SlotState = illegalState(ctx, "onConnectionAttemptSucceeded")
   def onConnectionAttemptFailed(ctx: SlotContext, cause: Throwable): SlotState = illegalState(ctx, "onConnectionAttemptFailed")
@@ -191,7 +192,8 @@ private[pool] object SlotState {
   private[pool] case object ToBeClosed extends ShouldCloseConnectionState(None)
   private[pool] case class Failed(cause: Throwable) extends ShouldCloseConnectionState(Some(cause))
 
-  private[pool] final case class Idle(override val stateTimeout: Duration) extends ConnectedState with IdleState {
+  private[pool] final case class Idle(keepAliveTimeout: Duration) extends ConnectedState with IdleState {
+    override def stateTimeout: Duration = keepAliveTimeout
     override def onNewRequest(ctx: SlotContext, requestContext: RequestContext): SlotState =
       PushingRequestToConnection(requestContext)
 
@@ -212,7 +214,7 @@ private[pool] object SlotState {
   private[pool] case object PreConnecting extends ConnectedState with IdleState {
     override def onConnectionAttemptSucceeded(ctx: SlotContext, outgoingConnection: Http.OutgoingConnection): SlotState = {
       ctx.debug("Slot connection was (pre-)established")
-      Idle(ctx.settings.maxConnectionIdleTimeout)
+      idle(ctx)
     }
     override def onNewRequest(ctx: SlotContext, requestContext: RequestContext): SlotState =
       Connecting(requestContext)
@@ -323,7 +325,7 @@ private[pool] object SlotState {
       else if (ctx.willCloseAfter(ongoingResponse) || ctx.isConnectionClosed)
         ToBeClosed // when would ctx.isConnectionClose be true? what that mean that the connection has already failed before? do we need that state at all?
       else
-        Idle(ctx.settings.maxConnectionIdleTimeout)
+        idle(ctx)
 
     override def onRequestEntityCompleted(ctx: SlotContext): SlotState = {
       require(waitingForEndOfRequestEntity)
@@ -335,10 +337,10 @@ private[pool] object SlotState {
 
     override def onRequestEntityCompleted(ctx: SlotContext): SlotState =
       if (ctx.isConnectionClosed) ToBeClosed
-      else Idle(ctx.settings.maxConnectionIdleTimeout)
+      else idle(ctx)
     override def onRequestEntityFailed(ctx: SlotContext, cause: Throwable): SlotState =
       if (ctx.isConnectionClosed) ToBeClosed // ignore error here
-      else Idle(ctx.settings.maxConnectionIdleTimeout)
+      else idle(ctx)
     override def onConnectionCompleted(ctx: SlotContext): SlotState = ToBeClosed
     override def onConnectionFailed(ctx: SlotContext, cause: Throwable): SlotState = Failed(cause)
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -26,6 +26,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   baseConnectionBackoff:             FiniteDuration,
   maxConnectionBackoff:              FiniteDuration,
   idleTimeout:                       Duration,
+  maxConnectionIdleTimeout:          Duration,
   connectionSettings:                ClientConnectionSettings,
   responseEntitySubscriptionTimeout: Duration,
   hostOverrides:                     immutable.Seq[(Regex, ConnectionPoolSettings)])
@@ -72,6 +73,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
     baseConnectionBackoff:             FiniteDuration                                   = baseConnectionBackoff,
     maxConnectionBackoff:              FiniteDuration                                   = maxConnectionBackoff,
     idleTimeout:                       Duration                                         = idleTimeout,
+    maxConnectionIdleTimeout:          Duration                                         = maxConnectionIdleTimeout,
     connectionSettings:                ClientConnectionSettings                         = connectionSettings,
     responseEntitySubscriptionTimeout: Duration                                         = responseEntitySubscriptionTimeout): ConnectionPoolSettings =
     copy(
@@ -84,6 +86,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
       baseConnectionBackoff,
       maxConnectionBackoff,
       idleTimeout,
+      maxConnectionIdleTimeout,
       connectionSettings,
       responseEntitySubscriptionTimeout,
       hostOverrides = hostOverrides.map { case (k, v) => k -> mapHostOverrides(v) })
@@ -105,6 +108,7 @@ private[akka] object ConnectionPoolSettingsImpl extends SettingsCompanionImpl[Co
       c.getFiniteDuration("base-connection-backoff"),
       c.getFiniteDuration("max-connection-backoff"),
       c.getPotentiallyInfiniteDuration("idle-timeout"),
+      c.getPotentiallyInfiniteDuration("max-connection-idle-timeout"),
       ClientConnectionSettingsImpl.fromSubConfig(root, c.getConfig("client")),
       c getPotentiallyInfiniteDuration "response-entity-subscription-timeout",
       List.empty

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -26,7 +26,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   baseConnectionBackoff:             FiniteDuration,
   maxConnectionBackoff:              FiniteDuration,
   idleTimeout:                       Duration,
-  maxConnectionIdleTimeout:          Duration,
+  keepAliveTimeout:                  Duration,
   connectionSettings:                ClientConnectionSettings,
   responseEntitySubscriptionTimeout: Duration,
   hostOverrides:                     immutable.Seq[(Regex, ConnectionPoolSettings)])
@@ -73,7 +73,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
     baseConnectionBackoff:             FiniteDuration                                   = baseConnectionBackoff,
     maxConnectionBackoff:              FiniteDuration                                   = maxConnectionBackoff,
     idleTimeout:                       Duration                                         = idleTimeout,
-    maxConnectionIdleTimeout:          Duration                                         = maxConnectionIdleTimeout,
+    keepAliveTimeout:                  Duration                                         = keepAliveTimeout,
     connectionSettings:                ClientConnectionSettings                         = connectionSettings,
     responseEntitySubscriptionTimeout: Duration                                         = responseEntitySubscriptionTimeout): ConnectionPoolSettings =
     copy(
@@ -86,7 +86,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
       baseConnectionBackoff,
       maxConnectionBackoff,
       idleTimeout,
-      maxConnectionIdleTimeout,
+      keepAliveTimeout,
       connectionSettings,
       responseEntitySubscriptionTimeout,
       hostOverrides = hostOverrides.map { case (k, v) => k -> mapHostOverrides(v) })
@@ -108,7 +108,7 @@ private[akka] object ConnectionPoolSettingsImpl extends SettingsCompanionImpl[Co
       c.getFiniteDuration("base-connection-backoff"),
       c.getFiniteDuration("max-connection-backoff"),
       c.getPotentiallyInfiniteDuration("idle-timeout"),
-      c.getPotentiallyInfiniteDuration("max-connection-idle-timeout"),
+      c.getPotentiallyInfiniteDuration("keep-alive-timeout"),
       ClientConnectionSettingsImpl.fromSubConfig(root, c.getConfig("client")),
       c getPotentiallyInfiniteDuration "response-entity-subscription-timeout",
       List.empty

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -31,6 +31,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def getBaseConnectionBackoff: FiniteDuration = baseConnectionBackoff
   def getMaxConnectionBackoff: FiniteDuration = maxConnectionBackoff
   def getIdleTimeout: Duration = idleTimeout
+  def getMaxConnectionIdleTimeout: Duration = maxConnectionIdleTimeout
   def getConnectionSettings: ClientConnectionSettings = connectionSettings
 
   @ApiMayChange
@@ -56,6 +57,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings
   def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings
   def withIdleTimeout(newValue: Duration): ConnectionPoolSettings
+  def withMaxConnectionIdleTimeout(newValue: Duration): ConnectionPoolSettings
   def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copyDeep(_.withConnectionSettings(newValue.asScala), connectionSettings = newValue.asScala)
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -31,7 +31,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def getBaseConnectionBackoff: FiniteDuration = baseConnectionBackoff
   def getMaxConnectionBackoff: FiniteDuration = maxConnectionBackoff
   def getIdleTimeout: Duration = idleTimeout
-  def getMaxConnectionIdleTimeout: Duration = maxConnectionIdleTimeout
+  def getKeepAliveTimeout: Duration = keepAliveTimeout
   def getConnectionSettings: ClientConnectionSettings = connectionSettings
 
   @ApiMayChange
@@ -57,7 +57,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings
   def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings
   def withIdleTimeout(newValue: Duration): ConnectionPoolSettings
-  def withMaxConnectionIdleTimeout(newValue: Duration): ConnectionPoolSettings
+  def withKeepAliveTimeout(newValue: Duration): ConnectionPoolSettings
   def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copyDeep(_.withConnectionSettings(newValue.asScala), connectionSettings = newValue.asScala)
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -66,7 +66,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   override def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionBackoff(newValue), maxConnectionBackoff = newValue)
   override def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withPipeliningLimit(newValue), pipeliningLimit = newValue)
   override def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withIdleTimeout(newValue), idleTimeout = newValue)
-  override def withKeepAliveTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withKeepAliveTimeout(newValue), idleTimeout = newValue)
+  override def withKeepAliveTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withKeepAliveTimeout(newValue), keepAliveTimeout = newValue)
   override def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionLifetime(newValue), maxConnectionLifetime = newValue)
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copyDeep(_.withConnectionSettings(newValue), connectionSettings = newValue)
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -28,6 +28,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   def baseConnectionBackoff: FiniteDuration
   def maxConnectionBackoff: FiniteDuration
   def idleTimeout: Duration
+  def maxConnectionIdleTimeout: Duration
   def connectionSettings: ClientConnectionSettings
   def maxConnectionLifetime: Duration
   private[akka] def hostOverrides: immutable.Seq[(Regex, ConnectionPoolSettings)]
@@ -65,6 +66,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   override def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionBackoff(newValue), maxConnectionBackoff = newValue)
   override def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withPipeliningLimit(newValue), pipeliningLimit = newValue)
   override def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withIdleTimeout(newValue), idleTimeout = newValue)
+  override def withMaxConnectionIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionIdleTimeout(newValue), idleTimeout = newValue)
   override def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionLifetime(newValue), maxConnectionLifetime = newValue)
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copyDeep(_.withConnectionSettings(newValue), connectionSettings = newValue)
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -28,7 +28,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   def baseConnectionBackoff: FiniteDuration
   def maxConnectionBackoff: FiniteDuration
   def idleTimeout: Duration
-  def maxConnectionIdleTimeout: Duration
+  def keepAliveTimeout: Duration
   def connectionSettings: ClientConnectionSettings
   def maxConnectionLifetime: Duration
   private[akka] def hostOverrides: immutable.Seq[(Regex, ConnectionPoolSettings)]
@@ -66,7 +66,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   override def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionBackoff(newValue), maxConnectionBackoff = newValue)
   override def withPipeliningLimit(newValue: Int): ConnectionPoolSettings = self.copyDeep(_.withPipeliningLimit(newValue), pipeliningLimit = newValue)
   override def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withIdleTimeout(newValue), idleTimeout = newValue)
-  override def withMaxConnectionIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionIdleTimeout(newValue), idleTimeout = newValue)
+  override def withKeepAliveTimeout(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withKeepAliveTimeout(newValue), idleTimeout = newValue)
   override def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copyDeep(_.withMaxConnectionLifetime(newValue), maxConnectionLifetime = newValue)
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copyDeep(_.withConnectionSettings(newValue), connectionSettings = newValue)
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -357,6 +357,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
           expectResponseEntityAsString() shouldEqual "/simple"
           val receivedFirstResponse = System.nanoTime()
 
+          // wait until pool closes connection because of keep-alive-timeout
           conn1.serverRequests.expectComplete()
           conn1.serverResponses.sendComplete()
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -345,6 +345,31 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         conn2.pushResponse(HttpResponse(entity = "response"))
         expectResponseEntityAsString() shouldEqual "response"
       }
+
+      "create a new connection when previous one timed out between requests" inWithShutdown
+        new SetupWithServerProbes(_.withKeepAliveTimeout(800.millis)) {
+          pushRequest(HttpRequest(uri = "/simple"))
+
+          val conn1 = expectNextConnection()
+          val req = conn1.expectRequest()
+          conn1.pushResponse(HttpResponse(headers = headers.Connection("keep-alive") :: Nil, entity = req.uri.path.toString))
+
+          expectResponseEntityAsString() shouldEqual "/simple"
+          val receivedFirstResponse = System.nanoTime()
+
+          conn1.serverRequests.expectComplete()
+          conn1.serverResponses.sendComplete()
+
+          val complete = System.nanoTime()
+          (System.nanoTime() - receivedFirstResponse).nanos should be >= 800.millis
+          println("XXX", System.nanoTime() - receivedFirstResponse)
+
+          pushRequest(HttpRequest(uri = "/next"))
+          val conn2 = expectNextConnection()
+          conn2.expectRequestToPath("/next")
+          conn2.pushResponse(HttpResponse(entity = "response"))
+          expectResponseEntityAsString() shouldEqual "response"
+        }
       "create a new connection when previous one was closed regularly between requests without sending a `Connection: close` header first" inWithShutdown new SetupWithServerProbes {
         pushRequest(HttpRequest(uri = "/simple"))
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
@@ -5,7 +5,6 @@
 package akka.http.impl.engine.client.pool
 
 import java.net.InetSocketAddress
-
 import akka.event.LoggingAdapter
 import akka.http.impl.engine.client.PoolFlow
 import akka.http.impl.engine.client.PoolFlow.RequestContext
@@ -20,6 +19,7 @@ import akka.testkit.AkkaSpec
 import akka.util.ByteString
 
 import scala.concurrent.Promise
+import scala.concurrent.duration.Duration
 import scala.util.Try
 
 class SlotStateSpec extends AkkaSpec {
@@ -53,7 +53,7 @@ class SlotStateSpec extends AkkaSpec {
       state = state.onResponseDispatchable(context)
       state = state.onResponseEntitySubscribed(context)
       state = state.onResponseEntityCompleted(context)
-      state should be(Idle)
+      state should be(Idle(Duration.Inf))
 
       state = state.onConnectionCompleted(context)
       state should be(ToBeClosed)
@@ -79,7 +79,7 @@ class SlotStateSpec extends AkkaSpec {
       state = state.onResponseDispatchable(context)
       state = state.onResponseEntitySubscribed(context)
       state = state.onResponseEntityCompleted(context)
-      state should be(Idle)
+      state should be(Idle(Duration.Inf))
     }
 
     "allow postponing completing the request until just after the response was dispatchable" in {
@@ -102,7 +102,7 @@ class SlotStateSpec extends AkkaSpec {
 
       state = state.onResponseEntitySubscribed(context)
       state = state.onResponseEntityCompleted(context)
-      state should be(Idle)
+      state should be(Idle(Duration.Inf))
     }
 
     "allow postponing completing the request until just after the response was subscribed" in {
@@ -125,7 +125,7 @@ class SlotStateSpec extends AkkaSpec {
       state = state.onRequestEntityCompleted(context)
 
       state = state.onResponseEntityCompleted(context)
-      state should be(Idle)
+      state should be(Idle(Duration.Inf))
     }
 
     "consider a slot 'idle' only when the request has been successfully sent" in {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -362,6 +362,8 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
             actualTimeout.nanos should be < serverTimeout
           } finally Await.result(b1.unbind(), 1.second.dilated)
         }
+
+        // keepAliveTimeout is not so easy to observe from the 'outside', so tested in SlotStateSpec instead
       }
     }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -363,7 +363,46 @@ class ClientServerSpec extends AkkaSpecWithMaterializer(
           } finally Await.result(b1.unbind(), 1.second.dilated)
         }
 
-        // keepAliveTimeout is not so easy to observe from the 'outside', so tested in SlotStateSpec instead
+        "avoid client vs. server race-condition for persistent connections with keep-alive-timeout" in Utils.assertAllStagesStopped {
+          def handler(request: HttpRequest): Future[HttpResponse] = Future.successful(HttpResponse())
+          val serverSettings = ServerSettings(system).mapTimeouts(_.withIdleTimeout(300.millis))
+          val binding = Http().newServerAt("127.0.0.1", 0).withSettings(serverSettings).bind(handler).futureValue
+          val uri = "http://" + binding.localAddress.getHostString + ":" + binding.localAddress.getPort
+
+          val clientSettings = ConnectionPoolSettings(system)
+            .withUpdatedConnectionSettings(
+              _.withTransport(new ClientTransport {
+                override def connectTo(host: String, port: Int, settings: ClientConnectionSettings)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[Http.OutgoingConnection]] =
+                  Flow[ByteString]
+                    .delay(200.millis, OverflowStrategy.backpressure) // delay request sending enough to make race-condition more likely
+                    .viaMat(ClientTransport.TCP.connectTo(host, port, settings))(Keep.right)
+              }))
+
+          def runRequest(clientSettings: ConnectionPoolSettings): Future[HttpResponse] =
+            Http().singleRequest(HttpRequest(method = POST, uri = uri), settings = clientSettings)
+
+          def runTest(clientSettings: ConnectionPoolSettings): Future[HttpResponse] = {
+            // send first request
+            runRequest(clientSettings).awaitResult(1.second)
+
+            // delay so that next request is sent before idle-timeout of 300 millis
+            // but will arrive only 200 millis later, which is after the idle-timeout
+            Thread.sleep(200)
+
+            // send second request, should run into server-side idle-timeout
+            runRequest(clientSettings)
+          }
+
+          val ex = Try(runTest(clientSettings).awaitResult(1.second)).failed.get
+          ex.getCause.getMessage.contains("connection closed") shouldBe true
+
+          val clientSettings2 = clientSettings.withKeepAliveTimeout(100.millis) // < 300 millis server idle timeout
+          // same test on new pool with keep-alive-timeout which should succeed
+          runTest(clientSettings2).awaitResult(1.second)
+
+          binding.unbind().awaitResult(1.second)
+          Http().shutdownAllConnectionPools().awaitResult(1.second)
+        }
       }
     }
 
@@ -896,44 +935,6 @@ Host: example.com
 
       binding.unbind().futureValue
       Http().shutdownAllConnectionPools().futureValue
-    }
-
-    "avoid client vs. server race-condition for persistent connections with keep-alive-timeout" in {
-      def handler(request: HttpRequest): Future[HttpResponse] = Future.successful(HttpResponse())
-      val serverSettings = ServerSettings(system).mapTimeouts(_.withIdleTimeout(300.millis))
-      val binding = Http().newServerAt("127.0.0.1", 0).withSettings(serverSettings).bind(handler).futureValue
-      val uri = "http://" + binding.localAddress.getHostString + ":" + binding.localAddress.getPort
-
-      val clientSettings = ConnectionPoolSettings(system)
-        .withUpdatedConnectionSettings(
-          _.withTransport(new ClientTransport {
-            override def connectTo(host: String, port: Int, settings: ClientConnectionSettings)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[Http.OutgoingConnection]] =
-              Flow[ByteString]
-                .delay(200.millis, OverflowStrategy.backpressure) // delay request sending enough to make race-condition more likely
-                .viaMat(ClientTransport.TCP.connectTo(host, port, settings))(Keep.right)
-          }))
-
-      def runRequest(clientSettings: ConnectionPoolSettings): Future[HttpResponse] =
-        Http().singleRequest(HttpRequest(method = POST, uri = uri), settings = clientSettings)
-
-      def runTest(clientSettings: ConnectionPoolSettings): Future[HttpResponse] = {
-        // send first request
-        runRequest(clientSettings).awaitResult(1.second)
-
-        // delay so that next request is sent before idle-timeout of 300 millis
-        // but will arrive only 200 millis later, which is after the idle-timeout
-        Thread.sleep(200)
-
-        runRequest(clientSettings)
-      }
-
-      // send second request, should run into server-side idle-timeout
-      val ex = Try(runTest(clientSettings).awaitResult(1.second)).failed.get
-      ex.getCause.getMessage.contains("connection closed") shouldBe true
-
-      val clientSettings2 = clientSettings.withKeepAliveTimeout(100.millis) // < 300 millis server idle timeout
-      // same test on new pool with keep-alive-timeout which should succeed
-      runTest(clientSettings2).awaitResult(1.second)
     }
   }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/PreviewServerSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/PreviewServerSettingsSpec.scala
@@ -11,7 +11,7 @@ class PreviewServerSettingsSpec extends AkkaSpec {
   def compileOnlySpec(body: => Unit) = ()
 
   "PreviewServerSettings" should {
-    "compile when set programatically" in compileOnlySpec {
+    "compile when set programmatically" in compileOnlySpec {
       ServerSettings(system)
         .withPreviewServerSettings(PreviewServerSettings(system).withEnableHttp2(true))
         .withRemoteAddressHeader(true)

--- a/docs/src/main/paradox/common/timeouts.md
+++ b/docs/src/main/paradox/common/timeouts.md
@@ -7,19 +7,19 @@ are left to the streaming APIs and are easily implementable as patterns in user-
 ## Common timeouts
 
 <a id="idle-timeouts"></a>
-### Idle timeouts
+### Connection-level idle timeout
 
-The `idle-timeout` is a global setting which sets the maximum inactivity time of a given connection.
-In other words, if a connection is open but no request/response is being written to it for over `idle-timeout` time,
-the connection will be automatically closed.
+The `idle-timeout` is a setting which sets the maximum inactivity time of a given connection. If no data is sent or received
+on a connection for over `idle-timeout` time, the connection will be automatically closed.
 
-The setting works the same way for all connections, be it server-side or client-side, and it's configurable
-independently for each of those using the following keys:
+This setting should be used as a last-resort safeguard to prevent unused or stuck connections from consuming resources for
+an indefinite time.
+
+The setting works the same way for server and client connections and it is configurable independently using the following keys:
 
 ```
 akka.http.server.idle-timeout
 akka.http.client.idle-timeout
-akka.http.host-connection-pool.idle-timeout
 akka.http.host-connection-pool.client.idle-timeout
 ```
 
@@ -71,22 +71,25 @@ is unable to be established for a given amount of time.
 
 It can be configured using the `akka.http.client.connecting-timeout` setting.
 
-### Keep-alive timeouts
+## Client pool timeouts
 
-When a server uses a `Connection: keep-alive` header to allow using the same
-connection to send a subsequent request, close the connection when no such
-request appears within the timeout.
-Set to `infinite` to allow the connection to remain open indefinitely
-(or be closed by the more general idle-timeout).
+### Keep-alive timeout
 
-This settings affects each single connection independently.
+HTTP connections are commonly used for multiple requests, that is, they are kept alive between requests. The
+`akka.http.host-connection-pool.keep-alive-timeout` setting configures how long a pool keeps a connection alive between
+requests before it closes the connection (and eventually reestablishes it).
 
-A common scenario where this setting can be useful is when a server (or reverse-proxy) closes a connection according to its keep-alive
-timeout and at the same time the client tries to send a request on the now-invalid connection.
-Such a call will fail with `UnexpectedConnectionClosureException`.
-This can be avoided by configuring this timeout with a value lower than the server-side keep-alive timeout.
+A common scenario where this setting is useful is to prevent a race-condition inherent in HTTP: in most cases, a server
+or reverse-proxy closes a persistent (kept-alive) connection after some time. HTTP does not define a protocol between
+client and server to negotiate a graceful tear down of an idle persistent connection. Therefore, it can happen that a server decides to
+close a connection at the same time that a client decides to send a new request. In that case, the request will fail to be processed,
+but the client cannot determine for which reason the server closed the connection and whether the request was (partly) processed or not.
+Such a condition can be observed when a request fails with an `UnexpectedConnectionClosureException`.
 
-It can be configured using the `akka.http.host-connection-pool.keep-alive-timeout` setting.
+To prevent this from happening, you can set the timeout to a lower value than the server-side keep-alive timeout
+(which you either have to know or find out experimentally).
+
+Set to `infinite` to allow the connection to remain open indefinitely (or be closed by the more general `idle-timeout`).
 
 ### Connection Lifetime timeout
 
@@ -94,3 +97,13 @@ This timeout configures a maximum amount of time, while the connection can be ke
 the server through a load balancer and client reconnecting helps the process of rebalancing between service instances.
 
 It can be configured using the `akka.http.host-connection-pool.max-connection-lifetime` setting.
+
+### Pool Idle timeout
+
+A connection pool to a target host will be shut down after the timeout given as `akka.http.host-connection-pool.idle-timeout`. This frees
+resources like open but idle pool connections and management structures.
+
+If the application connects to only a limited set of target hosts over its lifetime and resource usage for the pool is of no concern, the
+`idle-timeout` can be completely disabled by setting it to `infinite`.
+
+A pool will be automatically reestablished when a new request comes in for a target host.

--- a/docs/src/main/paradox/common/timeouts.md
+++ b/docs/src/main/paradox/common/timeouts.md
@@ -23,10 +23,6 @@ akka.http.host-connection-pool.idle-timeout
 akka.http.host-connection-pool.client.idle-timeout
 ```
 
-@@@ note
-For the client side connection pool, the idle period is counted only when the pool has no pending requests waiting.
-@@@
-
 ## Server timeouts
 
 <a id="request-timeout"></a>
@@ -73,7 +69,24 @@ The connecting timeout is the time period within which the TCP connecting proces
 Tweaking it should rarely be required, but it allows erroring out the connection in case a connection
 is unable to be established for a given amount of time.
 
-it can be configured using the `akka.http.client.connecting-timeout` setting.
+It can be configured using the `akka.http.client.connecting-timeout` setting.
+
+### Keep-alive timeouts
+
+When a server uses a `Connection: keep-alive` header to allow using the same
+connection to send a subsequent request, close the connection when no such
+request appears within the timeout.
+Set to `infinite` to allow the connection to remain open indefinitely
+(or be closed by the more general idle-timeout).
+
+This settings affects each single connection independently.
+
+A common scenario where this setting can be useful is when a server (or reverse-proxy) closes a connection according to its keep-alive
+timeout and at the same time the client tries to send a request on the now-invalid connection.
+Such a call will fail with `UnexpectedConnectionClosureException`.
+This can be avoided by configuring this timeout with a value lower than the server-side keep-alive timeout.
+
+It can be configured using the `akka.http.host-connection-pool.keep-alive-timeout` setting.
 
 ### Connection Lifetime timeout
 


### PR DESCRIPTION
References #3806, #3759 and #3481

Adds an extra timeout following the ideas discussed in https://github.com/akka/akka-http/issues/3806#issuecomment-829137002

