### PR TITLE
Fix dependency example for spray using scala/maven in introduction documentation 

### DIFF
--- a/docs/src/main/paradox/introduction.md
+++ b/docs/src/main/paradox/introduction.md
@@ -104,7 +104,7 @@ for JSON. An additional module provides JSON serialization using the spray-json 
 for details):
 
 @@dependency [sbt,Gradle,Maven] {
-  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-bom_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
+  bomGroup2="com.typesafe.akka" bomArtifact2="akka-http-spray-json_$scala.binary.version$" bomVersionSymbols2="AkkaHttpVersion"
   symbol="AkkaHttpVersion"
   value="$project.version$"
   group="com.typesafe.akka"


### PR DESCRIPTION
When walking through https://doc.akka.io/docs/akka-http/current/introduction.html#using-akka-http when I reached the section https://doc.akka.io/docs/akka-http/current/introduction.html#marshalling I tried to add the following to my `pom.xml` file:
```
<properties>
  <scala.binary.version>2.13</scala.binary.version>
</properties>
<dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>com.typesafe.akka</groupId>
      <artifactId>akka-http-bom_${scala.binary.version}</artifactId>
      <version>10.2.7</version>
      <type>pom</type>
      <scope>import</scope>
    </dependency>
  </dependencies>
</dependencyManagement>
<dependencies>
  <dependency>
    <groupId>com.typesafe.akka</groupId>
    <artifactId>akka-http-spray-json_${scala.binary.version}</artifactId>
  </dependency>
</dependencies>
```
But was getting import errors. When I instead changed `<artifactId>akka-http-bom_${scala.binary.version}</artifactId>` to `<artifactId>akka-http-spray-json_${scala.binary.version}</artifactId>` in the `dependencyManagement` section everything began to work which makes me think this piece of documentation needs to be updated (which I've tried to do).

Please let me know if I am wrong or if this does not fix the issue!