### PR TITLE
core: use LIFO ordering in retry buffer of connection pool

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -100,7 +100,7 @@ private[client] object NewHostConnectionPool {
             dispatchRequest(nextRequest)
             pullIfNeeded()
           } else // embargo might change state from unconnected -> embargoed losing an idle slot between the pull and the push here
-            retryBuffer.addLast(nextRequest)
+            retryBuffer.addFirst(nextRequest)
         }
         def onPull(): Unit =
           if (!slotsWaitingForDispatch.isEmpty)


### PR DESCRIPTION
During connection problems, all slots will back off connection attempts,
so that effectively only a single request can make a new attempt (out of
potentially `max-connections` ones already pulled into the pool). However,
the previous order of putting requests back into the retry buffer means that
all requests in the pool get equal chances to run again. This way all requests
will fail approximately at the same time only after all requests have almost
timed out.

Using a LIFO buffer instead, makes it more likely that only a single request
at a time will get the chance to make another try, so it can be failed earlier,
then the next, etc. It does not change the overall throughput of failing requests
but decreases the average latency.

Refs #4128