### PR TITLE
build: keep Scala version in one place

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.12.14, 2.13.6]
+        SCALA_VERSION: [2.12, 2.13]
         JABBA_JDK: [1.8, 1.11]
     steps:
       - name: Checkout
@@ -78,9 +78,9 @@ jobs:
       # Quick testing for PR validation
       - name: Validate pull request for JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}
         if: ${{ github.event_name == 'pull_request' }}
-        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 ++${{ matrix.SCALA_VERSION }} Test/compile validatePullRequest
+        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 -Dakka.build.scalaVersion=${{ matrix.SCALA_VERSION }} Test/compile validatePullRequest
 
       # Full testing for pushes
       - name: Run all tests JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}
         if: ${{ github.event_name == 'push' }}
-        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 ++${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues Test/compile test
+        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 -Dakka.build.scalaVersion=${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues Test/compile test

--- a/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/FastFuture-generic-signature.excludes
+++ b/akka-http-core/src/main/mima-filters/10.1.14.backwards.excludes/FastFuture-generic-signature.excludes
@@ -1,0 +1,4 @@
+# We now use Scala 2.13.7 to build Scala 2.13 artifacts, which sometimes
+# generates slightly different wildcards in generic signatures.
+# This is unlikely to be a problem:
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.util.FastFuture.*")

--- a/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/scala-2.13.7-signatures.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/scala-2.13.7-signatures.excludes
@@ -1,0 +1,18 @@
+# We now use Scala 2.13.7 to build Scala 2.13 artifacts, which sometimes
+# generates slightly different wildcards in generic signatures.
+# This is unlikely to be a problem:
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.util.FastFuture.*")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.engine.*")
+
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpMessage.withAttributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpMessage.attributes")
+
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpResponse.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpResponse.withAttributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpResponse.attributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpResponse.mapAttributes")
+
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpRequest.this")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpRequest.withAttributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpRequest.attributes")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.scaladsl.model.HttpRequest.mapAttributes")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,11 @@ object Dependencies {
 
   val Versions = Seq(
     crossScalaVersions := Seq(scala213Version, scala212Version),
-    scalaVersion := crossScalaVersions.value.head,
+    scalaVersion := (System.getProperty("akka.build.scalaVersion") match {
+      case "2.13" => scala213Version
+      case "2.12" => scala212Version
+      case null   => crossScalaVersions.value.head
+    })
   )
 
   object Provided {


### PR DESCRIPTION
rather than both in GHA config and project/Dependencies.scala