### PR TITLE
[10.1 backport] core: discard outgoing headers containing line breaks (#3922)

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
@@ -20,7 +20,7 @@ import org.openjdk.jmh.annotations._
 
 class ServerProcessingBenchmark extends CommonBenchmark {
   val request = ByteString("GET / HTTP/1.1\r\nHost: localhost\r\nUser-Agent: test\r\n\r\n")
-  val response = HttpResponse(headers = headers.Server("akka-http-bench") :: Nil)
+  val response = HttpResponse()
 
   var httpFlow: Flow[ByteString, ByteString, Any] = _
   implicit var system: ActorSystem = _
@@ -45,6 +45,7 @@ class ServerProcessingBenchmark extends CommonBenchmark {
       ConfigFactory.parseString(
         """
            akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 1
+           akka.http.server.server-header = "akka-http-bench"
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)

--- a/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/safe-header-rendering.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/safe-header-rendering.excludes
@@ -1,0 +1,5 @@
+# Add new methods to @InternalApi Rendering trait
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.util.Rendering.mark")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.util.Rendering.check")
+# for Scala 2.11
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.impl.util.Rendering.~~")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
@@ -9,6 +9,8 @@ import akka.annotation.InternalApi
 import akka.http.impl.engine.parsing.HttpMessageParser.StateResult
 import akka.http.impl.engine.parsing.ParserOutput.{ NeedMoreData, RemainingBytes, ResponseStart }
 import akka.http.impl.engine.parsing.{ HttpHeaderParser, HttpResponseParser, ParserOutput }
+import akka.http.impl.util.ByteStringRendering
+import akka.http.impl.util.Rendering.CrLf
 import akka.http.scaladsl.model.headers.{ HttpCredentials, `Proxy-Authorization` }
 import akka.http.scaladsl.model.{ HttpMethods, StatusCodes }
 import akka.http.scaladsl.settings.ClientConnectionSettings
@@ -53,17 +55,15 @@ private final class HttpsProxyGraphStage(
   override def shape: BidiShape[ByteString, ByteString, ByteString, ByteString] = BidiShape.apply(sslIn, bytesOut, bytesIn, sslOut)
 
   private val connectMsg = {
-    val renderedProxyAuth = proxyAuthorization.map { httpCredentials =>
-      ByteString(s"${`Proxy-Authorization`(httpCredentials)}\r\n")
-    } getOrElse ByteString.empty
+    val r = new ByteStringRendering(256)
 
-    // format: OFF
-    ByteString(
-      s"CONNECT $targetHostName:$targetPort HTTP/1.1\r\n" +
-      s"Host: $targetHostName\r\n") ++
-      renderedProxyAuth ++
-      ByteString("\r\n")
-    // format: ON
+    r ~~ "CONNECT " ~~ targetHostName ~~ ':' ~~ targetPort ~~ " HTTP/1.1" ~~ CrLf
+    r ~~ "Host: " ~~ targetHostName ~~ CrLf
+    proxyAuthorization.foreach { creds =>
+      r ~~ `Proxy-Authorization`(creds)
+    }
+    r ~~ CrLf
+    r.get
   }
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with StageLogging {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
@@ -130,7 +130,7 @@ private[http] object BodyPartRenderer {
     case x: RawHeader if (x is "content-type") || (x is "content-length") =>
       suppressionWarning(log, x, "illegal RawHeader")
 
-    case x => r ~~ x ~~ CrLf
+    case x => r ~~ x
   }
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -33,7 +33,7 @@ private[http] class HttpRequestRendererFactory(
   def renderToSource(ctx: RequestRenderingContext): Source[ByteString, Any] = render(ctx).byteStream
 
   def render(ctx: RequestRenderingContext): RequestRenderingOutput = {
-    val r = new ByteStringRendering(requestHeaderSizeHint)
+    val r = new ByteStringRendering(requestHeaderSizeHint, log.warning)
     import ctx.request._
 
     def renderRequestLine(): Unit = {
@@ -47,7 +47,7 @@ private[http] class HttpRequestRendererFactory(
       r ~~ ' ' ~~ protocol ~~ CrLf
     }
 
-    def render(h: HttpHeader) = r ~~ h ~~ CrLf
+    def render(h: HttpHeader) = r ~~ h
 
     @tailrec def renderHeaders(remaining: List[HttpHeader], hostHeaderSeen: Boolean = false,
                                userAgentSeen: Boolean = false, transferEncodingSeen: Boolean = false): Unit =
@@ -107,8 +107,8 @@ private[http] class HttpRequestRendererFactory(
         }
 
         case Nil =>
-          if (!hostHeaderSeen) r ~~ ctx.hostHeader ~~ CrLf
-          if (!userAgentSeen && userAgentHeader.isDefined) r ~~ userAgentHeader.get ~~ CrLf
+          if (!hostHeaderSeen) r ~~ ctx.hostHeader
+          if (!userAgentSeen && userAgentHeader.isDefined) r ~~ userAgentHeader.get
           if (entity.isChunked && !entity.isKnownEmpty && !transferEncodingSeen)
             r ~~ `Transfer-Encoding` ~~ ChunkedBytes ~~ CrLf
       }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -37,7 +37,7 @@ private[http] class HttpResponseRendererFactory(
   private val renderDefaultServerHeader: Rendering => Unit =
     serverHeader match {
       case Some(h) =>
-        val bytes = (new ByteArrayRendering(32) ~~ h ~~ CrLf).get
+        val bytes = (new ByteArrayRendering(128) ~~ h).get
         _ ~~ bytes
       case None => _ => ()
     }
@@ -148,7 +148,7 @@ private[http] class HttpResponseRendererFactory(
         }
 
         def render(ctx: ResponseRenderingContext): StrictOrStreamed = {
-          val r = new ByteArrayRendering(responseHeaderSizeHint)
+          val r = new ByteArrayRendering(responseHeaderSizeHint, log.warning)
 
           import ctx.response._
           val noEntity = entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD
@@ -160,7 +160,7 @@ private[http] class HttpResponseRendererFactory(
               case other      => throw new IllegalStateException(s"Unexpected protocol '$other'")
             }
 
-          def render(h: HttpHeader) = r ~~ h ~~ CrLf
+          def render(h: HttpHeader) = r ~~ h
 
           def mustRenderTransferEncodingChunkedHeader =
             entity.isChunked && (!entity.isKnownEmpty || ctx.requestMethod == HttpMethods.HEAD) && (ctx.requestProtocol == `HTTP/1.1`)
@@ -241,7 +241,7 @@ private[http] class HttpResponseRendererFactory(
             if (renderConnectionHeader)
               r ~~ Connection ~~ (if (close) CloseBytes else KeepAliveBytes) ~~ CrLf
             else if (connHeader != null && connHeader.hasUpgrade) {
-              r ~~ connHeader ~~ CrLf
+              r ~~ connHeader
               HttpHeader.fastFind(classOf[UpgradeToOtherProtocolResponseHeader], headers) match {
                 case OptionVal.Some(header) => closeMode = SwitchToOtherProtocol(header.handler)
                 case _                      => // nothing to do here...

--- a/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
@@ -8,13 +8,13 @@ import java.nio.CharBuffer
 import java.nio.charset.Charset
 import java.text.{ DecimalFormat, DecimalFormatSymbols }
 import java.util.Locale
-
 import akka.annotation.InternalApi
 
 import scala.annotation.tailrec
 import scala.collection.{ LinearSeq, immutable }
 import akka.parboiled2.{ CharPredicate, CharUtils }
 import akka.http.impl.model.parser.CharacterClasses
+import akka.http.scaladsl.model.HttpHeader
 import akka.util.{ ByteString, ByteStringBuilder }
 
 /**
@@ -191,6 +191,19 @@ private[http] trait Rendering {
     rec()
   }
 
+  protected def mark: Int
+  protected def check(mark: Int): Boolean
+  /**
+   * Renders a header safely, i.e. checking that it does not contain any CR of LF characters. If it does
+   * the header should be discarded.
+   */
+  def ~~(header: HttpHeader): this.type = {
+    val m = mark
+    header.render(this)
+    if (check(m)) this ~~ Rendering.CrLf
+    else this
+  }
+
   def ~~[T](value: T)(implicit ev: Renderer[T]): this.type = ev.render(this, value)
 
   /**
@@ -245,14 +258,33 @@ private[http] class StringRendering extends Rendering {
   }
   def ~~(bytes: ByteString): this.type = this ~~ bytes.toArray[Byte]
   def get: String = sb.toString
+
+  override protected def mark: Int = sb.length()
+  override protected def check(mark: Int): Boolean = {
+    val origMark = mark
+
+    @tailrec def rec(mark: Int): Boolean =
+      if (mark < sb.length()) {
+        val ch = sb.charAt(mark)
+        if (ch == '\r' || ch == '\n') {
+          sb.delete(origMark, sb.length())
+          false
+        } else rec(mark + 1)
+      } else true
+
+    rec(mark)
+  }
 }
 
 /**
  * INTERNAL API
  */
 @InternalApi
-private[http] class ByteArrayRendering(sizeHint: Int) extends Rendering {
+private[http] class ByteArrayRendering(sizeHint: Int, logDiscardedHeader: String => Unit = _ => ()) extends Rendering {
+  def this(sizeHint: Int) = this(sizeHint, _ => ())
+
   private[this] var array = new Array[Byte](sizeHint)
+
   private[this] var size = 0
 
   def get: Array[Byte] =
@@ -297,13 +329,31 @@ private[http] class ByteArrayRendering(sizeHint: Int) extends Rendering {
 
   def remainingCapacity: Int = array.length - size
   def asByteString: ByteString = ByteString.ByteString1(array, 0, size)
+
+  override protected def mark: Int = size
+  override protected def check(mark: Int): Boolean = {
+    val origMark = mark
+
+    @tailrec def rec(mark: Int): Boolean =
+      if (mark < size) {
+        if (array(mark) == '\r' || array(mark) == '\n') {
+          logDiscardedHeader("Invalid outgoing header was discarded. " + LogByteStringTools.printByteString(ByteString.fromArray(array, origMark, size - origMark)))
+          size = origMark
+          false
+        } else rec(mark + 1)
+      } else true
+
+    rec(mark)
+  }
 }
 
 /**
  * INTERNAL API
  */
 @InternalApi
-private[http] class ByteStringRendering(sizeHint: Int) extends Rendering {
+private[http] class ByteStringRendering(sizeHint: Int, logDiscardedHeader: String => Unit = _ => ()) extends Rendering {
+  def this(sizeHint: Int) = this(sizeHint, _ => ())
+
   private[this] val builder = new ByteStringBuilder
   builder.sizeHint(sizeHint)
 
@@ -322,6 +372,25 @@ private[http] class ByteStringRendering(sizeHint: Int) extends Rendering {
   def ~~(bytes: ByteString): this.type = {
     if (bytes.length > 0) builder ++= bytes
     this
+  }
+
+  override protected def mark: Int = builder.length
+  override protected def check(mark: Int): Boolean = {
+    val origMark = mark
+    val contents = builder.result()
+
+    @tailrec def rec(mark: Int): Boolean =
+      if (mark < builder.length) {
+        val ch = contents(mark)
+        if (ch == '\r' || ch == '\n') {
+          logDiscardedHeader("Invalid outgoing header was discarded. " + LogByteStringTools.printByteString(contents.drop(origMark)))
+          builder.clear()
+          builder.append(contents.take(origMark))
+          false
+        } else rec(mark + 1)
+      } else true
+
+    rec(mark)
   }
 }
 
@@ -372,5 +441,28 @@ private[http] class CustomCharsetByteStringRendering(nioCharset: Charset, sizeHi
       builder.putByteArrayUnsafe(bytes)
     }
     charBuffer.clear()
+  }
+
+  override protected def mark: Int = {
+    flushCharBuffer()
+    builder.length
+  }
+  override protected def check(mark: Int): Boolean = {
+    flushCharBuffer()
+
+    val origMark = mark
+    val contents = builder.result()
+
+    @tailrec def rec(mark: Int): Boolean =
+      if (mark < builder.length) {
+        val ch = contents(mark)
+        if (ch == '\r' || ch == '\n') {
+          builder.clear()
+          builder.append(contents.take(origMark))
+          false
+        } else rec(mark + 1)
+      } else true
+
+    rec(mark)
   }
 }


### PR DESCRIPTION
Refs akka#3717

To avoid accidental response splitting when applications put unsanitized request
data into outgoing responses.

We previously discussed introducing a check in the header models which could avoid
overhead during rendering. There are a lot of header models, however, which
all had to be checked one by one for potential issues. This would require a significant
effort now to check all the existing headers and would also make it easy to
reintroduce problems later on when headers are added or changed.

The approach here requires that all headers are rendered using the new overload of
`Rendering.~~`. When that method is used, we render the header and check afterwards
that the rendered data does not contain any CR or LF characters.

The performance overhead seems negligible, the new method did not turn up in profiling.
An explanation why going over the rendered header data directly after it has been rendered
is so cheap could be that
 - it has good locality because the data has just been written
 - it has good branch prediction because test will almost never fail
 - even if it has linear cost for big headers, those big headers will also have significant
   memory allocation cost which might dwarf the extra checking

(cherry picked from commit afecb315c4b8b09e8edcee6613ee68cb5f938b52)