### PR TITLE
core: don't include RequestTimeoutSupport if disabled

### DIFF
--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -43,7 +43,7 @@ akka.http {
     # the idle-timeout will kick in first and reset the TCP connection
     # without a response.
     #
-    # If this setting is not `infinite` the HTTP server layer attaches a
+    # If this setting is not `off` the HTTP server layer attaches a
     # `Timeout-Access` header to the request, which enables programmatic
     # customization of the timeout period and timeout response for each
     # request individually.

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -86,7 +86,8 @@ private[http] object HttpServerBluePrint {
     BidiFlow.fromFlows(Flow[HttpResponse], new PrepareRequests(settings))
 
   def requestTimeoutSupport(timeout: Duration, log: LoggingAdapter): BidiFlow[HttpResponse, HttpResponse, HttpRequest, HttpRequest, NotUsed] =
-    BidiFlow.fromGraph(new RequestTimeoutSupport(timeout, log)).reversed
+    if (timeout == Duration.Inf) BidiFlow.identity[HttpResponse, HttpRequest]
+    else BidiFlow.fromGraph(new RequestTimeoutSupport(timeout, log)).reversed
 
   /**
    * Two state stage, either transforms an incoming RequestOutput into a HttpRequest with strict entity and then pushes

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -86,7 +86,7 @@ private[http] object HttpServerBluePrint {
     BidiFlow.fromFlows(Flow[HttpResponse], new PrepareRequests(settings))
 
   def requestTimeoutSupport(timeout: Duration, log: LoggingAdapter): BidiFlow[HttpResponse, HttpResponse, HttpRequest, HttpRequest, NotUsed] =
-    if (timeout == Duration.Inf) BidiFlow.identity[HttpResponse, HttpRequest]
+    if (timeout == Duration.Zero) BidiFlow.identity[HttpResponse, HttpRequest]
     else BidiFlow.fromGraph(new RequestTimeoutSupport(timeout, log)).reversed
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ServerSettingsImpl.scala
@@ -81,7 +81,6 @@ private[http] object ServerSettingsImpl extends SettingsCompanionImpl[ServerSett
     bindTimeout:    FiniteDuration,
     lingerTimeout:  Duration) extends ServerSettings.Timeouts {
     require(idleTimeout > Duration.Zero, "idleTimeout must be infinite or > 0")
-    require(requestTimeout > Duration.Zero, "requestTimeout must be infinite or > 0")
     require(bindTimeout > Duration.Zero, "bindTimeout must be > 0")
     require(lingerTimeout > Duration.Zero, "lingerTimeout must be infinite or > 0")
   }
@@ -93,7 +92,7 @@ private[http] object ServerSettingsImpl extends SettingsCompanionImpl[ServerSett
       PreviewServerSettingsImpl.fromSubConfig(root, c.getConfig("preview")),
       Timeouts(
         c.getPotentiallyInfiniteDuration("idle-timeout"),
-        c.getPotentiallyInfiniteDuration("request-timeout"),
+        if (c.getString("request-timeout") == "off") Duration.Zero else c.getPotentiallyInfiniteDuration("request-timeout"),
         c.getFiniteDuration("bind-timeout"),
         c.getPotentiallyInfiniteDuration("linger-timeout")),
       c.getInt("max-connections"),


### PR DESCRIPTION
This is a small optimization for HTTP/1.1.

The documentation of `request-timeout` already hints that you will get
no dynamic request-timeout support if you turn off the feature by setting
it to `infinite`. For some reason never made use of that flexibility.

It turns out that request timeout support is expensive even if it is enabled,
so this will help HTTP/1.1 performance a bit.