### PR TITLE
core: enable idle-timeout when http2 is enabled

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/HttpConnectionIdleTimeoutBidi.scala
@@ -12,12 +12,17 @@ import akka.annotation.InternalApi
 import akka.stream.scaladsl.{ BidiFlow, Flow }
 import akka.util.ByteString
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.util.control.NoStackTrace
 
 /** INTERNAL API */
 @InternalApi
 private[akka] object HttpConnectionIdleTimeoutBidi {
+  def apply(idleTimeout: Duration, remoteAddress: Option[InetSocketAddress]): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
+    idleTimeout match {
+      case f: FiniteDuration => apply(f, remoteAddress)
+      case _                 => BidiFlow.identity
+    }
   def apply(idleTimeout: FiniteDuration, remoteAddress: Option[InetSocketAddress]): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] = {
     val connectionToString = remoteAddress match {
       case Some(addr) => s" on connection to [$addr]"


### PR DESCRIPTION
And run ClientServerSpec also with http2 enabled.

Fixes #3959