### PR TITLE
http2: properly propagate completion through PersistentConnection 

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
@@ -377,7 +377,7 @@ abstract class Http2PersistentClientSpec(tls: Boolean) extends AkkaSpecWithMater
 
     def shutdown(): Unit = {
       client.requestsOut.sendComplete()
-      client.responsesIn.cancel()
+      // persistent connection should propagate close signal eventually
 
       server.binding.terminate(100.millis).futureValue
     }


### PR DESCRIPTION
Detected by akka-grpc tests which will hang and eventually fail otherwise.