### PR TITLE
docs: backport release notes from 10.1

### DIFF
--- a/docs/src/main/paradox/release-notes/10.1.x.md
+++ b/docs/src/main/paradox/release-notes/10.1.x.md
@@ -1,5 +1,58 @@
 # 10.1.x Release Notes
 
+## 10.1.15
+
+This release is an important security fix release, backporting fixes from 10.2.7 to the 10.1.x line of releases. Note,
+that we do not plan any further releases for 10.1.x, so please consider upgrading soon to the latest supported release line,
+10.2.x. Due to our binary compatibility guarantees, as long as no deprecated methods were used, 10.2.x should be a drop-in
+replacement in 10.1.x projects, even when transitive dependencies depended on 10.1.x.
+
+Most importantly, we fixed a problem with parsing headers containing `comment` elements ([#3918](https://github.com/akka/akka-http/issues/3918)).
+The HTTP spec allows arbitrary
+nesting of those elements, e.g. in the `User-Agent` header. When such a header is parsed, an Akka HTTP application may
+fail fatally with a `StackOverflowError`. Akka HTTP 10.2.7 mitigates this issue by conservatively limiting the allowed
+depth of `comment` elements in headers.See @ref[the advisory for CVE-2021-42697](../security/2021-CVE-2021-42697-stack-overflow-parsing-user-agent.md)
+for more information about this security issue.
+
+Another issue has been fixed in relation to header rendering ([#3717](https://github.com/akka/akka-http/issues/3717)).
+Akka HTTP does not validate that header values (or keys)
+are well-formed when those are provided as Strings (e.g. in a `RawHeader`). In particular, HTTP headers are not allowed
+to contain the special characters `'\r'` or `'\n'` which are used to delineate headers in an HTTP message. Before 10.2.7,
+Akka HTTP would naively render those broken header values leading to broken HTTP messages. The generation of headers is
+usually in complete control of the application. However, an application may accidentally pass incoming unvalidated user
+data to response headers. In such a case, a remote user might be able to inject line terminators into the response headers
+leading to invalid or misleading HTTP response messages. Depending on the server setup, this can be a building block for
+severe attacks.
+
+To mitigate this issue, Akka HTTP now discards outgoing headers containing line terminators and logs a warning. Users
+are encouraged to be on the watch when creating headers (or any kind of outgoing data) from unvalidated user input as this
+is a common vector for different kinds of attacks.
+
+A few smaller issues have been backported as well, see below.
+
+#### akka-http-core
+
+* Discard outgoing headers containing line breaks [#3922](https://github.com/akka/akka-http/pull/3922)
+* Limit comment nesting in header parser [#3941](https://github.com/akka/akka-http/pull/3941)
+* Add pool keep-alive-timeout [#3816](https://github.com/akka/akka-http/pull/3816)
+* Don't send '100 Continue' if 'Content-Length' header is 0, doesn't exist or data got send early [#3787](https://github.com/akka/akka-http/pull/3787)
+* Update to Scala 2.13.7 [#3945](https://github.com/akka/akka-http/pull/3945)
+* Fix MessageSpec with higher test.timefactor values [#3880](https://github.com/akka/akka-http/pull/3880)
+
+## 10.1.14
+
+This release fixes [CVE-2021-23339](https://nvd.nist.gov/vuln/detail/CVE-2021-23339), a vulnerability regarding interpretation of `Transfer-Encoding` headers. See
+@ref:[Incorrect Handling Of Transfer-Encoding Header](../security/2021-02-24-incorrect-handling-of-Transfer-Encoding-header.md).
+
+The vulnerability cannot be exploited using just Akka HTTP itself. Instead, Akka HTTP must be use as a proxy and the downstream server must be vulnerable itself, so
+that the proxy and the downstream server disagree on how to interpret a malformed request containing both `Transfer-Encoding` and `Content-Length` headers potentially
+leading to a "Request Smuggling" vulnerability. If you are using Akka HTTP as a reverse proxy, make sure to upgrade to the latest version.
+
+Starting from this version, only a single `Transfer-Encoding: chunked` header is allowed. HTTP/1.1 specifies other encodings, however, those are not supported or
+implemented in Akka HTTP. Formerly, Akka HTTP would just pass on unsupported `Transfer-Encoding` headers to the user which lead to the above security issue. Since
+Akka HTTP implements the "Transfer" part of the protocol, it seems reasonable to lock down allowed values for `Transfer-Encoding` to prevent security issues like this.
+Please let us know if this leads to compatibility problems with your software.
+
 ## 10.1.13
 
 ### Changes since 10.1.12

--- a/docs/src/main/paradox/security/2021-CVE-2021-42697-stack-overflow-parsing-user-agent.md
+++ b/docs/src/main/paradox/security/2021-CVE-2021-42697-stack-overflow-parsing-user-agent.md
@@ -42,7 +42,7 @@ consequences for downstream user code which expects headers to be already parsed
 
 ## Fixed versions
 
-- akka-http `10.2.7`
+- akka-http `10.2.7`, `10.1.15`
 
 ## Acknowledgements
 


### PR DESCRIPTION
So, they will eventually part of the `current` docs as well.