### PR TITLE
Try to make GHA testing more reliable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,8 +41,11 @@ jobs:
           path: project/**/target
           key: build-target-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/**/*.scala') }}
 
+      - name: Compile everything
+        run: sbt "+~ ${{ matrix.SCALA_VERSION }} Test/compile"
+
       - name: Run all tests JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}, Akka ${{ matrix.AKKA_VERSION }}
-        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 -Dakka.http.build.akka.version=${{ matrix.AKKA_VERSION }} "+~ ${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues Test/compile test"
+        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 -Dakka.http.build.akka.version=${{ matrix.AKKA_VERSION }} "+~ ${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues test"
 
       - name: Upload test results
         uses: actions/upload-artifact@v2  # upload test results

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -75,15 +75,18 @@ jobs:
           path: project/**/target
           key: build-target-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/**/*.scala') }}
 
+      - name: Compile everything
+        run: sbt "+~ ${{ matrix.SCALA_VERSION }} Test/compile"
+
       # Quick testing for PR validation
       - name: Validate pull request for JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}
         if: ${{ github.event_name == 'pull_request' }}
-        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 "+~ ${{ matrix.SCALA_VERSION }} Test/compile validatePullRequest"
+        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 "+~ ${{ matrix.SCALA_VERSION }} validatePullRequest"
 
       # Full testing for pushes
       - name: Run all tests JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}
         if: ${{ github.event_name == 'push' }}
-        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 "+~ ${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues Test/compile test"
+        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 "+~ ${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues test"
 
       - name: Upload test results
         uses: actions/upload-artifact@v2  # upload test results

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -43,7 +43,7 @@ object Common extends AutoPlugin {
     Test / compile / scalacOptions += "-Wconf:msg=match may not be exhaustive:s",
 
     mimaReportSignatureProblems := true,
-    Test / parallelExecution := sys.props.getOrElse("akka.http.parallelExecution", "true") != "false"
+    Global / parallelExecution := sys.props.getOrElse("akka.http.parallelExecution", "true") != "false"
   )
 
   val specificationVersion: String = sys.props("java.specification.version")


### PR DESCRIPTION
By reducing concurrency in sbt. Previous runs have shown that compilation and tests could still run in parallel otherwise.

(Not completely sure to me how that can happen, it seems that fine-grained `concurrentRestrictions` are broken under aggregation. Also `Test/compile test` doesn't seem to guarantee sequential execution. We could use `;Test/compile;test` instead but that still seems to show the problem with aggregation, i.e. even if the project is fully compiled, just running `test` in the root project still executes test suites from multiple submodules concurrently even with `Test / parallelExecution := false`.)