### PR TITLE
Scala 3: try to make PR validation work (as well as possible right now)

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -81,7 +81,8 @@ jobs:
       # Quick testing for PR validation
       - name: Validate pull request for JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}
         if: ${{ github.event_name == 'pull_request' }}
-        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 "+~ ${{ matrix.SCALA_VERSION }} validatePullRequest"
+        # FIXME: revert back to `validatePullRequest` task, when all modules support Scala 3
+        run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 "+~ ${{ matrix.SCALA_VERSION }} executePullRequestValidation"
 
       # Full testing for pushes
       - name: Run all tests JDK ${{ matrix.JABBA_JDK }}, Scala ${{ matrix.SCALA_VERSION }}

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.12, 2.13, 3]
+        SCALA_VERSION: [2.13, 3]
         JABBA_JDK: [1.8]
     steps:
       - name: Checkout

--- a/akka-http-caching/src/test/scala/akka/http/scaladsl/server/directives/CachingDirectivesSpec.scala
+++ b/akka-http-caching/src/test/scala/akka/http/scaladsl/server/directives/CachingDirectivesSpec.scala
@@ -6,17 +6,16 @@ package akka.http.scaladsl.server.directives
 
 import akka.http.caching.scaladsl.{ CachingSettings, LfuCacheSettings }
 import akka.http.impl.util._
-import akka.http.scaladsl.model.{ HttpResponse, Uri }
-import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.model.headers.CacheDirectives._
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{ ExceptionHandler, RequestContext }
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.model.HttpMethods.GET
+import akka.http.scaladsl.model.headers.CacheDirectives._
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.{ HttpResponse, Uri }
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{ ExceptionHandler, RequestContext, RouteResult }
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.testkit._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-import akka.testkit._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -101,11 +100,10 @@ class CachingDirectivesSpec extends AnyWordSpec with Matchers with ScalatestRout
       }
 
       implicit val executor = system.dispatcher
+      val routeFunc = RouteResult.routeToFunction(route)
 
       Future.traverse(1 to 1000) { i =>
-        Future {
-          Get(s"/$i") ~> route ~> check {} // check blocks to wait for result
-        }
+        routeFunc(Get(s"/$i"))
       }.awaitResult(10.second.dilated)
     }
   }

--- a/akka-parsing/src/main/scala-2/akka/macros/LogHelperMacro.scala
+++ b/akka-parsing/src/main/scala-2/akka/macros/LogHelperMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.macros

--- a/akka-parsing/src/main/scala-3/akka/http/ccompat/pre213macro.scala
+++ b/akka-parsing/src/main/scala-3/akka/http/ccompat/pre213macro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.ccompat

--- a/akka-parsing/src/main/scala-3/akka/http/ccompat/since213macro.scala
+++ b/akka-parsing/src/main/scala-3/akka/http/ccompat/since213macro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.http.ccompat

--- a/akka-parsing/src/main/scala-3/akka/macros/LogHelperMacro.scala
+++ b/akka-parsing/src/main/scala-3/akka/macros/LogHelperMacro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2021-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.macros

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val root = Project(
     id = "akka-http-root",
     base = file(".")
   )
-  .enablePlugins(UnidocRoot, NoPublish, PublishRsyncPlugin, AggregatePRValidation)
+  .enablePlugins(UnidocRoot, NoPublish, PublishRsyncPlugin, AggregatePRValidation, NoScala3)
   .disablePlugins(MimaPlugin)
   .settings(
     // Unidoc doesn't like macro definitions
@@ -130,7 +130,7 @@ val scalaMacroSupport = Seq(
   }),
 )
 
-val scala3MigrationModeOption = 
+val scala3MigrationModeOption =
   scalacOptions ++= {
     if (scalaVersion.value startsWith "3")
       Seq("-source:3.0-migration")
@@ -295,7 +295,7 @@ lazy val httpJmhBench = project("akka-http-bench-jmh")
 
 lazy val httpMarshallersScala = project("akka-http-marshallers-scala")
   .settings(commonSettings)
-  .enablePlugins(NoPublish/*, AggregatePRValidation*/)
+  .enablePlugins(NoPublish, NoScala3 /*FIXME */ /*, AggregatePRValidation*/)
   .disablePlugins(MimaPlugin)
   .aggregate(httpSprayJson, httpXml)
 
@@ -315,7 +315,7 @@ lazy val httpSprayJson =
 
 lazy val httpMarshallersJava = project("akka-http-marshallers-java")
   .settings(commonSettings)
-  .enablePlugins(NoPublish/*, AggregatePRValidation*/)
+  .enablePlugins(NoPublish, NoScala3 /*FIXME */ /*, AggregatePRValidation*/)
   .disablePlugins(MimaPlugin)
   .aggregate(httpJackson)
 
@@ -507,7 +507,7 @@ lazy val compatibilityTests = Project("akka-http-compatibility-tests", file("akk
   )
 
 lazy val billOfMaterials = Project("bill-of-materials", file("akka-http-bill-of-materials"))
-  .enablePlugins(BillOfMaterialsPlugin)
+  .enablePlugins(BillOfMaterialsPlugin, NoScala3 /* FIXME */)
   .disablePlugins(MimaPlugin)
   .settings(
     name := "akka-http-bom",

--- a/project/AkkaDependency.scala
+++ b/project/AkkaDependency.scala
@@ -46,7 +46,7 @@ object AkkaDependency {
   // Default version updated only when needed, https://doc.akka.io//docs/akka/current/project/downstream-upgrade-strategy.html
   val minimumExpectedAkkaVersion = "2.6.18"
   val default = akkaDependency(defaultVersion = minimumExpectedAkkaVersion)
-  val minimumExpectedAkka26Version = "2.6.8"
+  val minimumExpectedAkka26Version = "2.6.18"
   val docs = akkaDependency(defaultVersion = minimumExpectedAkka26Version)
 
   lazy val masterSnapshot = Artifact(determineLatestSnapshot(), true)


### PR DESCRIPTION
 * 2.12: does not work as long as we have no solution for the `@pre213` annotation
 * 2.13: had a problem with Akka version in docs submodule
 * 3: had a problem with aggregating only the current subset of supported modules