### PR TITLE
Update to Jackson databind 2.13.4.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ import scala.language.implicitConversions
 object Dependencies {
   import DependencyHelpers._
 
-  val jacksonDatabindVersion = "2.13.4"
+  val jacksonDatabindVersion = "2.13.4.1"
   val jacksonXmlVersion = "2.13.4"
   val junitVersion = "4.13.2"
   val h2specVersion = "1.5.0"


### PR DESCRIPTION
* Fixes https://nvd.nist.gov/vuln/detail/CVE-2022-42003 (even if we were not really affected out of the box).
