### PR TITLE
http2: never create Default entity

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -55,13 +55,6 @@ private[http2] case class Http2SubStream(
         if (data == Source.empty || contentLength == 0 || !hasEntity) {
           if (contentTypeOption.isEmpty) HttpEntity.Empty
           else HttpEntity.Strict(contentType, ByteString.empty)
-        } else if (contentLength > 0) {
-          val byteSource: Source[ByteString, Any] = data.collect {
-            case b: ByteString             => b
-            case HttpEntity.Chunk(data, _) => data
-            // ignore: HttpEntity.LastChunk
-          }
-          HttpEntity.Default(contentType, contentLength, byteSource)
         } else {
           val chunkSource: Source[HttpEntity.ChunkStreamPart, Any] = data.map {
             case b: ByteString                 => HttpEntity.Chunk(b)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -297,8 +297,11 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
 
         val response = user.expectResponse()
         response.entity.contentType should ===(ContentTypes.`application/json`)
-        response.entity.isIndefiniteLength should ===(false)
-        response.entity.contentLengthOption should ===(Some(2000L))
+
+        // FIXME: contentLength is not reported in all cases with HTTP/2
+        // see https://github.com/akka/akka-http/issues/3843
+        // response.entity.isIndefiniteLength should ===(false)
+        // response.entity.contentLengthOption should ===(Some(2000L))
 
         network.sendDATA(TheStreamId, endStream = false, ByteString("x" * 1000))
         network.sendDATA(TheStreamId, endStream = true, ByteString("x" * 1000))

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -342,8 +342,10 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
             protocol = HttpProtocols.`HTTP/2.0`)) {
 
           receivedRequest.entity.contentType should ===(ContentTypes.`application/json`)
-          receivedRequest.entity.isIndefiniteLength should ===(false)
-          receivedRequest.entity.contentLengthOption should ===(Some(1337L))
+          // FIXME: contentLength is not reported in all cases with HTTP/2
+          // see https://github.com/akka/akka-http/issues/3843
+          // receivedRequest.entity.isIndefiniteLength should ===(false)
+          // receivedRequest.entity.contentLengthOption should ===(Some(1337L))
           entityDataIn.expectBytes(ByteString("x" * 1337))
           entityDataIn.expectComplete()
         }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -543,8 +543,10 @@ class RequestParsingSpec extends AkkaSpec() with Inside with Inspectors {
           Host(Uri.Host("example.org"))
         )
         inside(request.entity) {
-          case entity: HttpEntity.Default =>
-            entity.contentLength should ===(123.toLong)
+          case entity: HttpEntity =>
+            // FIXME: contentLength is not reported in all cases with HTTP/2
+            // see https://github.com/akka/akka-http/issues/3843
+            // entity.contentLength should ===(123.toLong)
             entity.contentType should ===(ContentType(MediaTypes.`image/jpeg`))
         }
         request.protocol should ===(HttpProtocols.`HTTP/2.0`)


### PR DESCRIPTION
This was supposed to be a small optimization to avoid having to wrap data elements into `Chunks` when it was unlikely that we expected a trailing header. The heuristic was whether we have seen a `content-length` header or not. However, with more of our optimizations applied, gRPC may actually send a
content-length header on the server side which means we miss out on trailers on the client side.

Let's revert this optimization for now, so that we can receive trailing headers in all cases again.

This should help unbreak tests at https://github.com/akka/akka-grpc/pull/1365