### PR TITLE
http2: ensure unhandled error ultimately get translated into GOAWAY frames

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
@@ -82,6 +82,7 @@ private[http] final class Http2Ext(private val config: Config)(implicit val syst
             httpPlusSwitching(http1, http2).addAttributes(prepareServerAttributes(settings, incoming))
               .watchTermination()(Keep.right)
               .join(incoming.flow)
+              .addAttributes(Http.cancellationStrategyAttributeForDelay(settings.streamCancellationDelay))
               .run().recover {
                 // Ignore incoming errors from the connection as they will cancel the binding.
                 // As far as it is known currently, these errors can only happen if a TCP error bubbles up

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -18,6 +18,7 @@ import akka.http.impl.util.LogByteStringTools.logTLSBidiBySetting
 import akka.http.impl.util.StreamUtils
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, Http2CommonSettings, ParserSettings, ServerSettings }
+import akka.stream.StreamTcpException
 import akka.stream.TLSProtocol._
 import akka.stream.scaladsl.{ BidiFlow, Flow, Source }
 import akka.util.{ ByteString, OptionVal }
@@ -25,6 +26,7 @@ import akka.util.{ ByteString, OptionVal }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.collection.immutable
+import scala.util.control.NonFatal
 
 /**
  * Represents one direction of an Http2 substream.
@@ -111,6 +113,7 @@ private[http] object Http2Blueprint {
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
       hpackCoding() atop
       framing(log) atop
+      errorHandling(log) atop
       idleTimeoutIfConfigured(settings.idleTimeout)
   }
 
@@ -128,6 +131,7 @@ private[http] object Http2Blueprint {
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
       hpackCoding() atop
       framingClient(log) atop
+      errorHandling(log) atop
       idleTimeoutIfConfigured(settings.idleTimeout)
   }
 
@@ -149,6 +153,22 @@ private[http] object Http2Blueprint {
       case f: FiniteDuration => HttpConnectionIdleTimeoutBidi(f, None)
       case _                 => BidiFlow.identity[ByteString, ByteString]
     }
+
+  def errorHandling(log: LoggingAdapter): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] = {
+    BidiFlow.fromFlows(
+      StreamUtils.encodeErrorAndComplete {
+        case ex: Http2Compliance.Http2ProtocolException =>
+          // protocol errors are most likely provoked by peer, so we don't log them noisily
+          if (log.isDebugEnabled) log.debug(s"HTTP2 connection failed with error [${ex.getMessage}]. Sending ${ex.errorCode} and closing connection.")
+          FrameRenderer.render(GoAwayFrame(0, ex.errorCode))
+        case ex: StreamTcpException => throw ex // TCP connection is probably broken: just forward exception
+        case NonFatal(ex) =>
+          log.error(ex, s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
+          FrameRenderer.render(GoAwayFrame(0, Http2Protocol.ErrorCode.INTERNAL_ERROR))
+      },
+      Flow[ByteString]
+    )
+  }
 
   def framing(log: LoggingAdapter): BidiFlow[FrameEvent, ByteString, ByteString, FrameEvent, NotUsed] =
     BidiFlow.fromFlows(

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Compliance.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Compliance.scala
@@ -12,12 +12,12 @@ import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 private[http2] object Http2Compliance {
 
   final class IllegalHttp2StreamIdException(id: Int, expected: String)
-    extends IllegalArgumentException(s"Illegal HTTP/2 stream id: [$id]. $expected!")
+    extends Http2ProtocolException(s"Illegal HTTP/2 stream id: [$id]. $expected!")
 
-  final class MissingHttpIdHeaderException extends IllegalArgumentException("Expected `Http2StreamIdHeader` header to be present but was missing!")
+  final class MissingHttpIdHeaderException extends Http2ProtocolException("Expected `Http2StreamIdHeader` header to be present but was missing!")
 
   final class IllegalHttp2StreamDependency(id: Int)
-    extends IllegalArgumentException(s"Illegal self dependency of stream for id: [$id]!")
+    extends Http2ProtocolException(s"Illegal self dependency of stream for id: [$id]!")
 
   final class IllegalPayloadInSettingsAckFrame(size: Int, expected: String) extends IllegalHttp2FrameSize(size, expected)
 
@@ -38,7 +38,9 @@ private[http2] object Http2Compliance {
     if (value > MaxFrameSize) throw new Http2ProtocolException(ErrorCode.PROTOCOL_ERROR, s"MAX_FRAME_SIZE MUST NOT be > than $MaxFrameSize, attempted setting to: $value!")
   }
 
-  class Http2ProtocolException(val errorCode: ErrorCode, message: String) extends IllegalStateException(message)
+  class Http2ProtocolException(val errorCode: ErrorCode, message: String) extends IllegalStateException(message) {
+    def this(message: String) = this(ErrorCode.PROTOCOL_ERROR, message)
+  }
   class Http2ProtocolStreamException(val streamId: Int, val errorCode: ErrorCode, message: String) extends IllegalStateException(message)
 
   final def requireZeroStreamId(id: Int): Unit =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
@@ -86,17 +86,18 @@ private[http] object ProtocolSwitch {
             val propagatePull =
               new OutHandler {
                 override def onPull(): Unit = pull(in)
+                override def onDownstreamFinish(): Unit = cancel(in)
               }
 
             val firstHandler =
               initialElement match {
-                case Some(ele) if out.isAvailable =>
-                  out.push(ele)
+                case Some(initial) if out.isAvailable =>
+                  out.push(initial)
                   propagatePull
-                case Some(ele) =>
+                case Some(initial) =>
                   new OutHandler {
                     override def onPull(): Unit = {
-                      out.push(initialElement.get)
+                      out.push(initial)
                       out.setHandler(propagatePull)
                     }
                   }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -6,6 +6,7 @@ package akka.http.impl.engine.http2
 
 import javax.net.ssl.SSLSession
 import akka.annotation.InternalApi
+import akka.http.impl.engine.http2.Http2Compliance.Http2ProtocolException
 import akka.http.impl.engine.parsing.HttpHeaderParser
 import akka.http.impl.engine.server.HttpAttributes
 import akka.http.scaladsl.model
@@ -182,7 +183,7 @@ private[http2] object RequestParsing {
   private[http2] def checkNoRegularHeadersBeforePseudoHeader(name: String, seenRegularHeader: Boolean): Unit =
     if (seenRegularHeader) malformedRequest(s"Pseudo-header field '$name' must not appear after a regular header")
   private[http2] def malformedRequest(msg: String): Nothing =
-    throw new RuntimeException(s"Malformed request: $msg")
+    throw new Http2ProtocolException(s"Malformed request: $msg")
   private[http2] def validateHeader(httpHeader: HttpHeader) = httpHeader.lowercaseName match {
     case "connection" =>
       // https://tools.ietf.org/html/rfc7540#section-8.1.2.2

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
@@ -14,6 +14,7 @@ import akka.util.OptionVal
 import Http2Protocol.{ ErrorCode, Flags, FrameType, SettingIdentifier }
 import akka.annotation.InternalApi
 import FrameEvent._
+import akka.http.impl.engine.http2.Http2Compliance.Http2ProtocolException
 import akka.stream.impl.io.ByteStringParser.ByteReader
 
 import scala.annotation.tailrec
@@ -170,7 +171,7 @@ private[http2] class Http2FrameParsing(shouldReadPreface: Boolean, log: LoggingA
           else if (reader.take(24) == Http2Protocol.ClientConnectionPreface)
             ParseResult(None, ReadFrame, acceptUpstreamFinish = false)
           else
-            throw new RuntimeException("Expected ConnectionPreface!")
+            throw new Http2ProtocolException("Expected ConnectionPreface!")
       }
 
       object ReadFrame extends Step {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -6,7 +6,6 @@ package akka.http.impl.engine.http2.hpack
 
 import java.io.IOException
 import java.nio.charset.StandardCharsets
-
 import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2._
@@ -16,8 +15,8 @@ import akka.util.ByteString
 import com.twitter.hpack.HeaderListener
 
 import scala.collection.immutable.VectorBuilder
-
 import FrameEvent._
+import akka.http.impl.engine.http2.Http2Compliance.Http2ProtocolException
 
 /**
  * INTERNAL API
@@ -91,6 +90,6 @@ private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEven
       }
     }
 
-    def protocolError(msg: String): Unit = failStage(new RuntimeException(msg)) // TODO: replace with right exception type
+    def protocolError(msg: String): Unit = failStage(new Http2ProtocolException(msg))
   }
 }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -24,7 +24,7 @@ class H2SpecIntegrationSpec extends AkkaSpec(
      akka {
        loglevel = DEBUG
        loggers = ["akka.http.impl.util.SilenceAllTestEventListener"]
-       http.server.log-unencrypted-network-bytes = off
+       http.server.log-unencrypted-network-bytes = 100
        http.server.preview.enable-http2 = on
        http.server.http2.log-frames = on
 


### PR DESCRIPTION
Should also fix #3693. Before, when a failure happened, cancellation might overtake the actual error and (due to TLSStage) lead to regular closure of the connection. Now cancellation is delayed and errors need to be dealt with. There's now a very late `errorHandling` stage that outputs proper `GOAWAY` frames for error conditions and closes the connection cleanly afterwards.