### PR TITLE
http2: avoid calling LoggingAdapter.isDebugEnabled in multiplexer

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -91,6 +91,8 @@ private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with Stage
   def createMultiplexer(prioritizer: StreamPrioritizer): Http2Multiplexer with OutHandler =
     new Http2Multiplexer with OutHandler with StateTimingSupport with LogHelper { self =>
       def log: LoggingAdapter = logic.log
+      // cache debug state at the beginning to avoid that this has to be queried all the time
+      override lazy val isDebugEnabled: Boolean = super.isDebugEnabled
 
       private var _currentInitialWindow: Int = Http2Protocol.InitialWindowSize
       override def currentInitialWindow: Int = _currentInitialWindow


### PR DESCRIPTION
This was previously optimized in Http2Demux but missed here as well.