### PR TITLE
http2: implement graceful termination for HTTP/2 servers

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
@@ -12,7 +12,6 @@ import akka.http.impl.engine.server.HttpServerBluePrint
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.headers
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow

--- a/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/4018-servertermination-http2-updates.excludes
+++ b/akka-http-core/src/main/mima-filters/10.2.7.backwards.excludes/4018-servertermination-http2-updates.excludes
@@ -1,0 +1,2 @@
+# Changed internal ServerTerminator from abstract class to trait
+ProblemFilters.exclude[MissingTypesProblem]("akka.http.impl.engine.server.GracefulTerminatorStage$ConnectionTerminator")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
@@ -233,7 +233,6 @@ private[http] final class Http2Ext(private val config: Config)(implicit val syst
       TLS(createEngine _, closing = TLSClosing.eagerClose)
 
     stack.joinMat(clientConnectionSettings.transport.connectTo(host, port, clientConnectionSettings)(system.classicSystem))(Keep.right)
-      .addAttributes(Http.cancellationStrategyAttributeForDelay(clientConnectionSettings.streamCancellationDelay))
   }
 
   def outgoingConnectionPriorKnowledge(host: String, port: Int, clientConnectionSettings: ClientConnectionSettings, log: LoggingAdapter): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
@@ -9,7 +9,7 @@ import akka.annotation.InternalApi
 import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
 import akka.http.impl.engine.HttpConnectionIdleTimeoutBidi
-import akka.http.impl.engine.server.{ MasterServerTerminator, UpgradeToOtherProtocolResponseHeader }
+import akka.http.impl.engine.server.{ GracefulTerminatorStage, MasterServerTerminator, ServerTerminator, UpgradeToOtherProtocolResponseHeader }
 import akka.http.impl.util.LogByteStringTools
 import akka.http.scaladsl.Http.OutgoingConnection
 import akka.http.scaladsl.{ ConnectionContext, Http, HttpsConnectionContext }
@@ -26,7 +26,7 @@ import akka.stream.impl.io.TlsUtils
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source, TLS, TLSPlacebo, Tcp }
 import akka.stream.{ IgnoreComplete, Materializer }
 import akka.util.ByteString
-import akka.{ Done, NotUsed }
+import akka.Done
 import com.typesafe.config.Config
 
 import javax.net.ssl.SSLEngine
@@ -70,8 +70,12 @@ private[http] final class Http2Ext(private val config: Config)(implicit val syst
       else if (connectionContext.isSecure) settings.defaultHttpsPort
       else settings.defaultHttpPort
 
-    val http1 = Flow[HttpRequest].mapAsync(settings.pipeliningLimit)(handleUpgradeRequests(handler, settings, log)).join(http.serverLayer(settings, log = log))
-    val http2 = Http2Blueprint.handleWithStreamIdHeader(settings.http2Settings.maxConcurrentStreams)(handler)(system.dispatcher).join(Http2Blueprint.serverStackTls(settings, log, telemetry, Http().dateHeaderRendering))
+    val http1: HttpImplementation =
+      Flow[HttpRequest].mapAsync(settings.pipeliningLimit)(handleUpgradeRequests(handler, settings, log))
+        .joinMat(GracefulTerminatorStage(system, settings) atop http.serverLayer(settings, log = log))(Keep.right)
+    val http2: HttpImplementation =
+      Http2Blueprint.handleWithStreamIdHeader(settings.http2Settings.maxConcurrentStreams)(handler)(system.dispatcher)
+        .joinMat(Http2Blueprint.serverStackTls(settings, log, telemetry, Http().dateHeaderRendering))(Keep.right)
 
     val masterTerminator = new MasterServerTerminator(log)
 
@@ -81,8 +85,13 @@ private[http] final class Http2Ext(private val config: Config)(implicit val syst
         incoming: Tcp.IncomingConnection =>
           try {
             httpPlusSwitching(http1, http2).addAttributes(prepareServerAttributes(settings, incoming))
-              .watchTermination()(Keep.right)
+              .watchTermination()(Keep.both)
               .join(HttpConnectionIdleTimeoutBidi(settings.idleTimeout, Some(incoming.remoteAddress)) join incoming.flow)
+              .mapMaterializedValue {
+                case (connectionTerminator, future) =>
+                  connectionTerminator.foreach(masterTerminator.registerConnection(_)(fm.executionContext))((fm.executionContext))
+                  future // drop the terminator matValue, we already registered is which is all we need to do here
+              }
               .addAttributes(Http.cancellationStrategyAttributeForDelay(settings.streamCancellationDelay))
               .run().recover {
                 // Ignore incoming errors from the connection as they will cancel the binding.
@@ -172,7 +181,7 @@ private[http] final class Http2Ext(private val config: Config)(implicit val syst
   val ConnectionUpgradeHeader = Connection(List("upgrade"))
   val UpgradeHeader = Upgrade(List(UpgradeProtocol("h2c")))
 
-  def httpsWithAlpn(httpsContext: HttpsConnectionContext, fm: Materializer)(http1: HttpImplementation, http2: HttpImplementation): Flow[ByteString, ByteString, NotUsed] = {
+  def httpsWithAlpn(httpsContext: HttpsConnectionContext, fm: Materializer)(http1: HttpImplementation, http2: HttpImplementation): Flow[ByteString, ByteString, Future[ServerTerminator]] = {
     // Mutable cell to transport the chosen protocol from the SSLEngine to
     // the switch stage.
     // Doesn't need to be volatile because there's a happens-before relationship (enforced by memory barriers)
@@ -224,6 +233,7 @@ private[http] final class Http2Ext(private val config: Config)(implicit val syst
       TLS(createEngine _, closing = TLSClosing.eagerClose)
 
     stack.joinMat(clientConnectionSettings.transport.connectTo(host, port, clientConnectionSettings)(system.classicSystem))(Keep.right)
+      .addAttributes(Http.cancellationStrategyAttributeForDelay(clientConnectionSettings.streamCancellationDelay))
   }
 
   def outgoingConnectionPriorKnowledge(host: String, port: Int, clientConnectionSettings: ClientConnectionSettings, log: LoggingAdapter): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = {
@@ -255,10 +265,11 @@ private[http] object Http2 extends ExtensionId[Http2Ext] with ExtensionIdProvide
   def createExtension(system: ExtendedActorSystem): Http2Ext =
     new Http2Ext(system.settings.config getConfig "akka.http")(system)
 
-  private[http] type HttpImplementation = Flow[SslTlsInbound, SslTlsOutbound, NotUsed]
-  private[http] type HttpPlusSwitching = (HttpImplementation, HttpImplementation) => Flow[ByteString, ByteString, NotUsed]
+  private[http] type HttpImplementation = Flow[SslTlsInbound, SslTlsOutbound, ServerTerminator]
+  private[http] type HttpPlusSwitching = (HttpImplementation, HttpImplementation) => Flow[ByteString, ByteString, Future[ServerTerminator]]
 
-  private[http] def priorKnowledge(http1: HttpImplementation, http2: HttpImplementation): Flow[ByteString, ByteString, NotUsed] =
-    TLSPlacebo().reversed join
+  private[http] def priorKnowledge(http1: HttpImplementation, http2: HttpImplementation): Flow[ByteString, ByteString, Future[ServerTerminator]] =
+    TLSPlacebo().reversed.joinMat(
       ProtocolSwitch.byPreface(http1, http2)
+    )(Keep.right)
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -158,7 +158,7 @@ private[http] object Http2Blueprint {
           FrameRenderer.render(GoAwayFrame(0, ex.errorCode))
         case ex: StreamTcpException => throw ex // TCP connection is probably broken: just forward exception
         case NonFatal(ex) =>
-          log.debug(s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
+          log.error(s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
           FrameRenderer.render(GoAwayFrame(0, Http2Protocol.ErrorCode.INTERNAL_ERROR))
       },
       Flow[ByteString]

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -14,13 +14,14 @@ import akka.http.impl.engine.http2.framing.{ FrameRenderer, Http2FrameParsing }
 import akka.http.impl.engine.http2.hpack.{ HeaderCompression, HeaderDecompression }
 import akka.http.impl.engine.parsing.HttpHeaderParser
 import akka.http.impl.engine.rendering.DateHeaderRendering
+import akka.http.impl.engine.server.ServerTerminator
 import akka.http.impl.util.LogByteStringTools.logTLSBidiBySetting
 import akka.http.impl.util.StreamUtils
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, Http2ClientSettings, Http2ServerSettings, ParserSettings, ServerSettings }
-import akka.stream.StreamTcpException
+import akka.stream.{ BidiShape, Graph, StreamTcpException }
 import akka.stream.TLSProtocol._
-import akka.stream.scaladsl.{ BidiFlow, Flow, Source }
+import akka.stream.scaladsl.{ BidiFlow, Flow, Keep, Source }
 import akka.util.{ ByteString, OptionVal }
 
 import scala.concurrent.duration.{ Duration, FiniteDuration }
@@ -88,7 +89,7 @@ private[http2] object Http2SubStream {
 @InternalApi
 private[http] object Http2Blueprint {
 
-  def serverStackTls(settings: ServerSettings, log: LoggingAdapter, telemetry: TelemetrySpi, dateHeaderRendering: DateHeaderRendering): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, NotUsed] =
+  def serverStackTls(settings: ServerSettings, log: LoggingAdapter, telemetry: TelemetrySpi, dateHeaderRendering: DateHeaderRendering): BidiFlow[HttpResponse, SslTlsOutbound, SslTlsInbound, HttpRequest, ServerTerminator] =
     serverStack(settings, log, telemetry = telemetry, dateHeaderRendering = dateHeaderRendering) atop
       unwrapTls atop
       logTLSBidiBySetting("server-plain-text", settings.logUnencryptedNetworkBytes)
@@ -100,10 +101,10 @@ private[http] object Http2Blueprint {
       initialDemuxerSettings: immutable.Seq[Setting] = Nil,
       upgraded: Boolean = false,
       telemetry: TelemetrySpi,
-    dateHeaderRendering: DateHeaderRendering): BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, NotUsed] = {
+    dateHeaderRendering: DateHeaderRendering): BidiFlow[HttpResponse, ByteString, ByteString, HttpRequest, ServerTerminator] = {
     val masterHttpHeaderParser = HttpHeaderParser(settings.parserSettings, log) // FIXME: reuse for framing
     telemetry.serverConnection atop
-      httpLayer(settings, log, dateHeaderRendering) atop
+      httpLayer(settings, log, dateHeaderRendering) atopKeepRight
       serverDemux(settings.http2Settings, initialDemuxerSettings, upgraded) atop
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
       hpackCoding(masterHttpHeaderParser, settings.parserSettings) atop
@@ -130,7 +131,7 @@ private[http] object Http2Blueprint {
       idleTimeoutIfConfigured(settings.idleTimeout)
   }
 
-  def httpLayerClient(masterHttpHeaderParser: HttpHeaderParser, settings: ClientConnectionSettings, log: LoggingAdapter): BidiFlow[HttpRequest, Http2SubStream, Http2SubStream, HttpResponse, NotUsed] = {
+  def httpLayerClient(masterHttpHeaderParser: HttpHeaderParser, settings: ClientConnectionSettings, log: LoggingAdapter): BidiFlow[HttpRequest, Http2SubStream, Http2SubStream, HttpResponse, NotUsed] =
     BidiFlow.fromFlows(
       Flow[HttpRequest].statefulMapConcat { () =>
         val renderer = new RequestRendering(settings, log)
@@ -141,7 +142,6 @@ private[http] object Http2Blueprint {
         stream => ResponseParsing.parseResponse(headerParser, settings.parserSettings, attrs)(stream)
       }
     )
-  }
 
   def idleTimeoutIfConfigured(timeout: Duration): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
     timeout match {
@@ -149,7 +149,7 @@ private[http] object Http2Blueprint {
       case _                 => BidiFlow.identity[ByteString, ByteString]
     }
 
-  def errorHandling(log: LoggingAdapter): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] = {
+  def errorHandling(log: LoggingAdapter): BidiFlow[ByteString, ByteString, ByteString, ByteString, NotUsed] =
     BidiFlow.fromFlows(
       StreamUtils.encodeErrorAndComplete {
         case ex: Http2Compliance.Http2ProtocolException =>
@@ -158,12 +158,11 @@ private[http] object Http2Blueprint {
           FrameRenderer.render(GoAwayFrame(0, ex.errorCode))
         case ex: StreamTcpException => throw ex // TCP connection is probably broken: just forward exception
         case NonFatal(ex) =>
-          log.error(ex, s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
+          log.debug(s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
           FrameRenderer.render(GoAwayFrame(0, Http2Protocol.ErrorCode.INTERNAL_ERROR))
       },
       Flow[ByteString]
     )
-  }
 
   def framing(log: LoggingAdapter): BidiFlow[FrameEvent, ByteString, ByteString, FrameEvent, NotUsed] =
     BidiFlow.fromFlows(
@@ -193,14 +192,14 @@ private[http] object Http2Blueprint {
    * Creates substreams for every stream and manages stream state machines
    * and handles priorization (TODO: later)
    */
-  def serverDemux(settings: Http2ServerSettings, initialDemuxerSettings: immutable.Seq[Setting], upgraded: Boolean): BidiFlow[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream, NotUsed] =
+  def serverDemux(settings: Http2ServerSettings, initialDemuxerSettings: immutable.Seq[Setting], upgraded: Boolean): BidiFlow[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream, ServerTerminator] =
     BidiFlow.fromGraph(new Http2ServerDemux(settings, initialDemuxerSettings, upgraded))
 
   /**
    * Creates substreams for every stream and manages stream state machines
    * and handles priorization (TODO: later)
    */
-  def clientDemux(settings: Http2ClientSettings, masterHttpHeaderParser: HttpHeaderParser): BidiFlow[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream, NotUsed] =
+  def clientDemux(settings: Http2ClientSettings, masterHttpHeaderParser: HttpHeaderParser): BidiFlow[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream, ServerTerminator] =
     BidiFlow.fromGraph(new Http2ClientDemux(settings, masterHttpHeaderParser))
 
   /**
@@ -257,4 +256,9 @@ private[http] object Http2Blueprint {
     BidiFlow.fromFlows(Flow[ByteString].map(SendBytes), Flow[SslTlsInbound].collect {
       case SessionBytes(_, bytes) => bytes
     })
+
+  implicit class BidiFlowExt[I1, O1, I2, O2, Mat](bidi: BidiFlow[I1, O1, I2, O2, Mat]) {
+    def atopKeepRight[OO1, II2, Mat2](other: Graph[BidiShape[O1, OO1, II2, I2], Mat2]): BidiFlow[I1, OO1, II2, O2, Mat2] =
+      bidi.atopMat(other)(Keep.right)
+  }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -241,12 +241,13 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
       private def triggerTermination(deadline: FiniteDuration): Unit = {
         // check if we are already terminating, otherwise start termination
         if (!terminating) {
-          log.debug("Termination now starting...")
+          log.debug(s"Termination of this connection was triggered. Sending GOAWAY and waiting for open requests to complete for $CompletionTimeout.")
           terminating = true
           pushGOAWAY(ErrorCode.NO_ERROR, "")
           lastIdBeforeTermination = lastStreamId()
           completeIfDone()
-          scheduleOnce(CompletionTimeout, deadline)
+          if (!isClosed(frameOut))
+            scheduleOnce(CompletionTimeout, deadline)
         }
       }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -238,18 +238,17 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
         terminateCallback.invoke(deadline)
         terminationPromise.future
       }
-      private def triggerTermination(deadline: FiniteDuration): Unit = {
+      private def triggerTermination(deadline: FiniteDuration): Unit =
         // check if we are already terminating, otherwise start termination
         if (!terminating) {
           log.debug(s"Termination of this connection was triggered. Sending GOAWAY and waiting for open requests to complete for $CompletionTimeout.")
           terminating = true
-          pushGOAWAY(ErrorCode.NO_ERROR, "")
+          pushGOAWAY(ErrorCode.NO_ERROR, "Voluntary connection close.")
           lastIdBeforeTermination = lastStreamId()
           completeIfDone()
           if (!isClosed(frameOut))
             scheduleOnce(CompletionTimeout, deadline)
         }
-      }
 
       def frameOutFinished(): Unit = {
         // make sure we clean up/fail substreams with a custom failure before stage is canceled

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
@@ -4,28 +4,29 @@
 
 package akka.http.impl.engine.http2
 
-import akka.NotUsed
 import akka.annotation.InternalApi
-import akka.http.impl.engine.server.HttpAttributes
+import akka.http.impl.engine.http2.Http2.HttpImplementation
+import akka.http.impl.engine.server.{ HttpAttributes, ServerTerminator }
 import akka.stream.ActorAttributes.Dispatcher
 import akka.stream.TLSProtocol.{ SessionBytes, SessionTruncated, SslTlsInbound, SslTlsOutbound }
 import akka.stream._
 import akka.stream.scaladsl.Flow
-import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import akka.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler }
 
 import javax.net.ssl.SSLException
+import scala.concurrent.{ Future, Promise }
 
 /** INTERNAL API */
 @InternalApi
 private[http] object ProtocolSwitch {
-  type HttpServerFlow = Flow[SslTlsInbound, SslTlsOutbound, NotUsed]
+  type HttpServerFlow = Flow[SslTlsInbound, SslTlsOutbound, Future[ServerTerminator]]
 
   def apply(
     chosenProtocolAccessor: SessionBytes => String,
-    http1Stack:             HttpServerFlow,
-    http2Stack:             HttpServerFlow): HttpServerFlow =
+    http1Stack:             HttpImplementation,
+    http2Stack:             HttpImplementation): HttpServerFlow =
     Flow.fromGraph(
-      new GraphStage[FlowShape[SslTlsInbound, SslTlsOutbound]] {
+      new GraphStageWithMaterializedValue[FlowShape[SslTlsInbound, SslTlsOutbound], Future[ServerTerminator]] {
 
         // --- outer ports ---
         val netIn = Inlet[SslTlsInbound]("AlpnSwitch.netIn")
@@ -35,114 +36,128 @@ private[http] object ProtocolSwitch {
         val shape: FlowShape[SslTlsInbound, SslTlsOutbound] =
           FlowShape(netIn, netOut)
 
-        def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
-          logic =>
+        override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[ServerTerminator]) = {
+          val terminatorPromise = Promise[ServerTerminator]()
 
-          // --- inner ports, bound to actual server in install call ---
-          val serverDataIn = new SubSinkInlet[SslTlsOutbound]("ServerImpl.netIn")
-          val serverDataOut = new SubSourceOutlet[SslTlsInbound]("ServerImpl.netOut")
-          // --- end of inner ports ---
+          object Logic extends GraphStageLogic(shape) {
+            logic =>
 
-          override def preStart(): Unit = pull(netIn)
+            // --- inner ports, bound to actual server in install call ---
+            val serverDataIn = new SubSinkInlet[SslTlsOutbound]("ServerImpl.netIn")
+            val serverDataOut = new SubSourceOutlet[SslTlsInbound]("ServerImpl.netOut")
+            // --- end of inner ports ---
 
-          setHandler(netIn, new InHandler {
-            def onPush(): Unit =
-              grab(netIn) match {
-                case first @ SessionBytes(session, bytes) =>
-                  val chosen = chosenProtocolAccessor(first)
-                  chosen match {
-                    case "h2" => install(http2Stack.addAttributes(HttpAttributes.tlsSessionInfo(session)), first)
-                    case _    => install(http1Stack, first)
-                  }
-                case SessionTruncated => failStage(new SSLException("TLS session was truncated (probably missing a close_notify packet)."))
-              }
-          })
+            override def preStart(): Unit = pull(netIn)
 
-          private val ignorePull = new OutHandler { def onPull(): Unit = () }
-
-          setHandler(netOut, ignorePull)
-
-          def install(serverImplementation: HttpServerFlow, firstElement: SslTlsInbound): Unit = {
-            val networkSide = Flow.fromSinkAndSource(serverDataIn.sink, serverDataOut.source)
-
-            connect(netIn, serverDataOut, Some(firstElement))
-
-            connect(serverDataIn, netOut)
-
-            val attrs =
-              Attributes(
-                // don't (re)set dispatcher attribute to avoid adding an explicit async boundary
-                // between low-level and high-level stages
-                inheritedAttributes.attributeList.filterNot(_.isInstanceOf[Dispatcher])
-              )
-            serverImplementation
-              .addAttributes(attrs) // propagate attributes to "real" server (such as HttpAttributes)
-              .join(networkSide)
-              .run()(interpreter.subFusingMaterializer)
-          }
-
-          // helpers to connect inlets and outlets also binding completion signals of given ports
-          def connect[T](in: Inlet[T], out: SubSourceOutlet[T], initialElement: Option[T]): Unit = {
-            val propagatePull =
-              new OutHandler {
-                override def onPull(): Unit = pull(in)
-                override def onDownstreamFinish(): Unit = cancel(in)
-              }
-
-            val firstHandler =
-              initialElement match {
-                case Some(initial) if out.isAvailable =>
-                  out.push(initial)
-                  propagatePull
-                case Some(initial) =>
-                  new OutHandler {
-                    override def onPull(): Unit = {
-                      out.push(initial)
-                      out.setHandler(propagatePull)
+            setHandler(netIn, new InHandler {
+              def onPush(): Unit =
+                grab(netIn) match {
+                  case first @ SessionBytes(session, bytes) =>
+                    val chosen = chosenProtocolAccessor(first)
+                    chosen match {
+                      case "h2" => install(http2Stack.addAttributes(HttpAttributes.tlsSessionInfo(session)), first)
+                      case _    => install(http1Stack, first)
                     }
-                  }
-                case None => propagatePull
-              }
-
-            out.setHandler(firstHandler)
-            setHandler(in, new InHandler {
-              override def onPush(): Unit = out.push(grab(in))
-
-              override def onUpstreamFinish(): Unit = {
-                out.complete()
-                super.onUpstreamFinish()
-              }
-
-              override def onUpstreamFailure(ex: Throwable): Unit = {
-                out.fail(ex)
-                super.onUpstreamFailure(ex)
-              }
+                  case SessionTruncated => failStage(new SSLException("TLS session was truncated (probably missing a close_notify packet)."))
+                }
             })
 
-            if (out.isAvailable) pull(in) // to account for lost pulls during initialization
-          }
-          def connect[T](in: SubSinkInlet[T], out: Outlet[T]): Unit = {
-            val handler = new InHandler {
-              override def onPush(): Unit = push(out, in.grab())
+            private val ignorePull = new OutHandler {
+              def onPull(): Unit = ()
             }
 
-            val outHandler = new OutHandler {
-              override def onPull(): Unit = in.pull()
-              override def onDownstreamFinish(): Unit = {
-                in.cancel()
-                super.onDownstreamFinish()
+            setHandler(netOut, ignorePull)
+
+            def install(serverImplementation: HttpImplementation, firstElement: SslTlsInbound): Unit = {
+              val networkSide = Flow.fromSinkAndSource(serverDataIn.sink, serverDataOut.source)
+
+              connect(netIn, serverDataOut, Some(firstElement))
+
+              connect(serverDataIn, netOut)
+
+              val attrs =
+                Attributes(
+                  // don't (re)set dispatcher attribute to avoid adding an explicit async boundary
+                  // between low-level and high-level stages
+                  inheritedAttributes.attributeList.filterNot(_.isInstanceOf[Dispatcher])
+                )
+
+              val serverTerminator =
+                serverImplementation
+                  .addAttributes(attrs) // propagate attributes to "real" server (such as HttpAttributes)
+                  .join(networkSide)
+                  .run()(interpreter.subFusingMaterializer)
+              terminatorPromise.success(serverTerminator)
+            }
+
+            // helpers to connect inlets and outlets also binding completion signals of given ports
+            def connect[T](in: Inlet[T], out: SubSourceOutlet[T], initialElement: Option[T]): Unit = {
+              val propagatePull =
+                new OutHandler {
+                  override def onPull(): Unit = pull(in)
+
+                  override def onDownstreamFinish(): Unit = cancel(in)
+                }
+
+              val firstHandler =
+                initialElement match {
+                  case Some(initial) if out.isAvailable =>
+                    out.push(initial)
+                    propagatePull
+                  case Some(initial) =>
+                    new OutHandler {
+                      override def onPull(): Unit = {
+                        out.push(initial)
+                        out.setHandler(propagatePull)
+                      }
+                    }
+                  case None => propagatePull
+                }
+
+              out.setHandler(firstHandler)
+              setHandler(in, new InHandler {
+                override def onPush(): Unit = out.push(grab(in))
+
+                override def onUpstreamFinish(): Unit = {
+                  out.complete()
+                  super.onUpstreamFinish()
+                }
+
+                override def onUpstreamFailure(ex: Throwable): Unit = {
+                  out.fail(ex)
+                  super.onUpstreamFailure(ex)
+                }
+              })
+
+              if (out.isAvailable) pull(in) // to account for lost pulls during initialization
+            }
+
+            def connect[T](in: SubSinkInlet[T], out: Outlet[T]): Unit = {
+              val handler = new InHandler {
+                override def onPush(): Unit = push(out, in.grab())
               }
-            }
-            in.setHandler(handler)
-            setHandler(out, outHandler)
 
-            if (isAvailable(out)) in.pull() // to account for lost pulls during initialization
+              val outHandler = new OutHandler {
+                override def onPull(): Unit = in.pull()
+
+                override def onDownstreamFinish(): Unit = {
+                  in.cancel()
+                  super.onDownstreamFinish()
+                }
+              }
+              in.setHandler(handler)
+              setHandler(out, outHandler)
+
+              if (isAvailable(out)) in.pull() // to account for lost pulls during initialization
+            }
           }
+
+          (Logic, terminatorPromise.future)
         }
       }
     )
 
-  def byPreface(http1Stack: HttpServerFlow, http2Stack: HttpServerFlow): HttpServerFlow = {
+  def byPreface(http1Stack: HttpImplementation, http2Stack: HttpImplementation): HttpServerFlow = {
     def chooseProtocol(sessionBytes: SessionBytes): String =
       if (sessionBytes.bytes.startsWith(Http2Protocol.ClientConnectionPreface)) "h2" else "http/1.1"
     ProtocolSwitch(chooseProtocol, http1Stack, http2Stack)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
@@ -19,12 +19,10 @@ import scala.concurrent.{ Future, Promise }
 /** INTERNAL API */
 @InternalApi
 private[http] object ProtocolSwitch {
-  type HttpServerFlow = Flow[SslTlsInbound, SslTlsOutbound, Future[ServerTerminator]]
-
   def apply(
     chosenProtocolAccessor: SessionBytes => String,
     http1Stack:             HttpImplementation,
-    http2Stack:             HttpImplementation): HttpServerFlow =
+    http2Stack:             HttpImplementation): Flow[SslTlsInbound, SslTlsOutbound, Future[ServerTerminator]] =
     Flow.fromGraph(
       new GraphStageWithMaterializedValue[FlowShape[SslTlsInbound, SslTlsOutbound], Future[ServerTerminator]] {
 
@@ -157,7 +155,7 @@ private[http] object ProtocolSwitch {
       }
     )
 
-  def byPreface(http1Stack: HttpImplementation, http2Stack: HttpImplementation): HttpServerFlow = {
+  def byPreface(http1Stack: HttpImplementation, http2Stack: HttpImplementation): Flow[SslTlsInbound, SslTlsOutbound, Future[ServerTerminator]] = {
     def chooseProtocol(sessionBytes: SessionBytes): String =
       if (sessionBytes.bytes.startsWith(Http2Protocol.ClientConnectionPreface)) "h2" else "http/1.1"
     ProtocolSwitch(chooseProtocol, http1Stack, http2Stack)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/ServerTerminator.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/ServerTerminator.scala
@@ -29,7 +29,7 @@ import scala.util.{ Failure, Success }
  */
 // "Hasta la vista, baby."
 @InternalApi
-private[http] abstract class ServerTerminator {
+private[http] trait ServerTerminator {
   /**
    * Initiate the termination sequence of this server.
    */

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.http.impl.engine.http2
 
-import akka.http.impl.engine.http2.FrameEvent.{ ParsedHeadersFrame, Setting, SettingsAckFrame, SettingsFrame, WindowUpdateFrame }
+import akka.http.impl.engine.http2.FrameEvent.{ ParsedHeadersFrame, Setting, SettingsFrame }
 import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
 import akka.http.impl.util.AkkaSpecWithMaterializer
 import akka.http.scaladsl.settings.Http2ServerSettings

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ProtocolSwitchSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ProtocolSwitchSpec.scala
@@ -6,7 +6,6 @@ package akka.http.impl.engine.http2
 
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import akka.Done
-import akka.NotUsed
 import akka.http.impl.engine.server.ServerTerminator
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer


### PR DESCRIPTION
The functionality is built directly into the Http2Demux which
has the state of all streams readily available. It supports the
same interface as the HTTP/1 version, though.

Fixes #3580