### PR TITLE
docs: display correct link to demo resource

### DIFF
--- a/docs/src/test/scala/docs/http/scaladsl/HttpServerRoutingMinimal.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/HttpServerRoutingMinimal.scala
@@ -28,7 +28,7 @@ object HttpServerRoutingMinimal {
 
     val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
 
-    println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
+    println(s"Server now online. Please navigate to http://localhost:8080/hello\nPress RETURN to stop...")
     StdIn.readLine() // let it run until user presses return
     bindingFuture
       .flatMap(_.unbind()) // trigger unbinding from the port


### PR DESCRIPTION
Clicking on the link in the output currently directs you to the root path of the server, displaying the message:

```
The requested resource could not be found.
```

This happens because the only path defined in the script is path("hello"), while we are directing the reader to path("").

As this is the first piece of code presented on the Akka-Http introduction page [1], it makes sense to make running the example as straightforward as possible. Showing the direct link in the terminal is the simplest way of doing that.

Alternatively, we could add a redirect in the routing, but I think that would end up too verbose:

```
    val route =
      concat(
        path("") {
          get {
            redirect("/hello", StatusCodes.TemporaryRedirect)
          }
        },
        path("hello") {
          get {
            complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, "<h1>Say hello to akka-http</h1>"))
          }
        }
      )
```

A third option is to simply change the route to `path("")`, but that would diminish the expressiveness of the example, as it would no longer clearly illustrate the routing functionality.

[1] https://doc.akka.io/docs/akka-http/current/introduction.html

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References #xxxx
