### PR TITLE
Allow to compile `akka-http` module with Scala 3

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/marshalling/Marshaller.scala
@@ -66,7 +66,7 @@ object Marshaller {
   // TODO make sure these are actually usable in a sane way
   def wrapEntity[A, C](f: function.BiFunction[ExecutionContext, C, A], m: Marshaller[A, RequestEntity], mediaType: MediaType): Marshaller[C, RequestEntity] = {
     val scalaMarshaller = m.asScalaCastOutput
-    fromScala(scalaMarshaller.wrapWithEC(mediaType.asScala) { ctx => c: C => f(ctx, c) }(ContentTypeOverrider.forEntity))
+    fromScala(scalaMarshaller.wrapWithEC(mediaType.asScala) { ctx => (c: C) => f(ctx, c) }(ContentTypeOverrider.forEntity))
   }
 
   def wrapEntity[A, C, E <: RequestEntity](f: function.Function[C, A], m: Marshaller[A, E], mediaType: MediaType): Marshaller[C, RequestEntity] = {

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RejectionHandler.scala
@@ -55,7 +55,7 @@ class RejectionHandlerBuilder(asScala: server.RejectionHandler.Builder) {
    * The list passed to the given function is guaranteed to be non-empty.
    */
   def handleAll[T <: Rejection](t: Class[T], handler: function.Function[java.util.List[T], Route]): RejectionHandlerBuilder = {
-    asScala.handleAll { rejections: collection.immutable.Seq[T] => handler.apply(rejections.asJava).delegate }(ClassTag(t))
+    asScala.handleAll { (rejections: collection.immutable.Seq[T]) => handler.apply(rejections.asJava).delegate }(ClassTag(t))
     this
   }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
@@ -389,13 +389,13 @@ object Rejections {
     supported:   java.lang.Iterable[MediaType],
     contentType: Optional[ContentType]): UnsupportedRequestContentTypeRejection =
     s.UnsupportedRequestContentTypeRejection(
-      supported = supported.asScala.map(m => scaladsl.model.ContentTypeRange(m.asScala)).toSet,
-      contentType = contentType.asScala.map(_.asScala))
+      supported = supported.asScala.map((m: MediaType) => scaladsl.model.ContentTypeRange(m.asScala)).toSet,
+      contentType = contentType.asScala.map((c: ContentType) => c.asScala))
 
   // for backwards compatibility
   def unsupportedRequestContentType(supported: java.lang.Iterable[MediaType]): UnsupportedRequestContentTypeRejection =
     s.UnsupportedRequestContentTypeRejection(
-      supported = supported.asScala.map(m => scaladsl.model.ContentTypeRange(m.asScala)).toSet,
+      supported = supported.asScala.map((m: MediaType) => scaladsl.model.ContentTypeRange(m.asScala)).toSet,
       contentType = None)
 
   def unsupportedRequestEncoding(supported: HttpEncoding): UnsupportedRequestEncodingRejection =
@@ -414,15 +414,15 @@ object Rejections {
   def unacceptedResponseContentType(
     supportedContentTypes: java.lang.Iterable[ContentType],
     supportedMediaTypes:   java.lang.Iterable[MediaType]): UnacceptedResponseContentTypeRejection = {
-    val s1: Set[Alternative] = supportedContentTypes.asScala.map(_.asScala).map(ct => ContentNegotiator.Alternative(ct)).toSet
-    val s2: Set[Alternative] = supportedMediaTypes.asScala.map(_.asScala).map(mt => ContentNegotiator.Alternative(mt)).toSet
+    val s1: Set[Alternative] = supportedContentTypes.asScala.map((c: ContentType) => c.asScala).map(ct => ContentNegotiator.Alternative(ct)).toSet
+    val s2: Set[Alternative] = supportedMediaTypes.asScala.map((m: MediaType) => m.asScala).map(mt => ContentNegotiator.Alternative(mt)).toSet
     s.UnacceptedResponseContentTypeRejection(s1 ++ s2)
   }
 
   def unacceptedResponseEncoding(supported: HttpEncoding) =
     s.UnacceptedResponseEncodingRejection(supported.asScala)
   def unacceptedResponseEncoding(supported: java.lang.Iterable[HttpEncoding]) =
-    s.UnacceptedResponseEncodingRejection(supported.asScala.map(_.asScala).toSet)
+    s.UnacceptedResponseEncodingRejection(supported.asScala.map((h: HttpEncoding) => h.asScala).toSet)
 
   def authenticationCredentialsMissing(challenge: HttpChallenge): AuthenticationFailedRejection =
     s.AuthenticationFailedRejection(s.AuthenticationFailedRejection.CredentialsMissing, challenge.asScala)

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/AttributeDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/AttributeDirectives.scala
@@ -20,7 +20,7 @@ abstract class AttributeDirectives extends HeaderDirectives {
    * If no attribute is found the request is rejected with a [[akka.http.javadsl.server.MissingAttributeRejection]].
    */
   def attribute[T](key: AttributeKey[T], inner: jf.Function[T, Route]) = RouteAdapter {
-    D.attribute(toScala(key)) { value: T =>
+    D.attribute(toScala(key)) { (value: T) =>
       inner.apply(value).delegate
     }
   }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/CacheConditionDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/CacheConditionDirectives.scala
@@ -74,7 +74,7 @@ abstract class CacheConditionDirectives extends BasicDirectives {
    * must be on a deeper level in your route structure in order to function correctly.
    */
   def conditional(eTag: Optional[EntityTag], lastModified: Optional[DateTime], inner: Supplier[Route]): Route = RouteAdapter {
-    D.conditional(eTag.asScala.map(_.asScala), lastModified.asScala.map(_.asScala)) { inner.get.delegate }
+    D.conditional(eTag.asScala.map((e: EntityTag) => e.asScala), lastModified.asScala.map((d: DateTime) => d.asScala)) { inner.get.delegate }
   }
 
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FramedEntityStreamingDirectives.scala
@@ -10,6 +10,7 @@ import akka.http.javadsl.marshalling.Marshaller
 import akka.http.javadsl.model.{ HttpEntity, _ }
 import akka.http.javadsl.server.Route
 import akka.http.javadsl.unmarshalling.Unmarshaller
+import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.server.{ Directives => D }
 import akka.stream.javadsl.Source
@@ -25,7 +26,7 @@ abstract class FramedEntityStreamingDirectives extends TimeoutDirectives {
   def entityAsSourceOf[T](um: Unmarshaller[ByteString, T], support: EntityStreamingSupport,
                           inner: java.util.function.Function[Source[T, NotUsed], Route]): Route = RouteAdapter {
     val umm = D.asSourceOf(um.asScala, support.asScala)
-    D.entity(umm) { s: akka.stream.scaladsl.Source[T, NotUsed] =>
+    D.entity(umm) { (s: akka.stream.scaladsl.Source[T, NotUsed]) =>
       inner(s.asJava).delegate
     }
   }
@@ -46,7 +47,7 @@ abstract class FramedEntityStreamingDirectives extends TimeoutDirectives {
     import akka.http.scaladsl.marshalling.PredefinedToResponseMarshallers._
     // don't try this at home:
     val mm = m.asScalaCastOutput[akka.http.scaladsl.model.RequestEntity].map(_.httpEntity.asInstanceOf[akka.http.scaladsl.model.RequestEntity])
-    implicit val mmm = fromEntityStreamingSupportAndEntityMarshaller[T, M](support.asScala, mm, null)
+    implicit val mmm: ToResponseMarshaller[akka.stream.scaladsl.Source[T, M]] = fromEntityStreamingSupportAndEntityMarshaller[T, M](support.asScala, mm, null)
     val response = ToResponseMarshallable(source.asScala)
     D.complete(response)
   }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/PathDirectives.scala
@@ -282,7 +282,7 @@ abstract class PathDirectives extends ParameterDirectives {
     D.ignoreTrailingSlash { inner.get.delegate }
   }
 
-  private def unmarshal[T](t: Unmarshaller[String, T], inner: JFunction[T, Route]) = { element: String =>
+  private def unmarshal[T](t: Unmarshaller[String, T], inner: JFunction[T, Route]) = { (element: String) =>
     D.extractRequestContext { ctx =>
       import ctx.executionContext
       import ctx.materializer

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -22,12 +22,13 @@ import akka.http.scaladsl.server.RouteResult
 import akka.http.scaladsl.server.directives.{ RouteDirectives => D }
 import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.util.FastFuture._
+import scala.concurrent.ExecutionContext
 
 abstract class RouteDirectives extends RespondWithDirectives {
   import RoutingJavaMapping.Implicits._
 
   // Don't try this at home – we only use it here for the java -> scala conversions
-  private implicit val conversionExecutionContext = ExecutionContexts.sameThreadExecutionContext
+  private implicit val conversionExecutionContext: ExecutionContext = ExecutionContexts.sameThreadExecutionContext
 
   /**
    * Java-specific call added so you can chain together multiple alternate routes using comma,

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -250,7 +250,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
    */
   @CorrespondsTo("complete")
   def completeWithFuture(value: CompletionStage[HttpResponse]) = RouteAdapter {
-    D.complete(value.asScala.fast.map(_.asScala).recover(unwrapCompletionException))
+    D.complete(value.asScala.fast.map((h: HttpResponse) => h.asScala).recover(unwrapCompletionException))
   }
 
   /**
@@ -258,7 +258,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
    */
   @CorrespondsTo("complete")
   def completeOKWithFuture(value: CompletionStage[RequestEntity]) = RouteAdapter {
-    D.complete(value.asScala.fast.map(_.asScala).recover(unwrapCompletionException))
+    D.complete(value.asScala.fast.map((r: RequestEntity) => r.asScala).recover(unwrapCompletionException))
   }
 
   /**
@@ -274,7 +274,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
    */
   @CorrespondsTo("complete")
   def completeWithFutureStatus(status: CompletionStage[StatusCode]): Route = RouteAdapter {
-    D.complete(status.asScala.fast.map(_.asScala).recover(unwrapCompletionException))
+    D.complete(status.asScala.fast.map((s: StatusCode) => s.asScala).recover(unwrapCompletionException))
   }
 
   /**
@@ -298,7 +298,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
    */
   def handle(handler: akka.japi.function.Function[HttpRequest, CompletionStage[HttpResponse]]): Route = {
     import akka.http.impl.util.JavaMapping._
-    RouteAdapter { ctx => handler(ctx.request).asScala.fast.map(response => RouteResult.Complete(response.asScala)) }
+    RouteAdapter { ctx => handler(ctx.request).asScala.fast.map((response: HttpResponse) => RouteResult.Complete(response.asScala)) }
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
@@ -235,7 +235,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
     authenticator: JFunction[Optional[HttpCredentials], CompletionStage[Either[HttpChallenge, T]]],
     inner:         JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      val scalaAuthenticator = { cred: Option[scaladsl.model.headers.HttpCredentials] =>
+      val scalaAuthenticator = { (cred: Option[scaladsl.model.headers.HttpCredentials]) =>
         authenticator.apply(cred.map(_.asJava).asJava).toScala.map(_.left.map(_.asScala))
       }
 
@@ -254,7 +254,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
     authenticator: JFunction[Optional[C], CompletionStage[Either[HttpChallenge, T]]],
     inner:         JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      val scalaAuthenticator = { cred: Option[scaladsl.model.headers.HttpCredentials] =>
+      val scalaAuthenticator = { (cred: Option[scaladsl.model.headers.HttpCredentials]) =>
         authenticator.apply(cred.filter(c.isInstance).map(_.asJava).asJava.asInstanceOf[Optional[C]]).toScala.map(_.left.map(_.asScala)) // TODO make sure cast is safe
       }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/WebSocketDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/WebSocketDirectives.scala
@@ -10,7 +10,6 @@ import java.util.Optional
 import java.util.function.{ Function => JFunction }
 
 import akka.NotUsed
-import scala.collection.JavaConverters._
 import akka.http.scaladsl.model.{ ws => s }
 import akka.http.javadsl.model.ws.Message
 import akka.http.javadsl.model.ws.UpgradeToWebSocket
@@ -50,7 +49,8 @@ abstract class WebSocketDirectives extends SecurityDirectives {
    * this is a WebSocket request. Rejects with an [[ExpectedWebSocketRequestRejection]], otherwise.
    */
   def extractOfferedWsProtocols(inner: JFunction[JList[String], Route]): Route = RouteAdapter {
-    D.extractOfferedWsProtocols { list =>
+    import scala.collection.JavaConverters._
+    D.extractOfferedWsProtocols { (list: Seq[String]) =>
       inner.apply(list.asJava).delegate
     }
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/PathDirectives.scala
@@ -51,7 +51,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
   def rawPathPrefix[L](pm: PathMatcher[L]): Directive[L] = {
     implicit val LIsTuple = pm.ev
     extract(ctx => pm(ctx.unmatchedPath)).flatMap {
-      case Matched(rest, values) => tprovide(values) & mapRequestContext(_ withUnmatchedPath rest)
+      case Matched(rest, values) => tprovide(values)(LIsTuple) & mapRequestContext(_ withUnmatchedPath rest)
       case Unmatched             => reject
     }
   }
@@ -90,7 +90,7 @@ trait PathDirectives extends PathMatchers with ImplicitPathMatcherConstruction w
   def pathSuffix[L](pm: PathMatcher[L]): Directive[L] = {
     implicit val LIsTuple = pm.ev
     extract(ctx => pm(ctx.unmatchedPath.reverse)).flatMap {
-      case Matched(rest, values) => tprovide(values) & mapRequestContext(_.withUnmatchedPath(rest.reverse))
+      case Matched(rest, values) => tprovide(values)(LIsTuple) & mapRequestContext(_.withUnmatchedPath(rest.reverse))
       case Unmatched             => reject
     }
   }

--- a/akka-http/src/main/scala/akka/http/scaladsl/settings/RoutingSettings.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/settings/RoutingSettings.scala
@@ -24,16 +24,16 @@ abstract class RoutingSettings private[akka] () extends akka.http.javadsl.settin
   def fileIODispatcher: String
 
   /* Java APIs */
-  def getVerboseErrorMessages: Boolean = verboseErrorMessages
-  def getFileGetConditional: Boolean = fileGetConditional
-  def getRenderVanityFooter: Boolean = renderVanityFooter
-  def getRangeCountLimit: Int = rangeCountLimit
-  def getRangeCoalescingThreshold: Long = rangeCoalescingThreshold
-  def getDecodeMaxBytesPerChunk: Int = decodeMaxBytesPerChunk
-  def getDecodeMaxSize: Long = decodeMaxSize
+  def getVerboseErrorMessages: Boolean = this.verboseErrorMessages
+  def getFileGetConditional: Boolean = this.fileGetConditional
+  def getRenderVanityFooter: Boolean = this.renderVanityFooter
+  def getRangeCountLimit: Int = this.rangeCountLimit
+  def getRangeCoalescingThreshold: Long = this.rangeCoalescingThreshold
+  def getDecodeMaxBytesPerChunk: Int = this.decodeMaxBytesPerChunk
+  def getDecodeMaxSize: Long = this.decodeMaxSize
   @deprecated("binary compatibility method. Use `akka.stream.materializer.blocking-io-dispatcher` to configure the dispatcher", since = "10.1.6")
   @Deprecated
-  def getFileIODispatcher: String = fileIODispatcher
+  def getFileIODispatcher: String = this.fileIODispatcher
 
   override def withVerboseErrorMessages(verboseErrorMessages: Boolean): RoutingSettings = self.copy(verboseErrorMessages = verboseErrorMessages)
   override def withFileGetConditional(fileGetConditional: Boolean): RoutingSettings = self.copy(fileGetConditional = fileGetConditional)

--- a/build.sbt
+++ b/build.sbt
@@ -130,6 +130,13 @@ val scalaMacroSupport = Seq(
   }),
 )
 
+val scala3MigrationModeOption = 
+  scalacOptions ++= {
+    if (scalaVersion.value startsWith "3")
+      Seq("-source:3.0-migration")
+    else
+      Nil
+  }
 
 lazy val parsing = project("akka-parsing")
   .settings(commonSettings)
@@ -157,14 +164,7 @@ lazy val httpCore = project("akka-http-core")
       if (System.getProperty("akka.http.test-against-akka-main", "false") == "true") AkkaDependency.masterSnapshot
       else AkkaDependency.default
   )
-  .settings(
-    scalacOptions ++= {
-      if (scalaVersion.value startsWith "3")
-        Seq("-source", "3.0-migration")
-      else
-        Nil
-    },
-  )
+  .settings(scala3MigrationModeOption)
   .settings(Dependencies.httpCore)
   .settings(VersionGenerator.versionSettings)
   .settings(scalaMacroSupport)
@@ -184,7 +184,7 @@ lazy val http = project("akka-http")
   .settings(scalaMacroSupport)
   .enablePlugins(BootstrapGenjavadoc, BoilerplatePlugin)
   .enablePlugins(ReproducibleBuildsPlugin)
-  .enablePlugins(NoScala3) // FIXME
+  .settings(scala3MigrationModeOption)
 
 def gustavDir(kind: String) = Def.task {
   val ver =

--- a/build.sbt
+++ b/build.sbt
@@ -184,7 +184,6 @@ lazy val http = project("akka-http")
   .settings(scalaMacroSupport)
   .enablePlugins(BootstrapGenjavadoc, BoilerplatePlugin)
   .enablePlugins(ReproducibleBuildsPlugin)
-  .settings(scala3MigrationModeOption)
 
 def gustavDir(kind: String) = Def.task {
   val ver =


### PR DESCRIPTION
This mostly involves specifying types for implicit vals and adding correct parentheses in lambda types. Compilation with `-source:3.0-migration` was simple, requiring only passing some implicits explicitly in `PathDirectives`. When I removed the option, another slightly more severe issue popped up, with the compiler seemingly incorrectly inferring types used in javadsl/scaladsl mappings - because of that, the compiler was unable to find the correct implicit. This was fixed by manually specifying types in places like this. What's interesting, this only happened when going through a collection previously converted from java collection (via `scala.collections.JavaConverters`). This can be for example observed in `Rejections.scala`.

Nevertheless, now the 'akka-http' module compiles with both 3.1.1, 3.1.2-RC3 and 2.13.8 (2.12.15 errored at the `akka-http-core` module).

References #4079, task "Enable `akka-http` module for Scala 3 (currently disabled in Scala 3) and make main code compile"
