### PR TITLE
Increase stream-cancellation-delay default to 1000 millis

### DIFF
--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -221,7 +221,7 @@ akka.http {
     # In most cases, there should be no reason to change this setting.
     #
     # Set to 0 to disable the delay.
-    stream-cancellation-delay = 100 millis
+    stream-cancellation-delay = 1000 millis
 
     http2 {
       # The maximum number of request per connection concurrently dispatched to the request handler.
@@ -519,7 +519,7 @@ akka.http {
     # In most cases, there should be no reason to change this setting.
     #
     # Set to 0 to disable the delay.
-    stream-cancellation-delay = 100 millis
+    stream-cancellation-delay = 1000 millis
   }
   #client-settings
 


### PR DESCRIPTION
This PR increases the `stream-cancellation-delay` value to 1000 since this value appears to cause less issues in producing the `NoMoreElementsNeeded Exception` error.

References #3201
