### PR TITLE
build: use fuzzy `+~` to switch Scala versions

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -78,9 +78,9 @@ jobs:
       # Quick testing for PR validation
       - name: Validate pull request for JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}
         if: ${{ github.event_name == 'pull_request' }}
-        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 -Dakka.build.scalaVersion=${{ matrix.SCALA_VERSION }} Test/compile validatePullRequest
+        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 "+~ ${{ matrix.SCALA_VERSION }} Test/compile validatePullRequest"
 
       # Full testing for pushes
       - name: Run all tests JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}
         if: ${{ github.event_name == 'push' }}
-        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 -Dakka.build.scalaVersion=${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues Test/compile test
+        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 "+~ ${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues Test/compile test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,15 +28,11 @@ object Dependencies {
 
   val scala212Version = "2.12.14"
   val scala213Version = "2.13.7"
+  val allScalaVersions = Seq(scala213Version, scala212Version)
 
   val Versions = Seq(
-    crossScalaVersions := Seq(scala213Version, scala212Version),
-    scalaVersion := (System.getProperty("akka.build.scalaVersion") match {
-      case "2.13" => scala213Version
-      case "2.12" => scala212Version
-      case null   => crossScalaVersions.value.head
-    })
-  )
+    crossScalaVersions := allScalaVersions,
+    scalaVersion := allScalaVersions.head)
 
   object Provided {
     val jsr305 = "com.google.code.findbugs" % "jsr305" % "3.0.2" % "provided" // ApacheV2

--- a/project/FuzzySwitch.scala
+++ b/project/FuzzySwitch.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2009-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka
+
+import sbt._
+import sbt.Keys._
+
+object FuzzySwitch extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override val projectSettings = Seq(
+    commands += fuzzySwitch
+  )
+
+  // So we can `sbt "+~ 3 clean compile"`
+  //
+  // The advantage over `++` is twofold:
+  // * `++` also requires the patch version, `+~` finds the first supported Scala version that matches the prefix (if any)
+  // * When subprojects need to be excluded, ++ needs to be specified for each command
+  //
+  // So the `++` equivalent of the above example is `sbt "++ 3.1.1-RC1 clean" "++ 3.1.1-RC1 compile"`
+  val fuzzySwitch: Command = Command.args("+~", "<version> <args>")({ (initialState: State, args: Seq[String]) =>
+    {
+      val requestedVersionPrefix = args.head
+      val requestedVersion = Dependencies.allScalaVersions.filter(_.startsWith(requestedVersionPrefix)).head
+
+      def run(state: State, command: String): State = {
+        val parsed = s"++ $requestedVersion $command".foldLeft(Cross.switchVersion.parser(state))((p, i) => p.derive(i))
+        parsed.resultEmpty match {
+          case e: sbt.internal.util.complete.Parser.Failure =>
+            throw new IllegalStateException(e.errors.mkString(", "))
+          case sbt.internal.util.complete.Parser.Value(v) =>
+            v()
+        }
+      }
+      val commands = args.tail
+      commands.foldLeft(initialState)(run)
+    }
+  })
+
+}


### PR DESCRIPTION
Keeping consistent with Akka (https://github.com/akka/akka/pull/30981)