### PR TITLE
http2: use cached ContentType.value instead of toString

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/cache-content-type-rendering.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.4.backwards.excludes/cache-content-type-rendering.excludes
@@ -1,4 +1,4 @@
 # add private[this] var to trait with completely sealed class hierarchy
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ContentType.akka$http$scaladsl$model$ContentType$$super$value")
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ContentType.akka$http$scaladsl$model$ContentType$$_value")
-ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ContentType.akka$http$scaladsl$model$ContentType$$_value_=")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ContentType.akka$http$scaladsl$model$ContentType$$super$toString")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ContentType.akka$http$scaladsl$model$ContentType$$_toString")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.model.ContentType.akka$http$scaladsl$model$ContentType$$_toString_=")

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentType.scala
@@ -48,11 +48,11 @@ sealed trait ContentType extends jm.ContentType with ValueRenderable {
   def mediaType: MediaType
   def charsetOption: Option[HttpCharset]
 
-  private[this] var _value: String = _
-  override def value: String = {
-    if (_value eq null)
-      _value = super.value
-    _value
+  private[this] var _toString: String = _
+  override def toString: String = {
+    if (_toString eq null)
+      _toString = super.toString
+    _toString
   }
 
   private[http] def render[R <: Rendering](r: R): r.type = r ~~ mediaType


### PR DESCRIPTION
Because that's the underlying value and what's used in HTTP/2.

Follow up to #3830.