### PR TITLE
core: avoid calling numConnectedSlots when possible #3904

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -328,7 +328,7 @@ private[client] object NewHostConnectionPool {
                     OptionVal.Some(Event.onResponseEntityCompleted)
                   case Unconnected if currentEmbargo != Duration.Zero =>
                     OptionVal.Some(Event.onNewConnectionEmbargo.preApply(currentEmbargo))
-                  case s if !s.isConnected && s.isIdle && numConnectedSlots < settings.minConnections =>
+                  case s if !s.isConnected && s.isIdle && settings.minConnections > 0 && numConnectedSlots < settings.minConnections =>
                     debug(s"Preconnecting because number of connected slots fell down to $numConnectedSlots")
                     OptionVal.Some(Event.onPreConnect)
                   case _ => OptionVal.None

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -328,7 +328,8 @@ private[client] object NewHostConnectionPool {
                     OptionVal.Some(Event.onResponseEntityCompleted)
                   case Unconnected if currentEmbargo != Duration.Zero =>
                     OptionVal.Some(Event.onNewConnectionEmbargo.preApply(currentEmbargo))
-				  // numConnectedSlots might be slow for big numbers of connections, so avoid calling if minConnections feature is disabled
+                  
+                  // numConnectedSlots might be slow for big numbers of connections, so avoid calling if minConnections feature is disabled
                   case s if !s.isConnected && s.isIdle && settings.minConnections > 0 && numConnectedSlots < settings.minConnections =>
                     debug(s"Preconnecting because number of connected slots fell down to $numConnectedSlots")
                     OptionVal.Some(Event.onPreConnect)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -327,8 +327,7 @@ private[client] object NewHostConnectionPool {
                     // the connection cannot drive these for a strict entity so we have to loop ourselves
                     OptionVal.Some(Event.onResponseEntityCompleted)
                   case Unconnected if currentEmbargo != Duration.Zero =>
-                    OptionVal.Some(Event.onNewConnectionEmbargo.preApply(currentEmbargo))
-                  
+                    OptionVal.Some(Event.onNewConnectionEmbargo.preApply(currentEmbargo))                 
                   // numConnectedSlots might be slow for big numbers of connections, so avoid calling if minConnections feature is disabled
                   case s if !s.isConnected && s.isIdle && settings.minConnections > 0 && numConnectedSlots < settings.minConnections =>
                     debug(s"Preconnecting because number of connected slots fell down to $numConnectedSlots")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -327,7 +327,7 @@ private[client] object NewHostConnectionPool {
                     // the connection cannot drive these for a strict entity so we have to loop ourselves
                     OptionVal.Some(Event.onResponseEntityCompleted)
                   case Unconnected if currentEmbargo != Duration.Zero =>
-                    OptionVal.Some(Event.onNewConnectionEmbargo.preApply(currentEmbargo))                 
+                    OptionVal.Some(Event.onNewConnectionEmbargo.preApply(currentEmbargo))
                   // numConnectedSlots might be slow for big numbers of connections, so avoid calling if minConnections feature is disabled
                   case s if !s.isConnected && s.isIdle && settings.minConnections > 0 && numConnectedSlots < settings.minConnections =>
                     debug(s"Preconnecting because number of connected slots fell down to $numConnectedSlots")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -328,6 +328,7 @@ private[client] object NewHostConnectionPool {
                     OptionVal.Some(Event.onResponseEntityCompleted)
                   case Unconnected if currentEmbargo != Duration.Zero =>
                     OptionVal.Some(Event.onNewConnectionEmbargo.preApply(currentEmbargo))
+				  // numConnectedSlots might be slow for big numbers of connections, so avoid calling if minConnections feature is disabled
                   case s if !s.isConnected && s.isIdle && settings.minConnections > 0 && numConnectedSlots < settings.minConnections =>
                     debug(s"Preconnecting because number of connected slots fell down to $numConnectedSlots")
                     OptionVal.Some(Event.onPreConnect)


### PR DESCRIPTION
Computing the number of connected slots is linear over the
max number of connections for a host. This change avoids
computing the number of connected slots for the preconnect
step when the minimum number of connections is zero.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
