### PR TITLE
Make `toStrictEntity` fail with bad request in case of entity errors

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
@@ -206,17 +206,19 @@ class BasicDirectivesSpec extends RoutingSpec {
           complete("content")
         }
       } ~> check {
-        entityAs[String] shouldEqual s"Request too large"
+        entityAs[String] shouldEqual "Request too large"
         status shouldEqual StatusCodes.BadRequest
       }
     }
 
     "return 400 Bad request on EntityStreamException" in {
       val errorMessage = "An EntityStreamException error"
-      val failingEntity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, Source.failed(EntityStreamException(errorMessage)))
+      val errorDetail = "The internal details of the error"
+      val entity = Source.failed(EntityStreamException(errorMessage, errorDetail))
+      val request = HttpEntity(ContentTypes.`text/plain(UTF-8)`, entity)
       val timeout = 10.milliseconds
 
-      Post("/abc", failingEntity) ~> {
+      Post("/abc", request) ~> {
         extractStrictEntity(timeout) { _ =>
           complete("content")
         }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
@@ -197,6 +197,21 @@ class BasicDirectivesSpec extends RoutingSpec {
       }
     }
 
+    "return 400 Bad request on EntityStreamException" in {
+      val errorMessage = "An EntityStreamException error"
+      val failingEntity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, Source.failed(EntityStreamException(errorMessage)))
+      val timeout = 10.milliseconds
+
+      Post("/abc", failingEntity) ~> {
+        extractStrictEntity(timeout) { _ =>
+          complete("content")
+        }
+      } ~> check {
+        entityAs[String] shouldEqual errorMessage
+        status shouldEqual StatusCodes.BadRequest
+      }
+    }
+
     "return 500 InternalServerError status if response generation timed out" in {
       Get("/abc") ~> {
         extractStrictEntity(1.second) { _ =>

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/BasicDirectivesSpec.scala
@@ -197,6 +197,20 @@ class BasicDirectivesSpec extends RoutingSpec {
       }
     }
 
+    "return 400 Bad Request if max size is exceeded" in {
+      val request = HttpEntity(ContentTypes.`text/plain(UTF-8)`, Source.single(ByteString("abcd")))
+      val timeout = 10.milliseconds
+
+      Post("/abc", request) ~> {
+        extractStrictEntity(timeout, 2) { _ =>
+          complete("content")
+        }
+      } ~> check {
+        entityAs[String] shouldEqual s"Request too large"
+        status shouldEqual StatusCodes.BadRequest
+      }
+    }
+
     "return 400 Bad request on EntityStreamException" in {
       val errorMessage = "An EntityStreamException error"
       val failingEntity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, Source.failed(EntityStreamException(errorMessage)))

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
@@ -402,6 +402,8 @@ trait BasicDirectives {
           throw IllegalRequestException(
             StatusCodes.RequestTimeout,
             ErrorInfo(s"Request timed out after $timeout while waiting for entity data", "Consider increasing the timeout for toStrict"))
+        case EntityStreamException(info) =>
+          throw IllegalRequestException(StatusCodes.BadRequest, info)
       }.flatMap { strictEntity =>
         val newCtx = ctx.mapRequest(_.withEntity(strictEntity))
         inner(())(newCtx)


### PR DESCRIPTION
Fixes https://github.com/akka/akka-http/issues/4134

Unsure what exactly to add to the docstring, if anything. Could be something like `Fails the route with an [IllegalRequestException] if the request framing is invalid` - thoughts?

This rethrows `EntityStreamException` as `IllegalRequestException`. This matches more things than the above issue - eg. situations such as exceeding the max entity size. Turns out, exceeding the max entity size also resulted in an internal server error previously and due to this change now results in a bad request - it really ought to be a 413 entity too large, but I can't really distinguish these errors as they currently use the same underlying exception types. But at least 400 Bad Request is better than 500 internal error.