### PR TITLE
http: only render date-header once per second

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
@@ -5,11 +5,11 @@
 package akka.http.impl.engine
 
 import java.util.concurrent.CountDownLatch
-
 import akka.actor.ActorSystem
 import akka.event.NoLogging
 import akka.http.CommonBenchmark
 import akka.http.impl.engine.server.HttpServerBluePrint
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.headers
@@ -55,7 +55,7 @@ class ServerProcessingBenchmark extends CommonBenchmark {
     mat = ActorMaterializer()
     httpFlow =
       Flow[HttpRequest].map(_ => response) join
-        (HttpServerBluePrint(ServerSettings(system), NoLogging, false) atop
+        (HttpServerBluePrint(ServerSettings(system), NoLogging, false, Http().dateHeaderRendering) atop
           TLSPlacebo())
   }
 

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/StreamServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/StreamServerProcessingBenchmark.scala
@@ -6,11 +6,11 @@ package akka.http.impl.engine
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorSystem
 import akka.event.NoLogging
 import akka.http.CommonBenchmark
 import akka.http.impl.engine.server.HttpServerBluePrint
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpRequest
@@ -104,7 +104,7 @@ class StreamServerProcessingBenchmark extends CommonBenchmark {
 
     httpFlow =
       Flow[HttpRequest].map(_ => response) join
-        (HttpServerBluePrint(ServerSettings(system), NoLogging, false) atop
+        (HttpServerBluePrint(ServerSettings(system), NoLogging, false, Http().dateHeaderRendering) atop
           TLSPlacebo())
   }
 

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem
 import akka.http.CommonBenchmark
 import akka.http.impl.engine.http2.FrameEvent.HeadersFrame
 import akka.http.impl.engine.http2.framing.FrameRenderer
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.http.scaladsl.model.HttpEntity.LastChunk
 import akka.http.scaladsl.model.headers.RawHeader
@@ -99,7 +100,7 @@ class H2ClientServerBenchmark extends CommonBenchmark {
       Http2Blueprint.handleWithStreamIdHeader(1)(req => {
         req.discardEntityBytes().future.map(_ => response)
       })(system.dispatcher)
-        .join(Http2Blueprint.serverStackTls(settings, log, NoOpTelemetry))
+        .join(Http2Blueprint.serverStackTls(settings, log, NoOpTelemetry, Http().dateHeaderRendering))
     val server: Flow[ByteString, ByteString, NotUsed] = Http2.priorKnowledge(http1, http2)
     val client: BidiFlow[HttpRequest, ByteString, ByteString, HttpResponse, NotUsed] = Http2Blueprint.clientStack(ClientConnectionSettings(system), log, NoOpTelemetry)
     httpFlow = client.join(server)

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
@@ -8,6 +8,7 @@ import akka.actor.ActorSystem
 import akka.http.CommonBenchmark
 import akka.http.impl.engine.http2.FrameEvent.{ DataFrame, HeadersFrame }
 import akka.http.impl.engine.http2.framing.FrameRenderer
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpEntity.{ Chunk, LastChunk }
 import akka.http.scaladsl.model.{ AttributeKeys, ContentTypes, HttpEntity, HttpResponse, Trailer }
 import akka.http.scaladsl.model.headers.RawHeader
@@ -124,7 +125,7 @@ class H2ServerProcessingBenchmark extends CommonBenchmark {
       Http2Blueprint.handleWithStreamIdHeader(1)(req => {
         req.discardEntityBytes().future.map(_ => response)
       })(system.dispatcher)
-        .join(Http2Blueprint.serverStackTls(settings, log, NoOpTelemetry))
+        .join(Http2Blueprint.serverStackTls(settings, log, NoOpTelemetry, Http().dateHeaderRendering))
     httpFlow = Http2.priorKnowledge(http1, http2)
   }
 

--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/changes-in-implementation.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/changes-in-implementation.excludes
@@ -1,0 +1,2 @@
+# changes in implementation classes
+ProblemFilters.exclude[Problem]("akka.http.impl.engine.*")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -7,6 +7,7 @@ package akka.http.impl.engine.http2
 import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.FrameEvent._
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
+import akka.http.impl.engine.rendering.DateHeaderRendering
 import akka.http.scaladsl.model.{ AttributeKey, HttpEntity }
 import akka.http.scaladsl.model.http2.PeerClosedStreamException
 import akka.http.scaladsl.settings.Http2CommonSettings
@@ -701,7 +702,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
         case HttpEntity.LastChunk(_, headers) =>
           if (headers.nonEmpty && !trailer.isEmpty)
             log.warning("Found both an attribute with trailing headers, and headers in the `LastChunk`. This is not supported.")
-          trailer = OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, HttpMessageRendering.renderHeaders(headers, log, isServer), None))
+          trailer = OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, HttpMessageRendering.renderHeaders(headers, log, isServer, shouldRenderAutoHeaders = false, dateHeaderRendering = DateHeaderRendering.Unavailable), None))
       }
 
       maybePull()

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
@@ -8,9 +8,8 @@ import java.util.concurrent.atomic.AtomicInteger
 import akka.annotation.InternalApi
 import akka.event.LoggingAdapter
 import akka.http.impl.engine.http2.FrameEvent.ParsedHeadersFrame
-import akka.http.impl.util.StringRendering
+import akka.http.impl.engine.rendering.DateHeaderRendering
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.Date
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.settings.ServerSettings
 import akka.util.OptionVal
@@ -20,7 +19,7 @@ import scala.collection.immutable.VectorBuilder
 
 /** INTERNAL API */
 @InternalApi
-private[http2] class ResponseRendering(settings: ServerSettings, val log: LoggingAdapter) extends MessageRendering[HttpResponse] {
+private[http2] class ResponseRendering(settings: ServerSettings, val log: LoggingAdapter, val dateHeaderRendering: DateHeaderRendering) extends MessageRendering[HttpResponse] {
 
   private def failBecauseOfMissingAttribute: Nothing =
     // attribute is missing, shutting down because we will most likely otherwise miss a response and leak a substream
@@ -58,6 +57,8 @@ private[http2] class RequestRendering(settings: ClientConnectionSettings, val lo
   }
 
   override lazy val peerIdHeader: Option[(String, String)] = settings.userAgentHeader.map(h => h.lowercaseName -> h.value)
+
+  override protected def dateHeaderRendering: DateHeaderRendering = DateHeaderRendering.Unavailable
 }
 
 /** INTERNAL API */
@@ -68,12 +69,13 @@ private[http2] sealed abstract class MessageRendering[R <: HttpMessage] extends 
   protected def nextStreamId(r: R): Int
   protected def initialHeaderPairs(r: R): VectorBuilder[(String, String)]
   protected def peerIdHeader: Option[(String, String)]
+  protected def dateHeaderRendering: DateHeaderRendering
 
   def apply(r: R): Http2SubStream = {
     val headerPairs = initialHeaderPairs(r)
 
     HttpMessageRendering.addContentHeaders(headerPairs, r.entity)
-    HttpMessageRendering.renderHeaders(r.headers, headerPairs, peerIdHeader, log, isServer = r.isResponse)
+    HttpMessageRendering.renderHeaders(r.headers, headerPairs, peerIdHeader, log, isServer = r.isResponse, shouldRenderAutoHeaders = true, dateHeaderRendering)
 
     val streamId = nextStreamId(r)
     val headersFrame = ParsedHeadersFrame(streamId, endStream = r.entity.isKnownEmpty, headerPairs.result(), None)
@@ -90,21 +92,6 @@ private[http2] sealed abstract class MessageRendering[R <: HttpMessage] extends 
 /** INTERNAL API */
 @InternalApi
 private[http2] object HttpMessageRendering {
-
-  @volatile
-  private var cachedDateHeader = (0L, ("", ""))
-
-  private def dateHeader(): (String, String) = {
-    val cachedSeconds = cachedDateHeader._1
-    val now = System.currentTimeMillis()
-    if (now / 1000 > cachedSeconds) {
-      val r = new StringRendering
-      DateTime(now).renderRfc1123DateTimeString(r)
-      cachedDateHeader = (now, Date.lowercaseName -> r.get)
-    }
-    cachedDateHeader._2
-  }
-
   /**
    * Mutates `headerPairs` adding headers related to content (type and length).
    */
@@ -115,12 +102,14 @@ private[http2] object HttpMessageRendering {
   }
 
   def renderHeaders(
-    headers:  immutable.Seq[HttpHeader],
-    log:      LoggingAdapter,
-    isServer: Boolean
+    headers:                 immutable.Seq[HttpHeader],
+    log:                     LoggingAdapter,
+    isServer:                Boolean,
+    shouldRenderAutoHeaders: Boolean,
+    dateHeaderRendering:     DateHeaderRendering
   ): Seq[(String, String)] = {
     val headerPairs = new VectorBuilder[(String, String)]()
-    renderHeaders(headers, headerPairs, None, log, isServer)
+    renderHeaders(headers, headerPairs, None, log, isServer, shouldRenderAutoHeaders, dateHeaderRendering)
     headerPairs.result()
   }
 
@@ -130,11 +119,13 @@ private[http2] object HttpMessageRendering {
    *                     peer. For example, a User-Agent on the client or a Server header on the server.
    */
   def renderHeaders(
-    headersSeq:   immutable.Seq[HttpHeader],
-    headerPairs:  VectorBuilder[(String, String)],
-    peerIdHeader: Option[(String, String)],
-    log:          LoggingAdapter,
-    isServer:     Boolean
+    headersSeq:              immutable.Seq[HttpHeader],
+    headerPairs:             VectorBuilder[(String, String)],
+    peerIdHeader:            Option[(String, String)],
+    log:                     LoggingAdapter,
+    isServer:                Boolean,
+    shouldRenderAutoHeaders: Boolean,
+    dateHeaderRendering:     DateHeaderRendering
   ): Unit = {
     def suppressionWarning(h: HttpHeader, msg: String): Unit =
       log.warning("Explicitly set HTTP header '{}' is ignored, {}", h, msg)
@@ -185,11 +176,11 @@ private[http2] object HttpMessageRendering {
       }
     }
 
-    if (!dateSeen && isServer) {
-      headerPairs += dateHeader()
+    if (shouldRenderAutoHeaders && !dateSeen && isServer) {
+      headerPairs += dateHeaderRendering.renderHeaderPair()
     }
 
-    if (!peerIdSeen) {
+    if (shouldRenderAutoHeaders && !peerIdSeen) {
       peerIdHeader match {
         case Some(peerIdTuple) => headerPairs += peerIdTuple
         case None              =>

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/DateHeaderRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/DateHeaderRendering.scala
@@ -35,17 +35,8 @@ import scala.concurrent.ExecutionContext
     case object Idle extends DateState
     case class AutoUpdated(value: String) extends DateState {
       var wasUsed: Boolean = false
-      private[this] var _pair: (String, String) = _
-      def headerPair: (String, String) = {
-        if (_pair eq null) _pair = "date" -> value
-        _pair
-      }
-      private[this] var _bytes: Array[Byte] = _
-      def headerBytes: Array[Byte] = {
-        if (_bytes eq null)
-          _bytes = (new ByteArrayRendering(48) ~~ headers.Date ~~ value ~~ CrLf).get
-        _bytes
-      }
+      val headerPair: (String, String) = "date" -> value
+      val headerBytes: Array[Byte] = (new ByteArrayRendering(48) ~~ headers.Date ~~ value ~~ CrLf).get
     }
     val dateState = new AtomicReference[DateState](Idle)
     val updateInterval = 1.second

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/DateHeaderRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/DateHeaderRendering.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.impl.engine.rendering
+
+import akka.actor.{ ClassicActorSystemProvider, Scheduler }
+import akka.annotation.InternalApi
+import akka.http.impl.util.Rendering.CrLf
+import akka.http.impl.util.{ ByteArrayRendering, StringRendering }
+import akka.http.scaladsl.model.{ DateTime, headers }
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
+
+/** INTERNAL API */
+@InternalApi private[http] trait DateHeaderRendering {
+  def renderHeaderPair(): (String, String)
+  def renderHeaderBytes(): Array[Byte]
+  def renderHeaderValue(): String
+}
+
+/** INTERNAL API */
+@InternalApi private[http] object DateHeaderRendering {
+  def apply(now: () => Long = () => System.currentTimeMillis())(implicit system: ClassicActorSystemProvider): DateHeaderRendering =
+    apply(system.classicSystem.scheduler, now)(system.classicSystem.dispatcher)
+
+  def apply(scheduler: Scheduler, now: () => Long)(implicit ec: ExecutionContext): DateHeaderRendering = {
+    def renderValue(): String =
+      DateTime(now()).renderRfc1123DateTimeString(new StringRendering).get
+
+    sealed trait DateState
+    /** Date has not been used for a while */
+    case object Idle extends DateState
+    case class AutoUpdated(value: String) extends DateState {
+      var wasUsed: Boolean = false
+      private[this] var _pair: (String, String) = _
+      def headerPair: (String, String) = {
+        if (_pair eq null) _pair = "date" -> value
+        _pair
+      }
+      private[this] var _bytes: Array[Byte] = _
+      def headerBytes: Array[Byte] = {
+        if (_bytes eq null)
+          _bytes = (new ByteArrayRendering(48) ~~ headers.Date ~~ value ~~ CrLf).get
+        _bytes
+      }
+    }
+    val dateState = new AtomicReference[DateState](Idle)
+    val updateInterval = 1.second
+    def scheduleAutoUpdate(): Unit =
+      try scheduler.scheduleOnce(updateInterval)(autoUpdate())
+      catch {
+        case _: IllegalStateException =>
+          // can fail during shutdown, no need to be noisy here
+          dateState.set(Idle)
+      }
+
+    def autoUpdate(): Unit =
+      dateState.get() match {
+        case a: AutoUpdated =>
+          if (a.wasUsed) {
+            dateState.set(AutoUpdated(renderValue()))
+            scheduleAutoUpdate()
+          } else
+            dateState.set(Idle) // wasn't retrieved, no reason to continue autoupdating
+        case Idle => new IllegalStateException("Should not happen, invariant is either state == Idle or scheduled both never both")
+      }
+
+    def get(rendered: String): AutoUpdated =
+      dateState.get() match {
+        case a: AutoUpdated =>
+          // might not be instantly visible on updater thread
+          // which might prevent automatic rescheduling in the worst case
+          a.wasUsed = true
+          a
+        case s @ Idle =>
+          val r = if (rendered ne null) rendered else renderValue()
+          val newValue = AutoUpdated(r)
+          newValue.wasUsed = true
+          // use CAS to avoid that multiple accessing threads schedule multiple timers
+          if (!dateState.compareAndSet(s, newValue)) get(rendered)
+          else {
+            scheduleAutoUpdate()
+            newValue
+          }
+      }
+
+    new DateHeaderRendering {
+      override def renderHeaderPair(): (String, String) = get(null).headerPair
+      override def renderHeaderBytes(): Array[Byte] = get(null).headerBytes
+      override def renderHeaderValue(): String = get(null).value
+    }
+  }
+
+  val Unavailable = new DateHeaderRendering {
+    override def renderHeaderPair(): (String, String) = throw new IllegalStateException("DateHeaderRendering is not available here")
+    override def renderHeaderBytes(): Array[Byte] = throw new IllegalStateException("DateHeaderRendering is not available here")
+    override def renderHeaderValue(): String = throw new IllegalStateException("DateHeaderRendering is not available here")
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -5,7 +5,6 @@
 package akka.http.impl.engine.server
 
 import java.util.concurrent.atomic.AtomicReference
-
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration.{ Deadline, Duration, FiniteDuration }
 import scala.collection.immutable
@@ -26,7 +25,7 @@ import akka.http.scaladsl.settings.ServerSettings
 import akka.http.impl.engine.parsing.ParserOutput._
 import akka.http.impl.engine.parsing._
 import akka.http.impl.engine.rendering.ResponseRenderingContext.CloseRequested
-import akka.http.impl.engine.rendering.{ HttpResponseRendererFactory, ResponseRenderingContext, ResponseRenderingOutput }
+import akka.http.impl.engine.rendering.{ DateHeaderRendering, HttpResponseRendererFactory, ResponseRenderingContext, ResponseRenderingOutput }
 import akka.http.impl.util._
 import akka.http.scaladsl.util.FastFuture.EnhancedFuture
 import akka.http.scaladsl.{ Http, TimeoutAccess }
@@ -61,12 +60,12 @@ import scala.util.Failure
  */
 @InternalApi
 private[http] object HttpServerBluePrint {
-  def apply(settings: ServerSettings, log: LoggingAdapter, isSecureConnection: Boolean): Http.ServerLayer =
+  def apply(settings: ServerSettings, log: LoggingAdapter, isSecureConnection: Boolean, dateHeaderRendering: DateHeaderRendering): Http.ServerLayer =
     userHandlerGuard(settings.pipeliningLimit) atop
       requestTimeoutSupport(settings.timeouts.requestTimeout, log) atop
       requestPreparation(settings) atop
       controller(settings, log) atop
-      parsingRendering(settings, log, isSecureConnection) atop
+      parsingRendering(settings, log, isSecureConnection, dateHeaderRendering) atop
       websocketSupport(settings, log) atop
       tlsSupport atop
       logTLSBidiBySetting("server-plain-text", settings.logUnencryptedNetworkBytes)
@@ -77,8 +76,8 @@ private[http] object HttpServerBluePrint {
   def websocketSupport(settings: ServerSettings, log: LoggingAdapter): BidiFlow[ResponseRenderingOutput, ByteString, SessionBytes, SessionBytes, NotUsed] =
     BidiFlow.fromGraph(new ProtocolSwitchStage(settings, log))
 
-  def parsingRendering(settings: ServerSettings, log: LoggingAdapter, isSecureConnection: Boolean): BidiFlow[ResponseRenderingContext, ResponseRenderingOutput, SessionBytes, RequestOutput, NotUsed] =
-    BidiFlow.fromFlows(rendering(settings, log), parsing(settings, log, isSecureConnection))
+  def parsingRendering(settings: ServerSettings, log: LoggingAdapter, isSecureConnection: Boolean, dateHeaderRendering: DateHeaderRendering): BidiFlow[ResponseRenderingContext, ResponseRenderingOutput, SessionBytes, RequestOutput, NotUsed] =
+    BidiFlow.fromFlows(rendering(settings, log, dateHeaderRendering), parsing(settings, log, isSecureConnection))
 
   def controller(settings: ServerSettings, log: LoggingAdapter): BidiFlow[HttpResponse, ResponseRenderingContext, RequestOutput, RequestOutput, NotUsed] =
     BidiFlow.fromGraph(new ControllerStage(settings, log)).reversed
@@ -251,10 +250,10 @@ private[http] object HttpServerBluePrint {
     Flow[SessionBytes].via(rootParser).map(establishAbsoluteUri)
   }
 
-  def rendering(settings: ServerSettings, log: LoggingAdapter): Flow[ResponseRenderingContext, ResponseRenderingOutput, NotUsed] = {
+  def rendering(settings: ServerSettings, log: LoggingAdapter, dateHeaderRendering: DateHeaderRendering): Flow[ResponseRenderingContext, ResponseRenderingOutput, NotUsed] = {
     import settings._
 
-    val responseRendererFactory = new HttpResponseRendererFactory(serverHeader, responseHeaderSizeHint, log)
+    val responseRendererFactory = new HttpResponseRendererFactory(serverHeader, responseHeaderSizeHint, log, dateHeaderRendering)
 
     Flow[ResponseRenderingContext]
       .via(responseRendererFactory.renderer.named("renderer"))

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -6,7 +6,6 @@ package akka.http.scaladsl
 
 import java.net.InetSocketAddress
 import java.util.concurrent.CompletionStage
-
 import javax.net.ssl._
 import akka.actor._
 import akka.annotation.DoNotInherit
@@ -17,6 +16,7 @@ import akka.http.impl.engine.HttpConnectionIdleTimeoutBidi
 import akka.http.impl.engine.client._
 import akka.http.impl.engine.http2.Http2
 import akka.http.impl.engine.http2.OutgoingConnectionBuilderImpl
+import akka.http.impl.engine.rendering.DateHeaderRendering
 import akka.http.impl.engine.server._
 import akka.http.impl.engine.ws.WebSocketClientBlueprint
 import akka.http.impl.settings.{ ConnectionPoolSetup, HostConnectionPoolSetup }
@@ -92,6 +92,9 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
   // ** SERVER ** //
 
   private[this] final val DefaultPortForProtocol = -1 // any negative value
+
+  // Date header rendering is shared across the system, so that date is only rendered once a second
+  private[http] val dateHeaderRendering = DateHeaderRendering()
 
   private type ServerLayerBidiFlow = BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, ServerTerminator]
   private type ServerLayerFlow = Flow[ByteString, ByteString, (Future[Done], ServerTerminator)]
@@ -381,7 +384,7 @@ class HttpExt private[http] (private val config: Config)(implicit val system: Ex
     remoteAddress:      Option[InetSocketAddress] = None,
     log:                LoggingAdapter            = system.log,
     isSecureConnection: Boolean                   = false): ServerLayer = {
-    val server = HttpServerBluePrint(settings, log, isSecureConnection)
+    val server = HttpServerBluePrint(settings, log, isSecureConnection, dateHeaderRendering)
       .addAttributes(HttpAttributes.remoteAddress(remoteAddress))
       .addAttributes(cancellationStrategyAttributeForDelay(settings.streamCancellationDelay))
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -16,6 +16,7 @@ import akka.http.impl.engine.server.HttpAttributes
 import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.http.impl.util.AkkaSpecWithMaterializer
 import akka.http.impl.util.LogByteStringTools
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.CacheDirectives
@@ -1374,7 +1375,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
     def settings: ServerSettings = ServerSettings(system).withServerHeader(None)
 
     final def theServer: BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, NotUsed] =
-      modifyServer(Http2Blueprint.serverStack(settings, system.log, telemetry = NoOpTelemetry))
+      modifyServer(Http2Blueprint.serverStack(settings, system.log, telemetry = NoOpTelemetry, dateHeaderRendering = Http().dateHeaderRendering))
         .atop(LogByteStringTools.logByteStringBidi("network-plain-text").addAttributes(Attributes(LogLevels(Logging.DebugLevel, Logging.DebugLevel, Logging.DebugLevel))))
 
     handlerFlow


### PR DESCRIPTION
Previously we cached the rendering but rendering actually was not the most expensive part but calling `System.currentTimeMillis` for every response. In this scheme, we only update once a second with the trade-off that reported times may be up to 1 second in the past.

It applies both to HTTP/2 and HTTP/1.1.

Before:

```
[info] Benchmark                                          Mode  Cnt       Score       Error  Units
[info] ServerProcessingBenchmark.benchRequestProcessing  thrpt    3  209478.673 ± 48778.234  ops/s
```

After:

```
[info] Benchmark                                          Mode  Cnt       Score       Error  Units
[info] ServerProcessingBenchmark.benchRequestProcessing  thrpt    3  270904.245 ± 29405.551  ops/s
```

which shows that this was a big issue for the HTTP/1.1 pipeline. The benchmark doesn't include networking so that improvement will be much less prominent for more real-world benchmarks.