### PR TITLE
http2: support Strict entities in Http2SubStream

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
@@ -4,16 +4,13 @@
 
 package akka.http.impl.engine.http2
 
-import java.util.concurrent.{ CountDownLatch, TimeUnit }
-
-import scala.concurrent.Await
-import scala.concurrent.Future
-import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.http.CommonBenchmark
-import akka.http.impl.engine.http2.FrameEvent.HeadersFrame
+import akka.http.impl.engine.http2.FrameEvent.{ DataFrame, HeadersFrame }
 import akka.http.impl.engine.http2.framing.FrameRenderer
-import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.HttpEntity.{ Chunk, LastChunk }
+import akka.http.scaladsl.model.{ AttributeKeys, ContentTypes, HttpEntity, HttpResponse, Trailer }
+import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.ActorMaterializer
 import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
@@ -22,24 +19,36 @@ import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
-/**
- * Emulates request bytes coming in, selecting HTTP/2 over HTTP/1, sending a static response back,
- * validating the response bytes come out again.
- */
-class H2ServerProcessingBenchmark extends CommonBenchmark {
-  // Obtained by converting the input request bytes from curl with --http2-prior-knowledge
-  def request(streamId: Int) =
-    FrameRenderer.render(HeadersFrame(streamId, endStream = true, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None))
+import java.util.concurrent.{ CountDownLatch, TimeUnit }
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
 
-  val response: HttpResponse = HPackSpecExamples.FirstResponse
+class H2ServerProcessingBenchmark extends CommonBenchmark {
+  @Param(Array("empty", "singleframe"))
+  var requestbody: String = _
+
+  @Param(Array("strict", "closedelimited", "chunked"))
+  var responsetype: String = _
+
+  var response: HttpResponse = _
 
   var httpFlow: Flow[ByteString, ByteString, Any] = _
   implicit var system: ActorSystem = _
   implicit var mat: ActorMaterializer = _
 
-  val packedResponse = ByteString(-62, -63, -64, -65, -66)
+  val packedResponse = ByteString(1, 5, 0, 0) // a HEADERS frame with end_stream == true
 
   val numRequests = 10000
+
+  val requestBytes = ByteString("abcde")
+
+  def requestWithoutBody(streamId: Int): ByteString =
+    FrameRenderer.render(HeadersFrame(streamId, endStream = true, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None))
+  def requestWithSingleFrameBody(streamId: Int): ByteString =
+    FrameRenderer.render(HeadersFrame(streamId, endStream = false, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None)) ++
+      FrameRenderer.render(DataFrame(streamId, endStream = true, requestBytes))
+
+  var requestDataCreator: Int => ByteString = _
 
   @Benchmark
   @OperationsPerInvocation(10000) // should be same as numRequest
@@ -47,7 +56,7 @@ class H2ServerProcessingBenchmark extends CommonBenchmark {
     val latch = new CountDownLatch(numRequests)
 
     val requests =
-      Source(Http2Protocol.ClientConnectionPreface +: Range(0, numRequests).map(i => request(1 + 2 * i)))
+      Source(Http2Protocol.ClientConnectionPreface +: Range(0, numRequests).map(i => requestDataCreator(1 + 2 * i)))
         .concatMat(Source.maybe)(Keep.right)
 
     val (in, done) =
@@ -70,13 +79,37 @@ class H2ServerProcessingBenchmark extends CommonBenchmark {
 
   @Setup
   def setup(): Unit = {
+    requestDataCreator = requestbody match {
+      case "empty"       => requestWithoutBody _
+      case "singleframe" => requestWithSingleFrameBody _
+    }
+
+    val trailerHeader = RawHeader("grpc-status", "9")
+    val responseBody = ByteString("hello")
+    response = responsetype match {
+      case "empty" =>
+        HPackSpecExamples.FirstResponse
+          .withEntity(HttpEntity.Empty)
+          .addAttribute(AttributeKeys.trailer, Trailer(trailerHeader :: Nil))
+      case "closedelimited" =>
+        HPackSpecExamples.FirstResponse
+          .withEntity(HttpEntity.CloseDelimited(ContentTypes.`text/plain(UTF-8)`, Source.single(responseBody)))
+          .addAttribute(AttributeKeys.trailer, Trailer(trailerHeader :: Nil))
+      case "chunked" =>
+        HPackSpecExamples.FirstResponse
+          .withEntity(HttpEntity.Chunked(ContentTypes.`text/plain(UTF-8)`, Source(Chunk(responseBody) :: LastChunk(trailer = trailerHeader :: Nil) :: Nil)))
+      case "strict" =>
+        HPackSpecExamples.FirstResponse
+          .withEntity(HttpEntity.Strict(ContentTypes.`text/plain(UTF-8)`, responseBody))
+          .addAttribute(AttributeKeys.trailer, Trailer(trailerHeader :: Nil))
+    }
     val config =
       ConfigFactory.parseString(
         s"""
-           #akka.loglevel = debug
            akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
-           #akka.http.server.log-unencrypted-network-bytes = 100
            akka.http.server.http2.max-concurrent-streams = $numRequests # needs to be >= `numRequests`
+           #akka.loglevel = debug
+           #akka.http.server.log-unencrypted-network-bytes = 100
          """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2ServerDemux.scala
@@ -362,7 +362,7 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
       //        keep the buffer limited to the number of concurrent streams as negotiated
       //        with the other side.
       val bufferedSubStreamOutput = new BufferedOutlet[Http2SubStream](substreamOut)
-      override def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Source[Any, Any], correlationAttributes: Map[AttributeKey[_], _]): Unit =
+      override def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Either[ByteString, Source[Any, Any]], correlationAttributes: Map[AttributeKey[_], _]): Unit =
         bufferedSubStreamOutput.push(Http2SubStream(initialHeaders, OptionVal.None, data, correlationAttributes))
 
       setHandler(substreamIn, new InHandler {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -40,7 +40,7 @@ class RequestParsingSpec extends AkkaSpec() with Inside with Inspectors {
           priorityInfo = None
         ),
         trailingHeaders = OptionVal.None,
-        data = data,
+        data = Right(data),
         correlationAttributes = Map.empty
       )
       // Create the parsing function


### PR DESCRIPTION
This avoids materializing a stream for outgoing Strict entities.

Another ready result from #3822.