### PR TITLE
core: cache ModeledHeader.value

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/modeled-header-value-cache.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/modeled-header-value-cache.excludes
@@ -1,0 +1,4 @@
+# Added a private[this] field to sealed trait / hierarchy
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.headers.ModeledHeader.akka$http$scaladsl$model$headers$ModeledHeader$$_value")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.headers.ModeledHeader.akka$http$scaladsl$model$headers$ModeledHeader$$_value_=")
+

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -62,8 +62,11 @@ sealed trait ModeledHeader extends HttpHeader with Serializable {
   def renderInRequests: Boolean = false // default implementation
   def renderInResponses: Boolean = false // default implementation
   def name: String = companion.name
-  private lazy val _value = renderValue(new StringRendering).get
-  def value: String = _value
+  private var _value: String = _
+  def value: String = {
+    if (_value eq null) _value = renderValue(new StringRendering).get
+    _value
+  }
   def lowercaseName: String = companion.lowercaseName
   final def render[R <: Rendering](r: R): r.type = renderValue(companion.render(r))
   protected[http] def renderValue[R <: Rendering](r: R): r.type

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -62,7 +62,8 @@ sealed trait ModeledHeader extends HttpHeader with Serializable {
   def renderInRequests: Boolean = false // default implementation
   def renderInResponses: Boolean = false // default implementation
   def name: String = companion.name
-  def value: String = renderValue(new StringRendering).get
+  private lazy val _value = renderValue(new StringRendering).get
+  def value: String = _value
   def lowercaseName: String = companion.lowercaseName
   final def render[R <: Rendering](r: R): r.type = renderValue(companion.render(r))
   protected[http] def renderValue[R <: Rendering](r: R): r.type

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/headers.scala
@@ -62,7 +62,7 @@ sealed trait ModeledHeader extends HttpHeader with Serializable {
   def renderInRequests: Boolean = false // default implementation
   def renderInResponses: Boolean = false // default implementation
   def name: String = companion.name
-  private var _value: String = _
+  private[this] var _value: String = _
   def value: String = {
     if (_value eq null) _value = renderValue(new StringRendering).get
     _value


### PR DESCRIPTION
This prevents that cached header instances have to re-render their value every time.

The assumption is that the lazy value access / initialization cost is negligible in comparison with rendering.