### PR TITLE
Update scala-xml to latest version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
   }
 
   object Compile {
-    val scalaXml      = "org.scala-lang.modules"      %% "scala-xml"                   % "1.3.0" // Scala License
+    val scalaXml      = "org.scala-lang.modules"      %% "scala-xml"                   % "2.1.0" // Scala License
 
     // For akka-http spray-json support
     val sprayJson   = "io.spray"                     %% "spray-json"                   % "1.3.6"       // ApacheV2


### PR DESCRIPTION
This PR updates scala-xml to the latest version being 2.1.0, see the release notes here https://github.com/scala/scala-xml/releases/tag/v2.1.0 .

I am creating this PR because it caused a dependency conflict, i.e.

```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* org.scala-lang.modules:scala-xml_2.13:2.1.0 (early-semver) is selected over 1.3.0
[error] 	    +- org.scoverage:scalac-scoverage-reporter_2.13:2.0.0 (depends on 2.1.0)
[error] 	    +- com.typesafe.akka:akka-http-xml_2.13:10.2.9        (depends on 1.3.0)
```

I am not sure what effects this will have with akka-http bincompat guarantees, it may be that this dependency bump can only be done for the next major release of akka-http?