### PR TITLE
scala 3: enable cross building for 2.12 again

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.13, 3]
+        SCALA_VERSION: [2.12, 2.13, 3]
         JABBA_JDK: [1.8]
     steps:
       - name: Checkout


### PR DESCRIPTION
To verify that we have nothing broken so far.