### PR TITLE
build: validate on Scala 2.13.7

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.12.14, 2.13.6]
+        SCALA_VERSION: [2.12.14, 2.13.7]
         JABBA_JDK: [1.8, 1.11]
     steps:
       - name: Checkout

--- a/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/FastFuture-generic-signature.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/FastFuture-generic-signature.excludes
@@ -1,0 +1,4 @@
+# We now use Scala 2.13.7 to build Scala 2.13 artifacts, which sometimes
+# generates slightly different wildcards in generic signatures.
+# This is unlikely to be a problem:
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.util.FastFuture.*")

--- a/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/FastFuture-generic-signature.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/FastFuture-generic-signature.excludes
@@ -1,4 +1,0 @@
-# We now use Scala 2.13.7 to build Scala 2.13 artifacts, which sometimes
-# generates slightly different wildcards in generic signatures.
-# This is unlikely to be a problem:
-ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.util.FastFuture.*")

--- a/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/FastFuture-generic-signature.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/FastFuture-generic-signature.excludes
@@ -1,0 +1,4 @@
+# We now use Scala 2.13.7 to build Scala 2.13 artifacts, which sometimes
+# generates slightly different wildcards in generic signatures.
+# This is unlikely to be a problem:
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.util.FastFuture.*")

--- a/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/scala-2.13.7-signatures.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/scala-2.13.7-signatures.excludes
@@ -1,0 +1,18 @@
+# We now use Scala 2.13.7 to build Scala 2.13 artifacts, which sometimes
+# generates slightly different wildcards in generic signatures.
+# This is unlikely to be a problem:
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.util.FastFuture.*")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.engine.*")
+
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpMessage.withAttributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpMessage.attributes")
+
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpResponse.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpResponse.withAttributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpResponse.attributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpResponse.mapAttributes")
+
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpRequest.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpRequest.withAttributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpRequest.attributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpRequest.mapAttributes")


### PR DESCRIPTION
Since that's what we publish with as well