### PR TITLE
Set the value of parsing.max-content-length = 0

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,0 +1,1 @@
+{"name":"sbt","version":"1.5.6","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/usr/lib/jvm/java-11-openjdk-amd64/bin/java","-Xms100m","-Xmx100m","-classpath","/home/knoldus/.local/share/JetBrains/IdeaIC2021.1/Scala/launcher/sbt-launch.jar","xsbt.boot.Boot","-bsp","--sbt-launch-jar=/home/knoldus/.local/share/JetBrains/IdeaIC2021.1/Scala/launcher/sbt-launch.jar"]}

--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,1 +1,0 @@
-{"name":"sbt","version":"1.5.6","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/usr/lib/jvm/java-11-openjdk-amd64/bin/java","-Xms100m","-Xmx100m","-classpath","/home/knoldus/.local/share/JetBrains/IdeaIC2021.1/Scala/launcher/sbt-launch.jar","xsbt.boot.Boot","-bsp","--sbt-launch-jar=/home/knoldus/.local/share/JetBrains/IdeaIC2021.1/Scala/launcher/sbt-launch.jar"]}

--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -187,7 +187,7 @@ akka.http {
       #
       # Set to `infinite` to completely disable entity length checks. (Even then you can still apply one
       # programmatically via `withSizeLimit`.)
-      max-content-length = 8m
+      max-content-length = 0
 
       # When a request is so malformed we cannot create a RequestContext out of it,
       # the regular exception handling does not apply, and a default error handling
@@ -385,7 +385,7 @@ akka.http {
       #
       # Set to `infinite` to completely disable entity length checks. (Even then you can still apply one
       # programmatically via `withSizeLimit`.)
-      max-content-length = infinite
+      max-content-length = 0
     }
 
     # Enables/disables the logging of unencrypted HTTP traffic to and from the HTTP

--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -51,7 +51,7 @@ private[akka] final case class ParserSettingsImpl(
   require(maxHeaderNameLength > 0, "max-header-name-length must be > 0")
   require(maxHeaderValueLength > 0, "max-header-value-length must be > 0")
   require(maxHeaderCount > 0, "max-header-count must be > 0")
-  require(maxContentLengthSetting.forall(_ > 0), "if set max-content-length must be > 0")
+  require(maxContentLengthSetting.forall(_ = 0), "if set max-content-length must be = 0")
   require(maxChunkExtLength > 0, "max-chunk-ext-length must be > 0")
   require(maxChunkSize > 0, "max-chunk-size must be > 0")
   require(maxCommentParsingDepth > 0, "max-comment-parsing-depth must be > 0")

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -43,7 +43,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
     akka.loglevel = WARNING
     akka.http.parsing.max-header-value-length = 32
     akka.http.parsing.max-uri-length = 40
-    akka.http.parsing.max-content-length = infinite""")
+    akka.http.parsing.max-content-length = 0""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
 

--- a/docs/src/test/java/docs/http/javadsl/Http2ClientApp.java
+++ b/docs/src/test/java/docs/http/javadsl/Http2ClientApp.java
@@ -39,7 +39,7 @@ public class Http2ClientApp {
         ConfigFactory.parseString(
             "#akka.loglevel = debug\n" +
                "akka.http.client.http2.log-frames = true\n" +
-               "akka.http.client.parsing.max-content-length = 20m"
+               "akka.http.client.parsing.max-content-length = 0"
         ).withFallback(ConfigFactory.load());
 
     ActorSystem system = ActorSystem.create("Http2ClientApp", config);

--- a/docs/src/test/scala/docs/http/scaladsl/Http2ClientApp.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/Http2ClientApp.scala
@@ -28,7 +28,7 @@ object Http2ClientApp extends App {
       """
          # akka.loglevel = debug
          akka.http.client.http2.log-frames = true
-         akka.http.client.parsing.max-content-length = 20m
+         akka.http.client.parsing.max-content-length = 0
       """
     ).withFallback(ConfigFactory.defaultApplication())
 


### PR DESCRIPTION
The value of `akka.http.client.parsing.max-content-length` has been set to `0` from `20m`

References #3903 
