### PR TITLE
fix(http2): h2c via Upgrade

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -255,13 +255,11 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
         if (initialRemoteSettings.nonEmpty) {
           debug(s"Applying ${initialRemoteSettings.length} initial settings!")
           applyRemoteSettings(initialRemoteSettings)
-          // applyRemoteSettings may or may not have pulled `substreamIn`
-          tryPullSubStreams()
-        } else {
-          pull(substreamIn)
         }
 
         pullFrameIn()
+        // applyRemoteSettings may or may not have pulled `substreamIn` already
+        tryPullSubStreams()
 
         // both client and server must send a settings frame as first frame
         multiplexer.pushControlFrame(SettingsFrame(initialLocalSettings))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -255,10 +255,13 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
         if (initialRemoteSettings.nonEmpty) {
           debug(s"Applying ${initialRemoteSettings.length} initial settings!")
           applyRemoteSettings(initialRemoteSettings)
+          // applyRemoteSettings may or may not have pulled `substreamIn`
+          tryPullSubStreams()
+        } else {
+          pull(substreamIn)
         }
 
         pullFrameIn()
-        pull(substreamIn)
 
         // both client and server must send a settings frame as first frame
         multiplexer.pushControlFrame(SettingsFrame(initialLocalSettings))

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2cUpgradeSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2cUpgradeSpec.scala
@@ -30,9 +30,17 @@ class H2cUpgradeSpec extends AkkaSpecWithMaterializer("""
     ).futureValue
 
     // https://tools.ietf.org/html/rfc7540#section-3.2
-    "respond with HTTP 101" in {
+    "respond with HTTP 101 and no initial settings" in {
       // Not the whole frame, but only the identifiers and values - so an empty string for 0 settings is valid:
-      val settings = ""
+      testWith("")
+    }
+
+    "respond with HTTP 101 and some initial settings" in {
+      // Not the whole frame, but only the identifiers and values - so an empty string for 0 settings is valid:
+      testWith("AAMAAABkAAQCAAAAAAIAAAAA")
+    }
+
+    def testWith(settings: String) {
       val upgradeRequest =
         s"""GET / HTTP/1.1
 Host: localhost

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2cUpgradeSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2cUpgradeSpec.scala
@@ -4,6 +4,8 @@
 
 package akka.http.impl.engine.http2
 
+import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
+import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier._
 import akka.http.impl.util._
 import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import akka.http.scaladsl.HttpConnectionContext
@@ -31,13 +33,22 @@ class H2cUpgradeSpec extends AkkaSpecWithMaterializer("""
 
     // https://tools.ietf.org/html/rfc7540#section-3.2
     "respond with HTTP 101 and no initial settings" in {
-      // Not the whole frame, but only the identifiers and values - so an empty string for 0 settings is valid:
-      testWith("")
+      val settings = encode(Nil)
+      // Settings are placed directly in the HTTP header, without any framing,
+      // so 'no settings' just yields the empty string:
+      settings shouldBe ""
+      testWith(settings)
     }
 
     "respond with HTTP 101 and some initial settings" in {
-      // Not the whole frame, but only the identifiers and values - so an empty string for 0 settings is valid:
-      testWith("AAMAAABkAAQCAAAAAAIAAAAA")
+      // real-world settings example as used by curl
+      val settings = encode(Seq(
+        (SETTINGS_MAX_CONCURRENT_STREAMS, 100),
+        (SETTINGS_INITIAL_WINDOW_SIZE, 33554432),
+        (SETTINGS_ENABLE_PUSH, 0)
+      ))
+      settings shouldBe "AAMAAABkAAQCAAAAAAIAAAAA"
+      testWith(settings)
     }
 
     def testWith(settings: String) {
@@ -67,5 +78,18 @@ HTTP2-Settings: $settings
       frameProbe.expectFrameFlagsStreamIdAndPayload(Http2Protocol.FrameType.SETTINGS)
       frameProbe.expectHeaderBlock(1, true)
     }
+  }
+
+  def encode(settings: Seq[(SettingIdentifier, Int)]): String = {
+    val bytes = settings.flatMap {
+      case (id, value) => Seq(
+        0.toByte,
+        id.id.toByte,
+        (value >> 24).toByte,
+        (value >> 16).toByte,
+        (value >> 8).toByte,
+        value.toByte)
+    }
+    ByteString.fromArrayUnsafe(bytes.toArray).encodeBase64.utf8String
   }
 }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
@@ -1,0 +1,57 @@
+package akka.http.impl.engine.http2
+
+import akka.http.impl.engine.http2.FrameEvent.{ ParsedHeadersFrame, Setting, SettingsAckFrame, SettingsFrame, WindowUpdateFrame }
+import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
+import akka.http.impl.util.AkkaSpecWithMaterializer
+import akka.http.scaladsl.settings.Http2ServerSettings
+import akka.stream.scaladsl.{ BidiFlow, Flow, Keep }
+import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import akka.util.{ ByteString, OptionVal }
+
+/**
+ * low-level tests testing Http2ServerDemux in isolation
+ */
+class Http2ServerDemuxSpec extends AkkaSpecWithMaterializer("""
+    akka.http.server.remote-address-header = on
+    akka.http.server.http2.log-frames = on
+    akka.stream.materializer.debug.fuzzing-mode = on
+  """) {
+  "Http2ServerDemux" should {
+    "not pull twice when started with initial RemoteSettings from HTTP/1.1 Upgrade" in {
+      val settings = Http2ServerSettings("")
+      val initialRemoteSettings = Seq[Setting](
+        (SettingIdentifier.SETTINGS_MAX_CONCURRENT_STREAMS, 100),
+        (SettingIdentifier.SETTINGS_INITIAL_WINDOW_SIZE, 335),
+        (SettingIdentifier.SETTINGS_ENABLE_PUSH, 0)
+      )
+      val bidi = BidiFlow.fromGraph(new Http2ServerDemux(settings, initialRemoteSettings, upgraded = true))
+
+      val ((substreamProducer, (frameConsumer, frameProducer)), substreamConsumer) = TestSource.probe[Http2SubStream]
+        .viaMat(bidi.joinMat(Flow.fromSinkAndSourceMat(TestSink.probe[FrameEvent], TestSource.probe[FrameEvent])(Keep.both))(Keep.right))(Keep.both)
+        .toMat(TestSink.probe[Http2SubStream])(Keep.both)
+        .run()
+
+      frameConsumer.request(1000)
+      substreamProducer.ensureSubscription()
+      substreamConsumer.request(1000)
+      frameProducer.ensureSubscription()
+
+      // The request is taken from the HTTP/1.1 request that had the Upgrade
+      // header and is passed to the handler code 'directly', bypassing the demux stage,
+      // so the first thing the demux stage sees of this request is the response:
+      val response = ParsedHeadersFrame(streamId = 1, endStream = true, Seq((":status", "200")), None)
+      substreamProducer.sendNext(new Http2SubStream(
+        response,
+        OptionVal.None,
+        Left(ByteString.empty),
+        Map.empty
+      ))
+
+      frameConsumer.expectNext shouldBe an[SettingsFrame]
+      // The client could send an 'ack' here, but doesn't need to
+      // frameProducer.sendNext(SettingsAckFrame(frame.asInstanceOf[SettingsFrame].settings))
+
+      frameConsumer.expectNext shouldBe (response)
+    }
+  }
+}

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.http.impl.engine.http2
 
 import akka.http.impl.engine.http2.FrameEvent.{ ParsedHeadersFrame, Setting, SettingsAckFrame, SettingsFrame, WindowUpdateFrame }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
@@ -12,6 +12,8 @@ import akka.stream.scaladsl.{ BidiFlow, Flow, Keep }
 import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
 import akka.util.{ ByteString, OptionVal }
 
+import scala.collection.immutable.Seq
+
 /**
  * low-level tests testing Http2ServerDemux in isolation
  */


### PR DESCRIPTION
When `SETTINGS_MAX_CONCURRENT_STREAMS` was set in the initial settings from
the `Upgrade` request, the input would be pulled twice, which is an error.

Fixes #3998