### PR TITLE
http2: add client-side cancellation propagation delay

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
@@ -234,6 +234,7 @@ private[http] final class Http2Ext(implicit val system: ActorSystem)
       TLS(createEngine _, closing = TLSClosing.eagerClose)
 
     stack.joinMat(clientConnectionSettings.transport.connectTo(host, port, clientConnectionSettings)(system.classicSystem))(Keep.right)
+      .addAttributes(Http.cancellationStrategyAttributeForDelay(clientConnectionSettings.streamCancellationDelay))
   }
 
   def outgoingConnectionPriorKnowledge(host: String, port: Int, clientConnectionSettings: ClientConnectionSettings, log: LoggingAdapter): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = {
@@ -243,6 +244,7 @@ private[http] final class Http2Ext(implicit val system: ActorSystem)
       TLSPlacebo()
 
     stack.joinMat(clientConnectionSettings.transport.connectTo(host, port, clientConnectionSettings)(system.classicSystem))(Keep.right)
+      .addAttributes(Http.cancellationStrategyAttributeForDelay(clientConnectionSettings.streamCancellationDelay))
   }
 
   private def prepareClientAttributes(serverHost: String, port: Int): Attributes =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -161,7 +161,7 @@ private[http] object Http2Blueprint {
           // idle timeout stage is propagating this error but since it is already coming back we just propagate without logging
           throw ex
         case NonFatal(ex) =>
-          log.debug(s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
+          log.error(s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
           FrameRenderer.render(GoAwayFrame(0, Http2Protocol.ErrorCode.INTERNAL_ERROR))
       },
       Flow[ByteString]

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -161,7 +161,7 @@ private[http] object Http2Blueprint {
           // idle timeout stage is propagating this error but since it is already coming back we just propagate without logging
           throw ex
         case NonFatal(ex) =>
-          log.error(s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
+          log.debug(s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
           FrameRenderer.render(GoAwayFrame(0, Http2Protocol.ErrorCode.INTERNAL_ERROR))
       },
       Flow[ByteString]

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
@@ -13,6 +13,7 @@ import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.settings.ServerSettings
+import akka.stream.StreamTcpException
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
 import akka.testkit.TestProbe
@@ -98,7 +99,8 @@ class Http2ClientServerSpec extends AkkaSpecWithMaterializer(
       clientResponsesIn.ensureSubscription()
       Thread.sleep(500)
       clientRequestsOut.expectCancellation()
-      clientResponsesIn.expectComplete()
+      // expect idle timeout connection abort exception to propagate to user
+      clientResponsesIn.expectError() shouldBe a[StreamTcpException]
     }
     "support client-side idle-timeout" in new TestSetup {
       override def clientSettings: ClientConnectionSettings = super.clientSettings.withIdleTimeout(100.millis)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
@@ -15,7 +15,7 @@ import akka.http.scaladsl.settings.Http2ClientSettings
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.{ ClientTransport, Http }
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.{ KillSwitches, UniqueKillSwitch }
+import akka.stream.{ KillSwitches, StreamTcpException, UniqueKillSwitch }
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.stream.testkit.scaladsl.StreamTestKit
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
@@ -364,7 +364,7 @@ abstract class Http2PersistentClientSpec(tls: Boolean) extends AkkaSpecWithMater
       })
 
     val killProbe = TestProbe()
-    def killConnection(): Unit = killProbe.expectMsgType[UniqueKillSwitch].abort(new RuntimeException("connection was killed"))
+    def killConnection(): Unit = killProbe.expectMsgType[UniqueKillSwitch].abort(new StreamTcpException("connection was killed"))
 
     object server {
       private lazy val requestProbe = TestProbe()


### PR DESCRIPTION
To avoid race conditions.

We might want to look into whether there's a better way to report errors like that.