### PR TITLE
Scala 3: Remove 3.0-migration compiler option from all modules

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/Query.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/Query.java
@@ -7,6 +7,7 @@ package akka.http.javadsl.model;
 import akka.http.impl.model.JavaQuery;
 import akka.http.impl.model.UriJavaAccessor;
 import akka.http.scaladsl.model.*;
+import akka.http.javadsl.model.HttpCharset;
 import akka.japi.Pair;
 import akka.parboiled2.CharPredicate;
 import akka.parboiled2.ParserInput$;

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
@@ -263,7 +263,7 @@ private[http] object Http2 extends ExtensionId[Http2Ext] with ExtensionIdProvide
   override def get(system: ClassicActorSystemProvider): Http2Ext = super.get(system)
   def apply()(implicit system: ClassicActorSystemProvider): Http2Ext = super.apply(system)
   override def apply(system: ActorSystem): Http2Ext = super.apply(system)
-  def lookup(): ExtensionId[_ <: Extension] = Http2
+  def lookup: ExtensionId[_ <: Extension] = Http2
   def createExtension(system: ExtendedActorSystem): Http2Ext = new Http2Ext()(system)
 
   private[http] type HttpImplementation = Flow[SslTlsInbound, SslTlsOutbound, ServerTerminator]

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -33,7 +33,7 @@ import akka.stream.scaladsl.Keep
 object Http extends ExtensionId[Http] with ExtensionIdProvider {
   override def get(system: ActorSystem): Http = super.get(system)
   override def get(system: ClassicActorSystemProvider): Http = super.get(system)
-  def lookup() = Http
+  def lookup = Http
   def createExtension(system: ExtendedActorSystem): Http = new Http(system)
 }
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -1105,7 +1105,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
   def apply()(implicit system: ClassicActorSystemProvider): HttpExt = super.apply(system)
   override def apply(system: ActorSystem): HttpExt = super.apply(system)
 
-  def lookup() = Http
+  def lookup = Http
 
   def createExtension(system: ExtendedActorSystem): HttpExt =
     new HttpExt(system.settings.config getConfig "akka.http")(system)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -53,40 +53,40 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   def modeledHeaderParsing: Boolean
 
   /* Java APIs */
-  override def getCookieParsingMode: js.ParserSettings.CookieParsingMode = cookieParsingMode
-  override def getHeaderValueCacheLimits: util.Map[String, Int] = headerValueCacheLimits.asJava
-  override def getMaxChunkExtLength = maxChunkExtLength
-  override def getUriParsingMode: akka.http.javadsl.model.Uri.ParsingMode = uriParsingMode
-  override def getMaxHeaderCount = maxHeaderCount
-  override def getMaxContentLength = maxContentLength
-  override def getMaxToStrictBytes = maxToStrictBytes
-  override def getMaxHeaderValueLength = maxHeaderValueLength
-  override def getIncludeTlsSessionInfoHeader = includeTlsSessionInfoHeader
-  override def getIncludeSslSessionAttribute = includeSslSessionAttribute
-  override def getIllegalHeaderWarnings = illegalHeaderWarnings
-  override def getIgnoreIllegalHeaderFor = ignoreIllegalHeaderFor
-  override def getMaxHeaderNameLength = maxHeaderNameLength
-  override def getMaxChunkSize = maxChunkSize
-  override def getMaxResponseReasonLength = maxResponseReasonLength
-  override def getMaxUriLength = maxUriLength
-  override def getMaxMethodLength = maxMethodLength
-  override def getMaxCommentParsingDepth: Int = maxCommentParsingDepth
-  override def getErrorLoggingVerbosity: js.ParserSettings.ErrorLoggingVerbosity = errorLoggingVerbosity
-  override def getIllegalResponseHeaderNameProcessingMode = illegalResponseHeaderNameProcessingMode
-  override def getIllegalResponseHeaderValueProcessingMode = illegalResponseHeaderValueProcessingMode
-  override def getConflictingContentTypeHeaderProcessingMode = conflictingContentTypeHeaderProcessingMode
+  override def getCookieParsingMode: js.ParserSettings.CookieParsingMode = this.cookieParsingMode
+  override def getHeaderValueCacheLimits: util.Map[String, Int] = this.headerValueCacheLimits.asJava
+  override def getMaxChunkExtLength = this.maxChunkExtLength
+  override def getUriParsingMode: akka.http.javadsl.model.Uri.ParsingMode = this.uriParsingMode
+  override def getMaxHeaderCount = this.maxHeaderCount
+  override def getMaxContentLength = this.maxContentLength
+  override def getMaxToStrictBytes = this.maxToStrictBytes
+  override def getMaxHeaderValueLength = this.maxHeaderValueLength
+  override def getIncludeTlsSessionInfoHeader = this.includeTlsSessionInfoHeader
+  override def getIncludeSslSessionAttribute = this.includeSslSessionAttribute
+  override def getIllegalHeaderWarnings = this.illegalHeaderWarnings
+  override def getIgnoreIllegalHeaderFor = this.ignoreIllegalHeaderFor
+  override def getMaxHeaderNameLength = this.maxHeaderNameLength
+  override def getMaxChunkSize = this.maxChunkSize
+  override def getMaxResponseReasonLength = this.maxResponseReasonLength
+  override def getMaxUriLength = this.maxUriLength
+  override def getMaxMethodLength = this.maxMethodLength
+  override def getMaxCommentParsingDepth: Int = this.maxCommentParsingDepth
+  override def getErrorLoggingVerbosity: js.ParserSettings.ErrorLoggingVerbosity = this.errorLoggingVerbosity
+  override def getIllegalResponseHeaderNameProcessingMode = this.illegalResponseHeaderNameProcessingMode
+  override def getIllegalResponseHeaderValueProcessingMode = this.illegalResponseHeaderValueProcessingMode
+  override def getConflictingContentTypeHeaderProcessingMode = this.conflictingContentTypeHeaderProcessingMode
 
   override def getCustomMethods = new Function[String, Optional[akka.http.javadsl.model.HttpMethod]] {
-    override def apply(t: String) = OptionConverters.toJava(customMethods(t))
+    override def apply(t: String) = OptionConverters.toJava(self.customMethods(t))
   }
   override def getCustomStatusCodes = new Function[Int, Optional[akka.http.javadsl.model.StatusCode]] {
-    override def apply(t: Int) = OptionConverters.toJava(customStatusCodes(t))
+    override def apply(t: Int) = OptionConverters.toJava(self.customStatusCodes(t))
   }
   override def getCustomMediaTypes = new akka.japi.function.Function2[String, String, Optional[akka.http.javadsl.model.MediaType]] {
     override def apply(mainType: String, subType: String): Optional[model.MediaType] =
-      OptionConverters.toJava(customMediaTypes(mainType, subType))
+      OptionConverters.toJava(self.customMediaTypes(mainType, subType))
   }
-  def getModeledHeaderParsing: Boolean = modeledHeaderParsing
+  def getModeledHeaderParsing: Boolean = this.modeledHeaderParsing
 
   // override for more specific return type
   override def withMaxUriLength(newValue: Int): ParserSettings = self.copy(maxUriLength = newValue)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -59,32 +59,32 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
 
   /* Java APIs */
 
-  override def getBacklog = backlog
-  override def getPreviewServerSettings: akka.http.javadsl.settings.PreviewServerSettings = previewServerSettings
-  override def getDefaultHostHeader = defaultHostHeader.asJava
-  override def getPipeliningLimit = pipeliningLimit
-  override def getParserSettings: js.ParserSettings = parserSettings
-  override def getMaxConnections = maxConnections
-  override def getTransparentHeadRequests = transparentHeadRequests
-  override def getResponseHeaderSizeHint = responseHeaderSizeHint
-  override def getVerboseErrorMessages = verboseErrorMessages
-  override def getSocketOptions = socketOptions.asJava
-  override def getServerHeader = OptionConverters.toJava(serverHeader.map(_.asJava))
-  override def getTimeouts = timeouts
-  override def getRawRequestUriHeader = rawRequestUriHeader
-  override def getRemoteAddressHeader = remoteAddressHeader
-  override def getRemoteAddressAttribute: Boolean = remoteAddressAttribute
-  override def getLogUnencryptedNetworkBytes = OptionConverters.toJava(logUnencryptedNetworkBytes)
+  override def getBacklog = this.backlog
+  override def getPreviewServerSettings: akka.http.javadsl.settings.PreviewServerSettings = this.previewServerSettings
+  override def getDefaultHostHeader = this.defaultHostHeader.asJava
+  override def getPipeliningLimit = this.pipeliningLimit
+  override def getParserSettings: js.ParserSettings = this.parserSettings
+  override def getMaxConnections = this.maxConnections
+  override def getTransparentHeadRequests = this.transparentHeadRequests
+  override def getResponseHeaderSizeHint = this.responseHeaderSizeHint
+  override def getVerboseErrorMessages = this.verboseErrorMessages
+  override def getSocketOptions = this.socketOptions.asJava
+  override def getServerHeader = OptionConverters.toJava(this.serverHeader.map(_.asJava))
+  override def getTimeouts = this.timeouts
+  override def getRawRequestUriHeader = this.rawRequestUriHeader
+  override def getRemoteAddressHeader = this.remoteAddressHeader
+  override def getRemoteAddressAttribute: Boolean = this.remoteAddressAttribute
+  override def getLogUnencryptedNetworkBytes = OptionConverters.toJava(this.logUnencryptedNetworkBytes)
   @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.getRandomFactory instead", since = "10.2.0")
   override def getWebsocketRandomFactory = new Supplier[Random] {
-    override def get(): Random = websocketRandomFactory()
+    override def get(): Random = self.websocketRandomFactory()
   }
-  override def getDefaultHttpPort: Int = defaultHttpPort
-  override def getDefaultHttpsPort: Int = defaultHttpsPort
+  override def getDefaultHttpPort: Int = this.defaultHttpPort
+  override def getDefaultHttpsPort: Int = this.defaultHttpsPort
   override def getTerminationDeadlineExceededResponse: akka.http.javadsl.model.HttpResponse =
-    terminationDeadlineExceededResponse
-  override def getParsingErrorHandler: String = parsingErrorHandler
-  override def getStreamCancellationDelay: FiniteDuration = streamCancellationDelay
+    this.terminationDeadlineExceededResponse
+  override def getParsingErrorHandler: String = this.parsingErrorHandler
+  override def getStreamCancellationDelay: FiniteDuration = this.streamCancellationDelay
   // ---
 
   // override for more specific return type
@@ -100,7 +100,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   override def withBacklog(newValue: Int): ServerSettings = self.copy(backlog = newValue)
   override def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ServerSettings = self.copy(socketOptions = newValue.asScala.toList)
   @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead", since = "10.2.0")
-  override def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
+  override def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ServerSettings = self.copy(websocketSettings = this.websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
     override def get(): Random = newValue.get()
   }))
   override def getWebsocketSettings: WebSocketSettings = self.websocketSettings
@@ -118,7 +118,7 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def withDefaultHostHeader(newValue: Host): ServerSettings = self.copy(defaultHostHeader = newValue)
   def withParserSettings(newValue: ParserSettings): ServerSettings = self.copy(parserSettings = newValue)
   @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.withRandomFactoryFactory instead", since = "10.2.0")
-  def withWebsocketRandomFactory(newValue: () => Random): ServerSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
+  def withWebsocketRandomFactory(newValue: () => Random): ServerSettings = self.copy(websocketSettings = this.websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
     override def get(): Random = newValue()
   }))
   def withWebsocketSettings(newValue: WebSocketSettings): ServerSettings = self.copy(websocketSettings = newValue)
@@ -126,11 +126,11 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   def withHttp2Settings(newValue: Http2ServerSettings): ServerSettings = copy(http2Settings = newValue)
 
   // Scala-only lenses
-  def mapHttp2Settings(f: Http2ServerSettings => Http2ServerSettings): ServerSettings = withHttp2Settings(f(http2Settings))
-  def mapParserSettings(f: ParserSettings => ParserSettings): ServerSettings = withParserSettings(f(parserSettings))
-  def mapPreviewServerSettings(f: PreviewServerSettings => PreviewServerSettings): ServerSettings = withPreviewServerSettings(f(previewServerSettings))
-  def mapWebsocketSettings(f: WebSocketSettings => WebSocketSettings): ServerSettings = withWebsocketSettings(f(websocketSettings))
-  def mapTimeouts(f: ServerSettings.Timeouts => ServerSettings.Timeouts): ServerSettings = withTimeouts(f(timeouts))
+  def mapHttp2Settings(f: Http2ServerSettings => Http2ServerSettings): ServerSettings = withHttp2Settings(f(this.http2Settings))
+  def mapParserSettings(f: ParserSettings => ParserSettings): ServerSettings = withParserSettings(f(this.parserSettings))
+  def mapPreviewServerSettings(f: PreviewServerSettings => PreviewServerSettings): ServerSettings = withPreviewServerSettings(f(this.previewServerSettings))
+  def mapWebsocketSettings(f: WebSocketSettings => WebSocketSettings): ServerSettings = withWebsocketSettings(f(this.websocketSettings))
+  def mapTimeouts(f: ServerSettings.Timeouts => ServerSettings.Timeouts): ServerSettings = withTimeouts(f(this.timeouts))
 
   /**
    * INTERNAL API

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/WebSocketSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/WebSocketSettings.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 abstract class WebSocketSettings extends akka.http.javadsl.settings.WebSocketSettings { self: WebSocketSettingsImpl =>
   def randomFactory: () => Random
   override final val getRandomFactory: Supplier[Random] = new Supplier[Random] {
-    override def get(): Random = randomFactory()
+    override def get(): Random = self.randomFactory()
   }
   override def periodicKeepAliveMode: String
   override def periodicKeepAliveMaxIdle: Duration
@@ -27,7 +27,7 @@ abstract class WebSocketSettings extends akka.http.javadsl.settings.WebSocketSet
    */
   def periodicKeepAliveData: () => ByteString
   final def getPeriodicKeepAliveData: Supplier[ByteString] = new Supplier[ByteString] {
-    override def get(): ByteString = periodicKeepAliveData()
+    override def get(): ByteString = self.periodicKeepAliveData()
   }
 
   override def withRandomFactoryFactory(newValue: Supplier[Random]): WebSocketSettings =

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -542,7 +542,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
         lazy val requestIn = TestPublisher.probe[RequestContext]()
         lazy val responseOut = TestSubscriber.probe[ResponseContext]()
 
-        protected val server: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]]
+        protected def server: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]]
 
         protected def settings: ConnectionPoolSettings
 
@@ -699,7 +699,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
           connection.acceptConnectionPromise.future
         }
 
-        protected override lazy val server =
+        protected override lazy val server: Flow[HttpRequest, HttpResponse, Future[Http.OutgoingConnection]] =
           Flow.fromSinkAndSourceMat(
             // buffer is needed because the async subscriber/publisher boundary will otherwise request > 1
             Flow[HttpRequest].buffer(1, OverflowStrategy.backpressure)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/ResponseParserSpec.scala
@@ -386,7 +386,7 @@ abstract class ResponseParserSpec(mode: String, newLine: String) extends AkkaSpe
       generalRawMultiParseTo(GET, expected: _*)
     def generalRawMultiParseTo(requestMethod: HttpMethod, expected: Either[ResponseOutput, HttpResponse]*): Matcher[Seq[String]] =
       equal(expected.map(strictEqualify))
-        .matcher[Seq[Either[ResponseOutput, StrictEqualHttpResponse]]] compose { input: Seq[String] =>
+        .matcher[Seq[Either[ResponseOutput, StrictEqualHttpResponse]]] compose { (input: Seq[String]) =>
           collectBlocking {
             rawParse(requestMethod, input: _*)
               .mapAsync(1) {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/DateTimeSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/DateTimeSpec.scala
@@ -33,7 +33,7 @@ class DateTimeSpec extends AnyWordSpec with Matchers {
         fmt
       }
       def rfc1123Format(dt: DateTime) = Rfc1123Format.format(new java.util.Date(dt.clicks))
-      val matchSimpleDateFormat: Matcher[DateTime] = Matcher { dt: DateTime =>
+      val matchSimpleDateFormat: Matcher[DateTime] = Matcher { (dt: DateTime) =>
         MatchResult(
           dt.toRfc1123DateTimeString == rfc1123Format(dt),
           dt.toRfc1123DateTimeString + " != " + rfc1123Format(dt),
@@ -79,7 +79,7 @@ class DateTimeSpec extends AnyWordSpec with Matchers {
   "The two DateTime implementations" should {
     "allow for transparent round-trip conversions" in {
       def roundTrip(dt: DateTime) = DateTime(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second)
-      val roundTripOk: Matcher[DateTime] = Matcher { dt: DateTime =>
+      val roundTripOk: Matcher[DateTime] = Matcher { (dt: DateTime) =>
         MatchResult(
           { val rt = roundTrip(dt); dt == rt && dt.weekday == rt.weekday },
           dt.toRfc1123DateTimeString + " != " + roundTrip(dt).toRfc1123DateTimeString,

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -273,7 +273,7 @@ class HttpEntitySpec extends AkkaSpecWithMaterializer {
     }
 
   def renderStrictDataAs(dataRendering: String): Matcher[Strict] =
-    Matcher { strict: Strict =>
+    Matcher { (strict: Strict) =>
       val expectedRendering = s"${strict.productPrefix}(${strict.contentType},$dataRendering)"
       MatchResult(
         strict.toString == expectedRendering,

--- a/akka-http-tests/src/test/scala-2.13-/src/main/akka/http/ccompat/ImplicitUtils.scala
+++ b/akka-http-tests/src/test/scala-2.13-/src/main/akka/http/ccompat/ImplicitUtils.scala
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.ccompat
+
+object ImplicitUtils

--- a/akka-http-tests/src/test/scala-2.13/src/main/akka/http/ccompat/ImplicitUtils.scala
+++ b/akka-http-tests/src/test/scala-2.13/src/main/akka/http/ccompat/ImplicitUtils.scala
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.ccompat
+
+object ImplicitUtils

--- a/akka-http-tests/src/test/scala-3/src/main/akka/http/ccompat/ImplicitUtils.scala
+++ b/akka-http-tests/src/test/scala-3/src/main/akka/http/ccompat/ImplicitUtils.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.http.ccompat
+
+import scala.collection.immutable.StringOps
+
+object ImplicitUtils {
+  // Scala 3 resolves implicit conversions differently than Scala 2,
+  // in some instances overriding StringOps operations, like *.
+  implicit class Scala3StringOpsFix(string: String) {
+    def *(amount: Int): String = StringOps(string) * amount
+  }
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -81,7 +81,7 @@ abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String
     }
   }
 
-  override def afterAll = TestKit.shutdownActorSystem(system)
+  override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 }
 
 class LegacyPoolDontLeakActorsOnFailingConnectionSpecs extends DontLeakActorsOnFailingConnectionSpecs("legacy")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -30,6 +30,8 @@ import org.scalatest.wordspec.AnyWordSpec
 @nowarn("msg=synchronous compression with `encode` is not supported in the future any more")
 class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with BeforeAndAfterAll with ScalaFutures {
 
+  import akka.http.ccompat.ImplicitUtils._
+
   val maxContentLength = 800
   // Protect network more than memory:
   val decodeMaxSize = 1600

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -20,6 +20,8 @@ import scala.concurrent.duration._
 
 class FileUploadDirectivesSpec extends RoutingSpec with Eventually {
 
+  import akka.http.ccompat.ImplicitUtils._
+
   // tests touches filesystem, so reqs may take longer than the default of 1.second to complete
   implicit val routeTimeout: RouteTestTimeout = RouteTestTimeout(6.seconds.dilated)
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FutureDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FutureDirectivesSpec.scala
@@ -123,7 +123,7 @@ class FutureDirectivesSpec extends RoutingSpec with Inside with TestKitBase {
       occurrences = 1,
       message = BasicRouteSpecs.defaultExnHandler500Error("XXX")
     ).intercept {
-        Get() ~> onSuccess(Future.failed(TestException)) { echoComplete } ~> check {
+        Get() ~> onSuccess(Future.failed[Int](TestException)) { echoComplete } ~> check {
           status shouldEqual StatusCodes.InternalServerError
         }
       }
@@ -137,7 +137,7 @@ class FutureDirectivesSpec extends RoutingSpec with Inside with TestKitBase {
       occurrences = 1,
       message = BasicRouteSpecs.defaultExnHandler500Error("XXX")
     ).intercept {
-        Get() ~> onSuccess(Future.failed(TestException)) { throwTestException("EX when ") } ~> check {
+        Get() ~> onSuccess(Future.failed[Unit](TestException)) { throwTestException("EX when ") } ~> check {
           status shouldEqual StatusCodes.InternalServerError
           responseAs[String] shouldEqual "There was an internal server error."
         }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -19,6 +19,8 @@ import scala.annotation.nowarn
 @nowarn("msg=use remote-address-attribute instead")
 class MiscDirectivesSpec extends RoutingSpec {
 
+  import akka.http.ccompat.ImplicitUtils._
+
   "the extractClientIP directive" should {
     "extract from a X-Forwarded-For header" in {
       Get() ~> addHeaders(`X-Forwarded-For`(remoteAddress("2.3.4.5")), RawHeader("x-real-ip", "1.2.3.4")) ~> {

--- a/build.sbt
+++ b/build.sbt
@@ -130,14 +130,6 @@ val scalaMacroSupport = Seq(
   }),
 )
 
-val scala3MigrationModeOption =
-  scalacOptions ++= {
-    if (scalaVersion.value startsWith "3")
-      Seq("-source:3.0-migration")
-    else
-      Nil
-  }
-
 lazy val parsing = project("akka-parsing")
   .settings(commonSettings)
   .settings(AutomaticModuleName.settings("akka.http.parsing"))
@@ -279,7 +271,6 @@ lazy val httpTests = project("akka-http-tests")
       targetFile
     }
   )
-  .settings(scala3MigrationModeOption)
 
 lazy val httpJmhBench = project("akka-http-bench-jmh")
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -164,7 +164,6 @@ lazy val httpCore = project("akka-http-core")
       if (System.getProperty("akka.http.test-against-akka-main", "false") == "true") AkkaDependency.masterSnapshot
       else AkkaDependency.default
   )
-  .settings(scala3MigrationModeOption)
   .settings(Dependencies.httpCore)
   .settings(VersionGenerator.versionSettings)
   .settings(scalaMacroSupport)


### PR DESCRIPTION
References #4079, task `Make compilation work without 3.0-migration compiler option`
