### PR TITLE
core: discard outgoing headers containing line breaks

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
@@ -24,7 +24,7 @@ import org.openjdk.jmh.annotations._
 
 class ServerProcessingBenchmark extends CommonBenchmark {
   val request = ByteString("GET / HTTP/1.1\r\nHost: localhost\r\nUser-Agent: test\r\n\r\n")
-  val response = HttpResponse(headers = headers.Server("akka-http-bench") :: Nil)
+  val response = HttpResponse()
 
   var httpFlow: Flow[ByteString, ByteString, Any] = _
   implicit var system: ActorSystem = _
@@ -49,6 +49,7 @@ class ServerProcessingBenchmark extends CommonBenchmark {
       ConfigFactory.parseString(
         """
            akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
+           akka.http.server.server-header = "akka-http-bench"
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)

--- a/akka-http-core/src/main/mima-filters/10.2.6.backwards.excludes/3922-safe-header-rendering.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.6.backwards.excludes/3922-safe-header-rendering.excludes
@@ -1,0 +1,3 @@
+# Add new methods to @InternalApi Rendering trait
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.util.Rendering.mark")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.util.Rendering.check")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
@@ -60,7 +60,7 @@ private final class HttpsProxyGraphStage(
     r ~~ "CONNECT " ~~ targetHostName ~~ ':' ~~ targetPort ~~ " HTTP/1.1" ~~ CrLf
     r ~~ "Host: " ~~ targetHostName ~~ CrLf
     proxyAuthorization.foreach { creds =>
-      r ~~ `Proxy-Authorization`(creds) ~~ CrLf
+      r ~~ `Proxy-Authorization`(creds)
     }
     r ~~ CrLf
     r.get

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
@@ -130,7 +130,7 @@ private[http] object BodyPartRenderer {
     case x: RawHeader if (x is "content-type") || (x is "content-length") =>
       suppressionWarning(log, x, "illegal RawHeader")
 
-    case x => r ~~ x ~~ CrLf
+    case x => r ~~ x
   }
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -47,7 +47,7 @@ private[http] class HttpRequestRendererFactory(
       r ~~ ' ' ~~ protocol ~~ CrLf
     }
 
-    def render(h: HttpHeader) = r ~~ h ~~ CrLf
+    def render(h: HttpHeader) = r ~~ h
 
     @tailrec def renderHeaders(remaining: List[HttpHeader], hostHeaderSeen: Boolean = false,
                                userAgentSeen: Boolean = false, transferEncodingSeen: Boolean = false): Unit =
@@ -107,8 +107,8 @@ private[http] class HttpRequestRendererFactory(
         }
 
         case Nil =>
-          if (!hostHeaderSeen) r ~~ ctx.hostHeader ~~ CrLf
-          if (!userAgentSeen && userAgentHeader.isDefined) r ~~ userAgentHeader.get ~~ CrLf
+          if (!hostHeaderSeen) r ~~ ctx.hostHeader
+          if (!userAgentSeen && userAgentHeader.isDefined) r ~~ userAgentHeader.get
           if (entity.isChunked && !entity.isKnownEmpty && !transferEncodingSeen)
             r ~~ `Transfer-Encoding` ~~ ChunkedBytes ~~ CrLf
       }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -33,7 +33,7 @@ private[http] class HttpRequestRendererFactory(
   def renderToSource(ctx: RequestRenderingContext): Source[ByteString, Any] = render(ctx).byteStream
 
   def render(ctx: RequestRenderingContext): RequestRenderingOutput = {
-    val r = new ByteStringRendering(requestHeaderSizeHint)
+    val r = new ByteStringRendering(requestHeaderSizeHint, log.warning)
     import ctx.request._
 
     def renderRequestLine(): Unit = {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -38,7 +38,7 @@ private[http] class HttpResponseRendererFactory(
   private val renderDefaultServerHeader: Rendering => Unit =
     serverHeader match {
       case Some(h) =>
-        val bytes = (new ByteArrayRendering(128) ~~ h ~~ CrLf).get
+        val bytes = (new ByteArrayRendering(128) ~~ h).get
         _ ~~ bytes
       case None => _ => ()
     }
@@ -142,7 +142,7 @@ private[http] class HttpResponseRendererFactory(
               case other      => throw new IllegalStateException(s"Unexpected protocol '$other'")
             }
 
-          def render(h: HttpHeader) = r ~~ h ~~ CrLf
+          def render(h: HttpHeader) = r ~~ h
 
           def mustRenderTransferEncodingChunkedHeader =
             entity.isChunked && (!entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD) && (ctx.requestProtocol == `HTTP/1.1`)
@@ -223,7 +223,7 @@ private[http] class HttpResponseRendererFactory(
             if (renderConnectionHeader)
               r ~~ Connection ~~ (if (close) CloseBytes else KeepAliveBytes) ~~ CrLf
             else if (connHeader != null && connHeader.hasUpgrade) {
-              r ~~ connHeader ~~ CrLf
+              r ~~ connHeader
               HttpHeader.fastFind(classOf[UpgradeToOtherProtocolResponseHeader], headers) match {
                 case OptionVal.Some(header) => closeMode = SwitchToOtherProtocol(header.handler)
                 case _                      => // nothing to do here...

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -130,7 +130,7 @@ private[http] class HttpResponseRendererFactory(
         }
 
         def render(ctx: ResponseRenderingContext): StrictOrStreamed = {
-          val r = new ByteArrayRendering(responseHeaderSizeHint)
+          val r = new ByteArrayRendering(responseHeaderSizeHint, log.warning)
 
           import ctx.response._
           val noEntity = entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD

--- a/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
@@ -9,7 +9,6 @@ import java.nio.charset.Charset
 import java.text.{ DecimalFormat, DecimalFormatSymbols }
 import java.util.Locale
 import akka.annotation.InternalApi
-import akka.event.LoggingAdapter
 
 import scala.annotation.tailrec
 import scala.collection.{ LinearSeq, immutable }
@@ -297,7 +296,10 @@ private[http] class StringRendering extends Rendering {
  */
 @InternalApi
 private[http] class ByteArrayRendering(sizeHint: Int, logDiscardedHeader: String => Unit = _ => ()) extends Rendering {
+  def this(sizeHint: Int) = this(sizeHint, _ => ())
+
   private[this] var array = new Array[Byte](sizeHint)
+
   private[this] var size = 0
 
   def get: Array[Byte] =
@@ -365,6 +367,8 @@ private[http] class ByteArrayRendering(sizeHint: Int, logDiscardedHeader: String
  */
 @InternalApi
 private[http] class ByteStringRendering(sizeHint: Int, logDiscardedHeader: String => Unit = _ => ()) extends Rendering {
+  def this(sizeHint: Int) = this(sizeHint, _ => ())
+
   private[this] val builder = new ByteStringBuilder
   builder.sizeHint(sizeHint)
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -25,6 +25,8 @@ import akka.testkit._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.util.{ Success, Try }
+
 class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
   val testConf: Config = ConfigFactory.parseString("""
     akka.event-handlers = ["akka.testkit.TestEventListener"]
@@ -459,6 +461,73 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
             |
             |"""
         }
+      }
+    }
+    "render headers safely" - {
+      val defaultResponse =
+        """HTTP/1.1 200 OK
+          |Server: akka-http/1.0.0
+          |Date: Thu, 25 Aug 2011 09:10:29 GMT
+          |Content-Length: 0
+          |
+          |"""
+
+      "when Server header contains CRLF" in new TestSetup() {
+        HttpResponse(200, headers.Server(ProductVersion("abc\ndef")) :: Nil) should renderTo(
+          // no Server header rendered at all but still better than rendering a broken one
+          """HTTP/1.1 200 OK
+            |Date: Thu, 25 Aug 2011 09:10:29 GMT
+            |Content-Length: 0
+            |
+            |"""
+        )
+      }
+      "when RawHeader header name contains CRLF" in new TestSetup() {
+        HttpResponse(200, headers.RawHeader("Abc-\nDef", "test") :: Nil) should renderTo(defaultResponse)
+      }
+      "when RawHeader header value contains CRLF" in new TestSetup() {
+        HttpResponse(200, headers.RawHeader("Test", "abc\ndef") :: Nil) should renderTo(defaultResponse)
+      }
+
+      // unlikely case: companion defines a broken name
+      case class MyBrokenHeader(value: String) extends ModeledCustomHeader[MyBrokenHeader] {
+        override def companion = MyBrokenHeader
+        def renderInRequests = false
+        def renderInResponses = true
+      }
+      object MyBrokenHeader extends ModeledCustomHeaderCompanion[MyBrokenHeader] {
+        override def name: String = "X-My-Broken\nHeader"
+        override def parse(value: String): Try[MyBrokenHeader] = Success(new MyBrokenHeader(value))
+      }
+
+      "when CustomModeledHeader header name contains CRLF" in new TestSetup() {
+        HttpResponse(200, MyBrokenHeader("test") :: Nil) should renderTo(defaultResponse)
+      }
+
+      case class MyHeader(value: String) extends ModeledCustomHeader[MyHeader] {
+        override def companion = MyHeader
+        def renderInRequests = false
+        def renderInResponses = true
+      }
+      object MyHeader extends ModeledCustomHeaderCompanion[MyHeader] {
+        override def name: String = "X-My-Header"
+        override def parse(value: String): Try[MyHeader] = Success(new MyHeader(value))
+      }
+      "when CustomModeledHeader header value contains CRLF" in new TestSetup() {
+        HttpResponse(200, MyHeader("abc\ndef") :: Nil) should renderTo(defaultResponse)
+      }
+
+      case class MyCustomHeader(name: String, value: String) extends CustomHeader {
+        def renderInRequests = false
+        def renderInResponses = true
+      }
+
+      "when CustomHeader header name contains CRLF" in new TestSetup() {
+        HttpResponse(200, MyCustomHeader("X-Broken\n-Header", "test") :: Nil) should renderTo(defaultResponse)
+      }
+
+      "when CustomHeader header value contains CRLF" in new TestSetup() {
+        HttpResponse(200, MyCustomHeader("X-Broken-Header", "abc\ndef") :: Nil) should renderTo(defaultResponse)
       }
     }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/util/RenderingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/RenderingSpec.scala
@@ -4,13 +4,16 @@
 
 package akka.http.impl.util
 
+import akka.http.scaladsl.model.headers.RawHeader
+import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
-class RenderingSpec extends AnyWordSpec with Matchers {
+import java.nio.charset.Charset
+import scala.reflect.{ ClassTag, classTag }
 
-  "The StringRendering" should {
+class RenderingSpec extends AnyFreeSpec with Matchers {
 
+  "The StringRendering should" - {
     "correctly render Ints and Longs to decimal" in {
       (new StringRendering ~~ 0).get shouldEqual "0"
       (new StringRendering ~~ 123456789).get shouldEqual "123456789"
@@ -33,6 +36,52 @@ class RenderingSpec extends AnyWordSpec with Matchers {
       (new StringRendering ~~# "").get shouldEqual "\"\""
       (new StringRendering ~~# "hello").get shouldEqual "hello"
       (new StringRendering ~~# """hel"lo""").get shouldEqual """"hel\"lo""""
+    }
+  }
+
+  "Renderings should" - {
+    trait RenderingSetup {
+      type R <: Rendering
+      def create(): R
+      def result(r: R): String
+      def tag: String
+    }
+    def setup[_R <: Rendering: ClassTag](_create: => _R)(_result: _R => String): RenderingSetup =
+      new RenderingSetup {
+        override type R = _R
+        override def create(): _R = _create
+        override def result(r: _R): String = _result(r)
+        override val tag: String = classTag[R].runtimeClass.getSimpleName
+      }
+
+    val renderings: Seq[RenderingSetup] = Seq(
+      setup(new StringRendering)(_.get),
+      setup(new ByteArrayRendering(1000))(r => new String(r.get)),
+      setup(new ByteStringRendering(1000))(_.get.utf8String),
+      setup(new CustomCharsetByteStringRendering(Charset.forName("ISO-8859-1"), 1000))(_.get.utf8String)
+    )
+
+    renderings.foreach { setup =>
+      setup.tag - {
+        "render correct headers correctly" in {
+          val r = setup.create()
+          val rendered = setup.result(r ~~ RawHeader("Test", "value"))
+
+          rendered shouldBe "Test: value\r\n"
+        }
+        "do not render header with invalid name" in {
+          val r = setup.create()
+          val rendered = setup.result(r ~~ RawHeader("X-Broken\r-Header", "value"))
+
+          rendered shouldBe ""
+        }
+        "do not render header with invalid value" in {
+          val r = setup.create()
+          val rendered = setup.result(r ~~ RawHeader("Test", "broken\nvalue"))
+
+          rendered shouldBe ""
+        }
+      }
     }
   }
 }

--- a/akka-http-core/src/test/scala/akka/http/impl/util/RenderingSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/RenderingSpec.scala
@@ -4,16 +4,18 @@
 
 package akka.http.impl.util
 
+import akka.event.Logging
 import akka.http.scaladsl.model.headers.RawHeader
-import org.scalatest.freespec.AnyFreeSpec
+import akka.testkit.EventFilter
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.charset.Charset
 import scala.reflect.{ ClassTag, classTag }
 
-class RenderingSpec extends AnyFreeSpec with Matchers {
+class RenderingSpec extends AkkaSpecWithMaterializer with Matchers {
+  override protected def failOnSevereMessages: Boolean = true
 
-  "The StringRendering should" - {
+  "The StringRendering should" should {
     "correctly render Ints and Longs to decimal" in {
       (new StringRendering ~~ 0).get shouldEqual "0"
       (new StringRendering ~~ 123456789).get shouldEqual "123456789"
@@ -39,7 +41,7 @@ class RenderingSpec extends AnyFreeSpec with Matchers {
     }
   }
 
-  "Renderings should" - {
+  "Renderings" should {
     trait RenderingSetup {
       type R <: Rendering
       def create(): R
@@ -56,13 +58,13 @@ class RenderingSpec extends AnyFreeSpec with Matchers {
 
     val renderings: Seq[RenderingSetup] = Seq(
       setup(new StringRendering)(_.get),
-      setup(new ByteArrayRendering(1000))(r => new String(r.get)),
-      setup(new ByteStringRendering(1000))(_.get.utf8String),
+      setup(new ByteArrayRendering(1000, Logging(system, "test").warning))(r => new String(r.get)),
+      setup(new ByteStringRendering(1000, Logging(system, "test").warning))(_.get.utf8String),
       setup(new CustomCharsetByteStringRendering(Charset.forName("ISO-8859-1"), 1000))(_.get.utf8String)
     )
 
     renderings.foreach { setup =>
-      setup.tag - {
+      setup.tag should {
         "render correct headers correctly" in {
           val r = setup.create()
           val rendered = setup.result(r ~~ RawHeader("Test", "value"))
@@ -71,13 +73,19 @@ class RenderingSpec extends AnyFreeSpec with Matchers {
         }
         "do not render header with invalid name" in {
           val r = setup.create()
-          val rendered = setup.result(r ~~ RawHeader("X-Broken\r-Header", "value"))
+          val rendered =
+            EventFilter.warning(pattern = "Invalid outgoing header was discarded").intercept {
+              setup.result(r ~~ RawHeader("X-Broken\r-Header", "value"))
+            }
 
           rendered shouldBe ""
         }
         "do not render header with invalid value" in {
           val r = setup.create()
-          val rendered = setup.result(r ~~ RawHeader("Test", "broken\nvalue"))
+          val rendered =
+            EventFilter.warning(pattern = "Invalid outgoing header was discarded").intercept {
+              setup.result(r ~~ RawHeader("Test", "broken\nvalue"))
+            }
 
           rendered shouldBe ""
         }


### PR DESCRIPTION
Refs #3717

To avoid accidental response splitting when applications put unsanitized request
data into outgoing responses.

We previously discussed introducing a check in the header models which could avoid
overhead during rendering. There are a lot of header models, however, which
all had to be checked one by one for potential issues. This would require a significant
effort now to check all the existing headers and would also make it easy to
reintroduce problems later on when headers are added or changed.

The approach here requires that all headers are rendered using the new overload of
`Rendering.~~`. When that method is used, we render the header and check afterwards
that the rendered data does not contain any CR or LF characters.

The performance overhead seems negligible, the new method did not turn up in profiling.
An explanation why going over the rendered header data directly after it has been rendered
is so cheap could be that
 - it has good locality because the data has just been written
 - it has good branch prediction because test will almost never fail
 - even if it has linear cost for big headers, those big headers will also have significant
   memory allocation cost which might dwarf the extra checking
