### PR TITLE
core: fail pool slot if connection is canceled before it is failed

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -532,7 +532,11 @@ private[client] object NewHostConnectionPool {
           def onPull(): Unit = () // emitRequests makes sure not to push too early
 
           override def onDownstreamFinish(): Unit =
-            withSlot(_.debug("Connection cancelled"))
+            withSlot { slot =>
+              slot.debug("Connection cancelled")
+              slot.onConnectionFailed(new IllegalStateException("Connection was cancelled (caused by a failure of the underlying HTTP connection)"))
+              responseIn.cancel()
+            }
 
           /** Helper that makes sure requestOut is pulled before pushing */
           private def emitRequest(request: HttpRequest): Unit =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -534,7 +534,10 @@ private[client] object NewHostConnectionPool {
           override def onDownstreamFinish(): Unit =
             withSlot { slot =>
               slot.debug("Connection cancelled")
-              slot.onConnectionFailed(new IllegalStateException("Connection was cancelled (caused by a failure of the underlying HTTP connection)"))
+              // Let's use StreamTcpException for now.
+              // FIXME: after moving to Akka 2.6.x only, we can use cancelation cause propagation which would probably also report
+              // a StreamTcpException here
+              slot.onConnectionFailed(new StreamTcpException("Connection was cancelled (caused by a failure of the underlying HTTP connection)"))
               responseIn.cancel()
             }
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -23,7 +23,6 @@ import akka.testkit._
 import akka.util.ByteString
 import org.scalactic.Tolerance
 import org.scalatest.concurrent.Eventually
-import org.scalatest.Assertion
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future, Promise }
@@ -281,8 +280,8 @@ class GracefulTerminationSpec
 
   }
 
-  private def ensureConnectionIsClosed(r: Future[HttpResponse]): Assertion =
-    (the[StreamTcpException] thrownBy Await.result(r, 1.second)).getMessage should endWith("Connection refused")
+  private def ensureConnectionIsClosed(r: Future[HttpResponse]): StreamTcpException =
+    the[StreamTcpException] thrownBy Await.result(r, 1.second)
 
   class TestSetup(overrideResponse: Option[HttpResponse] = None) {
     val counter = new AtomicInteger()


### PR DESCRIPTION
Refs #3662

In the issue, it was observed that a connection might only cancel a pool
connection but would not fail it (which was the implicit assumption of the
existing code). In this case a pool might get more and more unresponsive
with slots hanging after connections being canceled but not failed.

The exact condition could not be reproduced but let's be proactive here
and fail the slot if we see unexpected cancellation.