### PR TITLE
http2: when connection is aborted due to completion timeout, abort ongoing substreams (on Akka 2.6)

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -499,6 +499,7 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
         case CompletionTimeout =>
           info("Timeout: Peer didn't finish in-flight requests. Closing pending HTTP/2 streams. Increase this timeout via the 'completion-timeout' setting.")
 
+          shutdownStreamHandling()
           completeStage()
       }
 


### PR DESCRIPTION
Fixes #4059

With Akka 2.5, calling `shutdownStreamHandling()` in postStop was enough to abort
the substreams with an error.

Akka 2.6 has automatic substream cleanup which runs before `postStop` which would complete
substreams instead of aborting them with an error. Calling `shutdownStreamHandling` earlier
solved the problem in this case.