### PR TITLE
fix warnings. `formatted` => `format`

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
@@ -50,7 +50,7 @@ private[http2] object FrameLogger {
 
       bytes
         .take(num)
-        .map(_ formatted "%02x")
+        .map("%02x" format _)
         .mkString(" ") + ellipsis
     }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameLogger.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameLogger.scala
@@ -44,7 +44,7 @@ private[ws] object FrameLogger {
       val num = math.min(maxBytes, bytes.size)
       val ellipsis = if (num < bytes.size) s" [... ${bytes.size - num} more bytes]" else ""
       val first = bytes.take(num)
-      val h = first.map(_ formatted "%02x").mkString(" ")
+      val h = first.map("%02x" format _).mkString(" ")
       val ascii = first.map(LogByteStringTools.asASCII).mkString
       s"$WHITE$h$RESET | $WHITE$ascii$RESET$ellipsis"
     }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Protocol.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/Protocol.scala
@@ -55,7 +55,7 @@ private[http] object Protocol {
     case object Ping extends AbstractOpcode(0x9, "PING")
     case object Pong extends AbstractOpcode(0xA, "PONG")
 
-    case class Other(override val code: Byte) extends AbstractOpcode(code, code formatted "0x%02x")
+    case class Other(override val code: Byte) extends AbstractOpcode(code, "0x%02x" format code)
   }
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/util/LogByteStringTools.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/LogByteStringTools.scala
@@ -64,7 +64,7 @@ private[akka] object LogByteStringTools {
 
   def printByteString(bytes: ByteString, maxBytes: Int = MaxBytesPrinted, addPrefix: Boolean = true, indent: String = " "): String = {
     def formatBytes(bs: ByteString): Iterator[String] = {
-      def asHex(b: Byte): String = b formatted "%02X"
+      def asHex(b: Byte): String = "%02X" format b
 
       def formatLine(bs: ByteString): String = {
         val hex = bs.map(asHex).mkString(" ")

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/BoyerMooreSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/BoyerMooreSpec.scala
@@ -37,7 +37,7 @@ class BoyerMooreSpec extends AnyWordSpec with Matchers {
         val bmFinds = find(needle, haystack, skipFindsThatStartInFinds = true)
         val reFinds = findWithRegex(needle, haystack)
         if (bmFinds != reFinds) {
-          def showBytes(bs: Seq[Byte]): String = bs.map(b => (b & 0xff).formatted("%02x")).mkString(" ")
+          def showBytes(bs: Seq[Byte]): String = bs.map(b => "%02x".format(b & 0xff)).mkString(" ")
           def len(num: Int) = num * 2 + math.max(0, num - 1)
 
           def showFind(ix: Int): String = {


### PR DESCRIPTION
- https://github.com/scala/scala/pull/9783
- https://github.com/scala/bug/issues/12471

```
warn] /home/runner/work/akka-http/akka-http/akka-http-core/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala:53:16: method formatted in class StringFormat is deprecated (since 2.12.16): Use `formatString.format(value)` instead of `value.formatted(formatString)`,
[warn] or use the `f""` string interpolator. In Java 15 and later, `formatted` resolves to the new method in String which has reversed parameters.
[warn]         .map(_ formatted "%02x")
[warn]                ^
```
