### PR TITLE
[10.1 backport] core: add pool keep-alive-timeout (#3816)

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/keep-alive-timeout.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/keep-alive-timeout.excludes
@@ -1,0 +1,6 @@
+# Method added to class not meant for user extension:
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.scaladsl.settings.ConnectionPoolSettings.keepAliveTimeout")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.settings.ConnectionPoolSettings.withKeepAliveTimeout")
+
+ProblemFilters.exclude[Problem]("akka.http.impl.settings.ConnectionPoolSettingsImpl.*")
+ProblemFilters.exclude[Problem]("akka.http.impl.engine.client.pool.SlotState*")

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -426,6 +426,24 @@ akka.http {
     #  - new: the pool implementation that became the default in 10.1.x and will receive fixes and new features
     pool-implementation = new
 
+    # HTTP connections are commonly used for multiple requests, that is, they are kept alive between requests. The
+    # `akka.http.host-connection-pool.keep-alive-timeout` setting configures how long a pool keeps a connection alive between
+    # requests before it closes the connection (and eventually reestablishes it).
+    #
+    # A common scenario where this setting is useful is to prevent a race-condition inherent in HTTP: in most cases, a server
+    # or reverse-proxy closes a persistent (kept-alive) connection after some time. HTTP does not define a protocol between
+    # client and server to negotiate a graceful teardown of an idle persistent connection. Therefore, it can happen that a server decides to
+    # close a connection at the same time that a client decides to send a new request. In that case, the request will fail to be processed,
+    # but the client cannot determine for which reason the server closed the connection and whether the request was (partly) processed or not.
+    # Such a condition can be observed when a request fails with an `UnexpectedConnectionClosureException` or a `StreamTcpException` stating
+    # "Connection reset by peer".
+    #
+    # To prevent this from happening, you can set the timeout to a lower value than the server-side keep-alive timeout
+    # (which you either have to know or find out experimentally).
+    #
+    # Set to `infinite` to allow the connection to remain open indefinitely (or be closed by the more general `idle-timeout`).
+    keep-alive-timeout = infinite
+
     # The "new" pool implementation will fail a connection early and clear the slot if a response entity was not
     # subscribed during the given time period after the response was dispatched. In busy systems the timeout might be
     # too tight if a response is not picked up quick enough after it was dispatched by the pool.

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ConnectionPoolSettingsImpl.scala
@@ -24,6 +24,7 @@ private[akka] final case class ConnectionPoolSettingsImpl(
   baseConnectionBackoff:             FiniteDuration,
   maxConnectionBackoff:              FiniteDuration,
   idleTimeout:                       Duration,
+  keepAliveTimeout:                  Duration,
   connectionSettings:                ClientConnectionSettings,
   poolImplementation:                PoolImplementation,
   responseEntitySubscriptionTimeout: Duration)
@@ -75,6 +76,7 @@ private[akka] object ConnectionPoolSettingsImpl extends SettingsCompanionImpl[Co
       c.getFiniteDuration("base-connection-backoff"),
       c.getFiniteDuration("max-connection-backoff"),
       c.getPotentiallyInfiniteDuration("idle-timeout"),
+      c.getPotentiallyInfiniteDuration("keep-alive-timeout"),
       ClientConnectionSettingsImpl.fromSubConfig(root, c.getConfig("client")),
       c.getString("pool-implementation").toLowerCase match {
         case "legacy" => PoolImplementation.Legacy

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ConnectionPoolSettings.scala
@@ -34,6 +34,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def getBaseConnectionBackoff: FiniteDuration = baseConnectionBackoff
   def getMaxConnectionBackoff: FiniteDuration = maxConnectionBackoff
   def getIdleTimeout: Duration = idleTimeout
+  def getKeepAliveTimeout: Duration = keepAliveTimeout
   def getConnectionSettings: ClientConnectionSettings = connectionSettings
 
   @ApiMayChange
@@ -60,6 +61,7 @@ abstract class ConnectionPoolSettings private[akka] () { self: ConnectionPoolSet
   def withBaseConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(baseConnectionBackoff = newValue)
   def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(maxConnectionBackoff = newValue)
   def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue)
+  def withKeepAliveTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(keepAliveTimeout = newValue)
   def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copy(maxConnectionLifetime = newValue)
   def withConnectionSettings(newValue: ClientConnectionSettings): ConnectionPoolSettings = self.copy(connectionSettings = newValue.asScala)
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ConnectionPoolSettings.scala
@@ -34,6 +34,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   def baseConnectionBackoff: FiniteDuration
   def maxConnectionBackoff: FiniteDuration
   def idleTimeout: Duration
+  def keepAliveTimeout: Duration
   def connectionSettings: ClientConnectionSettings
   def maxConnectionLifetime: Duration
 
@@ -62,6 +63,7 @@ abstract class ConnectionPoolSettings extends js.ConnectionPoolSettings { self: 
   override def withMaxConnectionBackoff(newValue: FiniteDuration): ConnectionPoolSettings = self.copy(maxConnectionBackoff = newValue)
 
   override def withIdleTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(idleTimeout = newValue)
+  override def withKeepAliveTimeout(newValue: Duration): ConnectionPoolSettings = self.copy(keepAliveTimeout = newValue)
   override def withMaxConnectionLifetime(newValue: Duration): ConnectionPoolSettings = self.copy(maxConnectionLifetime = newValue)
 
   // overloads for idiomatic Scala use

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -316,6 +316,33 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         conn2.pushResponse(HttpResponse(entity = "response"))
         expectResponseEntityAsString() shouldEqual "response"
       }
+
+      "create a new connection when previous one timed out between requests because of keep-alive-timeout" inWithShutdown
+        new SetupWithServerProbes(_.withKeepAliveTimeout(800.millis)) {
+          pushRequest(HttpRequest(uri = "/simple"))
+
+          val conn1 = expectNextConnection()
+          val req = conn1.expectRequest()
+          conn1.pushResponse(HttpResponse(headers = headers.Connection("keep-alive") :: Nil, entity = req.uri.path.toString))
+
+          expectResponseEntityAsString() shouldEqual "/simple"
+          val receivedFirstResponse = System.nanoTime()
+
+          // wait until pool closes connection because of keep-alive-timeout
+          conn1.serverRequests.expectComplete()
+          conn1.serverResponses.sendComplete()
+
+          val lasted = System.nanoTime() - receivedFirstResponse
+
+          lasted.nanos should be >= 800.millis
+          lasted.nanos should be < 1500.millis
+
+          pushRequest(HttpRequest(uri = "/next"))
+          val conn2 = expectNextConnection()
+          conn2.expectRequestToPath("/next")
+          conn2.pushResponse(HttpResponse(entity = "response"))
+          expectResponseEntityAsString() shouldEqual "response"
+        }
       "create a new connection when previous one was closed regularly between requests without sending a `Connection: close` header first" inWithShutdown new SetupWithServerProbes {
         pendingIn(targetImpl = LegacyPoolImplementation) // flaky test, no reason to debug old client pool issues for now
         pushRequest(HttpRequest(uri = "/simple"))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/pool/SlotStateSpec.scala
@@ -5,7 +5,6 @@
 package akka.http.impl.engine.client.pool
 
 import java.net.InetSocketAddress
-
 import akka.event.LoggingAdapter
 import akka.http.impl.engine.client.PoolFlow
 import akka.http.impl.engine.client.PoolFlow.RequestContext
@@ -20,6 +19,7 @@ import akka.testkit.AkkaSpec
 import akka.util.ByteString
 
 import scala.concurrent.Promise
+import scala.concurrent.duration.Duration
 import scala.util.Try
 
 class SlotStateSpec extends AkkaSpec {
@@ -53,7 +53,7 @@ class SlotStateSpec extends AkkaSpec {
       state = state.onResponseDispatchable(context)
       state = state.onResponseEntitySubscribed(context)
       state = state.onResponseEntityCompleted(context)
-      state should be(Idle)
+      state should be(Idle(Duration.Inf))
 
       state = state.onConnectionCompleted(context)
       state should be(ToBeClosed)
@@ -79,7 +79,7 @@ class SlotStateSpec extends AkkaSpec {
       state = state.onResponseDispatchable(context)
       state = state.onResponseEntitySubscribed(context)
       state = state.onResponseEntityCompleted(context)
-      state should be(Idle)
+      state should be(Idle(Duration.Inf))
     }
 
     "allow postponing completing the request until just after the response was dispatchable" in {
@@ -102,7 +102,7 @@ class SlotStateSpec extends AkkaSpec {
 
       state = state.onResponseEntitySubscribed(context)
       state = state.onResponseEntityCompleted(context)
-      state should be(Idle)
+      state should be(Idle(Duration.Inf))
     }
 
     "allow postponing completing the request until just after the response was subscribed" in {
@@ -125,7 +125,7 @@ class SlotStateSpec extends AkkaSpec {
       state = state.onRequestEntityCompleted(context)
 
       state = state.onResponseEntityCompleted(context)
-      state should be(Idle)
+      state should be(Idle(Duration.Inf))
     }
 
     "consider a slot 'idle' only when the request has been successfully sent" in {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -367,6 +367,47 @@ class ClientServerSpec extends WordSpec with Matchers with BeforeAndAfterAll wit
             actualTimeout.nanos should be < serverTimeout
           } finally Await.result(b1.unbind(), 1.second.dilated)
         }
+
+        "avoid client vs. server race-condition for persistent connections with keep-alive-timeout" in Utils.assertAllStagesStopped {
+          def handler(request: HttpRequest): Future[HttpResponse] = Future.successful(HttpResponse())
+          val serverSettings = ServerSettings(system).mapTimeouts(_.withIdleTimeout(300.millis))
+          val binding = Http().bindAndHandleAsync(handler, "127.0.0.1", 0, settings = serverSettings).awaitResult(1.second.dilated)
+          val uri = "http://" + binding.localAddress.getHostString + ":" + binding.localAddress.getPort
+
+          val clientSettings = ConnectionPoolSettings(system)
+            .withUpdatedConnectionSettings(
+              _.withTransport(new ClientTransport {
+                override def connectTo(host: String, port: Int, settings: ClientConnectionSettings)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[Http.OutgoingConnection]] =
+                  Flow[ByteString]
+                    .delay(200.millis, OverflowStrategy.backpressure) // delay request sending enough to make race-condition more likely
+                    .viaMat(ClientTransport.TCP.connectTo(host, port, settings))(Keep.right)
+              }))
+
+          def runRequest(clientSettings: ConnectionPoolSettings): Future[HttpResponse] =
+            Http().singleRequest(HttpRequest(method = POST, uri = uri), settings = clientSettings)
+
+          def runTest(clientSettings: ConnectionPoolSettings): Future[HttpResponse] = {
+            // send first request
+            runRequest(clientSettings).awaitResult(1.second)
+
+            // delay so that next request is sent before idle-timeout of 300 millis
+            // but will arrive only 200 millis later, which is after the idle-timeout
+            Thread.sleep(200)
+
+            // send second request, should run into server-side idle-timeout
+            runRequest(clientSettings)
+          }
+
+          val ex = Try(runTest(clientSettings).awaitResult(1.second)).failed.get
+          ex.getCause.getMessage.contains("connection closed") shouldBe true
+
+          val clientSettings2 = clientSettings.withKeepAliveTimeout(100.millis) // < 300 millis server idle timeout
+          // same test on new pool with keep-alive-timeout which should succeed
+          runTest(clientSettings2).awaitResult(1.second)
+
+          binding.unbind().awaitResult(1.second)
+          Http().shutdownAllConnectionPools().awaitResult(1.second)
+        }
       }
     }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/PreviewServerSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/PreviewServerSettingsSpec.scala
@@ -11,7 +11,7 @@ class PreviewServerSettingsSpec extends AkkaSpec {
   def compileOnlySpec(body: => Unit) = ()
 
   "PreviewServerSettings" should {
-    "compile when set programatically" in compileOnlySpec {
+    "compile when set programmatically" in compileOnlySpec {
       ServerSettings(system)
         .withPreviewServerSettings(PreviewServerSettings(system).withEnableHttp2(true))
         .withRemoteAddressHeader(true)

--- a/docs/src/main/paradox/common/timeouts.md
+++ b/docs/src/main/paradox/common/timeouts.md
@@ -7,25 +7,21 @@ are left to the streaming APIs and are easily implementable as patterns in user-
 ## Common timeouts
 
 <a id="idle-timeouts"></a>
-### Idle timeouts
+### Connection-level idle timeout
 
-The `idle-timeout` is a global setting which sets the maximum inactivity time of a given connection.
-In other words, if a connection is open but no request/response is being written to it for over `idle-timeout` time,
-the connection will be automatically closed.
+The `idle-timeout` is a setting which sets the maximum inactivity time of a given connection. If no data is sent or received
+on a connection for over `idle-timeout` time, the connection will be automatically closed.
 
-The setting works the same way for all connections, be it server-side or client-side, and it's configurable
-independently for each of those using the following keys:
+This setting should be used as a last-resort safeguard to prevent unused or stuck connections from consuming resources for
+an indefinite time.
+
+The setting works the same way for server and client connections and it is configurable independently using the following keys:
 
 ```
 akka.http.server.idle-timeout
 akka.http.client.idle-timeout
-akka.http.host-connection-pool.idle-timeout
 akka.http.host-connection-pool.client.idle-timeout
 ```
-
-@@@ note
-For the client side connection pool, the idle period is counted only when the pool has no pending requests waiting.
-@@@
 
 ## Server timeouts
 
@@ -73,7 +69,28 @@ The connecting timeout is the time period within which the TCP connecting proces
 Tweaking it should rarely be required, but it allows erroring out the connection in case a connection
 is unable to be established for a given amount of time.
 
-it can be configured using the `akka.http.client.connecting-timeout` setting.
+It can be configured using the `akka.http.client.connecting-timeout` setting.
+
+## Client pool timeouts
+
+### Keep-alive timeout
+
+HTTP connections are commonly used for multiple requests, that is, they are kept alive between requests. The
+`akka.http.host-connection-pool.keep-alive-timeout` setting configures how long a pool keeps a connection alive between
+requests before it closes the connection (and eventually reestablishes it).
+
+A common scenario where this setting is useful is to prevent a race-condition inherent in HTTP: in most cases, a server
+or reverse-proxy closes a persistent (kept-alive) connection after some time. HTTP does not define a protocol between
+client and server to negotiate a graceful teardown of an idle persistent connection. Therefore, it can happen that a server decides to
+close a connection at the same time that a client decides to send a new request. In that case, the request will fail to be processed,
+but the client cannot determine for which reason the server closed the connection and whether the request was (partly) processed or not.
+Such a condition can be observed when a request fails with an `UnexpectedConnectionClosureException` or a `StreamTcpException` stating
+"Connection reset by peer".
+
+To prevent this from happening, you can set the timeout to a lower value than the server-side keep-alive timeout
+(which you either have to know or find out experimentally).
+
+Set to `infinite` to allow the connection to remain open indefinitely (or be closed by the more general `idle-timeout`).
 
 ### Connection Lifetime timeout
 
@@ -81,3 +98,13 @@ This timeout configures a maximum amount of time, while the connection can be ke
 the server through a load balancer and client reconnecting helps the process of rebalancing between service instances.
 
 It can be configured using the `akka.http.host-connection-pool.max-connection-lifetime` setting.
+
+### Pool Idle timeout
+
+A connection pool to a target host will be shut down after the timeout given as `akka.http.host-connection-pool.idle-timeout`. This frees
+resources like open but idle pool connections and management structures.
+
+If the application connects to only a limited set of target hosts over its lifetime and resource usage for the pool is of no concern, the
+`idle-timeout` can be completely disabled by setting it to `infinite`.
+
+A pool will be automatically reestablished when a new request comes in for a target host.


### PR DESCRIPTION
Co-authored-by: Arnout Engelen <arnout@bzzt.net>
Co-authored-by: Johannes Rudolph <johannes.rudolph@gmail.com>
(cherry picked from commit 814ad18fd5aad671de790995e10bb0c799ddb375)
(cherry picked from commit eb5557fa4cd2f43b453f280fbab231c115120d6e)