### PR TITLE
http2: cache expensive `isDebugEnabled` call

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -224,6 +224,8 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
       override def isUpgraded: Boolean = upgraded
 
       override protected def logSource: Class[_] = if (isServer) classOf[Http2ServerDemux] else classOf[Http2ClientDemux]
+      // cache debug state at the beginning to avoid that this has to be queried all the time
+      override lazy val isDebugEnabled: Boolean = super.isDebugEnabled
 
       def frameOutFinished(): Unit = {
         // make sure we clean up/fail substreams with a custom failure before stage is canceled

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -135,7 +135,7 @@ private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with Stage
         val newState = transition(_state)
         _state = newState
 
-        if (newState.name != oldState.name) recordStateChange(oldState.name, newState.name)
+        if (isDebugEnabled && newState.name != oldState.name) recordStateChange(oldState.name, newState.name)
         if (allDataFlushed(newState)) onAllDataFlushed()
       }
 

--- a/akka-parsing/src/main/scala/akka/macros/LogHelper.scala
+++ b/akka-parsing/src/main/scala/akka/macros/LogHelper.scala
@@ -18,6 +18,9 @@ import scala.reflect.macros.blackbox
 @InternalApi
 private[akka] trait LogHelper {
   def log: LoggingAdapter
+  def isDebugEnabled: Boolean = log.isDebugEnabled
+  def isInfoEnabled: Boolean = log.isInfoEnabled
+  def isWarningEnabled: Boolean = log.isWarningEnabled
 
   /** Override to prefix every log message with a user-defined context string */
   def prefixString: String = ""
@@ -37,7 +40,7 @@ private[akka] object LogHelper {
       {
         val logHelper = ctx.prefix.splice
         val log = logHelper.log
-        if (log.isDebugEnabled)
+        if (logHelper.isDebugEnabled)
           log.debug(logHelper.prefixString + msg.splice)
       }
     }
@@ -46,7 +49,7 @@ private[akka] object LogHelper {
       {
         val logHelper = ctx.prefix.splice
         val log = logHelper.log
-        if (log.isInfoEnabled)
+        if (logHelper.isInfoEnabled)
           log.info(logHelper.prefixString + msg.splice)
       }
     }
@@ -55,7 +58,7 @@ private[akka] object LogHelper {
       {
         val logHelper = ctx.prefix.splice
         val log = logHelper.log
-        if (log.isWarningEnabled)
+        if (logHelper.isWarningEnabled)
           log.warning(logHelper.prefixString + msg.splice)
       }
     }

--- a/akka-parsing/src/main/scala/akka/macros/LogHelper.scala
+++ b/akka-parsing/src/main/scala/akka/macros/LogHelper.scala
@@ -39,27 +39,24 @@ private[akka] object LogHelper {
     ctx.universe.reify {
       {
         val logHelper = ctx.prefix.splice
-        val log = logHelper.log
         if (logHelper.isDebugEnabled)
-          log.debug(logHelper.prefixString + msg.splice)
+          logHelper.log.debug(logHelper.prefixString + msg.splice)
       }
     }
   def infoMacro(ctx: LoggerContext)(msg: ctx.Expr[String]): ctx.Expr[Unit] =
     ctx.universe.reify {
       {
         val logHelper = ctx.prefix.splice
-        val log = logHelper.log
         if (logHelper.isInfoEnabled)
-          log.info(logHelper.prefixString + msg.splice)
+          logHelper.log.info(logHelper.prefixString + msg.splice)
       }
     }
   def warningMacro(ctx: LoggerContext)(msg: ctx.Expr[String]): ctx.Expr[Unit] =
     ctx.universe.reify {
       {
         val logHelper = ctx.prefix.splice
-        val log = logHelper.log
         if (logHelper.isWarningEnabled)
-          log.warning(logHelper.prefixString + msg.splice)
+          logHelper.log.warning(logHelper.prefixString + msg.splice)
       }
     }
 }


### PR DESCRIPTION
For Slf4j `isDebugEnabled` calls the Slf4jLoggingFilter which needs to look up
the concrete logger with `SLFLoggerFactory.getLogger` for each invocation.

In HTTP/2 we log a lot with debug so caching the value here can make a difference.

The disadvantage is that a dynamic logger level change will not directly apply
to already existing connections but only to new ones which seems like a
useful trade-off.