### PR TITLE
core: limit comment nesting in header parser

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.2.6.backwards.excludes/3918-add-new-parsing-setting.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.6.backwards.excludes/3918-add-new-parsing-setting.excludes
@@ -1,0 +1,7 @@
+# Add new setting to @DoNotInherit classes
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ParserSettings.getMaxCommentParsingDepth")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ParserSettings.maxCommentParsingDepth")
+
+# Changes to internal classes
+ProblemFilters.exclude[Problem]("akka.http.impl.model.parser.*")
+ProblemFilters.exclude[Problem]("akka.http.impl.settings.*")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -679,6 +679,10 @@ akka.http {
     max-chunk-ext-length       = 256
     max-chunk-size             = 1m
 
+    # HTTP comments (as e.g. prominently used in User-Agent headers) can be nested. To avoid too deep nesting
+    # and the associated parsing and storage cost, the depth of nested comments is limited to the given value.
+    max-comment-parsing-depth  = 5
+
     # The maximum number of bytes to allow when reading the entire entity into memory with `toStrict`
     # (which is used by the `toStrictEntity` and `extractStrictEntity` directives)
     max-to-strict-bytes = 8m

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -42,6 +42,7 @@ private[http] class HeaderParser(
   import CharacterClasses._
 
   override def customMediaTypes = settings.customMediaTypes
+  protected def maxCommentParsingDepth: Int = settings.maxCommentParsingDepth
 
   // http://www.rfc-editor.org/errata_search.php?rfc=7230 errata id 4189
   def `header-field-value`: Rule1[String] = rule {
@@ -191,19 +192,22 @@ private[http] object HeaderParser {
     def uriParsingMode: Uri.ParsingMode
     def cookieParsingMode: ParserSettings.CookieParsingMode
     def customMediaTypes: MediaTypes.FindCustom
+    def maxCommentParsingDepth: Int
     def illegalResponseHeaderNameProcessingMode: IllegalResponseHeaderNameProcessingMode
     def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode
   }
   def Settings(
-    uriParsingMode:    Uri.ParsingMode                          = Uri.ParsingMode.Relaxed,
-    cookieParsingMode: ParserSettings.CookieParsingMode         = ParserSettings.CookieParsingMode.RFC6265,
-    customMediaTypes:  MediaTypes.FindCustom                    = ConstantFun.scalaAnyTwoToNone,
-    modeValue:         IllegalResponseHeaderValueProcessingMode = ParserSettings.IllegalResponseHeaderValueProcessingMode.Error,
-    modeName:          IllegalResponseHeaderNameProcessingMode  = ParserSettings.IllegalResponseHeaderNameProcessingMode.Error): Settings = {
+    uriParsingMode:         Uri.ParsingMode                          = Uri.ParsingMode.Relaxed,
+    cookieParsingMode:      ParserSettings.CookieParsingMode         = ParserSettings.CookieParsingMode.RFC6265,
+    customMediaTypes:       MediaTypes.FindCustom                    = ConstantFun.scalaAnyTwoToNone,
+    maxCommentParsingDepth: Int                                      = 5,
+    modeValue:              IllegalResponseHeaderValueProcessingMode = ParserSettings.IllegalResponseHeaderValueProcessingMode.Error,
+    modeName:               IllegalResponseHeaderNameProcessingMode  = ParserSettings.IllegalResponseHeaderNameProcessingMode.Error): Settings = {
 
     val _uriParsingMode = uriParsingMode
     val _cookieParsingMode = cookieParsingMode
     val _customMediaTypes = customMediaTypes
+    val _maxCommentParsingDepth = maxCommentParsingDepth
     val _illegalResponseHeaderValueProcessingMode = modeValue
     val _illegalResponseHeaderNameProcessingMode = modeName
 
@@ -211,6 +215,7 @@ private[http] object HeaderParser {
       def uriParsingMode: Uri.ParsingMode = _uriParsingMode
       def cookieParsingMode: CookieParsingMode = _cookieParsingMode
       def customMediaTypes: MediaTypes.FindCustom = _customMediaTypes
+      def maxCommentParsingDepth: Int = _maxCommentParsingDepth
 
       def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode =
         _illegalResponseHeaderValueProcessingMode

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -27,6 +27,7 @@ private[akka] final case class ParserSettingsImpl(
   maxToStrictBytes:                           Long,
   maxChunkExtLength:                          Int,
   maxChunkSize:                               Int,
+  maxCommentParsingDepth:                     Int,
   uriParsingMode:                             Uri.ParsingMode,
   cookieParsingMode:                          CookieParsingMode,
   illegalHeaderWarnings:                      Boolean,
@@ -53,6 +54,7 @@ private[akka] final case class ParserSettingsImpl(
   require(maxContentLengthSetting.forall(_ > 0), "if set max-content-length must be > 0")
   require(maxChunkExtLength > 0, "max-chunk-ext-length must be > 0")
   require(maxChunkSize > 0, "max-chunk-size must be > 0")
+  require(maxCommentParsingDepth > 0, "max-comment-parsing-depth must be > 0")
 
   override val defaultHeaderValueCacheLimit: Int = headerValueCacheLimits("default")
 
@@ -92,6 +94,7 @@ object ParserSettingsImpl extends SettingsCompanionImpl[ParserSettingsImpl]("akk
       c.getPossiblyInfiniteBytes("max-to-strict-bytes"),
       c.getIntBytes("max-chunk-ext-length"),
       c.getIntBytes("max-chunk-size"),
+      c.getInt("max-comment-parsing-depth"),
       Uri.ParsingMode(c.getString("uri-parsing-mode")),
       CookieParsingMode(c.getString("cookie-parsing-mode")),
       c.getBoolean("illegal-header-warnings"),

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
@@ -35,6 +35,7 @@ abstract class ParserSettings private[akka] () extends BodyPartParser.Settings {
   def getMaxToStrictBytes: Long
   def getMaxChunkExtLength: Int
   def getMaxChunkSize: Int
+  def getMaxCommentParsingDepth: Int
   def getUriParsingMode: Uri.ParsingMode
   def getCookieParsingMode: ParserSettings.CookieParsingMode
   def getIllegalHeaderWarnings: Boolean
@@ -64,6 +65,7 @@ abstract class ParserSettings private[akka] () extends BodyPartParser.Settings {
   def withMaxToStrictBytes(newValue: Long): ParserSettings = self.copy(maxToStrictBytes = newValue)
   def withMaxChunkExtLength(newValue: Int): ParserSettings = self.copy(maxChunkExtLength = newValue)
   def withMaxChunkSize(newValue: Int): ParserSettings = self.copy(maxChunkSize = newValue)
+  def withMaxCommentParsingDepth(newValue: Int): ParserSettings = self.copy(maxCommentParsingDepth = newValue)
   def withUriParsingMode(newValue: Uri.ParsingMode): ParserSettings = self.copy(uriParsingMode = newValue.asScala)
   def withCookieParsingMode(newValue: ParserSettings.CookieParsingMode): ParserSettings = self.copy(cookieParsingMode = newValue.asScala)
   def withIllegalHeaderWarnings(newValue: Boolean): ParserSettings = self.copy(illegalHeaderWarnings = newValue)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -35,6 +35,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   def maxToStrictBytes: Long
   def maxChunkExtLength: Int
   def maxChunkSize: Int
+  def maxCommentParsingDepth: Int
   def uriParsingMode: Uri.ParsingMode
   def cookieParsingMode: ParserSettings.CookieParsingMode
   def illegalHeaderWarnings: Boolean
@@ -69,6 +70,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   override def getMaxResponseReasonLength = maxResponseReasonLength
   override def getMaxUriLength = maxUriLength
   override def getMaxMethodLength = maxMethodLength
+  override def getMaxCommentParsingDepth: Int = maxCommentParsingDepth
   override def getErrorLoggingVerbosity: js.ParserSettings.ErrorLoggingVerbosity = errorLoggingVerbosity
   override def getIllegalResponseHeaderNameProcessingMode = illegalResponseHeaderNameProcessingMode
   override def getIllegalResponseHeaderValueProcessingMode = illegalResponseHeaderValueProcessingMode
@@ -98,6 +100,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   override def withMaxToStrictBytes(newValue: Long): ParserSettings = self.copy(maxToStrictBytes = newValue)
   override def withMaxChunkExtLength(newValue: Int): ParserSettings = self.copy(maxChunkExtLength = newValue)
   override def withMaxChunkSize(newValue: Int): ParserSettings = self.copy(maxChunkSize = newValue)
+  override def withMaxCommentParsingDepth(newValue: Int): ParserSettings = self.copy(maxCommentParsingDepth = newValue)
   override def withIllegalHeaderWarnings(newValue: Boolean): ParserSettings = self.copy(illegalHeaderWarnings = newValue)
   override def withIncludeTlsSessionInfoHeader(newValue: Boolean): ParserSettings = self.copy(includeTlsSessionInfoHeader = newValue)
   override def withIncludeSslSessionAttribute(newValue: Boolean): ParserSettings = self.copy(includeSslSessionAttribute = newValue)

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.settings.ParserSettings.CookieParsingMode
 import akka.http.impl.model.parser.HeaderParser.Settings
 import org.scalatest.matchers.{ MatchResult, Matcher }
 import akka.http.impl.util._
-import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.{ HttpHeader, _ }
 import headers._
 import CacheDirectives._
 import MediaTypes._
@@ -16,8 +16,8 @@ import MediaRanges._
 import HttpCharsets._
 import HttpEncodings._
 import HttpMethods._
-import java.net.InetAddress
 
+import java.net.InetAddress
 import akka.http.scaladsl.model.MediaType.WithOpenCharset
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec
@@ -819,6 +819,10 @@ class HttpHeaderSpec extends AnyFreeSpec with Matchers {
 
       checkContentType("application/json", ContentType.WithMissingCharset(openJson))
       checkContentType("application/json; charset=UTF-8", ContentType(openJson, HttpCharsets.`UTF-8`))
+    }
+    "fail gracefully for deeply nested header comments" in {
+      parse("User-Agent", "(" * 10000).errors.head shouldEqual
+        ErrorInfo("Illegal HTTP header 'User-Agent': Illegal header value", "Header comment nested too deeply")
     }
   }
 

--- a/docs/src/main/paradox/security.md
+++ b/docs/src/main/paradox/security.md
@@ -17,6 +17,10 @@ to ensure that a fix can be provided without delay.
 
 ## Fixed Security Vulnerabilities
 
+### Fixed in Akka HTTP 10.2.7
+
+* @ref:[CVE-2021-42697: Stack overflow while parsing User-Agent header with deeply nested comments](security/2021-CVE-2021-42697-stack-overflow-parsing-user-agent.md)
+
 ### Fixed in Akka HTTP 10.2.4 & 10.1.14
 
 * @ref:[Incorrect handling of Transfer-Encoding header](security/2021-02-24-incorrect-handling-of-Transfer-Encoding-header.md)

--- a/docs/src/main/paradox/security/2021-CVE-2021-42697-stack-overflow-parsing-user-agent.md
+++ b/docs/src/main/paradox/security/2021-CVE-2021-42697-stack-overflow-parsing-user-agent.md
@@ -1,0 +1,53 @@
+# CVE-2021-42697: Stack overflow while parsing User-Agent header with deeply nested comments
+
+## Date
+
+2021-11-02
+
+## CVE
+
+CVE-2021-42697
+
+## Description of Vulnerability
+
+The HTTP specification [allows arbitrary nesting](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6)
+of `comment` elements in `User-Agent` and other headers. While parsing a request containing a `User-Agent`
+header with deeply nested comments, Akka HTTP may fail with a stack overflow in the parser. Stack overflows
+are handled as fatal errors in Akka leading to a complete shutdown of the application.
+
+## Severity
+
+Based on our assessment, the CVSS score of this vulnerability is 6.7, based on vector [(AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C)](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C&version=3.1).
+
+## Impact
+
+An Akka HTTP application server which is exposed to the internet can be remotely crashed
+by sending a crafted `User-Agent` header leading to a loss of availability.
+
+## Resolution
+
+Starting from Akka HTTP 10.2.7, parsing of nested comments will be limited to a configurable maximum depth.
+See `akka.http.parsing.max-comment-parsing-depth` in the @ref:[configuration](../configuration.md) for
+more information. The default value for that setting is currently conservatively set to `5`.
+
+## Workaround
+
+Set `akka.http.server.parsing.modeled-header-parsing = off` to avoid parsing headers to models.
+In this case, Akka HTTP will report most headers as `RawHeader`s. This will likely have
+consequences for downstream user code which expects headers to be already parsed.
+
+## Affected versions
+
+- All akka-http versions prior to `10.2.6`
+
+## Fixed versions
+
+- akka-http `10.2.7`
+
+## Acknowledgements
+
+Thanks, Simone Quatrini of SureCloud, for bringing this issue to our attention.
+
+## References
+
+* [#3918](https://github.com/akka/akka-http/issues/3918)

--- a/docs/src/main/paradox/security/2021.md
+++ b/docs/src/main/paradox/security/2021.md
@@ -3,7 +3,7 @@
 @@ toc
 
 @@@ index
-
+* [Stack overflow while parsing User-Agent header with deeply nested comments](2021-CVE-2021-42697-stack-overflow-parsing-user-agent.md)
 * [Incorrect handling of Transfer-Encoding header](2021-02-24-incorrect-handling-of-Transfer-Encoding-header.md)
 
 @@@


### PR DESCRIPTION
To avoid StackOverflowErrors while parsing headers based on user input.

Fixes #3918 / CVE-2021-42697