### PR TITLE
cache: avoid locking cache during directive processing

### DIFF
--- a/akka-http-caching/src/main/scala/akka/http/scaladsl/server/directives/CachingDirectives.scala
+++ b/akka-http-caching/src/main/scala/akka/http/scaladsl/server/directives/CachingDirectives.scala
@@ -13,6 +13,8 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.headers.CacheDirectives._
 
+import scala.concurrent.Future
+
 @ApiMayChange
 trait CachingDirectives {
   import akka.http.scaladsl.server.directives.BasicDirectives._
@@ -43,14 +45,17 @@ trait CachingDirectives {
    * Wraps its inner Route with caching support using the given [[Cache]] implementation and
    * keyer function. Note that routes producing streaming responses cannot be wrapped with this directive.
    */
-  def alwaysCache[K](cache: Cache[K, RouteResult], keyer: PartialFunction[RequestContext, K]): Directive0 = {
-    mapInnerRoute { route => ctx =>
-      keyer.lift(ctx) match {
-        case Some(key) => cache.apply(key, () => route(ctx))
-        case None      => route(ctx)
+  def alwaysCache[K](cache: Cache[K, RouteResult], keyer: PartialFunction[RequestContext, K]): Directive0 =
+    // Do directive processing asynchronously to avoid locking the cache accidentally (#4092)
+    // This will be slightly slower, but the rational here is that caching is used for slower kind of processing
+    // anyway so the performance hit should be acceptable.
+    CachingDirectives.asyncRoute &
+      mapInnerRoute { route => ctx =>
+        keyer.lift(ctx) match {
+          case Some(key) => cache.apply(key, () => route(ctx))
+          case None      => route(ctx)
+        }
       }
-    }
-  }
 
   /**
    * Creates an [[LfuCache]] with default settings obtained from the system's configuration.
@@ -65,4 +70,14 @@ trait CachingDirectives {
     LfuCache[K, RouteResult](settings)
 }
 
-object CachingDirectives extends CachingDirectives
+object CachingDirectives extends CachingDirectives {
+  /**
+   * Run all route processing asynchronously.
+   */
+  private[CachingDirectives] def asyncRoute: Directive0 =
+    Directive { inner => ctx =>
+      import ctx.executionContext
+      Future { inner(()) }
+        .flatMap(route => route(ctx))
+    }
+}


### PR DESCRIPTION
Threads competing to access the cache may block like this:

```
   java.lang.Thread.State: BLOCKED (on object monitor)
	at java.util.concurrent.ConcurrentHashMap.computeIfPresent(ConcurrentHashMap.java:1760)
	- waiting to lock <0x000000073cb6b320> (a java.util.concurrent.ConcurrentHashMap$Node)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.replace(BoundedLocalCache.java:2302)
	at com.github.benmanes.caffeine.cache.LocalAsyncCache.lambda$handleCompletion$7(LocalAsyncCache.java:210)
	at com.github.benmanes.caffeine.cache.LocalAsyncCache$$Lambda$105857/1233505965.accept(Unknown Source)
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:774)
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:750)
	at java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:457)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175)
```

when another thread is updating the same cache node synchronously. We have an async cache
but we actually have to use it asynchronously. This is not the default for
directive processing which uses FastFuture by default for faster but synchronous processing.

Fixes #4092
