### PR TITLE
docs: add Scaladex badge to ReadMe to show Scala version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Akka HTTP
 =========
 
-[![Latest version](https://index.scala-lang.org/akka/akka-http/akka-http-core/latest.svg)](https://index.scala-lang.org/akka/akka-http)
+[![akka-http-core Scala version support](https://index.scala-lang.org/akka/akka-http/akka-http-core/latest-by-scala-version.svg)](https://index.scala-lang.org/akka/akka-http/akka-http-core)
 
 The Akka HTTP modules implement a full server- and client-side HTTP stack on top
 of akka-actor and akka-stream. It's not a web-framework but rather a more


### PR DESCRIPTION
This badge summarises which versions of Scala are supported by Akka HTTP (and what the latest Akka HTTP version is for each of those Scala versions):

[![akka-http-core Scala version support](https://index.scala-lang.org/akka/akka-http/akka-http-core/latest-by-scala-version.svg)](https://index.scala-lang.org/akka/akka-http/akka-http-core)

More details on the badge format: https://github.com/scalacenter/scaladex/pull/660
