### PR TITLE
Allow trailing HTTP/2 headers on strict responses

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
@@ -46,7 +46,7 @@ class H2ClientServerBenchmark extends CommonBenchmark {
   val numRequests = 1000
 
   @Benchmark
-  @OperationsPerInvocation(10000) // should be same as numRequest
+  @OperationsPerInvocation(1000) // should be same as numRequest
   def benchRequestProcessing(): Unit = {
     implicit val ec: ExecutionContext = system.dispatcher
 

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
@@ -26,6 +26,10 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
 
+/**
+ * Test converting a HttpRequest to bytes at the client and back to a request at the server, and vice-versa
+ * for the response. Does not include the network.
+ */
 class H2ClientServerBenchmark extends CommonBenchmark {
   // Obtained by converting the input request bytes from curl with --http2-prior-knowledge
   def request(streamId: Int) =

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
@@ -4,56 +4,59 @@
 
 package akka.http.impl.engine.http2
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.CommonBenchmark
 import akka.http.impl.engine.http2.FrameEvent.HeadersFrame
 import akka.http.impl.engine.http2.framing.FrameRenderer
-import akka.http.scaladsl.model.{ HttpResponse }
-import akka.http.scaladsl.settings.ServerSettings
+import akka.http.scaladsl.client.RequestBuilding.Get
+import akka.http.scaladsl.model.HttpEntity.LastChunk
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpRequest, HttpResponse }
+import akka.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
 import akka.stream.ActorMaterializer
 import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
-import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.stream.scaladsl.{ BidiFlow, Flow, Keep, Sink, Source }
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
-import scala.concurrent.{ Await, Future }
+import scala.collection.immutable
 import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContext, Future }
 
-class H2ServerSwitchBenchmark extends CommonBenchmark {
+class H2ClientServerBenchmark extends CommonBenchmark {
   // Obtained by converting the input request bytes from curl with --http2-prior-knowledge
   def request(streamId: Int) =
     FrameRenderer.render(HeadersFrame(streamId, endStream = true, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None))
 
-  var response: HttpResponse = HPackSpecExamples.FirstResponse
+  @Param(Array("closedelimited", "chunked"))
+  var responsetype: String = _
 
-  var httpFlow: Flow[ByteString, ByteString, Any] = _
+  var response: HttpResponse = _
+  var httpFlow: Flow[HttpRequest, HttpResponse, Any] = _
   implicit var system: ActorSystem = _
   implicit var mat: ActorMaterializer = _
 
-  val packedResponse = ByteString(-62, -63, -64, -65, -66)
-
-  val numRequests = 10000
+  val numRequests = 1000
 
   @Benchmark
   @OperationsPerInvocation(10000) // should be same as numRequest
   def benchRequestProcessing(): Unit = {
+    implicit val ec: ExecutionContext = system.dispatcher
+
     val latch = new CountDownLatch(numRequests)
 
     val requests =
-      Source(Http2Protocol.ClientConnectionPreface +: Range(0, numRequests).map(i => request(1 + 2 * i)))
+      Source.repeat(Get("/")).take(numRequests)
         .concatMat(Source.maybe)(Keep.right)
 
     val (in, done) =
       requests
         .viaMat(httpFlow)(Keep.left)
         .toMat(Sink.foreach(res => {
-          // Skip headers/settings frames etc
-          if (res.containsSlice(HPackSpecExamples.C61FirstResponseWithHuffman)
-            || res.containsSlice(packedResponse)) {
-            latch.countDown()
-          }
+          res.discardEntityBytes().future.onComplete(_ => latch.countDown())
         }))(Keep.both)
         .run()
 
@@ -65,6 +68,12 @@ class H2ServerSwitchBenchmark extends CommonBenchmark {
 
   @Setup
   def setup(): Unit = {
+    response = responsetype match {
+      case "closedelimited" => HPackSpecExamples.FirstResponse
+      case "chunked" => HPackSpecExamples.FirstResponse.withEntity(
+        HttpEntity.Chunked(ContentTypes.NoContentType, Source.single(LastChunk(trailer = immutable.Seq(RawHeader("grpc-status", "9")))))
+      )
+    }
     val config =
       ConfigFactory.parseString(
         s"""
@@ -87,7 +96,9 @@ class H2ServerSwitchBenchmark extends CommonBenchmark {
         req.discardEntityBytes().future.map(_ => response)
       })(system.dispatcher)
         .join(Http2Blueprint.serverStackTls(settings, log, NoOpTelemetry))
-    httpFlow = Http2.priorKnowledge(http1, http2)
+    val server: Flow[ByteString, ByteString, NotUsed] = Http2.priorKnowledge(http1, http2)
+    val client: BidiFlow[HttpRequest, ByteString, ByteString, HttpResponse, NotUsed] = Http2Blueprint.clientStack(ClientConnectionSettings(system), log, NoOpTelemetry)
+    httpFlow = client.join(server)
   }
 
   @TearDown

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
@@ -5,6 +5,7 @@
 package akka.http.impl.engine.http2
 
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
+import scala.collection.immutable
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
@@ -66,7 +67,7 @@ class H2ServerProcessingBenchmark extends CommonBenchmark {
     response = responsetype match {
       case "closedelimited" => HPackSpecExamples.FirstResponse
       case "chunked" => HPackSpecExamples.FirstResponse.withEntity(
-        HttpEntity.Chunked(ContentTypes.NoContentType, Source.single(LastChunk(trailer = Seq(RawHeader("grpc-status", "9")))))
+        HttpEntity.Chunked(ContentTypes.NoContentType, Source.single(LastChunk(trailer = immutable.Seq(RawHeader("grpc-status", "9")))))
       )
     }
     val config =

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
@@ -4,54 +4,55 @@
 
 package akka.http.impl.engine.http2
 
-import java.util.concurrent.{ CountDownLatch, TimeUnit }
-import scala.collection.immutable
-import scala.concurrent.Await
-import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.http.CommonBenchmark
-import akka.http.scaladsl.client.RequestBuilding.Get
-import akka.http.scaladsl.model.HttpEntity.LastChunk
-import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpRequest, HttpResponse }
+import akka.http.impl.engine.http2.FrameEvent.HeadersFrame
+import akka.http.impl.engine.http2.framing.FrameRenderer
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.ActorMaterializer
+import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
-import scala.util.{ Failure, Success }
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
 
-class H2ServerProcessingBenchmark extends CommonBenchmark {
+class H2ServerSwitchBenchmark extends CommonBenchmark {
+  // Obtained by converting the input request bytes from curl with --http2-prior-knowledge
+  def request(streamId: Int) =
+    FrameRenderer.render(HeadersFrame(streamId, endStream = true, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None))
 
-  @Param(Array("closedelimited", "chunked"))
-  var responsetype: String = _
+  var response: HttpResponse = HPackSpecExamples.FirstResponse
 
-  var response: HttpResponse = _
-
-  var httpFlow: Flow[HttpRequest, HttpResponse, Any] = _
+  var httpFlow: Flow[ByteString, ByteString, Any] = _
   implicit var system: ActorSystem = _
   implicit var mat: ActorMaterializer = _
+
+  val packedResponse = ByteString(-62, -63, -64, -65, -66)
 
   val numRequests = 10000
 
   @Benchmark
   @OperationsPerInvocation(10000) // should be same as numRequest
   def benchRequestProcessing(): Unit = {
-    implicit val ec = system.dispatcher
-
     val latch = new CountDownLatch(numRequests)
 
     val requests =
-      Source.repeat(Get("/")).take(numRequests)
+      Source(Http2Protocol.ClientConnectionPreface +: Range(0, numRequests).map(i => request(1 + 2 * i)))
         .concatMat(Source.maybe)(Keep.right)
 
     val (in, done) =
       requests
         .viaMat(httpFlow)(Keep.left)
         .toMat(Sink.foreach(res => {
-          res.entity.dataBytes.runWith(Sink.ignore).onComplete {
-            case Success(_) => latch.countDown()
-            case Failure(e) => throw e
+          // Skip headers/settings frames etc
+          if (res.containsSlice(HPackSpecExamples.C61FirstResponseWithHuffman)
+            || res.containsSlice(packedResponse)) {
+            latch.countDown()
           }
         }))(Keep.both)
         .run()
@@ -64,12 +65,6 @@ class H2ServerProcessingBenchmark extends CommonBenchmark {
 
   @Setup
   def setup(): Unit = {
-    response = responsetype match {
-      case "closedelimited" => HPackSpecExamples.FirstResponse
-      case "chunked" => HPackSpecExamples.FirstResponse.withEntity(
-        HttpEntity.Chunked(ContentTypes.NoContentType, Source.single(LastChunk(trailer = immutable.Seq(RawHeader("grpc-status", "9")))))
-      )
-    }
     val config =
       ConfigFactory.parseString(
         s"""
@@ -81,10 +76,18 @@ class H2ServerProcessingBenchmark extends CommonBenchmark {
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
     mat = ActorMaterializer()
+    val settings = implicitly[ServerSettings]
+    val log = system.log
     implicit val ec = system.dispatcher
-    httpFlow = Http2Blueprint.handleWithStreamIdHeader(1)(req => {
-      req.discardEntityBytes().future.map(_ => response)
-    })(system.dispatcher)
+    val http1 = Flow[SslTlsInbound].mapAsync(1)(_ => {
+      Future.failed[SslTlsOutbound](new IllegalStateException("Failed h2 detection"))
+    })
+    val http2 =
+      Http2Blueprint.handleWithStreamIdHeader(1)(req => {
+        req.discardEntityBytes().future.map(_ => response)
+      })(system.dispatcher)
+        .join(Http2Blueprint.serverStackTls(settings, log, NoOpTelemetry))
+    httpFlow = Http2.priorKnowledge(http1, http2)
   }
 
   @TearDown

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerSwitchBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerSwitchBenchmark.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+
+import akka.actor.ActorSystem
+import akka.http.CommonBenchmark
+import akka.http.impl.engine.http2.FrameEvent.HeadersFrame
+import akka.http.impl.engine.http2.framing.FrameRenderer
+import akka.http.scaladsl.model.{ HttpResponse }
+import akka.http.scaladsl.settings.ServerSettings
+import akka.stream.ActorMaterializer
+import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.util.ByteString
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+class H2ServerSwitchBenchmark extends CommonBenchmark {
+  // Obtained by converting the input request bytes from curl with --http2-prior-knowledge
+  def request(streamId: Int) =
+    FrameRenderer.render(HeadersFrame(streamId, endStream = true, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None))
+
+  var response: HttpResponse = HPackSpecExamples.FirstResponse
+
+  var httpFlow: Flow[ByteString, ByteString, Any] = _
+  implicit var system: ActorSystem = _
+  implicit var mat: ActorMaterializer = _
+
+  val packedResponse = ByteString(-62, -63, -64, -65, -66)
+
+  val numRequests = 10000
+
+  @Benchmark
+  @OperationsPerInvocation(10000) // should be same as numRequest
+  def benchRequestProcessing(): Unit = {
+    val latch = new CountDownLatch(numRequests)
+
+    val requests =
+      Source(Http2Protocol.ClientConnectionPreface +: Range(0, numRequests).map(i => request(1 + 2 * i)))
+        .concatMat(Source.maybe)(Keep.right)
+
+    val (in, done) =
+      requests
+        .viaMat(httpFlow)(Keep.left)
+        .toMat(Sink.foreach(res => {
+          // Skip headers/settings frames etc
+          if (res.containsSlice(HPackSpecExamples.C61FirstResponseWithHuffman)
+            || res.containsSlice(packedResponse)) {
+            latch.countDown()
+          }
+        }))(Keep.both)
+        .run()
+
+    require(latch.await(10, TimeUnit.SECONDS), "Not all responses were received in time")
+
+    in.success(None)
+    Await.result(done, 10.seconds)
+  }
+
+  @Setup
+  def setup(): Unit = {
+    val config =
+      ConfigFactory.parseString(
+        s"""
+           #akka.loglevel = debug
+           akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
+           #akka.http.server.log-unencrypted-network-bytes = 100
+           akka.http.server.http2.max-concurrent-streams = $numRequests # needs to be >= `numRequests`
+         """)
+        .withFallback(ConfigFactory.load())
+    system = ActorSystem("AkkaHttpBenchmarkSystem", config)
+    mat = ActorMaterializer()
+    val settings = implicitly[ServerSettings]
+    val log = system.log
+    implicit val ec = system.dispatcher
+    val http1 = Flow[SslTlsInbound].mapAsync(1)(_ => {
+      Future.failed[SslTlsOutbound](new IllegalStateException("Failed h2 detection"))
+    })
+    val http2 =
+      Http2Blueprint.handleWithStreamIdHeader(1)(req => {
+        req.discardEntityBytes().future.map(_ => response)
+      })(system.dispatcher)
+        .join(Http2Blueprint.serverStackTls(settings, log, NoOpTelemetry))
+    httpFlow = Http2.priorKnowledge(http1, http2)
+  }
+
+  @TearDown
+  def tearDown(): Unit = {
+    system.terminate()
+  }
+}

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/AttributeKeys.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/AttributeKeys.java
@@ -13,4 +13,6 @@ public final class AttributeKeys {
             (AttributeKey<WebSocketUpgrade>)(Object)akka.http.scaladsl.model.AttributeKeys.webSocketUpgrade();
     public static final AttributeKey<SslSessionInfo> sslSession =
             (AttributeKey<SslSessionInfo>)(Object)akka.http.scaladsl.model.AttributeKeys.sslSession();
+    public static final AttributeKey<Trailer> trailer =
+            (AttributeKey<Trailer>)(Object)akka.http.scaladsl.model.AttributeKeys.trailer();
 }

--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/http2-strict-trailing-headers.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/http2-strict-trailing-headers.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[Problem]("akka.http.impl.engine.http2.*")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -33,7 +33,7 @@ private[http2] case class Http2SubStream(
   initialHeaders: ParsedHeadersFrame,
   // outgoing response trailing headers can either be passed in eagerly via an attribute
   // or streaming as the LastChunk of a chunked data stream
-  trailingHeaders:       Option[ParsedHeadersFrame],
+  trailingHeaders:       OptionVal[ParsedHeadersFrame],
   data:                  Source[Any /* ByteString | HttpEntity.ChunkStreamPart */ , Any],
   correlationAttributes: Map[AttributeKey[_], _]
 ) {
@@ -70,7 +70,7 @@ private[http2] case class Http2SubStream(
 }
 @InternalApi
 private[http2] object Http2SubStream {
-  def apply(entity: HttpEntity, headers: ParsedHeadersFrame, trailingHeaders: Option[ParsedHeadersFrame], correlationAttributes: Map[AttributeKey[_], _] = Map.empty): Http2SubStream = {
+  def apply(entity: HttpEntity, headers: ParsedHeadersFrame, trailingHeaders: OptionVal[ParsedHeadersFrame], correlationAttributes: Map[AttributeKey[_], _] = Map.empty): Http2SubStream = {
     val data =
       entity match {
         case HttpEntity.Chunked(_, chunks) => chunks

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -363,7 +363,7 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
       //        with the other side.
       val bufferedSubStreamOutput = new BufferedOutlet[Http2SubStream](substreamOut)
       override def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Source[Any, Any], correlationAttributes: Map[AttributeKey[_], _]): Unit =
-        bufferedSubStreamOutput.push(Http2SubStream(initialHeaders, data, correlationAttributes))
+        bufferedSubStreamOutput.push(Http2SubStream(initialHeaders, None, data, correlationAttributes))
 
       setHandler(substreamIn, new InHandler {
         def onPush(): Unit = {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -26,7 +26,7 @@ import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.InHandler
 import akka.stream.stage.StageLogging
 import akka.stream.stage.TimerGraphStageLogic
-import akka.util.ByteString
+import akka.util.{ ByteString, OptionVal }
 import com.github.ghik.silencer.silent
 
 import scala.collection.immutable
@@ -363,7 +363,7 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
       //        with the other side.
       val bufferedSubStreamOutput = new BufferedOutlet[Http2SubStream](substreamOut)
       override def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Source[Any, Any], correlationAttributes: Map[AttributeKey[_], _]): Unit =
-        bufferedSubStreamOutput.push(Http2SubStream(initialHeaders, None, data, correlationAttributes))
+        bufferedSubStreamOutput.push(Http2SubStream(initialHeaders, OptionVal.None, data, correlationAttributes))
 
       setHandler(substreamIn, new InHandler {
         def onPush(): Unit = {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -13,7 +13,7 @@ import akka.http.scaladsl.settings.Http2CommonSettings
 import akka.macros.LogHelper
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.stage.{ GraphStageLogic, InHandler, OutHandler }
-import akka.util.{ ByteString, OptionVal }
+import akka.util.ByteString
 
 import scala.collection.immutable
 import scala.util.control.NoStackTrace

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -686,7 +686,8 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
         case newData: ByteString          => buffer ++= newData
         case HttpEntity.Chunk(newData, _) => buffer ++= newData
         case HttpEntity.LastChunk(_, headers) =>
-          // TODO we should probably consider it 'invalid' when we see both 'eager' trailing headers and a LastChunk. Should we fail/log in that case?
+          if (headers.nonEmpty && trailer.nonEmpty)
+            log.warning("Found both an attribute with trailing headers, and headers in the `LastChunk`. This is not supported.")
           trailer = Some(ParsedHeadersFrame(streamId, endStream = true, HttpMessageRendering.renderHeaders(headers, log, isServer), None))
       }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
@@ -78,8 +78,8 @@ private[http2] sealed abstract class MessageRendering[R <: HttpMessage] extends 
     val streamId = nextStreamId(r)
     val headersFrame = ParsedHeadersFrame(streamId, endStream = r.entity.isKnownEmpty, headerPairs.result(), None)
     val trailingHeadersFrame: Option[ParsedHeadersFrame] =
-      r.attribute(AttributeKeys.trailingHeaders) match {
-        case Some(headers) => Some(ParsedHeadersFrame(streamId, true, headers.map(header => (header.name, header.value)), None))
+      r.attribute(AttributeKeys.trailer) match {
+        case Some(trailer) => Some(ParsedHeadersFrame(streamId, true, trailer.headers.map(header => (header.name, header.value)), None))
         case None          => None
       }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
@@ -5,7 +5,6 @@
 package akka.http.impl.engine.http2
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import akka.annotation.InternalApi
 import akka.event.LoggingAdapter
 import akka.http.impl.engine.http2.FrameEvent.ParsedHeadersFrame
@@ -14,6 +13,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.Date
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.settings.ServerSettings
+import akka.util.OptionVal
 
 import scala.collection.immutable
 import scala.collection.immutable.VectorBuilder
@@ -77,10 +77,10 @@ private[http2] sealed abstract class MessageRendering[R <: HttpMessage] extends 
 
     val streamId = nextStreamId(r)
     val headersFrame = ParsedHeadersFrame(streamId, endStream = r.entity.isKnownEmpty, headerPairs.result(), None)
-    val trailingHeadersFrame: Option[ParsedHeadersFrame] =
+    val trailingHeadersFrame =
       r.attribute(AttributeKeys.trailer) match {
-        case Some(trailer) => Some(ParsedHeadersFrame(streamId, true, trailer.headers, None))
-        case None          => None
+        case Some(trailer) => OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, trailer.headers, None))
+        case None          => OptionVal.None
       }
 
     Http2SubStream(r.entity, headersFrame, trailingHeadersFrame, r.attributes.filter(_._2.isInstanceOf[RequestResponseAssociation]))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
@@ -79,7 +79,7 @@ private[http2] sealed abstract class MessageRendering[R <: HttpMessage] extends 
     val headersFrame = ParsedHeadersFrame(streamId, endStream = r.entity.isKnownEmpty, headerPairs.result(), None)
     val trailingHeadersFrame: Option[ParsedHeadersFrame] =
       r.attribute(AttributeKeys.trailer) match {
-        case Some(trailer) => Some(ParsedHeadersFrame(streamId, true, trailer.headers.map(header => (header.name, header.value)), None))
+        case Some(trailer) => Some(ParsedHeadersFrame(streamId, true, trailer.headers, None))
         case None          => None
       }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -17,7 +17,6 @@ import akka.util.ByteString
 import akka.util.OptionVal
 import com.github.ghik.silencer.silent
 
-import java.net.InetSocketAddress
 import scala.annotation.tailrec
 import scala.collection.immutable.VectorBuilder
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/Trailer.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/Trailer.scala
@@ -10,8 +10,6 @@ import scala.collection.immutable
 
 /** Trailing headers for HTTP/2 responses */
 trait Trailer {
-  def getHeaders(): Iterable[HttpHeader]
-
   /**
    * Returns a copy of this trailer with the given header added to the list of headers.
    */

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/Trailer.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/Trailer.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.javadsl.model
 
 import akka.http.scaladsl.{ model => sm }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/Trailer.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/Trailer.scala
@@ -1,0 +1,28 @@
+package akka.http.javadsl.model
+
+import akka.http.scaladsl.{ model => sm }
+
+import scala.collection.immutable
+
+/** Trailing headers for HTTP/2 responses */
+trait Trailer {
+  def getHeaders(): Iterable[HttpHeader]
+
+  /**
+   * Returns a copy of this trailer with the given header added to the list of headers.
+   */
+  def addHeader(header: HttpHeader): Trailer
+
+  /**
+   * Returns a copy of this trailer with the given headers added to the list of headers.
+   */
+  def addHeaders(headers: Iterable[HttpHeader]): Trailer
+
+  /**
+   * Returns a copy of this trailer with new headers.
+   */
+  def withHeaders(headers: Iterable[HttpHeader]): Trailer
+}
+object Trailer {
+  def create(): Trailer = new sm.Trailer(immutable.Seq.empty)
+}

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKeys.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKeys.scala
@@ -5,13 +5,11 @@
 package akka.http.scaladsl.model
 
 import akka.http.scaladsl.model.ws.WebSocketUpgrade
-import scala.collection.immutable
 
 object AttributeKeys {
   val remoteAddress = AttributeKey[RemoteAddress]("remote-address")
   val webSocketUpgrade = AttributeKey[WebSocketUpgrade](name = "upgrade-to-websocket")
   val sslSession = AttributeKey[SslSessionInfo](name = "ssl-session")
-  // Trailing headers for HTTP/2 responses
-  val trailingHeaders = AttributeKey[immutable.Seq[HttpHeader]](name = "trailing-headers")
+  val trailer = AttributeKey[Trailer](name = "trailer")
 }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKeys.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/AttributeKeys.scala
@@ -5,10 +5,13 @@
 package akka.http.scaladsl.model
 
 import akka.http.scaladsl.model.ws.WebSocketUpgrade
+import scala.collection.immutable
 
 object AttributeKeys {
   val remoteAddress = AttributeKey[RemoteAddress]("remote-address")
   val webSocketUpgrade = AttributeKey[WebSocketUpgrade](name = "upgrade-to-websocket")
   val sslSession = AttributeKey[SslSessionInfo](name = "ssl-session")
+  // Trailing headers for HTTP/2 responses
+  val trailingHeaders = AttributeKey[immutable.Seq[HttpHeader]](name = "trailing-headers")
 }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Trailer.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Trailer.scala
@@ -26,11 +26,11 @@ class Trailer(@ApiMayChange val headers: immutable.Seq[(String, String)]) extend
   /**
    * Java API
    */
-  override def withHeaders(headers: Iterable[jm.HttpHeader]): Trailer = Trailer(Seq.empty).addHeaders(headers)
+  override def withHeaders(headers: Iterable[jm.HttpHeader]): Trailer = Trailer(immutable.Seq.empty).addHeaders(headers)
 }
 object Trailer {
-  def apply(): Trailer = new Trailer(Seq.empty)
+  def apply(): Trailer = new Trailer(immutable.Seq.empty)
   def apply(header: HttpHeader): Trailer =
     new Trailer(immutable.Seq(header).map(h => (h.name, h.value)))
-  def apply(headers: immutable.Seq[HttpHeader]) = new Trailer(Seq.empty).addHeaders(headers)
+  def apply(headers: immutable.Seq[HttpHeader]) = new Trailer(immutable.Seq.empty).addHeaders(headers)
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Trailer.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Trailer.scala
@@ -1,0 +1,30 @@
+package akka.http.scaladsl.model
+
+import akka.http.javadsl.{ model => jm }
+
+import scala.collection.immutable
+
+case class Trailer(headers: immutable.Seq[HttpHeader]) extends jm.Trailer {
+  /**
+   * Java API
+   */
+  override def getHeaders(): Iterable[HttpHeader] = headers
+
+  /**
+   * Java API
+   */
+  override def addHeader(header: jm.HttpHeader): Trailer = new Trailer(header.asInstanceOf[HttpHeader] +: headers)
+
+  /**
+   * Java API
+   */
+  override def addHeaders(headers: Iterable[jm.HttpHeader]): Trailer = ???
+
+  /**
+   * Java API
+   */
+  override def withHeaders(headers: Iterable[jm.HttpHeader]): Trailer = ???
+}
+object Trailer {
+  def apply(header: HttpHeader): Trailer = Trailer(immutable.Seq(header))
+}

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Trailer.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Trailer.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.scaladsl.model
 
 import akka.http.javadsl.{ model => jm }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Trailer.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Trailer.scala
@@ -4,31 +4,33 @@
 
 package akka.http.scaladsl.model
 
+import akka.annotation.ApiMayChange
 import akka.http.javadsl.{ model => jm }
 
 import scala.collection.immutable
 
-case class Trailer(headers: immutable.Seq[HttpHeader]) extends jm.Trailer {
+class Trailer(@ApiMayChange val headers: immutable.Seq[(String, String)]) extends jm.Trailer {
   /**
    * Java API
    */
-  override def getHeaders(): Iterable[HttpHeader] = headers
+  override def addHeader(header: jm.HttpHeader): Trailer = {
+    val sheader = header.asInstanceOf[HttpHeader]
+    new Trailer((sheader.name, sheader.value) +: headers)
+  }
 
   /**
    * Java API
    */
-  override def addHeader(header: jm.HttpHeader): Trailer = new Trailer(header.asInstanceOf[HttpHeader] +: headers)
+  override def addHeaders(headers: Iterable[jm.HttpHeader]): Trailer = headers.foldLeft(this)((acc, h) => acc.addHeader(h))
 
   /**
    * Java API
    */
-  override def addHeaders(headers: Iterable[jm.HttpHeader]): Trailer = ???
-
-  /**
-   * Java API
-   */
-  override def withHeaders(headers: Iterable[jm.HttpHeader]): Trailer = ???
+  override def withHeaders(headers: Iterable[jm.HttpHeader]): Trailer = Trailer(Seq.empty).addHeaders(headers)
 }
 object Trailer {
-  def apply(header: HttpHeader): Trailer = Trailer(immutable.Seq(header))
+  def apply(): Trailer = new Trailer(Seq.empty)
+  def apply(header: HttpHeader): Trailer =
+    new Trailer(immutable.Seq(header).map(h => (h.name, h.value)))
+  def apply(headers: immutable.Seq[HttpHeader]) = new Trailer(Seq.empty).addHeaders(headers)
 }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -18,7 +18,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.HttpEntity.{ Chunk, ChunkStreamPart, Chunked, LastChunk }
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model.headers.CacheDirectives._
-import akka.http.scaladsl.model.headers.{ RawHeader, `Access-Control-Allow-Origin`, `Cache-Control`, `Content-Length`, `Content-Type`, `User-Agent` }
+import akka.http.scaladsl.model.headers.{ RawHeader, `Access-Control-Allow-Origin`, `Cache-Control`, `Content-Length`, `Content-Type` }
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.stream.Attributes
 import akka.stream.Attributes.LogLevels

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
@@ -55,7 +55,11 @@ trait Http2FrameHpackSupport extends Http2FrameProbeDelegator with Http2FrameSen
     encodeHeaderPairs(headerPairsForHeaders(headers))
 
   def headersForRequest(request: HttpRequest): Seq[HttpHeader] =
-    headerPairsForRequest(request).map[HttpHeader]({ case (k, v) => RawHeader(k, v) })
+    headerPairsForRequest(request).map {
+      case (name, value) =>
+        val header: HttpHeader = RawHeader(name, value)
+        header
+    }
 
   def headersForResponse(response: HttpResponse): Seq[HttpHeader] =
     Seq(

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
@@ -54,6 +54,9 @@ trait Http2FrameHpackSupport extends Http2FrameProbeDelegator with Http2FrameSen
   def encodeHeaders(headers: Seq[HttpHeader]): ByteString =
     encodeHeaderPairs(headerPairsForHeaders(headers))
 
+  def headersForRequest(request: HttpRequest): Seq[HttpHeader] =
+    headerPairsForRequest(request).map[HttpHeader]({ case (k, v) => RawHeader(k, v) })
+
   def headersForResponse(response: HttpResponse): Seq[HttpHeader] =
     Seq(
       RawHeader(":status", response.status.intValue.toString),

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -250,7 +250,8 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         network.expectHeaderBlock(streamId, endStream = false)
         network.expectDATA(streamId, endStream = false, ByteString("Hello"))
         val trailingResponseHeaders = network.expectDecodedResponseHEADERSPairs(streamId)
-        println(trailingResponseHeaders)
+        trailingResponseHeaders.size should be(1)
+        trailingResponseHeaders.head should be(("Status", "grpc-status 10"))
       }
 
       "acknowledge change to SETTINGS_HEADER_TABLE_SIZE in next HEADER frame" inAssertAllStagesStopped new TestSetup with RequestResponseProbes {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -5,7 +5,6 @@
 package akka.http.impl.engine.http2
 
 import java.net.InetSocketAddress
-
 import akka.NotUsed
 import akka.event.Logging
 import akka.http.impl.engine.http2.FrameEvent._
@@ -17,6 +16,7 @@ import akka.http.impl.engine.server.HttpAttributes
 import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.http.impl.util.AkkaSpecWithMaterializer
 import akka.http.impl.util.LogByteStringTools
+import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.CacheDirectives
 import akka.http.scaladsl.model.headers.RawHeader
@@ -36,6 +36,7 @@ import akka.stream.testkit.TestSubscriber
 import akka.testkit._
 import akka.util.ByteString
 import com.github.ghik.silencer.silent
+
 import javax.net.ssl.SSLContext
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -235,6 +236,21 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
           protocol = HttpProtocols.`HTTP/2.0`))
         network.sendHEADERS(streamId, endStream = true, endHeaders = true, requestHeaderBlock)
         user.expectRequest().headers shouldBe expectedRequest.headers
+      }
+
+      "allow trailing headers on strict responses" inAssertAllStagesStopped new TestSetup with RequestResponseProbes {
+        val streamId = 1
+        network.sendHEADERS(streamId, endStream = true, network.headersForRequest(Get("/")))
+        user.expectRequest()
+        val response =
+          HttpResponse(StatusCodes.OK, entity = HttpEntity.Strict(ContentTypes.`application/octet-stream`, ByteString("Hello")))
+            .addAttribute(AttributeKeys.trailingHeaders, immutable.Seq[HttpHeader](RawHeader("Status", "grpc-status 10")))
+        user.emitResponse(streamId, response)
+
+        network.expectHeaderBlock(streamId, endStream = false)
+        network.expectDATA(streamId, endStream = false, ByteString("Hello"))
+        val trailingResponseHeaders = network.expectDecodedResponseHEADERSPairs(streamId)
+        println(trailingResponseHeaders)
       }
 
       "acknowledge change to SETTINGS_HEADER_TABLE_SIZE in next HEADER frame" inAssertAllStagesStopped new TestSetup with RequestResponseProbes {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -244,7 +244,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         user.expectRequest()
         val response =
           HttpResponse(StatusCodes.OK, entity = HttpEntity.Strict(ContentTypes.`application/octet-stream`, ByteString("Hello")))
-            .addAttribute(AttributeKeys.trailer, Trailer(immutable.Seq[HttpHeader](RawHeader("Status", "grpc-status 10"))))
+            .addAttribute(AttributeKeys.trailer, Trailer(RawHeader("Status", "grpc-status 10")))
         user.emitResponse(streamId, response)
 
         network.expectHeaderBlock(streamId, endStream = false)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -244,7 +244,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         user.expectRequest()
         val response =
           HttpResponse(StatusCodes.OK, entity = HttpEntity.Strict(ContentTypes.`application/octet-stream`, ByteString("Hello")))
-            .addAttribute(AttributeKeys.trailingHeaders, immutable.Seq[HttpHeader](RawHeader("Status", "grpc-status 10")))
+            .addAttribute(AttributeKeys.trailer, Trailer(immutable.Seq[HttpHeader](RawHeader("Status", "grpc-status 10"))))
         user.emitResponse(streamId, response)
 
         network.expectHeaderBlock(streamId, endStream = false)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -11,7 +11,7 @@ import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.Attributes
 import akka.stream.scaladsl.Source
 import akka.testkit.AkkaSpec
-import akka.util.ByteString
+import akka.util.{ ByteString, OptionVal }
 import org.scalatest.{ Inside, Inspectors }
 import FrameEvent._
 import akka.http.impl.engine.server.HttpAttributes
@@ -39,7 +39,7 @@ class RequestParsingSpec extends AkkaSpec() with Inside with Inspectors {
           keyValuePairs = keyValuePairs,
           priorityInfo = None
         ),
-        trailingHeaders = None,
+        trailingHeaders = OptionVal.None,
         data = data,
         correlationAttributes = Map.empty
       )

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -39,6 +39,7 @@ class RequestParsingSpec extends AkkaSpec() with Inside with Inspectors {
           keyValuePairs = keyValuePairs,
           priorityInfo = None
         ),
+        trailingHeaders = None,
         data = data,
         correlationAttributes = Map.empty
       )

--- a/docs/src/main/paradox/server-side/http2.md
+++ b/docs/src/main/paradox/server-side/http2.md
@@ -75,6 +75,23 @@ For the reason this approach is known as h2c with
 [Prior Knowledge](https://httpwg.org/specs/rfc7540.html#known-http) of HTTP/2
 support.
 
+## Trailing headers
+
+Like in the [HTTP/1.1 'Chunked' transfer encoding](https://datatracker.ietf.org/doc/html/rfc7230#section-4.1.2),
+HTTP/2 supports a [trailer part](https://httpwg.org/specs/rfc7540.html#rfc.section.8.1) containing headers
+after the body. Akka HTTP currently doesn't expose the trailing headers of the request. For the response, you
+can either model the trailing headers as the @scala[@scaladoc[HttpEntity.LastChunk](akka.http.scaladsl.model.HttpEntity.LastChunk)]@java[last chunk]
+of a @scala[@scaladoc[HttpEntity.Chunked](akka.http.scaladsl.model.HttpEntity.Chunked)]@java[chunked] response entity, or use the
+@apidoc[trailer](AttributeKeys$) attribute:
+
+Scala
+:   @@snip[Http2Spec.scala](/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala) { #trailingHeaders }
+
+Java
+:   @@snip[Http2Test.java](/docs/src/test/java/docs/http/javadsl/Http2Test.java) { #trailingHeaders }
+
+Having both a `trailingHeaders` attribute and a `LastChunk` element is not supported.
+
 ## Testing with cURL
 
 At this point you should be able to connect, but HTTP/2 may still not be available.

--- a/docs/src/test/java/docs/http/javadsl/Http2Test.java
+++ b/docs/src/test/java/docs/http/javadsl/Http2Test.java
@@ -9,6 +9,12 @@ import java.util.concurrent.CompletionStage;
 
 import akka.actor.ActorSystem;
 import akka.http.javadsl.HttpsConnectionContext;
+//#trailingHeaders
+import akka.http.javadsl.model.Trailer;
+import akka.http.javadsl.model.headers.RawHeader;
+import static akka.http.javadsl.model.AttributeKeys.trailer;
+
+//#trailingHeaders
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.japi.function.Function;
@@ -60,6 +66,10 @@ class Http2Test {
             .http2WithPriorKnowledge();
     //#http2ClientWithPriorKnowledge
 
-
+    //#trailingHeaders
+    HttpResponse.create()
+            .withStatus(200)
+            .addAttribute(trailer, Trailer.create().addHeader(RawHeader.create("name", "value")));
+    //#trailingHeaders
   }
 }

--- a/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2Spec.scala
@@ -61,4 +61,18 @@ object Http2Spec {
     Http().connectionTo("localhost").toPort(8080).http2WithPriorKnowledge()
     //#http2ClientWithPriorKnowledge
   }
+
+  {
+    //#trailingHeaders
+    import akka.http.scaladsl.model.ContentTypes
+    import akka.http.scaladsl.model.HttpEntity
+    import akka.http.scaladsl.model.Trailer
+    import akka.http.scaladsl.model.AttributeKeys.trailer
+    import akka.http.scaladsl.model.headers.RawHeader
+    import akka.util.ByteString
+
+    HttpResponse(StatusCodes.OK, entity = HttpEntity.Strict(ContentTypes.`text/plain(UTF-8)`, ByteString("Tralala")))
+      .addAttribute(trailer, Trailer(RawHeader("name", "value")))
+    //#trailingHeaders
+  }
 }


### PR DESCRIPTION
Through an attribute.

First step of the first bullet in #3815.

Still to do:
* [x] benchmark
* [x] Java API
* [x] documentation

It looks like there's more opportunity for optimization of strict HTTP/2 responses, but perhaps that should be a separate PR.