### PR TITLE
Update naming for status codes 413 and 422

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/StatusCodes.java
@@ -57,10 +57,16 @@ public final class StatusCodes {
     public static final StatusCode GONE = akka.http.scaladsl.model.StatusCodes.Gone();
     public static final StatusCode LENGTH_REQUIRED = akka.http.scaladsl.model.StatusCodes.LengthRequired();
     public static final StatusCode PRECONDITION_FAILED = akka.http.scaladsl.model.StatusCodes.PreconditionFailed();
+    public static final StatusCode CONTENT_TOO_LARGE = akka.http.scaladsl.model.StatusCodes.ContentTooLarge();
+
+    /**
+     * @deprecated deprecated in favor of CONTENT_TOO_LARGE
+     */
+    @Deprecated
     public static final StatusCode PAYLOAD_TOO_LARGE = akka.http.scaladsl.model.StatusCodes.PayloadTooLarge();
 
     /**
-     * @deprecated deprecated in favor of PAYLOAD_TOO_LARGE
+     * @deprecated deprecated in favor of CONTENT_TOO_LARGE
      */
     @Deprecated
     public static final StatusCode REQUEST_ENTITY_TOO_LARGE = akka.http.scaladsl.model.StatusCodes.RequestEntityTooLarge();
@@ -83,6 +89,12 @@ public final class StatusCodes {
     public static final StatusCode IM_A_TEAPOT = akka.http.scaladsl.model.StatusCodes.ImATeapot();
     public static final StatusCode ENHANCE_YOUR_CALM = akka.http.scaladsl.model.StatusCodes.EnhanceYourCalm();
     public static final StatusCode MISDIRECTED_REQUEST = akka.http.scaladsl.model.StatusCodes.MisdirectedRequest();
+    public static final StatusCode UNPROCESSABLE_CONTENT = akka.http.scaladsl.model.StatusCodes.UnprocessableContent();
+
+    /**
+     * @deprecated deprecated in favor of UNPROCESSABLE_CONTENT
+     */
+    @Deprecated
     public static final StatusCode UNPROCESSABLE_ENTITY = akka.http.scaladsl.model.StatusCodes.UnprocessableEntity();
     public static final StatusCode LOCKED = akka.http.scaladsl.model.StatusCodes.Locked();
     public static final StatusCode FAILED_DEPENDENCY = akka.http.scaladsl.model.StatusCodes.FailedDependency();

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
@@ -209,7 +209,7 @@ private[http] final class HttpRequestParser(
             setCompletionHandling(HttpMessageParser.CompletionOk)
             startNewMessage(input, bodyStart)
           } else if (!method.isEntityAccepted) {
-            failMessageStart(UnprocessableEntity, s"${method.name} requests must not have an entity")
+            failMessageStart(UnprocessableContent, s"${method.name} requests must not have an entity")
           } else if (contentLength <= input.size - bodyStart) {
             val cl = contentLength.toInt
             emitRequestStart(strictEntity(cth, input, bodyStart, cl))
@@ -221,7 +221,7 @@ private[http] final class HttpRequestParser(
           }
         } else {
           if (!method.isEntityAccepted) {
-            failMessageStart(UnprocessableEntity, s"${method.name} requests must not have an entity")
+            failMessageStart(UnprocessableContent, s"${method.name} requests must not have an entity")
           } else {
             if (clh.isEmpty) {
               emitRequestStart(chunkedEntity(cth), headers)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -499,7 +499,7 @@ private[http] object HttpServerBluePrint {
                 case None     => s"Aggregated data length of request entity exceeds the configured limit of $limit bytes"
               }
               val info = ErrorInfo(summary, "Consider increasing the value of akka.http.server.parsing.max-content-length")
-              finishWithIllegalRequestError(StatusCodes.PayloadTooLarge, info)
+              finishWithIllegalRequestError(StatusCodes.ContentTooLarge, info)
 
             case IllegalUriException(errorInfo) =>
               finishWithIllegalRequestError(StatusCodes.BadRequest, errorInfo)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala
@@ -141,9 +141,11 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val Gone                         = reg(c(410)("Gone", "The resource requested is no longer available and will not be available again."))
   val LengthRequired               = reg(c(411)("Length Required", "The request did not specify the length of its content, which is required by the requested resource."))
   val PreconditionFailed           = reg(c(412)("Precondition Failed", "The server does not meet one of the preconditions that the requester put on the request."))
-  val PayloadTooLarge              = reg(c(413)("Payload Too Large", "The request payload is larger than the server is willing or able to process."))
-  @deprecated("deprecated in favor of PayloadTooLarge", "10.1.11")
-  val RequestEntityTooLarge        = PayloadTooLarge
+  val ContentTooLarge              = reg(c(413)("Content Too Large", "The request content is larger than the server is willing or able to process."))
+  @deprecated("deprecated in favor of ContentTooLarge", "10.4.0")
+  val PayloadTooLarge              = ContentTooLarge
+  @deprecated("deprecated in favor of ContentTooLarge", "10.4.0")
+  val RequestEntityTooLarge        = ContentTooLarge
   val UriTooLong                   = reg(c(414)("URI Too Long", "The URI provided was too long for the server to process."))
   @deprecated("deprecated in favor of UriTooLong", "10.1.11")
   val RequestUriTooLong            = UriTooLong
@@ -155,7 +157,9 @@ object StatusCodes extends ObjectRegistry[Int, StatusCode] {
   val ImATeapot                    = reg(c(418)("I'm a teapot", "The resulting entity body MAY be short and stout."))
   val EnhanceYourCalm              = reg(c(420)("Enhance Your Calm", "You are being rate-limited.")) // Twitter only
   val MisdirectedRequest           = reg(c(421)("Misdirected Request", "The request was directed at a server that is not able to produce a response.")) // HTTP/2 only. https://tools.ietf.org/html/rfc7540#section-9.1.2
-  val UnprocessableEntity          = reg(c(422)("Unprocessable Entity", "The request was well-formed but was unable to be followed due to semantic errors."))
+  val UnprocessableContent          = reg(c(422)("Unprocessable Content", "The request was well-formed but was unable to be followed due to semantic errors."))
+  @deprecated("deprecated in favor of UnprocessableContent", "10.4.0")
+  val UnprocessableEntity          = UnprocessableContent
   val Locked                       = reg(c(423)("Locked", "The resource that is being accessed is locked."))
   val FailedDependency             = reg(c(424)("Failed Dependency", "The request failed due to failure of a previous request."))
   val TooEarly                     = reg(c(425)("Too Early", "The server is unwilling to risk processing a request that might be replayed.")) // RFC 8470

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -1345,7 +1345,7 @@ class HttpServerSpec extends AkkaSpec(
                 responses.sendError(error.asInstanceOf[Exception])
 
                 expectResponseWithWipedDate(
-                  s"""HTTP/1.1 413 Payload Too Large
+                  s"""HTTP/1.1 413 Content Too Large
                       |Server: akka-http/test
                       |Date: XXXX
                       |Connection: close
@@ -1369,7 +1369,7 @@ class HttpServerSpec extends AkkaSpec(
                 responses.sendError(error.asInstanceOf[Exception])
 
                 expectResponseWithWipedDate(
-                  s"""HTTP/1.1 413 Payload Too Large
+                  s"""HTTP/1.1 413 Content Too Large
                     |Server: akka-http/test
                     |Date: XXXX
                     |Connection: close

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
@@ -88,7 +88,7 @@ public class MiscDirectivesTest extends JUnitRouteTest {
 
     route
       .run(withEntityOfSize(501))
-      .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE);
+      .assertStatusCode(StatusCodes.CONTENT_TOO_LARGE);
 
   }
 

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/RouteDirectivesTest.java
@@ -89,7 +89,7 @@ public class RouteDirectivesTest extends JUnitRouteTest {
 
     route
       .run(HttpRequest.create("/limit-5").withEntity("1234567890"))
-      .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE)
+      .assertStatusCode(StatusCodes.CONTENT_TOO_LARGE)
       .assertEntity("EntityStreamSizeException: incoming entity size (10) exceeded size limit (5 bytes)! " +
               "This may have been a parser limit (set via `akka.http.[server|client].parsing.max-content-length`), " +
 	      "a decoder limit (set via `akka.http.routing.decode-max-size`), " +

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -66,7 +66,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
 
     "not accept entities bigger than configured with akka.http.parsing.max-content-length" in {
       Http().singleRequest(Post(s"http:/${binding.localAddress}/noDirective", entityOfSize(maxContentLength + 1)))
-        .futureValue.status shouldEqual StatusCodes.PayloadTooLarge
+        .futureValue.status shouldEqual StatusCodes.ContentTooLarge
     }
   }
 
@@ -102,7 +102,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
       data.size should be > decodeMaxSize
 
       Http().singleRequest(request)
-        .futureValue.status shouldEqual StatusCodes.PayloadTooLarge
+        .futureValue.status shouldEqual StatusCodes.ContentTooLarge
     }
   }
 
@@ -124,7 +124,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
     "reject a small request that decodes into a large chunked entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
       val response = Http().singleRequest(request).futureValue
-      response.status shouldEqual StatusCodes.PayloadTooLarge
+      response.status shouldEqual StatusCodes.ContentTooLarge
     }
   }
 
@@ -146,7 +146,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
     "reject a small request that decodes into a large non-chunked streaming entity" in {
       val request = Post(s"http:/${binding.localAddress}/noDirective", "x").withHeaders(`Content-Encoding`(HttpEncoding("custom")))
       val response = Http().singleRequest(request).futureValue
-      response.status shouldEqual StatusCodes.PayloadTooLarge
+      response.status shouldEqual StatusCodes.ContentTooLarge
     }
   }
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/MiscDirectivesSpec.scala
@@ -105,7 +105,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", entityOfSize(501)) ~> Route.seal(route) ~> check {
-        status shouldEqual StatusCodes.PayloadTooLarge
+        status shouldEqual StatusCodes.ContentTooLarge
         entityAs[String] should include("exceeded size limit")
       }
     }
@@ -123,7 +123,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", formDataOfSize(128)) ~> Route.seal(route) ~> check {
-        status shouldEqual StatusCodes.PayloadTooLarge
+        status shouldEqual StatusCodes.ContentTooLarge
         responseAs[String] shouldEqual "The request content was malformed:\n" +
           "EntityStreamSizeException: incoming entity size (134) " +
           "exceeded size limit (64 bytes)! " +
@@ -148,7 +148,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", entityOfSize(801)) ~> Route.seal(route) ~> check {
-        status shouldEqual StatusCodes.PayloadTooLarge
+        status shouldEqual StatusCodes.ContentTooLarge
         entityAs[String] should include("exceeded size limit")
       }
 
@@ -166,7 +166,7 @@ class MiscDirectivesSpec extends RoutingSpec {
       }
 
       Post("/abc", entityOfSize(401)) ~> Route.seal(route2) ~> check {
-        status shouldEqual StatusCodes.PayloadTooLarge
+        status shouldEqual StatusCodes.ContentTooLarge
         entityAs[String] should include("exceeded size limit")
       }
     }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -53,9 +53,9 @@ object ExceptionHandler {
         ctx.complete((status, info.format(settings.verboseErrorMessages)))
       }
       case e: EntityStreamSizeException => ctx => {
-        ctx.log.error(e, ErrorMessageTemplate, e, PayloadTooLarge)
+        ctx.log.error(e, ErrorMessageTemplate, e, ContentTooLarge)
         ctx.request.discardEntityBytes(ctx.materializer)
-        ctx.complete((PayloadTooLarge, e.getMessage))
+        ctx.complete((ContentTooLarge, e.getMessage))
       }
       case e: ExceptionWithErrorInfo => ctx => {
         ctx.log.error(e, ErrorMessageTemplate, e.info.formatPretty, InternalServerError)

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RejectionHandler.scala
@@ -190,7 +190,7 @@ object RejectionHandler {
         case MalformedRequestContentRejection(msg, throwable) => {
           val rejectionMessage = "The request content was malformed:\n" + msg
           throwable match {
-            case _: EntityStreamSizeException => rejectRequestEntityAndComplete((PayloadTooLarge, rejectionMessage))
+            case _: EntityStreamSizeException => rejectRequestEntityAndComplete((ContentTooLarge, rejectionMessage))
             case _                            => rejectRequestEntityAndComplete((BadRequest, rejectionMessage))
           }
         }

--- a/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/MiscDirectivesExamplesTest.java
@@ -86,7 +86,7 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
       .assertStatusCode(StatusCodes.OK);
 
     testRoute(route).run(withEntityOfSize.apply(501))
-      .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE);
+      .assertStatusCode(StatusCodes.CONTENT_TOO_LARGE);
     //#withSizeLimitExample
   }
 
@@ -111,7 +111,7 @@ public class MiscDirectivesExamplesTest extends JUnitRouteTest {
             .assertStatusCode(StatusCodes.OK);
 
     testRoute(route).run(withEntityOfSize.apply(801))
-            .assertStatusCode(StatusCodes.PAYLOAD_TOO_LARGE);
+            .assertStatusCode(StatusCodes.CONTENT_TOO_LARGE);
     //#withSizeLimitExampleNested
   }
 

--- a/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/server/directives/MiscDirectivesExamplesSpec.scala
@@ -129,7 +129,7 @@ class MiscDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     }
 
     Post("/abc", entityOfSize(501)) ~> Route.seal(route) ~> check {
-      status shouldEqual StatusCodes.PayloadTooLarge
+      status shouldEqual StatusCodes.ContentTooLarge
     }
 
     //#withSizeLimit-example
@@ -174,7 +174,7 @@ class MiscDirectivesExamplesSpec extends RoutingSpec with CompileOnlySpec {
     }
 
     Post("/abc", entityOfSize(801)) ~> Route.seal(route) ~> check {
-      status shouldEqual StatusCodes.PayloadTooLarge
+      status shouldEqual StatusCodes.ContentTooLarge
     }
     //#withSizeLimit-nested-example
   }


### PR DESCRIPTION
I think the naming changed in RFC 9110, see https://www.rfc-editor.org/rfc/rfc9110.html#name-413-content-too-large and https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content.