### PR TITLE
[10.1 backport] core: limit comment nesting in header parser

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/add-new-parsing-setting.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/add-new-parsing-setting.excludes
@@ -1,0 +1,7 @@
+# Add new setting to @DoNotInherit classes
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ParserSettings.getMaxCommentParsingDepth")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ParserSettings.maxCommentParsingDepth")
+
+# Changes to internal classes
+ProblemFilters.exclude[Problem]("akka.http.impl.model.parser.*")
+ProblemFilters.exclude[Problem]("akka.http.impl.settings.*")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -465,6 +465,10 @@ akka.http {
     # programmatically via `withSizeLimit`.)
     max-content-length = 8m
 
+    # HTTP comments (as e.g. prominently used in User-Agent headers) can be nested. To avoid too deep nesting
+    # and the associated parsing and storage cost, the depth of nested comments is limited to the given value.
+    max-comment-parsing-depth  = 5
+
     # The maximum number of bytes to allow when reading the entire entity into memory with `toStrict`
     # (which is used by the `toStrictEntity` and `extractStrictEntity` directives)
     max-to-strict-bytes = 8m

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/CommonRules.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.model.headers._
 import akka.parboiled2._
 import akka.shapeless._
 
-private[parser] trait CommonRules { this: Parser with StringBuilding =>
+private[parser] trait CommonRules { this: HeaderParser with Parser with StringBuilding =>
   import CharacterClasses._
 
   // ******************************************************************************************
@@ -49,14 +49,16 @@ private[parser] trait CommonRules { this: Parser with StringBuilding =>
   def `quoted-pair` = rule { '\\' ~ (`quotable-base` | `obs-text`) ~ appendSB() }
 
   // builds a string via the StringBuilding StringBuilder
-  def comment: Rule0 = rule {
-    ws('(') ~ clearSB() ~ zeroOrMore(ctext | `quoted-cpair` | `nested-comment`) ~ ws(')')
+  def comment(maxNesting: Int = maxCommentParsingDepth): Rule0 = rule {
+    ws('(') ~ clearSB() ~ zeroOrMore(ctext | `quoted-cpair` | `nested-comment`(maxNesting)) ~ ws(')')
   }
 
-  def `nested-comment` = {
-    var saved: String = null
-    rule { &('(') ~ run { saved = sb.toString } ~ (comment ~ prependSB(saved + " (") ~ appendSB(')') | setSB(saved) ~ test(false)) }
-  }
+  def `nested-comment`(maxNesting: Int) =
+    if (maxNesting == 0) throw new ParsingException(ErrorInfo("Illegal header value", "Header comment nested too deeply"))
+    else {
+      var saved: String = null
+      rule { &('(') ~ run { saved = sb.toString } ~ (comment(maxNesting - 1) ~ prependSB(saved + " (") ~ appendSB(')') | setSB(saved) ~ test(false)) }
+    }
 
   def ctext = rule { (`ctext-base` | `obs-text`) ~ appendSB() }
 
@@ -385,9 +387,9 @@ private[parser] trait CommonRules { this: Parser with StringBuilding =>
   def `product-version` = rule { token }
 
   def `product-or-comment` = rule(
-    product ~ comment ~> (ProductVersion(_, _, sb.toString))
+    product ~ comment() ~> (ProductVersion(_, _, sb.toString))
       | product ~> (ProductVersion(_, _))
-      | comment ~ push(ProductVersion("", "", sb.toString)))
+      | comment() ~ push(ProductVersion("", "", sb.toString)))
 
   def products = rule {
     `product-or-comment` ~ zeroOrMore(`product-or-comment`) ~> (_ +: _)

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -42,6 +42,7 @@ private[http] class HeaderParser(
   import CharacterClasses._
 
   override def customMediaTypes = settings.customMediaTypes
+  protected def maxCommentParsingDepth: Int = settings.maxCommentParsingDepth
 
   // http://www.rfc-editor.org/errata_search.php?rfc=7230 errata id 4189
   def `header-field-value`: Rule1[String] = rule {
@@ -190,23 +191,27 @@ private[http] object HeaderParser {
     def uriParsingMode: Uri.ParsingMode
     def cookieParsingMode: ParserSettings.CookieParsingMode
     def customMediaTypes: MediaTypes.FindCustom
+    def maxCommentParsingDepth: Int
     def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode
   }
   def Settings(
-    uriParsingMode:    Uri.ParsingMode                          = Uri.ParsingMode.Relaxed,
-    cookieParsingMode: ParserSettings.CookieParsingMode         = ParserSettings.CookieParsingMode.RFC6265,
-    customMediaTypes:  MediaTypes.FindCustom                    = ConstantFun.scalaAnyTwoToNone,
-    mode:              IllegalResponseHeaderValueProcessingMode = ParserSettings.IllegalResponseHeaderValueProcessingMode.Error): Settings = {
+    uriParsingMode:         Uri.ParsingMode                          = Uri.ParsingMode.Relaxed,
+    cookieParsingMode:      ParserSettings.CookieParsingMode         = ParserSettings.CookieParsingMode.RFC6265,
+    customMediaTypes:       MediaTypes.FindCustom                    = ConstantFun.scalaAnyTwoToNone,
+    maxCommentParsingDepth: Int                                      = 5,
+    mode:                   IllegalResponseHeaderValueProcessingMode = ParserSettings.IllegalResponseHeaderValueProcessingMode.Error): Settings = {
 
     val _uriParsingMode = uriParsingMode
     val _cookieParsingMode = cookieParsingMode
     val _customMediaTypes = customMediaTypes
     val _illegalResponseHeaderValueProcessingMode = mode
+    val _maxCommentParsingDepth = maxCommentParsingDepth
 
     new Settings {
       def uriParsingMode: Uri.ParsingMode = _uriParsingMode
       def cookieParsingMode: CookieParsingMode = _cookieParsingMode
       def customMediaTypes: MediaTypes.FindCustom = _customMediaTypes
+      def maxCommentParsingDepth: Int = _maxCommentParsingDepth
 
       def illegalResponseHeaderValueProcessingMode: IllegalResponseHeaderValueProcessingMode =
         _illegalResponseHeaderValueProcessingMode

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -26,6 +26,7 @@ private[akka] final case class ParserSettingsImpl(
   maxToStrictBytes:                         Long,
   maxChunkExtLength:                        Int,
   maxChunkSize:                             Int,
+  maxCommentParsingDepth:                   Int,
   uriParsingMode:                           Uri.ParsingMode,
   cookieParsingMode:                        CookieParsingMode,
   illegalHeaderWarnings:                    Boolean,
@@ -49,6 +50,7 @@ private[akka] final case class ParserSettingsImpl(
   require(maxContentLength > 0, "max-content-length must be > 0")
   require(maxChunkExtLength > 0, "max-chunk-ext-length must be > 0")
   require(maxChunkSize > 0, "max-chunk-size must be > 0")
+  require(maxCommentParsingDepth > 0, "max-comment-parsing-depth must be > 0")
 
   override val defaultHeaderValueCacheLimit: Int = headerValueCacheLimits("default")
 
@@ -79,6 +81,7 @@ object ParserSettingsImpl extends SettingsCompanionImpl[ParserSettingsImpl]("akk
       c.getPossiblyInfiniteBytes("max-to-strict-bytes"),
       c.getIntBytes("max-chunk-ext-length"),
       c.getIntBytes("max-chunk-size"),
+      c.getInt("max-comment-parsing-depth"),
       Uri.ParsingMode(c.getString("uri-parsing-mode")),
       CookieParsingMode(c.getString("cookie-parsing-mode")),
       c.getBoolean("illegal-header-warnings"),

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
@@ -34,6 +34,7 @@ abstract class ParserSettings private[akka] () extends BodyPartParser.Settings {
   def getMaxToStrictBytes: Long
   def getMaxChunkExtLength: Int
   def getMaxChunkSize: Int
+  def getMaxCommentParsingDepth: Int
   def getUriParsingMode: Uri.ParsingMode
   def getCookieParsingMode: ParserSettings.CookieParsingMode
   def getIllegalHeaderWarnings: Boolean
@@ -60,6 +61,7 @@ abstract class ParserSettings private[akka] () extends BodyPartParser.Settings {
   def withMaxToStrictBytes(newValue: Long): ParserSettings = self.copy(maxToStrictBytes = newValue)
   def withMaxChunkExtLength(newValue: Int): ParserSettings = self.copy(maxChunkExtLength = newValue)
   def withMaxChunkSize(newValue: Int): ParserSettings = self.copy(maxChunkSize = newValue)
+  def withMaxCommentParsingDepth(newValue: Int): ParserSettings = self.copy(maxCommentParsingDepth = newValue)
   def withUriParsingMode(newValue: Uri.ParsingMode): ParserSettings = self.copy(uriParsingMode = newValue.asScala)
   def withCookieParsingMode(newValue: ParserSettings.CookieParsingMode): ParserSettings = self.copy(cookieParsingMode = newValue.asScala)
   def withIllegalHeaderWarnings(newValue: Boolean): ParserSettings = self.copy(illegalHeaderWarnings = newValue)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -34,6 +34,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   def maxToStrictBytes: Long
   def maxChunkExtLength: Int
   def maxChunkSize: Int
+  def maxCommentParsingDepth: Int
   def uriParsingMode: Uri.ParsingMode
   def cookieParsingMode: ParserSettings.CookieParsingMode
   def illegalHeaderWarnings: Boolean
@@ -64,6 +65,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   override def getMaxResponseReasonLength = maxResponseReasonLength
   override def getMaxUriLength = maxUriLength
   override def getMaxMethodLength = maxMethodLength
+  override def getMaxCommentParsingDepth: Int = maxCommentParsingDepth
   override def getErrorLoggingVerbosity: js.ParserSettings.ErrorLoggingVerbosity = errorLoggingVerbosity
   override def getIllegalResponseHeaderValueProcessingMode = illegalResponseHeaderValueProcessingMode
 
@@ -90,6 +92,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   override def withMaxToStrictBytes(newValue: Long): ParserSettings = self.copy(maxToStrictBytes = newValue)
   override def withMaxChunkExtLength(newValue: Int): ParserSettings = self.copy(maxChunkExtLength = newValue)
   override def withMaxChunkSize(newValue: Int): ParserSettings = self.copy(maxChunkSize = newValue)
+  override def withMaxCommentParsingDepth(newValue: Int): ParserSettings = self.copy(maxCommentParsingDepth = newValue)
   override def withIllegalHeaderWarnings(newValue: Boolean): ParserSettings = self.copy(illegalHeaderWarnings = newValue)
   override def withIncludeTlsSessionInfoHeader(newValue: Boolean): ParserSettings = self.copy(includeTlsSessionInfoHeader = newValue)
   override def withModeledHeaderParsing(newValue: Boolean): ParserSettings = self.copy(modeledHeaderParsing = newValue)

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -9,7 +9,7 @@ import akka.http.impl.model.parser.HeaderParser.Settings
 import org.scalatest.{ FreeSpec, Matchers }
 import org.scalatest.matchers.{ MatchResult, Matcher }
 import akka.http.impl.util._
-import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.{ HttpHeader, _ }
 import headers._
 import CacheDirectives._
 import MediaTypes._
@@ -17,8 +17,8 @@ import MediaRanges._
 import HttpCharsets._
 import HttpEncodings._
 import HttpMethods._
-import java.net.InetAddress
 
+import java.net.InetAddress
 import akka.http.scaladsl.model.MediaType.WithOpenCharset
 import org.scalatest.exceptions.TestFailedException
 
@@ -761,6 +761,10 @@ class HttpHeaderSpec extends FreeSpec with Matchers {
 
       checkContentType("application/json", ContentType.WithMissingCharset(openJson))
       checkContentType("application/json; charset=UTF-8", ContentType(openJson, HttpCharsets.`UTF-8`))
+    }
+    "fail gracefully for deeply nested header comments" in {
+      parse("User-Agent", "(" * 10000).errors.head shouldEqual
+        ErrorInfo("Illegal HTTP header 'User-Agent': Illegal header value", "Header comment nested too deeply")
     }
   }
 


### PR DESCRIPTION
Fixes #3918

To avoid StackOverflowErrors while parsing headers based on user input.

(cherry picked from commit 6fd3c0dc2d9dc979bdc99395f39ec42e733011e4)