### PR TITLE
Optimize HTTP/2 header parsing by caching some header models directly in HPACK tables

### DIFF
--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Decoder.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Decoder.java
@@ -19,6 +19,7 @@ package akka.http.shaded.com.twitter.hpack;
 import java.io.IOException;
 import java.io.InputStream;
 
+import akka.http.impl.util.StringTools;
 import akka.http.shaded.com.twitter.hpack.HpackUtil.IndexType;
 
 import static akka.http.shaded.com.twitter.hpack.HeaderField.HEADER_ENTRY_OVERHEAD;
@@ -530,7 +531,7 @@ public final class Decoder {
     } else {
       result = buf;
     }
-    return new String(result, 0,0, result.length);
+    return StringTools.asciiStringFromBytes(result);
   }
 
   // Unsigned Little Endian Base 128 Variable-Length Integer Encoding

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Decoder.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Decoder.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Decoder.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Decoder.java
@@ -34,7 +34,7 @@ public final class Decoder {
   private static final IOException MAX_DYNAMIC_TABLE_SIZE_CHANGE_REQUIRED =
       new IOException("max dynamic table size change required");
 
-  private static final byte[] EMPTY = {};
+  private static final String EMPTY = "";
 
   private final DynamicTable dynamicTable;
 
@@ -51,7 +51,7 @@ public final class Decoder {
   private int skipLength;
   private int nameLength;
   private int valueLength;
-  private byte[] name;
+  private String name;
 
   private enum State {
     READ_HEADER_REPRESENTATION,
@@ -364,7 +364,7 @@ public final class Decoder {
           return;
         }
 
-        byte[] value = readStringLiteral(in, valueLength);
+        String value = readStringLiteral(in, valueLength);
         insertHeader(headerListener, name, value, indexType);
         state = State.READ_HEADER_REPRESENTATION;
         break;
@@ -475,7 +475,7 @@ public final class Decoder {
     }
   }
 
-  private void insertHeader(HeaderListener headerListener, byte[] name, byte[] value, IndexType indexType) {
+  private void insertHeader(HeaderListener headerListener, String name, String value, IndexType indexType) {
     Object parsedValue = addHeader(headerListener, name, value, null, indexType == IndexType.NEVER);
 
     switch (indexType) {
@@ -492,11 +492,11 @@ public final class Decoder {
     }
   }
 
-  private Object addHeader(HeaderListener headerListener, byte[] name, byte[] value, Object parsedValue, boolean sensitive) {
-    if (name.length == 0) {
+  private Object addHeader(HeaderListener headerListener, String name, String value, Object parsedValue, boolean sensitive) {
+    if (name.isEmpty()) {
       throw new AssertionError("name is empty");
     }
-    long newSize = headerSize + name.length + value.length;
+    long newSize = headerSize + name.length() + value.length();
     if (newSize <= maxHeaderSize) {
       parsedValue = headerListener.addHeader(name, value, parsedValue, sensitive);
       headerSize = (int) newSize;
@@ -518,17 +518,19 @@ public final class Decoder {
     return true;
   }
 
-  private byte[] readStringLiteral(InputStream in, int length) throws IOException {
+  private String readStringLiteral(InputStream in, int length) throws IOException {
     byte[] buf = new byte[length];
     if (in.read(buf) != length) {
       throw DECOMPRESSION_EXCEPTION;
     }
+    final byte[] result;
 
     if (huffmanEncoded) {
-      return Huffman.DECODER.decode(buf);
+      result = Huffman.DECODER.decode(buf);
     } else {
-      return buf;
+      result = buf;
     }
+    return new String(result, 0,0, result.length);
   }
 
   // Unsigned Little Endian Base 128 Variable-Length Integer Encoding

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/DynamicTable.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/DynamicTable.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Encoder.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Encoder.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 
+import akka.http.impl.util.StringTools;
 import akka.http.shaded.com.twitter.hpack.HpackUtil.IndexType;
-import akka.util.Unsafe;
 
 public final class Encoder {
 
@@ -173,15 +173,14 @@ public final class Encoder {
    * Encode string literal according to Section 5.2.
    */
   private void encodeStringLiteral(OutputStream out, String string) throws IOException {
-    byte[] stringBytes = new byte[string.length()];
-    Unsafe.copyUSAsciiStrToBytes(string, stringBytes);
-
-    int huffmanLength = Huffman.ENCODER.getEncodedLength(stringBytes);
-    if ((huffmanLength < stringBytes.length && !forceHuffmanOff) || forceHuffmanOn) {
+    int length = string.length();
+    int huffmanLength = Huffman.ENCODER.getEncodedLength(string);
+    if ((huffmanLength < length && !forceHuffmanOff) || forceHuffmanOn) {
       encodeInteger(out, 0x80, 7, huffmanLength);
-      Huffman.ENCODER.encode(out, stringBytes);
+      Huffman.ENCODER.encode(out, string);
     } else {
-      encodeInteger(out, 0x00, 7, stringBytes.length);
+      byte[] stringBytes = StringTools.asciiStringBytes(string);
+      encodeInteger(out, 0x00, 7, length);
       out.write(stringBytes, 0, stringBytes.length);
     }
   }

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Encoder.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Encoder.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderField.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderField.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +22,6 @@
 
 package akka.http.shaded.com.twitter.hpack;
 
-import static akka.http.shaded.com.twitter.hpack.HpackUtil.ISO_8859_1;
 import static akka.http.shaded.com.twitter.hpack.HpackUtil.requireNonNull;
 
 class HeaderField implements Comparable<HeaderField> {

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderField.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderField.java
@@ -32,6 +32,7 @@ class HeaderField implements Comparable<HeaderField> {
 
   final byte[] name;
   final byte[] value;
+  Object parsedValue = null;
 
   // This constructor can only be used if name and value are ISO-8859-1 encoded.
   HeaderField(String name, String value) {
@@ -41,6 +42,11 @@ class HeaderField implements Comparable<HeaderField> {
   HeaderField(byte[] name, byte[] value) {
     this.name = requireNonNull(name);
     this.value = requireNonNull(value);
+  }
+  HeaderField(byte[] name, byte[] value, Object parsedValue) {
+    this.name = requireNonNull(name);
+    this.value = requireNonNull(value);
+    this.parsedValue = parsedValue;
   }
 
   int size() {

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderField.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderField.java
@@ -26,31 +26,27 @@ class HeaderField implements Comparable<HeaderField> {
   // overhead associated with the structure.
   static final int HEADER_ENTRY_OVERHEAD = 32;
 
-  static int sizeOf(byte[] name, byte[] value) {
-    return name.length + value.length + HEADER_ENTRY_OVERHEAD;
+  static int sizeOf(String name, String value) {
+    return name.length() + value.length() + HEADER_ENTRY_OVERHEAD;
   }
 
-  final byte[] name;
-  final byte[] value;
+  final String name;
+  final String value;
   Object parsedValue = null;
 
   // This constructor can only be used if name and value are ISO-8859-1 encoded.
   HeaderField(String name, String value) {
-    this(name.getBytes(ISO_8859_1), value.getBytes(ISO_8859_1));
-  }
-
-  HeaderField(byte[] name, byte[] value) {
     this.name = requireNonNull(name);
     this.value = requireNonNull(value);
   }
-  HeaderField(byte[] name, byte[] value, Object parsedValue) {
+  HeaderField(String name, String value, Object parsedValue) {
     this.name = requireNonNull(name);
     this.value = requireNonNull(value);
     this.parsedValue = parsedValue;
   }
 
   int size() {
-    return name.length + value.length + HEADER_ENTRY_OVERHEAD;
+    return name.length() + value.length() + HEADER_ENTRY_OVERHEAD;
   }
 
   @Override
@@ -62,21 +58,8 @@ class HeaderField implements Comparable<HeaderField> {
     return ret;
   }
 
-  private int compareTo(byte[] s1, byte[] s2) {
-    int len1 = s1.length;
-    int len2 = s2.length;
-    int lim = Math.min(len1, len2);
-
-    int k = 0;
-    while (k < lim) {
-      byte b1 = s1[k];
-      byte b2 = s2[k];
-      if (b1 != b2) {
-        return b1 - b2;
-      }
-      k++;
-    }
-    return len1 - len2;
+  private int compareTo(String s1, String s2) {
+    return s1.compareTo(s2);
   }
 
   @Override
@@ -88,15 +71,11 @@ class HeaderField implements Comparable<HeaderField> {
       return false;
     }
     HeaderField other = (HeaderField) obj;
-    boolean nameEquals = HpackUtil.equals(name, other.name);
-    boolean valueEquals = HpackUtil.equals(value, other.value);
-    return nameEquals && valueEquals;
+    return name.equals(other.name) && value.equals(other.value);
   }
 
   @Override
   public String toString() {
-    String nameString = new String(name);
-    String valueString = new String(value);
-    return nameString + ": " + valueString;
+    return name + ": " + value;
   }
 }

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderListener.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderListener.java
@@ -22,5 +22,5 @@ public interface HeaderListener {
    * emitHeader is called by the decoder during header field emission.
    * The name and value byte arrays must not be modified.
    */
-  public void addHeader(byte[] name, byte[] value, boolean sensitive);
+  public Object addHeader(byte[] name, byte[] value, Object parsed, boolean sensitive);
 }

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderListener.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderListener.java
@@ -22,5 +22,5 @@ public interface HeaderListener {
    * emitHeader is called by the decoder during header field emission.
    * The name and value byte arrays must not be modified.
    */
-  public Object addHeader(byte[] name, byte[] value, Object parsed, boolean sensitive);
+  public Object addHeader(String name, String value, Object parsed, boolean sensitive);
 }

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderListener.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HeaderListener.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HpackUtil.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HpackUtil.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Huffman.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/Huffman.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HuffmanDecoder.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HuffmanDecoder.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HuffmanEncoder.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HuffmanEncoder.java
@@ -38,39 +38,25 @@ final class HuffmanEncoder {
    * Compresses the input string literal using the Huffman coding.
    * @param  out  the output stream for the compressed data
    * @param  data the string literal to be Huffman encoded
-   * @throws IOException if an I/O error occurs.
-   * @see    HuffmanEncoder#encode(OutputStream, byte[], int, int)
-   */
-  public void encode(OutputStream out, byte[] data) throws IOException {
-    encode(out, data, 0, data.length);
-  }
-
-  /**
-   * Compresses the input string literal using the Huffman coding.
-   * @param  out  the output stream for the compressed data
-   * @param  data the string literal to be Huffman encoded
    * @param  off  the start offset in the data
    * @param  len  the number of bytes to encode
    * @throws IOException if an I/O error occurs. In particular,
    *         an <code>IOException</code> may be thrown if the
    *         output stream has been closed.
    */
-  public void encode(OutputStream out, byte[] data, int off, int len) throws IOException {
+  public void encode(OutputStream out, String string) throws IOException {
     if (out == null) {
       throw new NullPointerException("out");
-    } else if (data == null) {
-      throw new NullPointerException("data");
-    } else if (off < 0 || len < 0 || (off + len) < 0 || off > data.length || (off + len) > data.length) {
-      throw new IndexOutOfBoundsException();
-    } else if (len == 0) {
-      return;
+    } else if (string == null) {
+      throw new NullPointerException("string");
     }
 
     long current = 0;
     int n = 0;
+    int len = string.length();
 
     for (int i = 0; i < len; i++) {
-      int b = data[off + i] & 0xFF;
+      int b = string.charAt(i) & 0xFF;
       int code = codes[b];
       int nbits = lengths[b];
 
@@ -96,13 +82,13 @@ final class HuffmanEncoder {
    * @param  data the string literal to be Huffman encoded
    * @return the number of bytes required to Huffman encode <code>data</code>
    */
-  public int getEncodedLength(byte[] data) {
+  public int getEncodedLength(String data) {
     if (data == null) {
       throw new NullPointerException("data");
     }
     long len = 0;
-    for (byte b : data) {
-      len += lengths[b & 0xFF];
+    for (int i = 0; i < data.length(); i++) {
+      len += lengths[data.charAt(i) & 0xFF];
     }
     return (int)((len + 7) >> 3);
   }

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HuffmanEncoder.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/HuffmanEncoder.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/StaticTable.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/StaticTable.java
@@ -111,8 +111,7 @@ final class StaticTable {
    * Returns the lowest index value for the given header field name in the static table.
    * Returns -1 if the header field name is not in the static table.
    */
-  static int getIndex(byte[] name) {
-    String nameString = new String(name, 0, name.length, ISO_8859_1);
+  static int getIndex(String nameString) {
     Integer index = STATIC_INDEX_BY_NAME.get(nameString);
     if (index == null) {
       return -1;
@@ -124,7 +123,7 @@ final class StaticTable {
    * Returns the index value for the given header field in the static table.
    * Returns -1 if the header field is not in the static table.
    */
-  static int getIndex(byte[] name, byte[] value) {
+  static int getIndex(String name, String value) {
     int index = getIndex(name);
     if (index == -1) {
       return -1;
@@ -133,10 +132,7 @@ final class StaticTable {
     // Note this assumes all entries for a given header field are sequential.
     while (index <= length) {
       HeaderField entry = getEntry(index);
-      if (!HpackUtil.equals(name, entry.name)) {
-        break;
-      }
-      if (HpackUtil.equals(value, entry.value)) {
+      if (name.equals(entry.name) && value.equals(entry.value)) {
         return index;
       }
       index++;
@@ -153,8 +149,7 @@ final class StaticTable {
     // save the smallest index for a given name in the map.
     for (int index = length; index > 0; index--) {
       HeaderField entry = getEntry(index);
-      String name = new String(entry.name, 0, entry.name.length, ISO_8859_1);
-      ret.put(name, index);
+      ret.put(entry.name, index);
     }
     return ret;
   }

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/StaticTable.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/StaticTable.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/package-info.java
+++ b/akka-http-core/src/main/java/akka/http/shaded/com/twitter/hpack/package-info.java
@@ -1,4 +1,10 @@
 /*
+ * Copyright (C) 2009-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+/*
+ * Adapted from github.com/twitter/hpack with this license:
+ *
  * Copyright 2014 Twitter, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -103,7 +103,7 @@ private[http] object FrameEvent {
   final case class ParsedHeadersFrame(
     streamId:      Int,
     endStream:     Boolean,
-    keyValuePairs: Seq[(String, String)],
+    keyValuePairs: Seq[(String, AnyRef)],
     priorityInfo:  Option[PriorityFrame]
   ) extends StreamFrameEvent
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -100,12 +100,13 @@ private[http] object Http2Blueprint {
       initialDemuxerSettings: immutable.Seq[Setting] = Nil,
       upgraded: Boolean = false,
       telemetry: TelemetrySpi,
-      dateHeaderRendering: DateHeaderRendering): BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, NotUsed] = {
+    dateHeaderRendering: DateHeaderRendering): BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, NotUsed] = {
+    val masterHttpHeaderParser = HttpHeaderParser(settings.parserSettings, log) // FIXME: reuse for framing
     telemetry.serverConnection atop
       httpLayer(settings, log, dateHeaderRendering) atop
       serverDemux(settings.http2Settings, initialDemuxerSettings, upgraded) atop
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
-      hpackCoding() atop
+      hpackCoding(masterHttpHeaderParser) atop
       framing(log) atop
       errorHandling(log) atop
       idleTimeoutIfConfigured(settings.idleTimeout)
@@ -123,7 +124,7 @@ private[http] object Http2Blueprint {
       httpLayerClient(masterHttpHeaderParser, settings, log) atop
       clientDemux(settings.http2Settings, masterHttpHeaderParser) atop
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
-      hpackCoding() atop
+      hpackCoding(masterHttpHeaderParser) atop
       framingClient(log) atop
       errorHandling(log) atop
       idleTimeoutIfConfigured(settings.idleTimeout)
@@ -182,10 +183,10 @@ private[http] object Http2Blueprint {
    * TODO: introduce another FrameEvent type that exclude HeadersFrame and ContinuationFrame from
    * reaching the higher-level.
    */
-  def hpackCoding(): BidiFlow[FrameEvent, FrameEvent, FrameEvent, FrameEvent, NotUsed] =
+  def hpackCoding(masterHttpHeaderParser: HttpHeaderParser): BidiFlow[FrameEvent, FrameEvent, FrameEvent, FrameEvent, NotUsed] =
     BidiFlow.fromFlows(
       Flow[FrameEvent].via(HeaderCompression),
-      Flow[FrameEvent].via(HeaderDecompression)
+      Flow[FrameEvent].via(new HeaderDecompression(masterHttpHeaderParser))
     )
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -106,7 +106,7 @@ private[http] object Http2Blueprint {
       httpLayer(settings, log, dateHeaderRendering) atop
       serverDemux(settings.http2Settings, initialDemuxerSettings, upgraded) atop
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
-      hpackCoding(masterHttpHeaderParser) atop
+      hpackCoding(masterHttpHeaderParser, settings.parserSettings) atop
       framing(log) atop
       errorHandling(log) atop
       idleTimeoutIfConfigured(settings.idleTimeout)
@@ -124,7 +124,7 @@ private[http] object Http2Blueprint {
       httpLayerClient(masterHttpHeaderParser, settings, log) atop
       clientDemux(settings.http2Settings, masterHttpHeaderParser) atop
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
-      hpackCoding(masterHttpHeaderParser) atop
+      hpackCoding(masterHttpHeaderParser, settings.parserSettings) atop
       framingClient(log) atop
       errorHandling(log) atop
       idleTimeoutIfConfigured(settings.idleTimeout)
@@ -183,10 +183,10 @@ private[http] object Http2Blueprint {
    * TODO: introduce another FrameEvent type that exclude HeadersFrame and ContinuationFrame from
    * reaching the higher-level.
    */
-  def hpackCoding(masterHttpHeaderParser: HttpHeaderParser): BidiFlow[FrameEvent, FrameEvent, FrameEvent, FrameEvent, NotUsed] =
+  def hpackCoding(masterHttpHeaderParser: HttpHeaderParser, parserSettings: ParserSettings): BidiFlow[FrameEvent, FrameEvent, FrameEvent, FrameEvent, NotUsed] =
     BidiFlow.fromFlows(
       Flow[FrameEvent].via(HeaderCompression),
-      Flow[FrameEvent].via(new HeaderDecompression(masterHttpHeaderParser))
+      Flow[FrameEvent].via(new HeaderDecompression(masterHttpHeaderParser, parserSettings))
     )
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -46,7 +46,7 @@ private[http2] class Http2ClientDemux(http2Settings: Http2ClientSettings, master
   def wrapTrailingHeaders(headers: ParsedHeadersFrame): Option[ChunkStreamPart] = {
     val headerParser = masterHttpHeaderParser.createShallowCopy()
     Some(LastChunk(extension = "", headers.keyValuePairs.map {
-      case (name, value) => parseHeaderPair(headerParser, name, value)
+      case (name, value) => parseHeaderPair(headerParser, name, value.asInstanceOf[String])
     }.toList))
   }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -11,8 +11,7 @@ import akka.http.impl.engine.http2.Http2Protocol.ErrorCode.FLOW_CONTROL_ERROR
 import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
 import akka.http.impl.engine.http2.RequestParsing.parseHeaderPair
 import akka.http.impl.engine.parsing.HttpHeaderParser
-import akka.http.scaladsl.model.AttributeKey
-import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.{ AttributeKey, HttpEntity, HttpHeader }
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
 import akka.http.scaladsl.model.HttpEntity.LastChunk
 import akka.http.scaladsl.settings.{ Http2ClientSettings, Http2CommonSettings, Http2ServerSettings }
@@ -46,7 +45,8 @@ private[http2] class Http2ClientDemux(http2Settings: Http2ClientSettings, master
   def wrapTrailingHeaders(headers: ParsedHeadersFrame): Option[ChunkStreamPart] = {
     val headerParser = masterHttpHeaderParser.createShallowCopy()
     Some(LastChunk(extension = "", headers.keyValuePairs.map {
-      case (name, value) => parseHeaderPair(headerParser, name, value.asInstanceOf[String])
+      case (name, value: HttpHeader) => value
+      case (name, value)             => parseHeaderPair(headerParser, name, value.asInstanceOf[String])
     }.toList))
   }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -82,9 +82,9 @@ private[http2] object RequestParsing {
         val (path, rawQueryString) = pathAndRawQuery
         val authorityOrDefault: Uri.Authority = if (authority == null) Uri.Authority.Empty else authority
         val uri = Uri(scheme, authorityOrDefault, path, rawQueryString)
-        val request = HttpRequest(
-          method, uri, headers.result(), entity, HttpProtocols.`HTTP/2.0`
-        ).addAttribute(Http2.streamId, subStream.streamId)
+        val request = new HttpRequest(
+          method, uri, headers.result(), Map(Http2.streamId -> subStream.streamId), entity, HttpProtocols.`HTTP/2.0` // FIXME supply all attributes in one go
+        )
         val requestWithSession = sslSessionAttribute match {
           case Some(sslSession) => request.addAttribute(AttributeKeys.sslSession, SslSessionInfo(sslSession))
           case None             => request

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -165,6 +165,9 @@ private[http2] object RequestParsing {
             cookiesBuilder.append(value)
             rec(remainingHeaders.tail, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookiesBuilder, true, headers)
 
+          case (name, httpHeader: HttpHeader) =>
+            // FIXME: move validation to HeaderDecompression validateHeader(httpHeader)
+            rec(remainingHeaders.tail, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookies, true, headers += httpHeader)
           case (name, value: String) =>
             val httpHeader = parseHeaderPair(httpHeaderParser, name, value)
             validateHeader(httpHeader)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -168,9 +168,7 @@ private[http2] object RequestParsing {
               rec(incomingHeaders, offset + 1, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookiesBuilder, true, headers)
 
             case _ =>
-              val header = OtherHeader.get(value)
-              validateHeader(header)
-              rec(incomingHeaders, offset + 1, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookies, true, headers += header)
+              rec(incomingHeaders, offset + 1, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookies, true, headers += OtherHeader.get(value))
           }
         }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -56,7 +56,7 @@ private[http2] object RequestParsing {
     { subStream =>
       @tailrec
       def rec(
-        remainingHeaders:  Seq[(String, String)],
+        remainingHeaders:  Seq[(String, AnyRef)],
         method:            HttpMethod                 = null,
         scheme:            String                     = null,
         authority:         Uri.Authority              = null,
@@ -98,18 +98,18 @@ private[http2] object RequestParsing {
             case None                => requestWithSession
           }
         } else remainingHeaders.head match {
-          case (":scheme", value) =>
+          case (":scheme", value: String) =>
             checkUniquePseudoHeader(":scheme", scheme)
             checkNoRegularHeadersBeforePseudoHeader(":scheme", seenRegularHeader)
             rec(remainingHeaders.tail, method, value, authority, pathAndRawQuery, contentType, contentLength, cookies, seenRegularHeader, headers)
-          case (":method", value) =>
+          case (":method", value: String) =>
             checkUniquePseudoHeader(":method", method)
             checkNoRegularHeadersBeforePseudoHeader(":method", seenRegularHeader)
             val m = HttpMethods.getForKey(value)
               .orElse(serverSettings.parserSettings.customMethods(value))
               .getOrElse(malformedRequest(s"Unknown HTTP method: '$value'"))
             rec(remainingHeaders.tail, m, scheme, authority, pathAndRawQuery, contentType, contentLength, cookies, seenRegularHeader, headers)
-          case (":path", value) =>
+          case (":path", value: String) =>
             checkUniquePseudoHeader(":path", pathAndRawQuery)
             checkNoRegularHeadersBeforePseudoHeader(":path", seenRegularHeader)
             val newPathAndRawQuery: (Uri.Path, Option[String]) = try {
@@ -118,7 +118,7 @@ private[http2] object RequestParsing {
               case IllegalUriException(info) => throw new ParsingException(info)
             }
             rec(remainingHeaders.tail, method, scheme, authority, newPathAndRawQuery, contentType, contentLength, cookies, seenRegularHeader, headers)
-          case (":authority", value) =>
+          case (":authority", value: String) =>
             checkUniquePseudoHeader(":authority", authority)
             checkNoRegularHeadersBeforePseudoHeader(":authority", seenRegularHeader)
             val newAuthority: Uri.Authority = try {
@@ -130,20 +130,24 @@ private[http2] object RequestParsing {
           case (":status", _) =>
             malformedRequest("Pseudo-header ':status' is for responses only; it cannot appear in a request")
 
-          case ("content-type", ct) =>
+          case ("content-type", ct: String) =>
             if (contentType.isEmpty) {
               val contentTypeValue = ContentType.parse(ct).right.getOrElse(malformedRequest(s"Invalid content-type: '$ct'"))
               rec(remainingHeaders.tail, method, scheme, authority, pathAndRawQuery, OptionVal.Some(contentTypeValue), contentLength, cookies, true, headers)
             } else malformedRequest("HTTP message must not contain more than one content-type header")
 
-          case ("content-length", length) =>
+          case ("content-type", contentTypeValue: ContentType) =>
+            if (contentType.isEmpty) rec(remainingHeaders.tail, method, scheme, authority, pathAndRawQuery, OptionVal.Some(contentTypeValue), contentLength, cookies, true, headers)
+            else malformedRequest("HTTP message must not contain more than one content-type header")
+
+          case ("content-length", length: String) =>
             if (contentLength == -1) {
               val contentLengthValue = length.toLong
               if (contentLengthValue < 0) malformedRequest("HTTP message must not contain a negative content-length header")
               rec(remainingHeaders.tail, method, scheme, authority, pathAndRawQuery, contentType, contentLengthValue, cookies, true, headers)
             } else malformedRequest("HTTP message must not contain more than one content-length header")
 
-          case ("cookie", value) =>
+          case ("cookie", value: String) =>
             // Compress cookie headers as described here https://tools.ietf.org/html/rfc7540#section-8.1.2.5
             val cookiesBuilder = if (cookies == null) {
               new StringBuilder
@@ -153,7 +157,7 @@ private[http2] object RequestParsing {
             cookiesBuilder.append(value)
             rec(remainingHeaders.tail, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookiesBuilder, true, headers)
 
-          case (name, value) =>
+          case (name, value: String) =>
             val httpHeader = parseHeaderPair(httpHeaderParser, name, value)
             validateHeader(httpHeader)
             rec(remainingHeaders.tail, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookies, true, headers += httpHeader)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestParsing.scala
@@ -168,7 +168,9 @@ private[http2] object RequestParsing {
               rec(incomingHeaders, offset + 1, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookiesBuilder, true, headers)
 
             case _ =>
-              rec(incomingHeaders, offset + 1, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookies, true, headers += OtherHeader.get(value))
+              val header = OtherHeader.get(value)
+              validateHeader(header)
+              rec(incomingHeaders, offset + 1, method, scheme, authority, pathAndRawQuery, contentType, contentLength, cookies, true, headers += header)
           }
         }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
@@ -93,8 +93,7 @@ private[http2] object ResponseParsing {
         case (name, _) if name.startsWith(":") =>
           malformedRequest(s"Unexpected pseudo-header '$name' in response")
 
-        case (name, httpHeader: HttpHeader) =>
-          // FIXME: move validation to HeaderDecompression validateHeader(httpHeader)
+        case (_, httpHeader: HttpHeader) =>
           rec(remainingHeaders.tail, status, contentType, contentLength, seenRegularHeader = true, headers += httpHeader)
 
         case (name, value: String) =>

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
@@ -38,7 +38,7 @@ private[http2] object ResponseParsing {
 
     @tailrec
     def rec(
-      remainingHeaders:  Seq[(String, String)],
+      remainingHeaders:  Seq[(String, AnyRef)],
       status:            StatusCode                = null,
       contentType:       OptionVal[ContentType]    = OptionVal.None,
       contentLength:     Long                      = -1,
@@ -66,18 +66,24 @@ private[http2] object ResponseParsing {
         }
 
       } else remainingHeaders.head match {
-        case (":status", statusCodeValue) =>
+        case (":status", statusCodeValue: String) =>
           checkUniquePseudoHeader(":status", status)
           checkNoRegularHeadersBeforePseudoHeader(":status", seenRegularHeader)
           rec(remainingHeaders.tail, statusCodeValue.toInt, contentType, contentLength, seenRegularHeader, headers)
 
-        case ("content-type", ct) =>
+        case ("content-type", ct: String) =>
           if (contentType.isEmpty) {
             val contentTypeValue = ContentType.parse(ct).right.getOrElse(malformedRequest(s"Invalid content-type: '$ct'"))
             rec(remainingHeaders.tail, status, OptionVal.Some(contentTypeValue), contentLength, seenRegularHeader, headers)
           } else malformedRequest("HTTP message must not contain more than one content-type header")
 
-        case ("content-length", length) =>
+        case ("content-type", contentTypeValue: ContentType) =>
+          if (contentType.isEmpty)
+            rec(remainingHeaders.tail, status, OptionVal.Some(contentTypeValue), contentLength, seenRegularHeader, headers)
+          else
+            malformedRequest("HTTP message must not contain more than one content-type header")
+
+        case ("content-length", length: String) =>
           if (contentLength == -1) {
             val contentLengthValue = length.toLong
             if (contentLengthValue < 0) malformedRequest("HTTP message must not contain a negative content-length header")
@@ -87,7 +93,7 @@ private[http2] object ResponseParsing {
         case (name, _) if name.startsWith(":") =>
           malformedRequest(s"Unexpected pseudo-header '$name' in response")
 
-        case (name, value) =>
+        case (name, value: String) =>
           val httpHeader = parseHeaderPair(httpHeaderParser, name, value)
           validateHeader(httpHeader)
           rec(remainingHeaders.tail, status, contentType, contentLength, seenRegularHeader = true, headers += httpHeader)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -41,8 +41,10 @@ private[http2] object HeaderCompression extends GraphStage[FlowShape[FrameEvent,
 
         case ParsedHeadersFrame(streamId, endStream, kvs, prioInfo) =>
           kvs.foreach {
+            case (key, value: String) =>
+              encoder.encodeHeader(os, key, value, false)
             case (key, value) =>
-              encoder.encodeHeader(os, key, value.asInstanceOf[String], false)
+              throw new IllegalStateException(s"Didn't expect key-value-pair [$key] -> [$value](${value.getClass}) here.")
           }
           val result = ByteString(os.toByteArray)
           os.reset()

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -10,7 +10,7 @@ import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
 import akka.http.impl.engine.http2._
 import akka.stream.{ Attributes, FlowShape, Inlet, Outlet }
 import akka.stream.stage.{ GraphStage, GraphStageLogic, OutHandler, StageLogging }
-import akka.util.{ ByteString, Unsafe }
+import akka.util.ByteString
 
 import scala.collection.immutable
 import FrameEvent._
@@ -42,12 +42,7 @@ private[http2] object HeaderCompression extends GraphStage[FlowShape[FrameEvent,
         case ParsedHeadersFrame(streamId, endStream, kvs, prioInfo) =>
           kvs.foreach {
             case (key, value) =>
-              val keyBytes = new Array[Byte](key.length)
-              Unsafe.copyUSAsciiStrToBytes(key, keyBytes)
-              val valueStr = value.asInstanceOf[String]
-              val valueBytes = new Array[Byte](valueStr.length)
-              Unsafe.copyUSAsciiStrToBytes(valueStr, valueBytes)
-              encoder.encodeHeader(os, keyBytes, valueBytes, false)
+              encoder.encodeHeader(os, key, value.asInstanceOf[String], false)
           }
           val result = ByteString(os.toByteArray)
           os.reset()

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -44,8 +44,9 @@ private[http2] object HeaderCompression extends GraphStage[FlowShape[FrameEvent,
             case (key, value) =>
               val keyBytes = new Array[Byte](key.length)
               Unsafe.copyUSAsciiStrToBytes(key, keyBytes)
-              val valueBytes = new Array[Byte](value.length)
-              Unsafe.copyUSAsciiStrToBytes(value, valueBytes)
+              val valueStr = value.asInstanceOf[String]
+              val valueBytes = new Array[Byte](valueStr.length)
+              Unsafe.copyUSAsciiStrToBytes(valueStr, valueBytes)
               encoder.encodeHeader(os, keyBytes, valueBytes, false)
           }
           val result = ByteString(os.toByteArray)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -44,7 +44,7 @@ private[http2] object HeaderCompression extends GraphStage[FlowShape[FrameEvent,
         case ParsedHeadersFrame(streamId, endStream, kvs, prioInfo) =>
           kvs.foreach {
             case (key, value) =>
-              encoder.encodeHeader(os, key.getBytes(HeaderDecompression.UTF8), value.getBytes(HeaderDecompression.UTF8), false)
+              encoder.encodeHeader(os, key.getBytes(HeaderDecompression.US_ASCII), value.getBytes(HeaderDecompression.US_ASCII), false)
           }
           val result = ByteString(os.toByteArray)
           os.reset()

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -9,7 +9,8 @@ import java.nio.charset.StandardCharsets
 import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2._
-import akka.http.impl.engine.http2.RequestParsing.{ checkNoRegularHeadersBeforePseudoHeader, checkUniquePseudoHeader, malformedRequest }
+import akka.http.impl.engine.http2.RequestParsing.{ checkNoRegularHeadersBeforePseudoHeader, checkUniquePseudoHeader, malformedRequest, parseHeaderPair }
+import akka.http.impl.engine.parsing.HttpHeaderParser
 import akka.http.scaladsl.model.{ ContentType, IllegalUriException, ParsingException, Uri }
 import akka.http.shaded.com.twitter.hpack.HeaderListener
 import akka.stream._
@@ -26,7 +27,7 @@ import akka.http.impl.engine.http2.Http2Compliance.Http2ProtocolException
  * Can be used on server and client side.
  */
 @InternalApi
-private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEvent, FrameEvent]] {
+private[http2] class HeaderDecompression(masterHeaderParser: HttpHeaderParser) extends GraphStage[FlowShape[FrameEvent, FrameEvent]] {
   val UTF8 = StandardCharsets.UTF_8
   val US_ASCII = StandardCharsets.US_ASCII
 
@@ -36,6 +37,7 @@ private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEven
   val shape = FlowShape(eventsIn, eventsOut)
 
   def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new HandleOrPassOnStage[FrameEvent, FrameEvent](shape) {
+    val httpHeaderParser = masterHeaderParser.createShallowCopy()
     val decoder = new akka.http.shaded.com.twitter.hpack.Decoder(Http2Protocol.InitialMaxHeaderListSize, Http2Protocol.InitialMaxHeaderTableSize)
 
     become(Idle)
@@ -80,9 +82,16 @@ private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEven
                 }
                 headers += name -> newPathAndRawQuery
                 newPathAndRawQuery
-              case _ =>
+              case "content-length" | "cookie" =>
                 headers += name -> value
                 value
+              case x if x(0) == ':' =>
+                headers += name -> value
+                value
+              case _ =>
+                val parsed = parseHeaderPair(httpHeaderParser, name, value)
+                headers += name -> parsed
+                parsed
             }
           }
         }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -48,7 +48,7 @@ private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEven
     def parseAndEmit(streamId: Int, endStream: Boolean, payload: ByteString, prioInfo: Option[PriorityFrame]): Unit = {
       val headers = new VectorBuilder[(String, String)]
       object Receiver extends HeaderListener {
-        def addHeader(name: Array[Byte], value: Array[Byte], sensitive: Boolean): Unit =
+        def addHeader(name: Array[Byte], value: Array[Byte], parsed: AnyRef, sensitive: Boolean): Unit =
           // TODO: optimization: use preallocated strings for well-known names, similar to what happens in HeaderParser
           headers += byteArrayToAsciiString(name) -> byteArrayToAsciiString(value)
       }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -26,6 +26,7 @@ import akka.http.impl.engine.http2.Http2Compliance.Http2ProtocolException
 @InternalApi
 private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEvent, FrameEvent]] {
   val UTF8 = StandardCharsets.UTF_8
+  val US_ASCII = StandardCharsets.US_ASCII
 
   val eventsIn = Inlet[FrameEvent]("HeaderDecompression.eventsIn")
   val eventsOut = Outlet[FrameEvent]("HeaderDecompression.eventsOut")
@@ -46,7 +47,7 @@ private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEven
       object Receiver extends HeaderListener {
         def addHeader(name: Array[Byte], value: Array[Byte], sensitive: Boolean): Unit =
           // TODO: optimization: use preallocated strings for well-known names, similar to what happens in HeaderParser
-          headers += new String(name, UTF8) -> new String(value, UTF8)
+          headers += new String(name, US_ASCII) -> new String(value, US_ASCII)
       }
       try {
         decoder.decode(ByteStringInputStream(payload), Receiver)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -61,13 +61,13 @@ private[http2] class HeaderDecompression(masterHeaderParser: HttpHeaderParser, p
             }
 
             name match {
-              case "content-type"   => handle(ContentType.parse(parserSettings, value))
-              case ":authority"     => handle(Authority.parse(parserSettings, value))
-              case ":path"          => handle(PathAndQuery.parse(parserSettings, value))
-              case ":method"        => handle(Method.parse(parserSettings, value))
-              case ":scheme"        => handle(Scheme.parse(parserSettings, value))
-              case "content-length" => handle(ContentLength.parse(parserSettings, value))
-              case "cookie"         => handle(Cookie.parse(parserSettings, value))
+              case "content-type"   => handle(ContentType.parse(name, value, parserSettings))
+              case ":authority"     => handle(Authority.parse(name, value, parserSettings))
+              case ":path"          => handle(PathAndQuery.parse(name, value, parserSettings))
+              case ":method"        => handle(Method.parse(name, value, parserSettings))
+              case ":scheme"        => handle(Scheme.parse(name, value, parserSettings))
+              case "content-length" => handle(ContentLength.parse(name, value, parserSettings))
+              case "cookie"         => handle(Cookie.parse(name, value, parserSettings))
               case x if x(0) == ':' => handle(value)
               case _ =>
                 // cannot use OtherHeader.parse because that doesn't has access to header parser

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -27,7 +27,7 @@ import scala.collection.immutable.VectorBuilder
  * Can be used on server and client side.
  */
 @InternalApi
-private[http2] class HeaderDecompression(masterHeaderParser: HttpHeaderParser, parserSettings: ParserSettings) extends GraphStage[FlowShape[FrameEvent, FrameEvent]] {
+private[http2] final class HeaderDecompression(masterHeaderParser: HttpHeaderParser, parserSettings: ParserSettings) extends GraphStage[FlowShape[FrameEvent, FrameEvent]] {
   val UTF8 = StandardCharsets.UTF_8
   val US_ASCII = StandardCharsets.US_ASCII
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -9,8 +9,8 @@ import java.nio.charset.StandardCharsets
 import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2._
-import akka.http.impl.engine.http2.RequestParsing.malformedRequest
-import akka.http.scaladsl.model.ContentType
+import akka.http.impl.engine.http2.RequestParsing.{ checkNoRegularHeadersBeforePseudoHeader, checkUniquePseudoHeader, malformedRequest }
+import akka.http.scaladsl.model.{ ContentType, IllegalUriException, ParsingException, Uri }
 import akka.http.shaded.com.twitter.hpack.HeaderListener
 import akka.stream._
 import akka.stream.stage.{ GraphStage, GraphStageLogic }
@@ -53,18 +53,37 @@ private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEven
         def addHeader(nameBytes: Array[Byte], valueBytes: Array[Byte], parsed: AnyRef, sensitive: Boolean): AnyRef = {
           // TODO: optimization: use preallocated strings for well-known names, similar to what happens in HeaderParser
           val name = byteArrayToAsciiString(nameBytes)
-          def value = byteArrayToAsciiString(valueBytes)
 
           if (parsed ne null) {
             headers += name -> parsed
             parsed
-          } else if (name == "content-type") {
-            val contentTypeValue = ContentType.parse(value).right.getOrElse(malformedRequest(s"Invalid content-type: '$value'"))
-            headers += name -> contentTypeValue
-            contentTypeValue
           } else {
-            headers += name -> value
-            value
+            val value = byteArrayToAsciiString(valueBytes)
+            name match {
+              case "content-type" =>
+                val contentTypeValue = ContentType.parse(value).right.getOrElse(malformedRequest(s"Invalid content-type: '$value'"))
+                headers += name -> contentTypeValue
+                contentTypeValue
+              case ":authority" =>
+                val authority: Uri.Authority = try {
+                  Uri.parseHttp2AuthorityPseudoHeader(value /*FIXME: , mode = serverSettings.parserSettings.uriParsingMode*/ )
+                } catch {
+                  case IllegalUriException(info) => throw new ParsingException(info)
+                }
+                headers += name -> authority
+                authority
+              case ":path" =>
+                val newPathAndRawQuery: (Uri.Path, Option[String]) = try {
+                  Uri.parseHttp2PathPseudoHeader(value /* FIXME:, mode = serverSettings.parserSettings.uriParsingMode */ )
+                } catch {
+                  case IllegalUriException(info) => throw new ParsingException(info)
+                }
+                headers += name -> newPathAndRawQuery
+                newPathAndRawQuery
+              case _ =>
+                headers += name -> value
+                value
+            }
           }
         }
       }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -9,6 +9,8 @@ import java.nio.charset.StandardCharsets
 import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2._
+import akka.http.impl.engine.http2.RequestParsing.malformedRequest
+import akka.http.scaladsl.model.ContentType
 import akka.http.shaded.com.twitter.hpack.HeaderListener
 import akka.stream._
 import akka.stream.stage.{ GraphStage, GraphStageLogic }
@@ -46,11 +48,25 @@ private[http2] object HeaderDecompression extends GraphStage[FlowShape[FrameEven
       new String(bs, 0, 0, bs.length)
 
     def parseAndEmit(streamId: Int, endStream: Boolean, payload: ByteString, prioInfo: Option[PriorityFrame]): Unit = {
-      val headers = new VectorBuilder[(String, String)]
+      val headers = new VectorBuilder[(String, AnyRef)]
       object Receiver extends HeaderListener {
-        def addHeader(name: Array[Byte], value: Array[Byte], parsed: AnyRef, sensitive: Boolean): Unit =
+        def addHeader(nameBytes: Array[Byte], valueBytes: Array[Byte], parsed: AnyRef, sensitive: Boolean): AnyRef = {
           // TODO: optimization: use preallocated strings for well-known names, similar to what happens in HeaderParser
-          headers += byteArrayToAsciiString(name) -> byteArrayToAsciiString(value)
+          val name = byteArrayToAsciiString(nameBytes)
+          def value = byteArrayToAsciiString(valueBytes)
+
+          if (parsed ne null) {
+            headers += name -> parsed
+            parsed
+          } else if (name == "content-type") {
+            val contentTypeValue = ContentType.parse(value).right.getOrElse(malformedRequest(s"Invalid content-type: '$value'"))
+            headers += name -> contentTypeValue
+            contentTypeValue
+          } else {
+            headers += name -> value
+            value
+          }
+        }
       }
       try {
         decoder.decode(ByteStringInputStream(payload), Receiver)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -71,7 +71,9 @@ private[http2] class HeaderDecompression(masterHeaderParser: HttpHeaderParser, p
               case x if x(0) == ':' => handle(value)
               case _ =>
                 // cannot use OtherHeader.parse because that doesn't has access to header parser
-                handle(parseHeaderPair(httpHeaderParser, name, value))
+                val header = parseHeaderPair(httpHeaderParser, name, value)
+                RequestParsing.validateHeader(header)
+                handle(header)
             }
           }
         }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/Http2HeaderParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/Http2HeaderParsing.scala
@@ -3,50 +3,72 @@ package akka.http.impl.engine.http2.hpack
 import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.RequestParsing.malformedRequest
 import akka.http.scaladsl.model
-import model.{ HttpHeader, HttpMethod, HttpMethods, IllegalUriException, ParsingException, Uri }
+import akka.http.scaladsl.model.HttpHeader.ParsingResult
+import model.{ HttpHeader, HttpMethod, HttpMethods, IllegalUriException, ParsingException, StatusCode, Uri }
 import akka.http.scaladsl.settings.ParserSettings
 
 @InternalApi
 private[akka] object Http2HeaderParsing {
-  sealed trait HeaderParser[+T] {
-    def parse(parserSettings: ParserSettings, value: String): T
+  sealed abstract class HeaderParser[+T](val headerName: String) {
+    def parse(name: String, value: String, parserSettings: ParserSettings): T
     def get(value: AnyRef): T = value.asInstanceOf[T]
   }
-  sealed abstract class Unparsed extends HeaderParser[String] {
-    override def parse(parserSettings: ParserSettings, value: String): String = value
+  sealed abstract class Verbatim(headerName: String) extends HeaderParser[String](headerName) {
+    override def parse(name: String, value: String, parserSettings: ParserSettings): String = value
   }
 
-  object Scheme extends Unparsed
-  object Method extends HeaderParser[HttpMethod] {
-    override def parse(parserSettings: ParserSettings, value: String): HttpMethod =
+  object Scheme extends Verbatim(":scheme")
+  object Method extends HeaderParser[HttpMethod](":method") {
+    override def parse(name: String, value: String, parserSettings: ParserSettings): HttpMethod =
       HttpMethods.getForKey(value)
         .orElse(parserSettings.customMethods(value))
         .getOrElse(malformedRequest(s"Unknown HTTP method: '$value'"))
   }
-  object PathAndQuery extends HeaderParser[(Uri.Path, Option[String])] {
-    override def parse(parserSettings: ParserSettings, value: String): (Uri.Path, Option[String]) =
+  object PathAndQuery extends HeaderParser[(Uri.Path, Option[String])](":path") {
+    override def parse(name: String, value: String, parserSettings: ParserSettings): (Uri.Path, Option[String]) =
       try {
         Uri.parseHttp2PathPseudoHeader(value, mode = parserSettings.uriParsingMode)
       } catch {
         case IllegalUriException(info) => throw new ParsingException(info)
       }
   }
-  object Authority extends HeaderParser[Uri.Authority] {
-    override def parse(parserSettings: ParserSettings, value: String): Uri.Authority =
+  object Authority extends HeaderParser[Uri.Authority](":authority") {
+    override def parse(name: String, value: String, parserSettings: ParserSettings): Uri.Authority =
       try {
         Uri.parseHttp2AuthorityPseudoHeader(value /*FIXME: , mode = serverSettings.parserSettings.uriParsingMode*/ )
       } catch {
         case IllegalUriException(info) => throw new ParsingException(info)
       }
   }
-  object ContentType extends HeaderParser[model.ContentType] {
-    override def parse(parserSettings: ParserSettings, value: String): model.ContentType =
+  object Status extends HeaderParser[StatusCode](":status") {
+    override def parse(name: String, value: String, parserSettings: ParserSettings): StatusCode =
+      value.toInt
+  }
+  object ContentType extends HeaderParser[model.ContentType]("content-type") {
+    override def parse(name: String, value: String, parserSettings: ParserSettings): model.ContentType =
       model.ContentType.parse(value).right.getOrElse(malformedRequest(s"Invalid content-type: '$value'"))
   }
-  object ContentLength extends Unparsed
-  object Cookie extends Unparsed
-  object OtherHeader extends HeaderParser[HttpHeader] {
-    override def parse(parserSettings: ParserSettings, value: String): HttpHeader =
+  object ContentLength extends Verbatim("content-length")
+  object Cookie extends Verbatim("cookie")
+  object OtherHeader extends HeaderParser[HttpHeader]("<other>") {
+    override def parse(name: String, value: String, parserSettings: ParserSettings): HttpHeader =
       throw new IllegalStateException("Needs to be parsed directly")
+  }
+
+  val Parsers: Map[String, HeaderParser[AnyRef]] =
+    Seq(
+      Method, Scheme, Authority, PathAndQuery, ContentType, Status, ContentLength, Cookie
+    ).map(p => p.headerName -> p).toMap
+
+  def parse(name: String, value: String, parserSettings: ParserSettings): (String, AnyRef) = {
+    name -> Parsers.getOrElse(name, Modeled).parse(name, value, parserSettings)
+  }
+
+  private object Modeled extends HeaderParser[HttpHeader]("<modeled>") {
+    override def parse(name: String, value: String, parserSettings: ParserSettings): HttpHeader =
+      HttpHeader.parse(name, value, parserSettings) match {
+        case ParsingResult.Ok(header, _) => header
+        case ParsingResult.Error(error)  => throw new IllegalStateException(error.detail)
+      }
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/Http2HeaderParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/Http2HeaderParsing.scala
@@ -1,0 +1,52 @@
+package akka.http.impl.engine.http2.hpack
+
+import akka.annotation.InternalApi
+import akka.http.impl.engine.http2.RequestParsing.malformedRequest
+import akka.http.scaladsl.model
+import model.{ HttpHeader, HttpMethod, HttpMethods, IllegalUriException, ParsingException, Uri }
+import akka.http.scaladsl.settings.ParserSettings
+
+@InternalApi
+private[akka] object Http2HeaderParsing {
+  sealed trait HeaderParser[+T] {
+    def parse(parserSettings: ParserSettings, value: String): T
+    def get(value: AnyRef): T = value.asInstanceOf[T]
+  }
+  sealed abstract class Unparsed extends HeaderParser[String] {
+    override def parse(parserSettings: ParserSettings, value: String): String = value
+  }
+
+  object Scheme extends Unparsed
+  object Method extends HeaderParser[HttpMethod] {
+    override def parse(parserSettings: ParserSettings, value: String): HttpMethod =
+      HttpMethods.getForKey(value)
+        .orElse(parserSettings.customMethods(value))
+        .getOrElse(malformedRequest(s"Unknown HTTP method: '$value'"))
+  }
+  object PathAndQuery extends HeaderParser[(Uri.Path, Option[String])] {
+    override def parse(parserSettings: ParserSettings, value: String): (Uri.Path, Option[String]) =
+      try {
+        Uri.parseHttp2PathPseudoHeader(value, mode = parserSettings.uriParsingMode)
+      } catch {
+        case IllegalUriException(info) => throw new ParsingException(info)
+      }
+  }
+  object Authority extends HeaderParser[Uri.Authority] {
+    override def parse(parserSettings: ParserSettings, value: String): Uri.Authority =
+      try {
+        Uri.parseHttp2AuthorityPseudoHeader(value /*FIXME: , mode = serverSettings.parserSettings.uriParsingMode*/ )
+      } catch {
+        case IllegalUriException(info) => throw new ParsingException(info)
+      }
+  }
+  object ContentType extends HeaderParser[model.ContentType] {
+    override def parse(parserSettings: ParserSettings, value: String): model.ContentType =
+      model.ContentType.parse(value).right.getOrElse(malformedRequest(s"Invalid content-type: '$value'"))
+  }
+  object ContentLength extends Unparsed
+  object Cookie extends Unparsed
+  object OtherHeader extends HeaderParser[HttpHeader] {
+    override def parse(parserSettings: ParserSettings, value: String): HttpHeader =
+      throw new IllegalStateException("Needs to be parsed directly")
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/Http2HeaderParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/Http2HeaderParsing.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.impl.engine.http2.hpack
 
 import akka.annotation.InternalApi

--- a/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedByteArray.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedByteArray.scala
@@ -5,7 +5,6 @@
 package akka.http.impl.util
 
 import akka.annotation.InternalApi
-import com.github.ghik.silencer.silent
 
 import scala.annotation.tailrec
 
@@ -32,8 +31,4 @@ private[http] class EnhancedByteArray(val underlying: Array[Byte]) extends AnyVa
 
     other.length == underlying.length && xor() == 0
   }
-
-  @silent("deprecated")
-  def asciiString: String =
-    new String(underlying, 0, 0, underlying.length)
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedByteArray.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedByteArray.scala
@@ -5,6 +5,7 @@
 package akka.http.impl.util
 
 import akka.annotation.InternalApi
+import com.github.ghik.silencer.silent
 
 import scala.annotation.tailrec
 
@@ -31,4 +32,8 @@ private[http] class EnhancedByteArray(val underlying: Array[Byte]) extends AnyVa
 
     other.length == underlying.length && xor() == 0
   }
+
+  @silent("deprecated")
+  def asciiString: String =
+    new String(underlying, 0, 0, underlying.length)
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StringTools.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StringTools.scala
@@ -1,0 +1,16 @@
+package akka.http.impl.util
+
+import akka.annotation.InternalApi
+import com.github.ghik.silencer.silent
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[http] object StringTools {
+  @silent("deprecated")
+  def asciiStringFromBytes(bytes: Array[Byte]): String =
+    // Deprecated constructor but also (unfortunately) the fastest way to convert a ASCII encoded byte array
+    // into a String without extra copying.
+    new String(bytes, 0)
+}

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StringTools.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StringTools.scala
@@ -1,6 +1,7 @@
 package akka.http.impl.util
 
 import akka.annotation.InternalApi
+import akka.util.Unsafe
 import com.github.ghik.silencer.silent
 
 /**
@@ -13,4 +14,10 @@ private[http] object StringTools {
     // Deprecated constructor but also (unfortunately) the fastest way to convert a ASCII encoded byte array
     // into a String without extra copying.
     new String(bytes, 0)
+
+  def asciiStringBytes(string: String): Array[Byte] = {
+    val bytes = new Array[Byte](string.length)
+    Unsafe.copyUSAsciiStrToBytes(string, bytes)
+    bytes
+  }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/StringTools.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StringTools.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.impl.util
 
 import akka.annotation.InternalApi

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
@@ -86,7 +86,7 @@ trait Http2FrameHpackSupport extends Http2FrameProbeDelegator with Http2FrameSen
   def encodeHeaderPairs(headerPairs: Seq[(String, String)]): ByteString = {
     val bos = new ByteArrayOutputStream()
 
-    def encode(name: String, value: String): Unit = encoder.encodeHeader(bos, name.getBytes, value.getBytes, false)
+    def encode(name: String, value: String): Unit = encoder.encodeHeader(bos, name, value, false)
 
     headerPairs.foreach((encode _).tupled)
 
@@ -100,8 +100,8 @@ trait Http2FrameHpackSupport extends Http2FrameProbeDelegator with Http2FrameSen
     val hs = new VectorBuilder[(String, String)]()
 
     decoder.decode(bis, new HeaderListener {
-      def addHeader(name: Array[Byte], value: Array[Byte], parsedValue: AnyRef, sensitive: Boolean): AnyRef = {
-        hs += new String(name) -> new String(value)
+      def addHeader(name: String, value: String, parsedValue: AnyRef, sensitive: Boolean): AnyRef = {
+        hs += name -> value
         parsedValue
       }
     })

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
@@ -100,7 +100,7 @@ trait Http2FrameHpackSupport extends Http2FrameProbeDelegator with Http2FrameSen
     val hs = new VectorBuilder[(String, String)]()
 
     decoder.decode(bis, new HeaderListener {
-      def addHeader(name: Array[Byte], value: Array[Byte], sensitive: Boolean): Unit =
+      def addHeader(name: Array[Byte], value: Array[Byte], parsedValue: AnyRef, sensitive: Boolean): Unit =
         hs += new String(name) -> new String(value)
     })
     hs.result()

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2FrameHpackSupport.scala
@@ -100,8 +100,10 @@ trait Http2FrameHpackSupport extends Http2FrameProbeDelegator with Http2FrameSen
     val hs = new VectorBuilder[(String, String)]()
 
     decoder.decode(bis, new HeaderListener {
-      def addHeader(name: Array[Byte], value: Array[Byte], parsedValue: AnyRef, sensitive: Boolean): Unit =
+      def addHeader(name: Array[Byte], value: Array[Byte], parsedValue: AnyRef, sensitive: Boolean): AnyRef = {
         hs += new String(name) -> new String(value)
+        parsedValue
+      }
     })
     hs.result()
   }


### PR DESCRIPTION
Aside from the write coalescing work (which is now continued in https://github.com/akka/akka/pull/30334) this is the biggest chunk of performance improvements that I have queued.

Tests should be fine but some cleanups are still pending.