### PR TITLE
build: run full validation when workflow definition has changed

### DIFF
--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -99,7 +99,7 @@ object ValidatePullRequest extends AutoPlugin {
   val additionalTasks = settingKey[Seq[TaskKey[_]]]("Additional tasks for pull request validation")
 
   // The set of (top-level) files or directories to watch for build changes.
-  val BuildFilesAndDirectories = Set("project", "build.sbt")
+  val BuildFilesAndDirectories = Set("project", "build.sbt", ".github/workflows")
 
   def changedDirectoryIsDependency(changedDirs: Set[String], name: String, graphsToTest: Seq[(Configuration, ModuleGraph)])(log: Logger): Boolean = {
     val dirsOrExperimental = changedDirs.flatMap(dir => Set(dir, s"$dir-experimental"))


### PR DESCRIPTION
Avoid to slip in untested code, if breakage is caused by workflow changes like in #3878.