### PR TITLE
docs: replace deprecated functions in Routing DSL docs

### DIFF
--- a/docs/src/main/paradox/routing-dsl/overview.md
+++ b/docs/src/main/paradox/routing-dsl/overview.md
@@ -19,8 +19,8 @@ As an alternative Akka HTTP provides a flexible DSL for expressing your service 
 composable elements (called @ref[Directives](directives/index.md)) in a concise and readable way. Directives are assembled into a so called
 *route structure* which, at its top-level, can be used to create a handler @apidoc[Flow] or async handler function that
 can be directly supplied to a `bind` call. @scala[The conversion from @scaladoc[Route](akka.http.scaladsl.server.index#Route=akka.http.scaladsl.server.RequestContext=%3Escala.concurrent.Future[akka.http.scaladsl.server.RouteResult]) to flow can either be invoked explicitly
-using `Route.handlerFlow` or, otherwise, the conversion is also provided implicitly by
-`RouteResult.route2HandlerFlow` <a id="^1" href="#1">[1]</a>.]
+using `Route.toFlow` or, otherwise, the conversion is also provided implicitly by
+`RouteResult.routeToFlow` <a id="^1" href="#1">[1]</a>.]
 
 Here's the complete example rewritten using the composable high-level API:
 
@@ -77,6 +77,6 @@ For learning how to work with the Routing DSL you should first understand the co
 type. However, as @scala[@scaladoc[Route](akka.http.scaladsl.server.index#Route=akka.http.scaladsl.server.RequestContext=%3Escala.concurrent.Future[akka.http.scaladsl.server.RouteResult])]@java[@javadoc[Route](akka.http.javadsl.server.Route)] is just a type alias for `RequestContext => Future[RouteResult]`, there's no
 companion object for @scala[@scaladoc[Route](akka.http.scaladsl.server.index#Route=akka.http.scaladsl.server.RequestContext=%3Escala.concurrent.Future[akka.http.scaladsl.server.RouteResult])]@java[@javadoc[Route](akka.http.javadsl.server.Route)]. Fortunately, the [implicit scope](https://www.scala-lang.org/files/archive/spec/2.11/07-implicits.html#implicit-parameters) for finding an implicit conversion also
 includes all types that are "associated with any part" of the source type which in this case means that the
-implicit conversion will also be picked up from `RouteResult.route2HandlerFlow` automatically.
+implicit conversion will also be picked up from `RouteResult.routeToFlow` automatically.
 
 @@@

--- a/docs/src/main/paradox/routing-dsl/rejections.md
+++ b/docs/src/main/paradox/routing-dsl/rejections.md
@@ -37,7 +37,7 @@ Unhandled rejections will simply continue to flow through the route structure.
 
 The default `RejectionHandler` applied by the top-level glue code that turns a @scala[@scaladoc[Route](akka.http.scaladsl.server.index#Route=akka.http.scaladsl.server.RequestContext=%3Escala.concurrent.Future[akka.http.scaladsl.server.RouteResult])]@java[@javadoc[Route](akka.http.javadsl.server.Route)] into a
 @apidoc[Flow] or async handler function for the @ref[low-level API](../server-side/low-level-api.md)
-@scala[(via `Route.handlerFlow` or `Route.asyncHandler`)]
+@scala[(via `Route.toFlow` or `Route.toFunction`)]
 will handle *all* rejections that reach it.
 
 

--- a/docs/src/main/paradox/routing-dsl/routes.md
+++ b/docs/src/main/paradox/routing-dsl/routes.md
@@ -39,11 +39,11 @@ instances to convert rejections and exceptions into appropriate HTTP responses f
 @ref[Sealing a Route](#sealing-a-route) is described more in detail later. 
 
 
-Using `Route.handlerFlow` or `Route.asyncHandler` a @scala[@scaladoc[Route](akka.http.scaladsl.server.index#Route=akka.http.scaladsl.server.RequestContext=%3Escala.concurrent.Future[akka.http.scaladsl.server.RouteResult])]@java[@javadoc[Route](akka.http.javadsl.server.Route)] can be lifted into a handler @apidoc[Flow] or async handler
+Using `Route.toFlow` or `Route.toFunction` a @scala[@scaladoc[Route](akka.http.scaladsl.server.index#Route=akka.http.scaladsl.server.RequestContext=%3Escala.concurrent.Future[akka.http.scaladsl.server.RouteResult])]@java[@javadoc[Route](akka.http.javadsl.server.Route)] can be lifted into a handler @apidoc[Flow] or async handler
 function to be used with a `bindAndHandleXXX` call from the @ref[Core Server API](../server-side/low-level-api.md).
 
 Note: There is also an implicit conversion from @scala[@scaladoc[Route](akka.http.scaladsl.server.index#Route=akka.http.scaladsl.server.RequestContext=%3Escala.concurrent.Future[akka.http.scaladsl.server.RouteResult])]@java[@javadoc[Route](akka.http.javadsl.server.Route)] to @apidoc[Flow[HttpRequest, HttpResponse, Unit]] defined in the
-@apidoc[RouteResult] companion, which relies on `Route.handlerFlow`.
+@apidoc[RouteResult] companion, which relies on `Route.toFlow`.
 
 <a id="requestcontext"></a>
 ## RequestContext


### PR DESCRIPTION
Replace deprecated functions in Routing DSL docs page:
Route.handlerFlow -> Route.toFlow
Route.asyncHandler -> Route.toFunction
RouteResult.route2HandlerFlow -> RouteResult.routeToFlow
