### PR TITLE
core: move `isStrict` up a level to ws.Message

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/websocket-isstrict.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/websocket-isstrict.excludes
@@ -1,0 +1,2 @@
+# move `isStrict` method to superclass
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.ws.Message.isStrict")

--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/websocket-isstrict.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/websocket-isstrict.excludes
@@ -1,2 +1,2 @@
-# move `isStrict` method to superclass
+# Move `isStrict` method to superclass which does not support user extension
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.model.ws.Message.isStrict")

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
@@ -6,6 +6,7 @@ package akka.http.javadsl.model.ws
 
 import java.util.concurrent.CompletionStage
 
+import akka.annotation.DoNotInherit
 import akka.http.scaladsl.{ model => sm }
 import akka.stream.Materializer
 import akka.stream.javadsl.Source
@@ -17,6 +18,7 @@ import scala.compat.java8.FutureConverters._
 /**
  * Represents a WebSocket message. A message can either be a binary message or a text message.
  */
+@DoNotInherit
 abstract class Message {
   /**
    * Is this message a text message? If true, [[asTextMessage]] will return this

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
@@ -24,6 +24,9 @@ abstract class Message {
    */
   def isText: Boolean
 
+  /** Is this message a strict one? */
+  def isStrict: Boolean
+
   /**
    * Returns this TextMessage if it is a text message, throws otherwise.
    */
@@ -55,9 +58,6 @@ abstract class TextMessage extends Message {
    * Returns a source of the text message data.
    */
   def getStreamedText: Source[String, _]
-
-  /** Is this message a strict one? */
-  def isStrict: Boolean
 
   /**
    * Returns the strict message text if this message is strict, throws otherwise.
@@ -121,9 +121,6 @@ abstract class BinaryMessage extends Message {
    * Returns a source of the binary message data.
    */
   def getStreamedData: Source[ByteString, _]
-
-  /** Is this message a strict one? */
-  def isStrict: Boolean
 
   /**
    * Returns the strict message data if this message is strict, throws otherwise.


### PR DESCRIPTION
All websocket message types already define a `def isStrict: Boolean`.
The change here is just to declare `def isStrict: Boolean` on the base
class.

References #3844