### PR TITLE
http2: avoid creating GenericOutlet for every out element

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/BufferedOutletSupport.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/BufferedOutletSupport.scala
@@ -99,7 +99,7 @@ private[http2] class BufferedOutletExtended[T](outlet: GenericOutlet[T]) extends
  */
 @InternalApi
 private[http2] trait GenericOutletSupport { logic: GraphStageLogic =>
-  implicit def fromSubSourceOutlet[T](subSourceOutlet: SubSourceOutlet[T]): GenericOutlet[T] =
+  def fromSubSourceOutlet[T](subSourceOutlet: SubSourceOutlet[T]): GenericOutlet[T] =
     new GenericOutlet[T] {
       def setHandler(handler: OutHandler): Unit = subSourceOutlet.setHandler(handler)
       def push(elem: T): Unit = subSourceOutlet.push(elem)
@@ -107,7 +107,7 @@ private[http2] trait GenericOutletSupport { logic: GraphStageLogic =>
       def fail(cause: Throwable): Unit = subSourceOutlet.fail(cause)
       def canBePushed: Boolean = subSourceOutlet.isAvailable
     }
-  implicit def fromOutlet[T](outlet: Outlet[T]): GenericOutlet[T] =
+  def fromOutlet[T](outlet: Outlet[T]): GenericOutlet[T] =
     new GenericOutlet[T] {
       def setHandler(handler: OutHandler): Unit = logic.setHandler(outlet, handler)
       def push(elem: T): Unit = logic.emit(outlet, elem)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -233,11 +233,11 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
 
       override def pushFrameOut(event: FrameEvent): Unit = {
         pingState.onDataFrameSeen()
-        frameOut.push(event)
+        push(frameOut, event)
       }
 
       val multiplexer = createMultiplexer(StreamPrioritizer.first())
-      frameOut.setHandler(multiplexer)
+      setHandler(frameOut, multiplexer)
 
       val pingState = ConfigurablePing.PingState(http2Settings)
 
@@ -366,7 +366,7 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
       // -----------------------------------------------------------------
       // FIXME: What if user handler doesn't pull in new substreams? Should we reject them
       //        after a while or buffer only a limited amount?
-      val bufferedSubStreamOutput = new BufferedOutlet[Http2SubStream](substreamOut)
+      val bufferedSubStreamOutput = new BufferedOutlet[Http2SubStream](fromOutlet(substreamOut))
       override def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Either[ByteString, Source[Any, Any]], correlationAttributes: Map[AttributeKey[_], _]): Unit =
         bufferedSubStreamOutput.push(Http2SubStream(initialHeaders, OptionVal.None, data, correlationAttributes))
 


### PR DESCRIPTION
A nicer solution would be to be able to use an implicit value class
which isn't possible as an inner class.