### PR TITLE
End HTTP/2 stream with empty DATA rather than empty HEADERS

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
@@ -81,8 +81,8 @@ private[http2] sealed abstract class MessageRendering[R <: HttpMessage] extends 
     val headersFrame = ParsedHeadersFrame(streamId, endStream = r.entity.isKnownEmpty, headerPairs.result(), None)
     val trailingHeadersFrame =
       r.attribute(AttributeKeys.trailer) match {
-        case Some(trailer) => OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, trailer.headers, None))
-        case None          => OptionVal.None
+        case Some(trailer) if trailer.headers.nonEmpty => OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, trailer.headers, None))
+        case None                                      => OptionVal.None
       }
 
     Http2SubStream(r.entity, headersFrame, trailingHeadersFrame, r.attributes.filter(_._2.isInstanceOf[RequestResponseAssociation]))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -32,7 +32,6 @@ private[http2] object HeaderCompression extends GraphStage[FlowShape[FrameEvent,
     val encoder = new akka.http.shaded.com.twitter.hpack.Encoder(Http2Protocol.InitialMaxHeaderTableSize)
     val os = new ByteArrayOutputStream(128)
 
-<<<<<<< HEAD
     def onPull(): Unit = pull(eventsIn)
     def onPush(): Unit = grab(eventsIn) match {
       case ack @ SettingsAckFrame(s) =>


### PR DESCRIPTION
When ending the stream without any payload, use a DATA frame rather than
a HEADERS frame to work around https://github.com/golang/go/issues/47851.

Tested with https://github.com/raboof/http2-from-go-to-akka-http