### PR TITLE
http2: defer enqueing out streams when state machine is already running

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -149,6 +149,16 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
   private def updateState(streamId: Int, handle: StreamState => StreamState, event: String, eventArg: AnyRef = null): Unit =
     updateStateAndReturn(streamId, x => (handle(x), ()), event, eventArg)
 
+  // Calling multiplexer.enqueueOutStream directly out of the state machine is not allowed, because it might try to
+  // reenter the state machine with `pullNextState`. This call defers enqueuing until the current state machine operation
+  // is done.
+  private var deferredStreamToEnqueue: Int = -1
+  private def enqueueOutStream(streamId: Int): Unit = if (stateMachineRunning) {
+    require(deferredStreamToEnqueue == -1, "Only one stream can be enqueued during a single state change")
+    deferredStreamToEnqueue = streamId
+  } else
+    multiplexer.enqueueOutStream(streamId)
+
   private var stateMachineRunning = false
   private def updateStateAndReturn[R](streamId: Int, handle: StreamState => (StreamState, R), event: String, eventArg: AnyRef = null): R = {
     require(!stateMachineRunning, "State machine already running")
@@ -168,8 +178,15 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
     debug(s"Incoming side of stream [$streamId] changed state: ${oldState.stateName} -> ${newState.stateName} after handling [$event${if (eventArg ne null) s"($eventArg)" else ""}]")
 
     stateMachineRunning = false
+    if (deferredStreamToEnqueue != -1) {
+      val streamId = deferredStreamToEnqueue
+      deferredStreamToEnqueue = -1
+      if (streamStates.contains(streamId))
+        multiplexer.enqueueOutStream(streamId)
+    }
     ret
   }
+
   /** Called to cleanup any state when the connection is torn down */
   def shutdownStreamHandling(): Unit = updateAllStates({ id => id.shutdown(); Closed }, "shutdownStreamHandling")
 
@@ -674,7 +691,7 @@ private[http2] trait Http2StreamHandling { self: GraphStageLogic with LogHelper 
     def enqueueIfPossible(): Unit =
       if (canSend && !isEnqueued) {
         isEnqueued = true
-        multiplexer.enqueueOutStream(streamId)
+        enqueueOutStream(streamId)
       }
 
     def registerIncomingData(inlet: SubSinkInlet[_]): Unit = {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -250,6 +250,41 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
         trailingResponseHeaders.size should be(1)
         trailingResponseHeaders.head should be(("Status", "grpc-status 10"))
       }
+      "consider stream as closed after sending out strict response > WINDOW_SIZE" inAssertAllStagesStopped new TestSetup with RequestResponseProbes {
+        override def settings: ServerSettings =
+          // allow only single stream to be able to probe whether main stream is closed
+          super.settings.mapHttp2Settings(_.withMaxConcurrentStreams(1))
+
+        network.sendSETTING(SettingIdentifier.SETTINGS_INITIAL_WINDOW_SIZE, 1000)
+        network.expectSettingsAck()
+
+        val streamId = 1
+        network.sendHEADERS(streamId, endStream = true, network.headersForRequest(Get("/")))
+        user.expectRequest()
+        val response =
+          HttpResponse(StatusCodes.OK, entity = HttpEntity.Strict(
+            ContentTypes.`application/octet-stream`,
+            ByteString("a" * 2000))) // > default INITIAL_WINDOW_SIZE
+            .addAttribute(AttributeKeys.trailer, Trailer(RawHeader("Status", "grpc-status 10")))
+
+        // single configured stream is ongoing, so extra streams will be refused
+        network.sendRequest(3, HttpRequest())
+        network.expectRST_STREAM(3, ErrorCode.REFUSED_STREAM)
+
+        user.emitResponse(streamId, response)
+
+        network.expectHeaderBlock(streamId, endStream = false)
+        network.expectDATA(streamId, endStream = false, ByteString("a" * 1000))
+        network.toNet.request(5)
+        network.sendWINDOW_UPDATE(streamId, 1000)
+        network.expectDATA(streamId, endStream = false, ByteString("a" * 1000))
+        val trailingResponseHeaders = network.expectDecodedResponseHEADERSPairs(streamId)
+        trailingResponseHeaders.size should be(1)
+        trailingResponseHeaders.head should be(("Status", "grpc-status 10"))
+
+        network.sendRequest(5, HttpRequest())
+        user.expectRequest()
+      }
 
       "acknowledge change to SETTINGS_HEADER_TABLE_SIZE in next HEADER frame" inAssertAllStagesStopped new TestSetup with RequestResponseProbes {
         network.sendSETTING(SettingIdentifier.SETTINGS_HEADER_TABLE_SIZE, 8192)


### PR DESCRIPTION
To avoid reentering the state machine which will break setting intermediate states.

Refs #4087