### PR TITLE
Remove the requirement of max-open-requests being a power of two

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -35,8 +35,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   require(minConnections >= 0, "min-connections must be >= 0")
   require(minConnections <= maxConnections, "min-connections must be <= max-connections")
   require(maxRetries >= 0, "max-retries must be >= 0")
-  require(maxOpenRequests > 0, "max-open-requests must be a power of 2 > 0.")
-  require((maxOpenRequests & (maxOpenRequests - 1)) == 0, "max-open-requests must be a power of 2. " + suggestPowerOfTwo(maxOpenRequests))
+  require(maxOpenRequests > 0, "max-open-requests must be > 0")
   require(pipeliningLimit > 0, "pipelining-limit must be > 0")
   require(maxConnectionLifetime > Duration.Zero, "max-connection-lifetime must be > 0")
   require(idleTimeout >= Duration.Zero, "idle-timeout must be >= 0")
@@ -50,15 +49,6 @@ private[akka] final case class ConnectionPoolSettingsImpl(
 
   def withUpdatedConnectionSettings(f: ClientConnectionSettings => ClientConnectionSettings): ConnectionPoolSettingsImpl =
     copy(connectionSettings = f(connectionSettings), hostOverrides = hostOverrides.map { case (k, v) => k -> v.withUpdatedConnectionSettings(f) })
-
-  private def suggestPowerOfTwo(around: Int): String = {
-    val firstBit = 31 - Integer.numberOfLeadingZeros(around)
-
-    val below = 1 << firstBit
-    val above = 1 << (firstBit + 1)
-
-    s"Perhaps try $below or $above."
-  }
 
   /** INTERNAL API */
   private[http] def copyDeep(

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -35,12 +35,9 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
     "allow max-open-requests = 1" in {
       config("akka.http.host-connection-pool.max-open-requests = 1").maxOpenRequests should be(1)
     }
-    "produce a nice error message when max-open-requests" in {
-      expectError("akka.http.host-connection-pool.max-open-requests = 10") should include("Perhaps try 8 or 16")
-      expectError("akka.http.host-connection-pool.max-open-requests = 100") should include("Perhaps try 64 or 128")
-      expectError("akka.http.host-connection-pool.max-open-requests = 1000") should include("Perhaps try 512 or 1024")
+    "allow max-open-requests = 42" in {
+      config("akka.http.host-connection-pool.max-open-requests = 42").maxOpenRequests should be(42)
     }
-
     "allow per host overrides" in {
 
       val settingsString =


### PR DESCRIPTION
There seems to be no practical reason for this limitation.