### PR TITLE
build: cancel outdated builds

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -6,6 +6,11 @@ on:
     branches: [ master ]
     tags-ignore: [ v* ]
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   formatting-check:
     name: Check for missing formatting


### PR DESCRIPTION
To avoid that a bunch of workflows is run when you push to a PR in quick
succession.