### PR TITLE
build: don't aggregate scalafix tests which breaks paradox too easily

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val userProjects: Seq[ProjectReference] = List[ProjectReference](
   httpSprayJson,
   httpXml,
   httpJackson,
-  httpScalafix,
+  httpScalafixRules, // don't aggregate tests for now as this will break with Scala compiler updates too easily
 )
 lazy val aggregatedProjects: Seq[ProjectReference] = userProjects ++ List[ProjectReference](
   httpTests,


### PR DESCRIPTION
Especially when we want to update a Scala version before Scalafix has released
the latest version.

Currently, this breaks publishing snapshot documentation.