### PR TITLE
http2: add setting to automatically collect (request) entity data into strict entities

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
@@ -7,23 +7,16 @@ package akka.http.impl.engine.http2
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.CommonBenchmark
-import akka.http.impl.engine.http2.FrameEvent.HeadersFrame
-import akka.http.impl.engine.http2.framing.FrameRenderer
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.client.RequestBuilding.Get
-import akka.http.scaladsl.model.HttpEntity.LastChunk
-import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpRequest, HttpResponse }
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
 import akka.stream.ActorMaterializer
 import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
 import akka.stream.scaladsl.{ BidiFlow, Flow, Keep, Sink, Source }
 import akka.util.ByteString
-import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, ExecutionContext, Future }
 
@@ -31,15 +24,7 @@ import scala.concurrent.{ Await, ExecutionContext, Future }
  * Test converting a HttpRequest to bytes at the client and back to a request at the server, and vice-versa
  * for the response. Does not include the network.
  */
-class H2ClientServerBenchmark extends CommonBenchmark {
-  // Obtained by converting the input request bytes from curl with --http2-prior-knowledge
-  def request(streamId: Int) =
-    FrameRenderer.render(HeadersFrame(streamId, endStream = true, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None))
-
-  @Param(Array("closedelimited", "chunked"))
-  var responsetype: String = _
-
-  var response: HttpResponse = _
+class H2ClientServerBenchmark extends CommonBenchmark with H2RequestResponseBenchmark {
   var httpFlow: Flow[HttpRequest, HttpResponse, Any] = _
   implicit var system: ActorSystem = _
   implicit var mat: ActorMaterializer = _
@@ -54,7 +39,7 @@ class H2ClientServerBenchmark extends CommonBenchmark {
     val latch = new CountDownLatch(numRequests)
 
     val requests =
-      Source.repeat(Get("/")).take(numRequests)
+      Source.repeat(request).take(numRequests)
         .concatMat(Source.maybe)(Keep.right)
 
     val (in, done) =
@@ -73,21 +58,8 @@ class H2ClientServerBenchmark extends CommonBenchmark {
 
   @Setup
   def setup(): Unit = {
-    response = responsetype match {
-      case "closedelimited" => HPackSpecExamples.FirstResponse
-      case "chunked" => HPackSpecExamples.FirstResponse.withEntity(
-        HttpEntity.Chunked(ContentTypes.NoContentType, Source.single(LastChunk(trailer = immutable.Seq(RawHeader("grpc-status", "9")))))
-      )
-    }
-    val config =
-      ConfigFactory.parseString(
-        s"""
-           #akka.loglevel = debug
-           akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
-           #akka.http.server.log-unencrypted-network-bytes = 100
-           akka.http.server.http2.max-concurrent-streams = $numRequests # needs to be >= `numRequests`
-         """)
-        .withFallback(ConfigFactory.load())
+    initRequestResponse()
+
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
     mat = ActorMaterializer()
     val settings = implicitly[ServerSettings]

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2RequestResponseBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2RequestResponseBenchmark.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.http2
+
+import akka.http.impl.engine.http2.FrameEvent.{ DataFrame, HeadersFrame }
+import akka.http.impl.engine.http2.framing.FrameRenderer
+import akka.http.scaladsl.model.HttpEntity.{ Chunk, LastChunk }
+import akka.http.scaladsl.model.{ AttributeKeys, ContentTypes, HttpEntity, HttpMethods, HttpRequest, HttpResponse, Trailer }
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.typesafe.config.ConfigFactory
+import org.openjdk.jmh.annotations.Param
+
+trait H2RequestResponseBenchmark {
+  @Param(Array("1"))
+  var minStrictEntitySize: String = _
+
+  @Param(Array("empty", "singleframe"))
+  var requestbody: String = _
+
+  @Param(Array("strict", "closedelimited" /* Not enable by default:, "chunked", "empty"*/ ))
+  var responsetype: String = _
+
+  protected var response: HttpResponse = _
+
+  private val requestBytes = ByteString("abcde")
+  private def requestWithoutBody(streamId: Int): ByteString =
+    FrameRenderer.render(HeadersFrame(streamId, endStream = true, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None))
+  private def requestWithSingleFrameBody(streamId: Int): ByteString =
+    FrameRenderer.render(HeadersFrame(streamId, endStream = false, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None)) ++
+      FrameRenderer.render(DataFrame(streamId, endStream = true, requestBytes))
+
+  protected var requestDataCreator: Int => ByteString = _
+  protected var request: HttpRequest = _
+
+  def numRequests: Int
+  lazy val config =
+    ConfigFactory.parseString(
+      s"""
+           akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
+           akka.http.server.http2.max-concurrent-streams = $numRequests # needs to be >= `numRequests`
+           akka.http.server.http2.min-collect-strict-entity-size = $minStrictEntitySize
+           #akka.loglevel = debug
+           #akka.http.server.log-unencrypted-network-bytes = 100
+         """)
+      .withFallback(ConfigFactory.load())
+
+  def initRequestResponse(): Unit = {
+    requestbody match {
+      case "empty" =>
+        requestDataCreator = requestWithoutBody _
+        request = HttpRequest(method = HttpMethods.POST, uri = "/")
+      case "singleframe" =>
+        requestDataCreator = requestWithSingleFrameBody _
+        request = HttpRequest(method = HttpMethods.POST, uri = "/", entity = HttpEntity(requestBytes))
+    }
+
+    val trailerHeader = RawHeader("grpc-status", "9")
+    val responseBody = ByteString("hello")
+    response = responsetype match {
+      case "empty" =>
+        HPackSpecExamples.FirstResponse
+          .withEntity(HttpEntity.Empty)
+          .addAttribute(AttributeKeys.trailer, Trailer(trailerHeader :: Nil))
+      case "closedelimited" =>
+        HPackSpecExamples.FirstResponse
+          .withEntity(HttpEntity.CloseDelimited(ContentTypes.`text/plain(UTF-8)`, Source.single(responseBody)))
+          .addAttribute(AttributeKeys.trailer, Trailer(trailerHeader :: Nil))
+      case "chunked" =>
+        HPackSpecExamples.FirstResponse
+          .withEntity(HttpEntity.Chunked(ContentTypes.`text/plain(UTF-8)`, Source(Chunk(responseBody) :: LastChunk(trailer = trailerHeader :: Nil) :: Nil)))
+      case "strict" =>
+        HPackSpecExamples.FirstResponse
+          .withEntity(HttpEntity.Strict(ContentTypes.`text/plain(UTF-8)`, responseBody))
+          .addAttribute(AttributeKeys.trailer, Trailer(trailerHeader :: Nil))
+    }
+  }
+}

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
@@ -6,32 +6,19 @@ package akka.http.impl.engine.http2
 
 import akka.actor.ActorSystem
 import akka.http.CommonBenchmark
-import akka.http.impl.engine.http2.FrameEvent.{ DataFrame, HeadersFrame }
-import akka.http.impl.engine.http2.framing.FrameRenderer
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.HttpEntity.{ Chunk, LastChunk }
-import akka.http.scaladsl.model.{ AttributeKeys, ContentTypes, HttpEntity, HttpResponse, Trailer }
-import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.ActorMaterializer
 import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.util.ByteString
-import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations._
 
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
-import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
 
-class H2ServerProcessingBenchmark extends CommonBenchmark {
-  @Param(Array("empty", "singleframe"))
-  var requestbody: String = _
-
-  @Param(Array("strict", "closedelimited", "chunked"))
-  var responsetype: String = _
-
-  var response: HttpResponse = _
+class H2ServerProcessingBenchmark extends CommonBenchmark with H2RequestResponseBenchmark {
 
   var httpFlow: Flow[ByteString, ByteString, Any] = _
   implicit var system: ActorSystem = _
@@ -40,16 +27,6 @@ class H2ServerProcessingBenchmark extends CommonBenchmark {
   val packedResponse = ByteString(1, 5, 0, 0) // a HEADERS frame with end_stream == true
 
   val numRequests = 10000
-
-  val requestBytes = ByteString("abcde")
-
-  def requestWithoutBody(streamId: Int): ByteString =
-    FrameRenderer.render(HeadersFrame(streamId, endStream = true, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None))
-  def requestWithSingleFrameBody(streamId: Int): ByteString =
-    FrameRenderer.render(HeadersFrame(streamId, endStream = false, endHeaders = true, HPackSpecExamples.C41FirstRequestWithHuffman, None)) ++
-      FrameRenderer.render(DataFrame(streamId, endStream = true, requestBytes))
-
-  var requestDataCreator: Int => ByteString = _
 
   @Benchmark
   @OperationsPerInvocation(10000) // should be same as numRequest
@@ -80,39 +57,8 @@ class H2ServerProcessingBenchmark extends CommonBenchmark {
 
   @Setup
   def setup(): Unit = {
-    requestDataCreator = requestbody match {
-      case "empty"       => requestWithoutBody _
-      case "singleframe" => requestWithSingleFrameBody _
-    }
+    initRequestResponse()
 
-    val trailerHeader = RawHeader("grpc-status", "9")
-    val responseBody = ByteString("hello")
-    response = responsetype match {
-      case "empty" =>
-        HPackSpecExamples.FirstResponse
-          .withEntity(HttpEntity.Empty)
-          .addAttribute(AttributeKeys.trailer, Trailer(trailerHeader :: Nil))
-      case "closedelimited" =>
-        HPackSpecExamples.FirstResponse
-          .withEntity(HttpEntity.CloseDelimited(ContentTypes.`text/plain(UTF-8)`, Source.single(responseBody)))
-          .addAttribute(AttributeKeys.trailer, Trailer(trailerHeader :: Nil))
-      case "chunked" =>
-        HPackSpecExamples.FirstResponse
-          .withEntity(HttpEntity.Chunked(ContentTypes.`text/plain(UTF-8)`, Source(Chunk(responseBody) :: LastChunk(trailer = trailerHeader :: Nil) :: Nil)))
-      case "strict" =>
-        HPackSpecExamples.FirstResponse
-          .withEntity(HttpEntity.Strict(ContentTypes.`text/plain(UTF-8)`, responseBody))
-          .addAttribute(AttributeKeys.trailer, Trailer(trailerHeader :: Nil))
-    }
-    val config =
-      ConfigFactory.parseString(
-        s"""
-           akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
-           akka.http.server.http2.max-concurrent-streams = $numRequests # needs to be >= `numRequests`
-           #akka.loglevel = debug
-           #akka.http.server.log-unencrypted-network-bytes = 100
-         """)
-        .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
     mat = ActorMaterializer()
     val settings = implicitly[ServerSettings]

--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/http2-add-new-setting.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/http2-add-new-setting.excludes
@@ -1,0 +1,9 @@
+# add new settings to @DoNotInherit traits
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.Http2CommonSettings.minCollectStrictEntitySize")
+
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.Http2ServerSettings.minCollectStrictEntitySize")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.Http2ServerSettings.withMinCollectStrictEntitySize")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings.minCollectStrictEntitySize")
+ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("akka.http.scaladsl.settings.Http2ServerSettings.minCollectStrictEntitySize")
+
+ProblemFilters.exclude[Problem]("akka.http.scaladsl.settings.Http2ServerSettings#Http2ServerSettingsImpl*")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -260,6 +260,19 @@ akka.http {
       # be increased for high bandwidth-delay-product connections.
       incoming-stream-level-buffer-size = 512kB
 
+      # For incoming requests, the infrastructure collects at least the given number of bytes before dispatching a HttpRequest.
+      # If all request data is received before or when the threshold is reached, the entity data is dispatched as a strict entity
+      # which allows more efficient processing of the request data without involving streams.
+      #
+      # If the given value is 0, the request is immediately dispatched and always carries a stream of data.
+      # You can use value `1` to create a strict entity if the request contains at most a single data frame, and a streamed
+      # entity otherwise.
+      #
+      # Note, that if enabled, requests that expect data (endStream = false on HEADERS) but never received a DATA frame will never be
+      # dispatched. In a regular HTTP context, this is uncommon. It would require that a client would expect data from the server first
+      # before sending any own data.
+      min-collect-strict-entity-size = 0
+
       # The maximum number of outgoing control frames to buffer when the peer does not read from its TCP connection before
       # backpressuring incoming frames.
       #

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/Http2ServerSettings.scala
@@ -22,6 +22,9 @@ trait Http2ServerSettings { self: scaladsl.settings.Http2ServerSettings =>
   def getIncomingStreamLevelBufferSize: Int = incomingStreamLevelBufferSize
   def withIncomingStreamLevelBufferSize(newIncomingStreamLevelBufferSize: Int): Http2ServerSettings
 
+  def minCollectStrictEntitySize: Int
+  def withMinCollectStrictEntitySize(newValue: Int): Http2ServerSettings
+
   def getMaxConcurrentStreams: Int = maxConcurrentStreams
   def withMaxConcurrentStreams(newValue: Int): Http2ServerSettings
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
@@ -26,6 +26,8 @@ private[http] trait Http2CommonSettings {
   def incomingConnectionLevelBufferSize: Int
   def incomingStreamLevelBufferSize: Int
 
+  def minCollectStrictEntitySize: Int
+
   def logFrames: Boolean
   def maxConcurrentStreams: Int
   def outgoingControlFrameBufferSize: Int
@@ -68,6 +70,9 @@ trait Http2ServerSettings extends javadsl.settings.Http2ServerSettings with Http
   def incomingStreamLevelBufferSize: Int
   def withIncomingStreamLevelBufferSize(newValue: Int): Http2ServerSettings = copy(incomingStreamLevelBufferSize = newValue)
 
+  def minCollectStrictEntitySize: Int
+  def withMinCollectStrictEntitySize(newValue: Int): Http2ServerSettings = copy(minCollectStrictEntitySize = newValue)
+
   def maxConcurrentStreams: Int
   override def withMaxConcurrentStreams(newValue: Int): Http2ServerSettings = copy(maxConcurrentStreams = newValue)
 
@@ -100,6 +105,7 @@ object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
     requestEntityChunkSize:            Int,
     incomingConnectionLevelBufferSize: Int,
     incomingStreamLevelBufferSize:     Int,
+    minCollectStrictEntitySize:        Int,
     outgoingControlFrameBufferSize:    Int,
     logFrames:                         Boolean,
     pingInterval:                      FiniteDuration,
@@ -110,6 +116,7 @@ object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
     require(requestEntityChunkSize > 0, "request-entity-chunk-size must be > 0")
     require(incomingConnectionLevelBufferSize > 0, "incoming-connection-level-buffer-size must be > 0")
     require(incomingStreamLevelBufferSize > 0, "incoming-stream-level-buffer-size must be > 0")
+    require(minCollectStrictEntitySize >= 0, "min-collect-strict-entity-size must be >= 0")
     require(outgoingControlFrameBufferSize > 0, "outgoing-control-frame-buffer-size must be > 0")
     Http2CommonSettings.validate(this)
   }
@@ -120,6 +127,7 @@ object Http2ServerSettings extends SettingsCompanion[Http2ServerSettings] {
       requestEntityChunkSize = c.getIntBytes("request-entity-chunk-size"),
       incomingConnectionLevelBufferSize = c.getIntBytes("incoming-connection-level-buffer-size"),
       incomingStreamLevelBufferSize = c.getIntBytes("incoming-stream-level-buffer-size"),
+      minCollectStrictEntitySize = c.getIntBytes("min-collect-strict-entity-size"),
       outgoingControlFrameBufferSize = c.getIntBytes("outgoing-control-frame-buffer-size"),
       logFrames = c.getBoolean("log-frames"),
       pingInterval = c.getFiniteDuration("ping-interval"),
@@ -147,6 +155,8 @@ trait Http2ClientSettings extends javadsl.settings.Http2ClientSettings with Http
 
   def incomingStreamLevelBufferSize: Int
   override def withIncomingStreamLevelBufferSize(newValue: Int): Http2ClientSettings = copy(incomingStreamLevelBufferSize = newValue)
+
+  def minCollectStrictEntitySize: Int = 0 // not yet supported on client side
 
   def maxConcurrentStreams: Int
   override def withMaxConcurrentStreams(newValue: Int): Http2ClientSettings = copy(maxConcurrentStreams = newValue)


### PR DESCRIPTION
As prototyped in #3822.

It is currently only support for request entities. I'll create an issue to also support that functionality for the client side (which should be somewhat easy to add but needs tests).