### PR TITLE
build: don't publish snapshot docs from release-10.1 branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,9 @@ jobs:
 
   publish-docs:
     name: Publish documentation
+    # only publish when a tag is published (otherwise, snapshots of old branches will overwrite
+    # snapshot docs from main)
+    if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
To avoid overwriting main snapshot docs...