### PR TITLE
http-tests: allow to compile with Scala 3 with 3.0-migration option

### DIFF
--- a/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -16,15 +16,16 @@ import org.scalatest.concurrent.ScalaFutures
 import spray.json.{ JsArray, JsString, JsValue }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import spray.json.RootJsonFormat
 
 class SprayJsonSupportSpec extends AnyWordSpec with Matchers with ScalaFutures {
   import SprayJsonSupport._
   import SprayJsonSupportSpec._
   import spray.json.DefaultJsonProtocol._
 
-  implicit val exampleFormat = jsonFormat1(Example.apply)
-  implicit val sys = ActorSystem("SprayJsonSupportSpec")
-  implicit val mat = ActorMaterializer()
+  implicit val exampleFormat: RootJsonFormat[Example] = jsonFormat1(Example.apply)
+  implicit val sys: ActorSystem = ActorSystem("SprayJsonSupportSpec")
+  implicit val mat: ActorMaterializer = ActorMaterializer()
   implicit val ec: ExecutionContext = sys.dispatcher
 
   val TestString = "Contains all UTF-8 characters: 2-byte: £, 3-byte: ﾖ, 4-byte: 😁, 4-byte as a literal surrogate pair: \uD83D\uDE01"

--- a/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/http/AkkaHttpServerLatencyMultiNodeSpec.scala
@@ -244,7 +244,7 @@ class AkkaHttpServerLatencyMultiNodeSpec extends MultiNodeSpec(AkkaHttpServerLat
     runOn(loadGenerator) {
       info(s"${id} => running: $cmd")
       import akka.pattern.ask
-      implicit val timeout = Timeout(30.minutes) // we don't want to timeout here
+      implicit val timeout: Timeout = Timeout(30.minutes) // we don't want to timeout here
 
       val res = (loadGeneratorActor ? LoadGenCommand(cmd)).mapTo[LoadGenResults]
       val results = Await.result(res, timeout.duration)

--- a/akka-http-tests/src/multi-jvm/scala/akka/remote/testkit/MultiNodeConfig.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/remote/testkit/MultiNodeConfig.scala
@@ -22,7 +22,7 @@ import akka.testkit.TestEvent._
 import scala.concurrent.duration._
 import akka.remote.testconductor.RoleName
 import akka.actor.RootActorPath
-import akka.event.{ Logging, LoggingAdapter }
+import akka.event.{ Logging, LogSource, LoggingAdapter }
 
 /**
  * Configure the role names and participants of the test, including configuration settings.
@@ -261,13 +261,13 @@ abstract class MultiNodeSpec(val myself: RoleName, _system: ActorSystem, _roles:
     this(config.myself, ActorSystem(MultiNodeSpec.getCallerName(classOf[MultiNodeSpec]), ConfigFactory.load(config.config)),
       config.roles, config.deployments)
 
-  val log: LoggingAdapter = Logging(system, this.getClass)
+  val log: LoggingAdapter = Logging(system, this.getClass)(LogSource.fromClass)
 
   /**
    * Enrich `.await()` onto all Awaitables, using remaining duration from the innermost
    * enclosing `within` block or QueryTimeout.
    */
-  implicit def awaitHelper[T](w: Awaitable[T]) = new AwaitHelper(w)
+  implicit def awaitHelper[T](w: Awaitable[T]): AwaitHelper[T] = new AwaitHelper(w)
   class AwaitHelper[T](w: Awaitable[T]) {
     def await: T = Await.result(w, remainingOr(testConductor.Settings.QueryTimeout.duration))
   }

--- a/akka-http-tests/src/multi-jvm/scala/akka/remote/testkit/PerfFlamesSupport.scala
+++ b/akka-http-tests/src/multi-jvm/scala/akka/remote/testkit/PerfFlamesSupport.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 /**
  * Support trait allowing trivially recording perf metrics from [[MultiNodeSpec]]s
  */
-private[akka] trait PerfFlamesSupport { _: MultiNodeSpec =>
+private[akka] trait PerfFlamesSupport { multiNodeSpec: MultiNodeSpec =>
 
   /**
    * Runs `perf-java-flames` script on given node (JVM process).

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
 class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
   with Directives with RequestBuilding {
 
-  implicit val mat = ActorMaterializer()
+  implicit val mat: ActorMaterializer = ActorMaterializer()
 
   "Http" should {
     "find media types in a set if they differ in casing" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
@@ -11,7 +11,7 @@ import akka.http.scaladsl.model._
 import akka.testkit.AkkaSpec
 
 class FormDataSpec extends AkkaSpec {
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
   import system.dispatcher
 
   val formData = FormData(Map("surname" -> "Smith", "age" -> "42"))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/TestSingleRequest.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/TestSingleRequest.scala
@@ -19,8 +19,8 @@ object TestSingleRequest extends App {
     akka.log-dead-letters = off
     akka.stream.materializer.debug.fuzzing-mode = off
     """)
-  implicit val system = ActorSystem("ServerTest", testConf)
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
   import system.dispatcher
 
   val url = StdIn.readLine("url? ")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
@@ -70,8 +70,8 @@ Consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
 voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
 est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy e""".replace("\r\n", "\n")
 
-  implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -12,10 +12,11 @@ import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import spray.json.{ JsValue, PrettyPrinter, JsonPrinter, DefaultJsonProtocol }
 
 import scala.collection.immutable.ListMap
+import spray.json.RootJsonFormat
 
 class SprayJsonSupportSpec extends JsonSupportSpec {
   object EmployeeJsonProtocol extends DefaultJsonProtocol {
-    implicit val employeeFormat = jsonFormat5(Employee.apply)
+    implicit val employeeFormat: RootJsonFormat[Employee] = jsonFormat5(Employee.apply)
   }
   import EmployeeJsonProtocol._
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/FromStatusCodeAndXYZMarshallerSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/FromStatusCodeAndXYZMarshallerSpec.scala
@@ -9,13 +9,14 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.Accept
 import akka.http.scaladsl.model.{ ContentTypes, MediaRanges, MediaTypes }
 import akka.http.scaladsl.server.{ Route, RoutingSpec }
+import spray.json.RootJsonFormat
 
 class FromStatusCodeAndXYZMarshallerSpec extends RoutingSpec {
   case class ErrorInfo(errorMessage: String)
   // a somewhat arbitrary ErrorInfo marshaller that can either return a text or an application/json response
   implicit val errorInfoMarshaller: ToEntityMarshaller[ErrorInfo] = {
     import spray.json.DefaultJsonProtocol._
-    implicit val errorInfoFormat = jsonFormat1(ErrorInfo.apply _)
+    implicit val errorInfoFormat: RootJsonFormat[ErrorInfo] = jsonFormat1(ErrorInfo.apply _)
     Marshaller.oneOf(
       Marshaller.StringMarshaller.compose[ErrorInfo](_.errorMessage),
       SprayJsonSupport.sprayJsonMarshaller(errorInfoFormat)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -25,8 +25,8 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with MultipartMarshallers with MarshallingTestUtils {
-  implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
   import system.dispatcher
 
   override val testConfig = ConfigFactory.load()

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/BasicRouteSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/BasicRouteSpecs.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.model
 import model.HttpMethods._
 import model.StatusCodes
 import akka.testkit.EventFilter
+import akka.http.scaladsl.server.util.ConstructFromTuple
 
 object BasicRouteSpecs {
   private[http] def defaultExnHandler500Error(message: String) = {
@@ -148,7 +149,7 @@ class BasicRouteSpecs extends RoutingSpec {
     "extract one argument" in {
       case class MyNumber(i: Int)
 
-      val abcPath = path("abc" / IntNumber).as(MyNumber)(echoComplete)
+      val abcPath = path("abc" / IntNumber).as(ConstructFromTuple.instance1(MyNumber))(echoComplete)
 
       Get("/abc/5") ~> abcPath ~> check {
         responseAs[String] shouldEqual "MyNumber(5)"
@@ -157,7 +158,7 @@ class BasicRouteSpecs extends RoutingSpec {
     "extract two arguments" in {
       case class Person(name: String, age: Int)
 
-      val personPath = path("person" / Segment / IntNumber).as(Person)(echoComplete)
+      val personPath = path("person" / Segment / IntNumber).as(ConstructFromTuple.instance2(Person))(echoComplete)
 
       Get("/person/john/38") ~> personPath ~> check {
         responseAs[String] shouldEqual "Person(john,38)"
@@ -168,7 +169,7 @@ class BasicRouteSpecs extends RoutingSpec {
         require(i > 10)
       }
 
-      val abcPath = path("abc" / IntNumber).as(MyValidNumber)(echoComplete)
+      val abcPath = path("abc" / IntNumber).as(ConstructFromTuple.instance1(MyValidNumber))(echoComplete)
 
       Get("/abc/5") ~> abcPath ~> check {
         rejection shouldBe a[ValidationRejection]

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
@@ -27,9 +27,9 @@ object ConnectionTestApp {
     }
     """)
 
-  implicit val system = ActorSystem("ConnectionTest", testConf)
+  implicit val system: ActorSystem = ActorSystem("ConnectionTest", testConf)
   import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   val clientFlow = Http().superPool[Int]()
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -23,6 +23,7 @@ import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
+import akka.event.LogSource
 
 abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String)
   extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with WithLogCapturing {
@@ -37,10 +38,10 @@ abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String
 
       http.host-connection-pool.base-connection-backoff = 0 ms
     }""").withFallback(ConfigFactory.load())
-  implicit val system = ActorSystem("DontLeakActorsOnFailingConnectionSpecs-" + poolImplementation, config)
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem("DontLeakActorsOnFailingConnectionSpecs-" + poolImplementation, config)
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
-  val log = Logging(system, getClass)
+  val log = Logging(system, getClass)(LogSource.fromClass)
 
   "Http.superPool" should {
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala
@@ -16,9 +16,10 @@ import akka.stream.scaladsl._
 import akka.testkit._
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
+import spray.json.RootJsonFormat
 
 class EntityStreamingSpec extends RoutingSpec with ScalaFutures {
-  implicit override val patience = PatienceConfig(5.seconds.dilated(system), 200.millis)
+  implicit override val patience: PatienceConfig = PatienceConfig(5.seconds.dilated(system), 200.millis)
 
   //#models
   case class Tweet(uid: Int, txt: String)
@@ -35,8 +36,8 @@ class EntityStreamingSpec extends RoutingSpec with ScalaFutures {
     extends akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
     with spray.json.DefaultJsonProtocol {
 
-    implicit val tweetFormat = jsonFormat2(Tweet.apply)
-    implicit val measurementFormat = jsonFormat2(Measurement.apply)
+    implicit val tweetFormat: RootJsonFormat[Tweet] = jsonFormat2(Tweet.apply)
+    implicit val measurementFormat: RootJsonFormat[Measurement] = jsonFormat2(Measurement.apply)
   }
 
   "spray-json-response-streaming" in {
@@ -278,6 +279,13 @@ class EntityStreamingSpec extends RoutingSpec with ScalaFutures {
               .runFold(0) { (cnt, _) => cnt + 1 }
 
           complete {
+            implicit val marshaller = // Scala 3 workaround for missing implicit conversion
+              Marshaller.futureMarshaller(
+                Marshaller.liftMarshaller(
+                  sprayJsonMarshaller(mapFormat(StringJsonFormat, StringJsonFormat))
+                )
+              )
+
             measurementsSubmitted.map(n => Map("msg" -> s"""Total metrics received: $n"""))
           }
         }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -41,12 +41,12 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
     akka.http.server.parsing.max-content-length = $maxContentLength
     akka.http.routing.decode-max-size = $decodeMaxSize
     """)
-  implicit val system = ActorSystem(getClass.getSimpleName, testConf)
+  implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
   val random = new scala.util.Random(42)
 
-  implicit val defaultPatience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(5, Millis))
+  implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(5, Millis))
 
   "a normal route" should {
     val route = path("noDirective") {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
@@ -20,12 +20,12 @@ object TcpLeakApp extends App {
     akka.loglevel = DEBUG
     akka.log-dead-letters = on
     akka.io.tcp.trace-logging = on""")
-  implicit val system = ActorSystem("ServerTest", testConf)
-  implicit val fm = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
+  implicit val fm: ActorMaterializer = ActorMaterializer()
 
   import system.dispatcher
 
-  val tcpFlow = Tcp().outgoingConnection(new InetSocketAddress("127.0.0.1", 1234)).named("TCP-outgoingConnection")
+  val tcpFlow = Tcp(system).outgoingConnection(new InetSocketAddress("127.0.0.1", 1234)).named("TCP-outgoingConnection")
   List
     .fill(100)(
       Source

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -18,6 +18,8 @@ import akka.http.scaladsl.common.EntityStreamingSupport
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.io.StdIn
+import akka.http.scaladsl.common.JsonEntityStreamingSupport
+import spray.json.RootJsonFormat
 
 object TestServer extends App {
   val testConf: Config = ConfigFactory.parseString("""
@@ -26,16 +28,16 @@ object TestServer extends App {
     akka.stream.materializer.debug.fuzzing-mode = off
     """)
 
-  implicit val system = ActorSystem("ServerTest", testConf)
+  implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   import spray.json.DefaultJsonProtocol._
   import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
   final case class Tweet(message: String)
-  implicit val tweetFormat = jsonFormat1(Tweet)
+  implicit val tweetFormat: RootJsonFormat[Tweet] = jsonFormat1(Tweet)
 
-  implicit val jsonStreaming = EntityStreamingSupport.json()
+  implicit val jsonStreaming: JsonEntityStreamingSupport = EntityStreamingSupport.json()
 
   import ScalaXmlSupport._
   import Directives._

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CodingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/CodingDirectivesSpec.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 
 class CodingDirectivesSpec extends RoutingSpec with Inside {
 
-  implicit val routeTestTimeout = RouteTestTimeout(3.seconds.dilated)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(3.seconds.dilated)
 
   val echoRequestContent: Route = { ctx => ctx.complete(ctx.request.entity.dataBytes.utf8String) }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileAndResourceDirectivesSpec.scala
@@ -23,7 +23,7 @@ import akka.testkit._
 class FileAndResourceDirectivesSpec extends RoutingSpec with Inspectors with Inside {
 
   // operations touch files, can be randomly hit by slowness
-  implicit val routeTestTimeout = RouteTestTimeout(3.seconds.dilated)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(3.seconds.dilated)
 
   // need to serve from the src directory, when sbt copies the resource directory over to the
   // target directory it will resolve symlinks in the process

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
 class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
 
   // tests touches filesystem, so reqs may take longer than the default of 1.second to complete
-  implicit val routeTimeout = RouteTestTimeout(6.seconds.dilated)
+  implicit val routeTimeout: RouteTestTimeout = RouteTestTimeout(6.seconds.dilated)
 
   "the storeUploadedFile directive" should {
     val data = s"<int>${"42" * 1000000}</int>" // ~2MB of data

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FormFieldDirectivesSpec.scala
@@ -13,9 +13,11 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller.HexInt
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.MediaTypes._
 import akka.http.impl.util.BenchUtils
+import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import scala.xml.NodeSeq
 
 class FormFieldDirectivesSpec extends RoutingSpec {
-  implicit val nodeSeqUnmarshaller =
+  implicit val nodeSeqUnmarshaller: FromEntityUnmarshaller[NodeSeq] =
     ScalaXmlSupport.nodeSeqUnmarshaller(`text/xml`, `text/html`, `text/plain`)
 
   val nodeSeq: xml.NodeSeq = <b>yes</b>

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MarshallingDirectivesSpec.scala
@@ -225,7 +225,7 @@ class MarshallingDirectivesSpec extends RoutingSpec with Inside {
   "The marshalling infrastructure for JSON" should {
     import spray.json._
     case class Foo(name: String)
-    implicit val fooFormat = jsonFormat1(Foo)
+    implicit val fooFormat: RootJsonFormat[Foo] = jsonFormat1(Foo)
     val foo = Foo("Hällö")
 
     "render JSON with UTF-8 encoding if no `Accept-Charset` request header is present" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/ParameterDirectivesSpec.scala
@@ -9,6 +9,7 @@ import org.scalatest.Inside
 import akka.http.scaladsl.unmarshalling.Unmarshaller, Unmarshaller._
 import akka.http.scaladsl.model.StatusCodes
 import org.scalatest.freespec.AnyFreeSpec
+import akka.http.scaladsl.server.util.ConstructFromTuple
 
 class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with Inside {
   "when used with 'as[Int]' the parameter directive should" - {
@@ -273,7 +274,7 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
     "extract a parameter value as Case Class" in {
       case class Color(red: Int, green: Int, blue: Int)
       Get("/?red=90&green=50&blue=0") ~> {
-        parameters("red".as[Int], "green".as[Int], "blue".as[Int]).as(Color) { color =>
+        parameters("red".as[Int], "green".as[Int], "blue".as[Int]).as(ConstructFromTuple.instance3(Color)) { color =>
           complete(s"${color.red} ${color.green} ${color.blue}")
         }
       } ~> check { responseAs[String] shouldEqual "90 50 0" }
@@ -285,7 +286,7 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
         require(0 <= blue && blue <= 255)
       }
       Get("/?red=500&green=0&blue=0") ~> {
-        parameters("red".as[Int], "green".as[Int], "blue".as[Int]).as(Color) { color =>
+        parameters("red".as[Int], "green".as[Int], "blue".as[Int]).as(ConstructFromTuple.instance3(Color)) { color =>
           complete(s"${color.red} ${color.green} ${color.blue}")
         }
       } ~> check {
@@ -299,7 +300,7 @@ class ParameterDirectivesSpec extends AnyFreeSpec with GenericRoutingSpec with I
         require(0 <= blue && blue <= 255)
       }
       Get("/?red=0&green=0&blue=0") ~> {
-        parameters("red".as[Int], "green".as[Int], "blue".as[Int]).as(Color) { _ =>
+        parameters("red".as[Int], "green".as[Int], "blue".as[Int]).as(ConstructFromTuple.instance3(Color)) { _ =>
           throw new IllegalArgumentException
         }
       } ~> check {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -91,16 +91,17 @@ class RouteDirectivesSpec extends AnyWordSpec with GenericRoutingSpec {
               registerUser(name).map[ToResponseMarshallable] {
                 case Registered(_) => HttpEntity.Empty
                 case AlreadyRegistered =>
-                  import spray.json.DefaultJsonProtocol._
                   import SprayJsonSupport._
-                  implicit val marshaller = // Scala 3 workaround for missing implicit conversion
-                    Marshaller.fromStatusCodeAndValue[StatusCodes.ClientError, Map[String, String]](
-                      a => a,
-                      sprayJsonMarshaller(mapFormat(StringJsonFormat, StringJsonFormat)
-                      )
-                    )
 
-                  StatusCodes.BadRequest -> Map("error" -> "User already Registered")
+                  // FIXME: Scala 3 workaround, which cannot figure out the implicit itself
+                  // Needs to avoid importing more implicits accidentally from DefaultJsonProtocol to avoid ambiguity in
+                  // Scala 2
+                  implicit val mapFormat: spray.json.RootJsonFormat[Map[String, String]] = {
+                    import spray.json.DefaultJsonProtocol
+                    import DefaultJsonProtocol._
+                    DefaultJsonProtocol.mapFormat
+                  }
+                  StatusCodes.BadRequest -> Map[String, String]("error" -> "User already Registered")
               }
             }
           }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/RouteDirectivesSpec.scala
@@ -93,6 +93,13 @@ class RouteDirectivesSpec extends AnyWordSpec with GenericRoutingSpec {
                 case AlreadyRegistered =>
                   import spray.json.DefaultJsonProtocol._
                   import SprayJsonSupport._
+                  implicit val marshaller = // Scala 3 workaround for missing implicit conversion
+                    Marshaller.fromStatusCodeAndValue[StatusCodes.ClientError, Map[String, String]](
+                      a => a,
+                      sprayJsonMarshaller(mapFormat(StringJsonFormat, StringJsonFormat)
+                      )
+                    )
+
                   StatusCodes.BadRequest -> Map("error" -> "User already Registered")
               }
             }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/TimeoutDirectivesSpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ Future, Promise }
 
 class TimeoutDirectivesSpec extends RoutingSpec {
 
-  implicit val routeTestTimeout = RouteTestTimeout(5.seconds.dilated)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.seconds.dilated)
 
   "Request Timeout" should {
     "be configurable in routing layer" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/util/TupleOpsSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/util/TupleOpsSpec.scala
@@ -14,9 +14,9 @@ class TupleOpsSpec extends AnyWordSpec with Matchers {
 
     "support folding over tuples using a binary poly-function" in {
       object Funky extends BinaryPolyFunc {
-        implicit def step1 = at[Double, Int](_ + _)
-        implicit def step2 = at[Double, Symbol]((d, s) => (d + s.name.tail.toInt).toByte)
-        implicit def step3 = at[Byte, String]((byte, s) => byte + s.toLong)
+        implicit def step1: BinaryPolyFunc.Case[Double, Int, this.type] { type Out = Double } = at[Double, Int](_ + _)
+        implicit def step2: BinaryPolyFunc.Case[Double, Symbol, this.type] { type Out = Byte } = at[Double, Symbol]((d, s) => (d + s.name.tail.toInt).toByte)
+        implicit def step3: BinaryPolyFunc.Case[Byte, String, this.type] { type Out = Long } = at[Byte, String]((byte, s) => byte + s.toLong)
       }
       (1, Symbol("X2"), "3").foldLeft(0.0)(Funky) shouldEqual 6L
     }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -23,8 +23,8 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class UnmarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
-  implicit val system = ActorSystem(getClass.getSimpleName)
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   override val testConfig = ConfigFactory.load()
 

--- a/build.sbt
+++ b/build.sbt
@@ -281,7 +281,7 @@ lazy val httpTests = project("akka-http-tests")
       targetFile
     }
   )
-  .enablePlugins(NoScala3) // FIXME
+  .settings(scala3MigrationModeOption)
 
 lazy val httpJmhBench = project("akka-http-bench-jmh")
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -303,14 +303,12 @@ lazy val httpXml =
     .settings(AutomaticModuleName.settings("akka.http.marshallers.scalaxml"))
     .addAkkaModuleDependency("akka-stream", "provided")
     .settings(Dependencies.httpXml)
-    .enablePlugins(NoScala3) // FIXME
 
 lazy val httpSprayJson =
   httpMarshallersScalaSubproject("spray-json")
     .settings(AutomaticModuleName.settings("akka.http.marshallers.sprayjson"))
     .addAkkaModuleDependency("akka-stream", "provided")
     .settings(Dependencies.httpSprayJson)
-    .enablePlugins(NoScala3) // FIXME
 
 lazy val httpMarshallersJava = project("akka-http-marshallers-java")
   .settings(commonSettings)
@@ -326,7 +324,6 @@ lazy val httpJackson =
     .dependsOn(httpTestkit % "test")
     .settings(Dependencies.httpJackson)
     .enablePlugins(ScaladocNoVerificationOfDiagrams)
-    .enablePlugins(NoScala3) // FIXME
 
 lazy val httpCaching = project("akka-http-caching")
   .settings(commonSettings)


### PR DESCRIPTION
This also includes `akka-http-spray-json` and `akka-http-scala-xml `, on which the tests depend.
Because of changes to type inference, some tests had to be slightly adjusted (beyond defining types explicitly). They all compile, though running tests locally concludes with a somewhat confusing message:
```
[info] ScalaTest
[info] Run completed in 40 seconds, 36 milliseconds.
[info] Total number of tests run: 1273
[info] Suites: completed 65, aborted 0
[info] Tests: succeeded 1273, failed 0, canceled 0, ignored 0, pending 40
[info] All tests passed.
[info] multi-jvm
[info] akka.http.AkkaHttpServerLatencyMultiNodeSpec
[error] Failed: Total 1432, Failed 0, Errors 0, Passed 1432, Pending 40
[error] (akka-http-tests / Test / test) sbt.TestsFailedException: Tests unsuccessful
```
`3.0-migration` compiler option was used - there are still some errors when compiling without it that I was not able to iron out yet.

References #4079, tasks `akka-http-tests` (with 3.0-migration option), `akka-http-spray-json`, `akka-http-scala-xml `
