### PR TITLE
chore: Silence or fix most compilation warnings

### DIFF
--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ConnectionPoolBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ConnectionPoolBenchmark.scala
@@ -14,7 +14,6 @@ import akka.http.impl.util.enhanceString_
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
 import akka.http.scaladsl.{ ClientTransport, Http }
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
@@ -33,7 +32,6 @@ class ConnectionPoolBenchmark extends CommonBenchmark {
   var maxConnections: String = _
 
   implicit var system: ActorSystem = _
-  implicit var mat: ActorMaterializer = _
   implicit def ec: ExecutionContext = system.dispatcher
 
   private var poolSettings: ConnectionPoolSettings = _
@@ -67,7 +65,6 @@ class ConnectionPoolBenchmark extends CommonBenchmark {
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
-    mat = ActorMaterializer()
 
     val responseBytes = ByteString(
       """HTTP/1.1 200 OK

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HttpEntityBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/HttpEntityBenchmark.scala
@@ -11,7 +11,6 @@ import akka.dispatch.ExecutionContexts
 import akka.http.CommonBenchmark
 import akka.http.scaladsl.model.{ ContentTypes, HttpEntity }
 import akka.stream.scaladsl.Source
-import akka.stream.{ ActorMaterializer, Materializer }
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
 import org.openjdk.jmh.annotations.{ Benchmark, Param, Setup, TearDown }
@@ -21,14 +20,13 @@ class HttpEntityBenchmark extends CommonBenchmark {
   var entityType: String = _
 
   implicit var system: ActorSystem = _
-  implicit var mat: Materializer = _
 
   var entity: HttpEntity = _
 
   @Benchmark
   def discardBytes(): Unit = {
     val latch = new CountDownLatch(1)
-    entity.discardBytes(mat)
+    entity.discardBytes()
       .future
       .onComplete(_ => latch.countDown())(ExecutionContexts.parasitic)
     latch.await()
@@ -44,7 +42,6 @@ class HttpEntityBenchmark extends CommonBenchmark {
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
-    mat = ActorMaterializer()
 
     entity = entityType match {
       case "strict" =>

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/ServerProcessingBenchmark.scala
@@ -13,7 +13,6 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.TLSPlacebo
@@ -27,7 +26,6 @@ class ServerProcessingBenchmark extends CommonBenchmark {
 
   var httpFlow: Flow[ByteString, ByteString, Any] = _
   implicit var system: ActorSystem = _
-  implicit var mat: ActorMaterializer = _
 
   @Benchmark
   @OperationsPerInvocation(10000)
@@ -52,7 +50,6 @@ class ServerProcessingBenchmark extends CommonBenchmark {
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
-    mat = ActorMaterializer()
     httpFlow =
       Flow[HttpRequest].map(_ => response) join
         (HttpServerBluePrint(ServerSettings(system), NoLogging, false, Http().dateHeaderRendering) atop

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/StreamServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/StreamServerProcessingBenchmark.scala
@@ -17,7 +17,6 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.headers
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
@@ -47,7 +46,6 @@ class StreamServerProcessingBenchmark extends CommonBenchmark {
   var httpFlow: Flow[ByteString, ByteString, Any] = _
 
   implicit var system: ActorSystem = _
-  implicit var mat: ActorMaterializer = _
 
   @Benchmark
   def benchRequestProcessing(): Unit = {
@@ -73,7 +71,6 @@ class StreamServerProcessingBenchmark extends CommonBenchmark {
         """)
         .withFallback(ConfigFactory.load())
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
-    mat = ActorMaterializer()
 
     val bytesPerChunk = totalBytes.toInt / numChunks.toInt
     totalExpectedBytes = numRequestsPerConnection.toInt * bytesPerChunk * numChunks.toInt

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ClientServerBenchmark.scala
@@ -11,7 +11,6 @@ import akka.http.impl.engine.server.ServerTerminator
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, ServerSettings }
-import akka.stream.ActorMaterializer
 import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
 import akka.stream.scaladsl.{ BidiFlow, Flow, Keep, Sink, Source }
 import akka.util.ByteString
@@ -28,7 +27,6 @@ import scala.concurrent.{ Await, ExecutionContext, Future }
 class H2ClientServerBenchmark extends CommonBenchmark with H2RequestResponseBenchmark {
   var httpFlow: Flow[HttpRequest, HttpResponse, Any] = _
   implicit var system: ActorSystem = _
-  implicit var mat: ActorMaterializer = _
 
   val numRequests = 1000
 
@@ -62,7 +60,6 @@ class H2ClientServerBenchmark extends CommonBenchmark with H2RequestResponseBenc
     initRequestResponse()
 
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
-    mat = ActorMaterializer()
     val settings = implicitly[ServerSettings]
     val log = system.log
     implicit val ec = system.dispatcher

--- a/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/impl/engine/http2/H2ServerProcessingBenchmark.scala
@@ -9,7 +9,6 @@ import akka.http.CommonBenchmark
 import akka.http.impl.engine.server.ServerTerminator
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.ActorMaterializer
 import akka.stream.TLSProtocol.{ SslTlsInbound, SslTlsOutbound }
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.util.ByteString
@@ -23,7 +22,6 @@ class H2ServerProcessingBenchmark extends CommonBenchmark with H2RequestResponse
 
   var httpFlow: Flow[ByteString, ByteString, Any] = _
   implicit var system: ActorSystem = _
-  implicit var mat: ActorMaterializer = _
 
   val packedResponse = ByteString(1, 5, 0, 0) // a HEADERS frame with end_stream == true
 
@@ -61,7 +59,6 @@ class H2ServerProcessingBenchmark extends CommonBenchmark with H2RequestResponse
     initRequestResponse()
 
     system = ActorSystem("AkkaHttpBenchmarkSystem", config)
-    mat = ActorMaterializer()
     val settings = implicitly[ServerSettings]
     val log = system.log
     implicit val ec = system.dispatcher

--- a/akka-http-bench-jmh/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
+++ b/akka-http-bench-jmh/src/main/scala/akka/http/scaladsl/unmarshalling/sse/LineParserBenchmark.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.TimeUnit
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ FileIO, Keep, RunnableGraph, Sink, Source }
 import akka.util.ByteString
 import org.openjdk.jmh.annotations._
@@ -23,7 +22,6 @@ import scala.concurrent.duration._
 @BenchmarkMode(Array(Mode.AverageTime))
 class LineParserBenchmark {
   implicit val system: ActorSystem = ActorSystem("line-parser-benchmark")
-  implicit val mat: ActorMaterializer = ActorMaterializer()
 
   // @formatter:off
   @Param(Array(

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/HttpsProxyGraphStage.scala
@@ -168,7 +168,7 @@ private final class HttpsProxyGraphStage(
         }
       }
 
-      override def onDownstreamFinish(): Unit = cancel(sslIn)
+      override def onDownstreamFinish(cause: Throwable): Unit = cancel(sslIn)
 
     })
 
@@ -177,7 +177,7 @@ private final class HttpsProxyGraphStage(
         pull(bytesIn)
       }
 
-      override def onDownstreamFinish(): Unit = cancel(bytesIn)
+      override def onDownstreamFinish(cause: Throwable): Unit = cancel(bytesIn)
 
     })
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/OutgoingConnectionBlueprint.scala
@@ -198,7 +198,7 @@ private[http] object OutgoingConnectionBlueprint {
         if (!entitySubstreamStarted) pull(responseOutputIn)
       }
 
-      override def onDownstreamFinish(): Unit = {
+      override def onDownstreamFinish(cause: Throwable): Unit = {
         // if downstream cancels while streaming entity,
         // make sure we also cancel the entity source, but
         // after being done with streaming the entity

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterface.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterface.scala
@@ -14,7 +14,6 @@ import akka.http.impl.util._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.Http
 import akka.macros.LogHelper
-import akka.stream.ActorMaterializer
 import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet
@@ -58,7 +57,7 @@ private[http] object PoolInterface {
     import poolId.hcps
     import hcps._
     import setup.{ connectionContext, settings }
-    implicit val system = fm.asInstanceOf[ActorMaterializer].system
+    implicit val system = fm.system
     val log: LoggingAdapter = Logging(system, poolId)(PoolLogSource)
 
     log.debug("Creating pool.")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolMasterActor.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolMasterActor.scala
@@ -170,7 +170,7 @@ private[http] final class PoolMasterActor extends Actor with ActorLogging {
           // to this actor by the pool actor, they will be retried once the shutdown
           // has completed.
           val completed = pool.shutdown()(context.dispatcher)
-          shutdownCompletedPromise.tryCompleteWith(completed.map(_ => Done)(ExecutionContexts.sameThreadExecutionContext))
+          shutdownCompletedPromise.tryCompleteWith(completed.map(_ => Done)(ExecutionContexts.parasitic))
           statusById += poolId -> PoolInterfaceShuttingDown(shutdownCompletedPromise)
         case Some(PoolInterfaceShuttingDown(formerPromise)) =>
           // Pool is already shutting down, mirror the existing promise.

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/client/pool/NewHostConnectionPool.scala
@@ -362,8 +362,8 @@ private[client] object NewHostConnectionPool {
             def loop[U](event: Event[U], arg: U, remainingIterations: Int): Unit =
               if (remainingIterations > 0)
                 runOneTransition(event, arg) match {
-                  case OptionVal.None       => // no more changes
                   case OptionVal.Some(next) => loop(next, (), remainingIterations - 1)
+                  case _                    => // no more changes
                 }
               else
                 throw new IllegalStateException(
@@ -450,7 +450,7 @@ private[client] object NewHostConnectionPool {
                   entityComplete.onComplete(safely {
                     case Success(_)     => withSlot(_.onRequestEntityCompleted())
                     case Failure(cause) => withSlot(_.onRequestEntityFailed(cause))
-                  })(ExecutionContexts.sameThreadExecutionContext)
+                  })(ExecutionContexts.parasitic)
                   request.withEntity(newEntity)
               }
 
@@ -504,9 +504,9 @@ private[client] object NewHostConnectionPool {
                       ongoingResponseEntity = None
                       ongoingResponseEntityKillSwitch = None
                     }
-                  }(ExecutionContexts.sameThreadExecutionContext)
+                  }(ExecutionContexts.parasitic)
                 case Failure(_) => throw new IllegalStateException("Should never fail")
-              })(ExecutionContexts.sameThreadExecutionContext)
+              })(ExecutionContexts.parasitic)
 
               withSlot(_.onResponseReceived(response.withEntity(newEntity)))
             }
@@ -531,7 +531,7 @@ private[client] object NewHostConnectionPool {
 
           def onPull(): Unit = () // emitRequests makes sure not to push too early
 
-          override def onDownstreamFinish(): Unit =
+          override def onDownstreamFinish(cause: Throwable): Unit =
             withSlot { slot =>
               slot.debug("Connection cancelled")
               // Let's use StreamTcpException for now.
@@ -553,7 +553,7 @@ private[client] object NewHostConnectionPool {
                   requestOut.setHandler(connection)
                 }
 
-                override def onDownstreamFinish(): Unit = connection.onDownstreamFinish()
+                override def onDownstreamFinish(cause: Throwable): Unit = connection.onDownstreamFinish(cause)
               })
         }
         def openConnection(slot: Slot): SlotConnection = {
@@ -588,7 +588,7 @@ private[client] object NewHostConnectionPool {
                 onConnectionAttemptFailed(currentEmbargoLevel)
                 sl.onConnectionAttemptFailed(cause)
               }
-          })(ExecutionContexts.sameThreadExecutionContext)
+          })(ExecutionContexts.parasitic)
 
           slotCon
         }
@@ -601,9 +601,9 @@ private[client] object NewHostConnectionPool {
           log.debug("Pool upstream failed with {}", ex)
           super.onUpstreamFailure(ex)
         }
-        override def onDownstreamFinish(): Unit = {
+        override def onDownstreamFinish(cause: Throwable): Unit = {
           log.debug("Pool downstream cancelled")
-          super.onDownstreamFinish()
+          super.onDownstreamFinish(cause)
         }
         override def postStop(): Unit = {
           slots.foreach(_.shutdown())

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2.scala
@@ -29,6 +29,7 @@ import akka.util.ByteString
 import akka.Done
 
 import javax.net.ssl.SSLEngine
+import scala.annotation.nowarn
 import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
@@ -101,7 +102,7 @@ private[http] final class Http2Ext(implicit val system: ActorSystem)
                 // See https://github.com/akka/akka/issues/17992
                 case NonFatal(ex) =>
                   Done
-              }(ExecutionContexts.sameThreadExecutionContext)
+              }(ExecutionContexts.parasitic)
           } catch {
             case NonFatal(e) =>
               log.error(e, "Could not materialize handling flow for {}", incoming)
@@ -195,6 +196,8 @@ private[http] final class Http2Ext(implicit val system: ActorSystem)
     def getChosenProtocol(): String = chosenProtocol.getOrElse(Http2AlpnSupport.HTTP11) // default to http/1, e.g. when ALPN jar is missing
 
     var eng: Option[SSLEngine] = None
+
+    @nowarn("msg=deprecated")
     def createEngine(): SSLEngine = {
       val engine = httpsContext.sslContextData match {
         case Left(ssl) =>
@@ -215,6 +218,7 @@ private[http] final class Http2Ext(implicit val system: ActorSystem)
 
   def outgoingConnection(host: String, port: Int, connectionContext: HttpsConnectionContext, clientConnectionSettings: ClientConnectionSettings, log: LoggingAdapter): Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]] = {
     def createEngine(): SSLEngine = {
+      @nowarn("msg=deprecated")
       val engine = connectionContext.sslContextData match {
         // TODO FIXME configure hostname verification for this case
         case Left(ssl) =>

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -163,6 +163,7 @@ private[http] object Http2Blueprint {
         case NonFatal(ex) =>
           log.error(s"HTTP2 connection failed with error [${ex.getMessage}]. Sending INTERNAL_ERROR and closing connection.")
           FrameRenderer.render(GoAwayFrame(0, Http2Protocol.ErrorCode.INTERNAL_ERROR))
+        case other: Throwable => throw other // compiler completeness check pleaser
       },
       Flow[ByteString]
     )

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Multiplexer.scala
@@ -123,9 +123,9 @@ private[http2] trait Http2MultiplexerSupport { logic: GraphStageLogic with Stage
       /** Network pulls in new frames */
       def onPull(): Unit = updateState(_.onPull())
 
-      override def onDownstreamFinish(): Unit = {
+      override def onDownstreamFinish(cause: Throwable): Unit = {
         frameOutFinished()
-        super.onDownstreamFinish()
+        super.onDownstreamFinish(cause)
       }
 
       private var _state: MultiplexerState = Idle

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -779,7 +779,7 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
           if (headers.nonEmpty && !trailer.isEmpty)
             log.warning("Found both an attribute with trailing headers, and headers in the `LastChunk`. This is not supported.")
           trailer = OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, HttpMessageRendering.renderHeaders(headers, log, isServer, shouldRenderAutoHeaders = false, dateHeaderRendering = DateHeaderRendering.Unavailable), None))
-        case other => throw new IllegalArgumentException(s"Unexpected stream element $other") // compiler completeness check pleaser
+        case _ => throw new IllegalArgumentException("Unexpected stream element") // compiler completeness check pleaser
       }
 
       maybePull()

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
@@ -82,7 +82,7 @@ private[http2] sealed abstract class MessageRendering[R <: HttpMessage] extends 
     val trailingHeadersFrame =
       r.attribute(AttributeKeys.trailer) match {
         case Some(trailer) if trailer.headers.nonEmpty => OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, trailer.headers, None))
-        case None                                      => OptionVal.None
+        case _                                         => OptionVal.None
       }
 
     Http2SubStream(r.entity, headersFrame, trailingHeadersFrame, r.attributes.filter(_._2.isInstanceOf[RequestResponseAssociation]))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/ProtocolSwitch.scala
@@ -90,7 +90,7 @@ private[http] object ProtocolSwitch {
                 new OutHandler {
                   override def onPull(): Unit = pull(in)
 
-                  override def onDownstreamFinish(): Unit = cancel(in)
+                  override def onDownstreamFinish(cause: Throwable): Unit = cancel(in)
                 }
 
               val firstHandler =
@@ -134,9 +134,9 @@ private[http] object ProtocolSwitch {
               val outHandler = new OutHandler {
                 override def onPull(): Unit = in.pull()
 
-                override def onDownstreamFinish(): Unit = {
+                override def onDownstreamFinish(cause: Throwable): Unit = {
                   in.cancel()
-                  super.onDownstreamFinish()
+                  super.onDownstreamFinish(cause)
                 }
               }
               in.setHandler(handler)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
@@ -101,7 +101,7 @@ private[http2] object ResponseParsing {
           validateHeader(httpHeader)
           rec(remainingHeaders.tail, status, contentType, contentLength, seenRegularHeader = true, headers += httpHeader)
 
-        case other => throw new IllegalStateException(s"Unexpected remaining header $other") // compiler completeness check pleaser
+        case _ => throw new IllegalStateException("Unexpected remaining header") // compiler completeness check pleaser
       }
 
     rec(subStream.initialHeaders.keyValuePairs)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
@@ -100,6 +100,8 @@ private[http2] object ResponseParsing {
           val httpHeader = parseHeaderPair(httpHeaderParser, name, value)
           validateHeader(httpHeader)
           rec(remainingHeaders.tail, status, contentType, contentLength, seenRegularHeader = true, headers += httpHeader)
+
+        case other => throw new IllegalStateException(s"Unexpected remaining header $other") // compiler completeness check pleaser
       }
 
     rec(subStream.initialHeaders.keyValuePairs)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
@@ -91,7 +91,8 @@ private[http2] object FrameRenderer {
               b.putInt32(value)
 
               renderNext(remaining)
-            case Nil =>
+            case Nil   =>
+            case other => throw new IllegalArgumentException(s"Unexpected remaining: $other") // compiler completeness check pleaser
           }
 
         renderNext(settings)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/framing/FrameRenderer.scala
@@ -91,8 +91,8 @@ private[http2] object FrameRenderer {
               b.putInt32(value)
 
               renderNext(remaining)
-            case Nil   =>
-            case other => throw new IllegalArgumentException(s"Unexpected remaining: $other") // compiler completeness check pleaser
+            case Nil =>
+            case _   => throw new IllegalArgumentException("Unexpected remaining") // compiler completeness check pleaser
           }
 
         renderNext(settings)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/framing/Http2FrameParsing.scala
@@ -31,7 +31,7 @@ private[http] object Http2FrameParsing {
         val read0 = SettingIdentifier.byId(id) match {
           case OptionVal.Some(s) =>
             Setting(s, value) :: read
-          case OptionVal.None =>
+          case _ =>
             log.debug("Ignoring unknown setting identifier {}", id)
             read
         }
@@ -185,7 +185,7 @@ private[http2] class Http2FrameParsing(shouldReadPreface: Boolean, log: LoggingA
           val maybeframe = FrameType.byId(tpe) match {
             case OptionVal.Some(ft) =>
               Some(parseFrame(ft, flags, streamId, new ByteReader(payload), log))
-            case OptionVal.None =>
+            case _ =>
               log.debug("Ignoring unknown frame type {}", tpe)
               None
           }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpHeaderParser.scala
@@ -133,7 +133,7 @@ private[engine] final class HttpHeaderParser private (
           case valueParser: HeaderValueParser => startValueBranch(valueIx, valueParser) // no header yet of this type
           case EmptyHeader =>
             resultHeader = EmptyHeader; cursor
-          case other => throw new IllegalStateException(s"Unexpected value at $valueIx: $other") // compiler completeness check pleaser
+          case _ => throw new IllegalStateException(s"Unexpected value at $valueIx") // compiler completeness check pleaser
         }
       case nodeChar =>
         val char = CharUtils.toLowerCase(byteChar(input, cursor))
@@ -511,7 +511,7 @@ private[http] object HttpHeaderParser {
             else parser.insert(ByteString(insertName), valueParser)()
           case header: String =>
             parser.parseHeaderLine(ByteString(header + "\r\nx"))()
-          case other => throw new IllegalArgumentException(s"Unexpected parser: $other") // compiler completeness check pleaser
+          case _ => throw new IllegalArgumentException(s"Unexpected parser at $pivot") // compiler completeness check pleaser
         }
         insertInGoodOrder(items)(startIx, pivot)
         insertInGoodOrder(items)(pivot + 1, endIx)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpMessageParser.scala
@@ -97,7 +97,7 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
       case ele: Output @unchecked =>
         result = null
         ele
-      case other => throw new IllegalArgumentException(s"Unexpected result: $other") // compiler completeness check pleaser
+      case _ => throw new IllegalArgumentException("Unexpected result") // compiler completeness check pleaser
     }
 
   protected final def shouldComplete(): Boolean = {
@@ -307,7 +307,7 @@ private[http] trait HttpMessageParser[Output >: MessageOutput <: ParserOutput] {
       buffer += old
       buffer += output
       result = buffer
-    case other => throw new IllegalArgumentException(s"Unexpected output: $other") // compiler completeness check pleaser
+    case _ => throw new IllegalArgumentException("Unexpected output") // compiler completeness check pleaser
   }
 
   protected final def continue(input: ByteString, offset: Int)(next: (ByteString, Int) => StateResult): StateResult = {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/parsing/HttpRequestParser.scala
@@ -191,7 +191,7 @@ private[http] final class HttpRequestParser(
               Handshake.Server.websocketUpgrade(headers, hostHeaderPresent, websocketSettings, headerParser.log) match {
                 case OptionVal.Some(upgrade) =>
                   RequestStart(method, uri, protocol, attributes.updated(AttributeKeys.webSocketUpgrade, upgrade), upgrade :: allHeaders0, createEntity, expect100continue, closeAfterResponseCompletion)
-                case OptionVal.None =>
+                case _ => // OptionVal.None
                   RequestStart(method, uri, protocol, attributes, allHeaders0, createEntity, expect100continue, closeAfterResponseCompletion)
               }
             } else RequestStart(method, uri, protocol, attributes, allHeaders0, createEntity, expect100continue, closeAfterResponseCompletion)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
@@ -56,6 +56,7 @@ private[http] object BodyPartRenderer {
                 case Strict(_, data)           => chunkStream((r ~~ data).get)
                 case Default(_, _, data)       => bodyPartChunks(data)
                 case IndefiniteLength(_, data) => bodyPartChunks(data)
+                case other                     => throw new IllegalArgumentException(s"Unexpected entity: $other") // compiler completeness check pleaser
               }
 
             renderBoundary(r, boundary, suppressInitialCrLf = !firstBoundaryRendered)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/BodyPartRenderer.scala
@@ -56,7 +56,7 @@ private[http] object BodyPartRenderer {
                 case Strict(_, data)           => chunkStream((r ~~ data).get)
                 case Default(_, _, data)       => bodyPartChunks(data)
                 case IndefiniteLength(_, data) => bodyPartChunks(data)
-                case other                     => throw new IllegalArgumentException(s"Unexpected entity: $other") // compiler completeness check pleaser
+                case _                         => throw new IllegalArgumentException("Unexpected entity") // compiler completeness check pleaser
               }
 
             renderBoundary(r, boundary, suppressInitialCrLf = !firstBoundaryRendered)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/DateHeaderRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/DateHeaderRendering.scala
@@ -66,12 +66,12 @@ import scala.concurrent.ExecutionContext
           // which might prevent automatic rescheduling in the worst case
           a.wasUsed = true
           a
-        case s @ Idle =>
+        case Idle =>
           val r = if (rendered ne null) rendered else renderValue()
           val newValue = AutoUpdated(r)
           newValue.wasUsed = true
           // use CAS to avoid that multiple accessing threads schedule multiple timers
-          if (!dateState.compareAndSet(s, newValue)) get(rendered)
+          if (!dateState.compareAndSet(Idle, newValue)) get(rendered)
           else {
             scheduleAutoUpdate()
             newValue

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpRequestRendererFactory.scala
@@ -121,7 +121,7 @@ private[http] class HttpRequestRendererFactory(
       val stream = ctx.sendEntityTrigger match {
         case None => headerPart ++ body
         case Some(future) =>
-          val barrier = Source.fromFuture(future).drop(1).asInstanceOf[Source[ByteString, Any]]
+          val barrier = Source.future(future).drop(1).asInstanceOf[Source[ByteString, Any]]
           (headerPart ++ barrier ++ body).recoverWithRetries(-1, { case HttpResponseParser.OneHundredContinueError => Source.empty })
       }
       RequestRenderingOutput.Streamed(stream)

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/rendering/HttpResponseRendererFactory.scala
@@ -113,7 +113,7 @@ private[http] class HttpResponseRendererFactory(
             override def onPull(): Unit =
               if (!headersSent) sendHeaders()
               else sinkIn.pull()
-            override def onDownstreamFinish(): Unit = {
+            override def onDownstreamFinish(cause: Throwable): Unit = {
               completeStage()
               stopTransfer()
             }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -510,7 +510,7 @@ private[http] object HttpServerBluePrint {
               log.error(e, "Internal server error, sending 500 response")
               emitErrorResponse(HttpResponse(StatusCodes.InternalServerError))
 
-            case other => throw new IllegalStateException(s"Unexpected error: $other") // compiler completeness check pleaser
+            case ex => throw new IllegalStateException("Unexpected error", ex) // compiler completeness check pleaser
           }
       })
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameOutHandler.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameOutHandler.scala
@@ -65,7 +65,8 @@ private[http] class FrameOutHandler(serverSide: Boolean, _closeTimeout: FiniteDu
             log.error(e, s"Websocket handler failed with ${e.getMessage}")
             setHandler(in, new WaitingForPeerCloseFrame())
             push(out, FrameEvent.closeFrame(Protocol.CloseCodes.UnexpectedCondition, "internal error"))
-          case Tick => pull(in) // ignore
+          case Tick  => pull(in) // ignore
+          case other => throw new IllegalStateException(s"Unexpected element type: $other") // compiler completeness check pleaser
         }
 
       override def onUpstreamFinish(): Unit = {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameOutHandler.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/FrameOutHandler.scala
@@ -65,8 +65,8 @@ private[http] class FrameOutHandler(serverSide: Boolean, _closeTimeout: FiniteDu
             log.error(e, s"Websocket handler failed with ${e.getMessage}")
             setHandler(in, new WaitingForPeerCloseFrame())
             push(out, FrameEvent.closeFrame(Protocol.CloseCodes.UnexpectedCondition, "internal error"))
-          case Tick  => pull(in) // ignore
-          case other => throw new IllegalStateException(s"Unexpected element type: $other") // compiler completeness check pleaser
+          case Tick => pull(in) // ignore
+          case _    => throw new IllegalStateException("Unexpected element type") // compiler completeness check pleaser
         }
 
       override def onUpstreamFinish(): Unit = {

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/UpgradeToWebSocketLowLevel.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/UpgradeToWebSocketLowLevel.scala
@@ -11,11 +11,14 @@ import akka.http.scaladsl.model.ws.UpgradeToWebSocket
 import akka.http.scaladsl.model.ws.WebSocketUpgrade
 import akka.stream.{ FlowShape, Graph }
 
+import scala.annotation.nowarn
+
 /**
  * Currently internal API to handle FrameEvents directly.
  *
  * INTERNAL API
  */
+@nowarn("msg=deprecated")
 @InternalApi
 private[http] abstract class UpgradeToWebSocketLowLevel extends InternalCustomHeader("UpgradeToWebSocket") with UpgradeToWebSocket with WebSocketUpgrade {
   /**

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
@@ -156,6 +156,7 @@ private[http] object WebSocket {
               (Source.single(first) ++ remaining)
                 .collect { case b: BinaryMessagePart if b.data.nonEmpty => b.data }
             )
+          case other => throw new IllegalStateException(s"Unexpected type value: $other") // compiler completeness check pleaser
         }
 
     def prepareMessages: Flow[MessagePart, Message, NotUsed] =

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/ws/WebSocket.scala
@@ -156,7 +156,7 @@ private[http] object WebSocket {
               (Source.single(first) ++ remaining)
                 .collect { case b: BinaryMessagePart if b.data.nonEmpty => b.data }
             )
-          case other => throw new IllegalStateException(s"Unexpected type value: $other") // compiler completeness check pleaser
+          case _ => throw new IllegalStateException("Unexpected type value") // compiler completeness check pleaser
         }
 
     def prepareMessages: Flow[MessagePart, Message, NotUsed] =

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
@@ -27,10 +27,11 @@ private[parser] trait ContentTypeHeader { this: Parser with CommonRules with Com
       case Nil =>
         val parameters = if (builder eq null) Map.empty[String, String] else builder.result()
         getMediaType(main, sub, charset.isDefined, parameters) match {
-          case x: MediaType.Binary                               => ContentType.Binary(x)
-          case x: MediaType.WithFixedCharset                     => ContentType.WithFixedCharset(x)
+          case x: MediaType.Binary => ContentType.Binary(x)
+          case x: MediaType.WithFixedCharset => ContentType.WithFixedCharset(x)
           case x: MediaType.WithOpenCharset if charset.isDefined => ContentType.WithCharset(x, charset.get)
-          case x: MediaType.WithOpenCharset if charset.isEmpty   => ContentType.WithMissingCharset(x)
+          case x: MediaType.WithOpenCharset if charset.isEmpty => ContentType.WithMissingCharset(x)
+          case other => throw new IllegalStateException(s"Unexpected type value: $other") // compiler completeness check pleaser
         }
 
       case Seq((key, value), tail @ _*) if equalsAsciiCaseInsensitive(key, "charset") =>
@@ -40,5 +41,6 @@ private[parser] trait ContentTypeHeader { this: Parser with CommonRules with Com
         val b = if (builder eq null) TreeMap.newBuilder[String, String] else builder
         b += kvp
         contentType(main, sub, tail, charset, b)
+      case other => throw new IllegalStateException(s"Unexpected params: $other") // compiler completeness check pleaser
     }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/ContentTypeHeader.scala
@@ -31,7 +31,7 @@ private[parser] trait ContentTypeHeader { this: Parser with CommonRules with Com
           case x: MediaType.WithFixedCharset => ContentType.WithFixedCharset(x)
           case x: MediaType.WithOpenCharset if charset.isDefined => ContentType.WithCharset(x, charset.get)
           case x: MediaType.WithOpenCharset if charset.isEmpty => ContentType.WithMissingCharset(x)
-          case other => throw new IllegalStateException(s"Unexpected type value: $other") // compiler completeness check pleaser
+          case _ => throw new IllegalStateException("Unexpected media type value") // compiler completeness check pleaser
         }
 
       case Seq((key, value), tail @ _*) if equalsAsciiCaseInsensitive(key, "charset") =>
@@ -41,6 +41,6 @@ private[parser] trait ContentTypeHeader { this: Parser with CommonRules with Com
         val b = if (builder eq null) TreeMap.newBuilder[String, String] else builder
         b += kvp
         contentType(main, sub, tail, charset, b)
-      case other => throw new IllegalStateException(s"Unexpected params: $other") // compiler completeness check pleaser
+      case _ => throw new IllegalStateException("Unexpected params") // compiler completeness check pleaser
     }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -75,6 +75,7 @@ private[http] class HeaderParser(
       error match {
         case IllegalUriException(info) => info
         case NonFatal(e)               => ErrorInfo.fromCompoundString(e.getMessage)
+        case other                     => throw new IllegalStateException(s"Unexpected error: $other") // compiler completeness check pleaser
       }
     }
   def ruleNotFound(ruleName: String): Result = HeaderParser.RuleNotFound

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/HeaderParser.scala
@@ -75,7 +75,7 @@ private[http] class HeaderParser(
       error match {
         case IllegalUriException(info) => info
         case NonFatal(e)               => ErrorInfo.fromCompoundString(e.getMessage)
-        case other                     => throw new IllegalStateException(s"Unexpected error: $other") // compiler completeness check pleaser
+        case ex                        => throw new IllegalStateException("Unexpected error", ex) // compiler completeness check pleaser
       }
     }
   def ruleNotFound(ruleName: String): Result = HeaderParser.RuleNotFound

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/LinkHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/LinkHeader.scala
@@ -79,6 +79,6 @@ private[parser] trait LinkHeader { this: Parser with CommonRules with CommonActi
       case Seq((x: LinkParams.`type`), tail @ _*)   => sanitize(tail, if (seenType) result else result :+ x, seenRel, seenMedia, seenTitle, seenTitleS, seenType = true)
       case Seq(head, tail @ _*)                     => sanitize(tail, result :+ head, seenRel, seenMedia, seenTitle, seenTitleS, seenType)
       case Nil                                      => result
-      case other                                    => throw new IllegalArgumentException(s"Unexpected params: $other") // compiler completeness check pleaser
+      case _                                        => throw new IllegalArgumentException("Unexpected params") // compiler completeness check pleaser
     }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/model/parser/LinkHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/model/parser/LinkHeader.scala
@@ -79,5 +79,6 @@ private[parser] trait LinkHeader { this: Parser with CommonRules with CommonActi
       case Seq((x: LinkParams.`type`), tail @ _*)   => sanitize(tail, if (seenType) result else result :+ x, seenRel, seenMedia, seenTitle, seenTitleS, seenType = true)
       case Seq(head, tail @ _*)                     => sanitize(tail, result :+ head, seenRel, seenMedia, seenTitle, seenTitleS, seenType)
       case Nil                                      => result
+      case other                                    => throw new IllegalArgumentException(s"Unexpected params: $other") // compiler completeness check pleaser
     }
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/One2OneBidiFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/One2OneBidiFlow.scala
@@ -78,7 +78,7 @@ private[http] object One2OneBidiFlow {
         override def onPull(): Unit =
           if (insideWrappedFlow < maxPending || maxPending == -1) pull(in)
           else pullSuppressed = true
-        override def onDownstreamFinish(): Unit = cancel(in)
+        override def onDownstreamFinish(cause: Throwable): Unit = cancel(in)
       })
 
       setHandler(fromWrapped, new InHandler {
@@ -101,7 +101,7 @@ private[http] object One2OneBidiFlow {
 
       setHandler(out, new OutHandler {
         override def onPull(): Unit = pull(fromWrapped)
-        override def onDownstreamFinish(): Unit = cancel(fromWrapped)
+        override def onDownstreamFinish(cause: Throwable): Unit = cancel(fromWrapped)
       })
     }
   }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
@@ -141,7 +141,7 @@ private[http] object Renderer {
           case Nil              => r ~~ empty
           case x: IndexedSeq[T] => recI(x)
           case x: LinearSeq[T]  => recL(x)
-          case other            => throw new IllegalStateException(s"Unexpected type value: $other") // compiler completeness check pleaser
+          case _                => throw new IllegalStateException("Unexpected type value") // compiler completeness check pleaser
         }
       }
     }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala
@@ -141,6 +141,7 @@ private[http] object Renderer {
           case Nil              => r ~~ empty
           case x: IndexedSeq[T] => recI(x)
           case x: LinearSeq[T]  => recL(x)
+          case other            => throw new IllegalStateException(s"Unexpected type value: $other") // compiler completeness check pleaser
         }
       }
     }

--- a/akka-http-core/src/main/scala/akka/http/impl/util/SocketOptionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/SocketOptionSettings.scala
@@ -19,12 +19,12 @@ private[http] object SocketOptionSettings {
         case x           => cons(f(c, setting)) :: Nil
       }
 
-    so("so-receive-buffer-size")(_ getIntBytes _)(Inet.SO.ReceiveBufferSize) :::
-      so("so-send-buffer-size")(_ getIntBytes _)(Inet.SO.SendBufferSize) :::
-      so("so-reuse-address")(_ getBoolean _)(Inet.SO.ReuseAddress) :::
-      so("so-traffic-class")(_ getInt _)(Inet.SO.TrafficClass) :::
-      so("tcp-keep-alive")(_ getBoolean _)(Tcp.SO.KeepAlive) :::
-      so("tcp-oob-inline")(_ getBoolean _)(Tcp.SO.OOBInline) :::
-      so("tcp-no-delay")(_ getBoolean _)(Tcp.SO.TcpNoDelay)
+    so("so-receive-buffer-size")(_ getIntBytes _)(Inet.SO.ReceiveBufferSize.apply) :::
+      so("so-send-buffer-size")(_ getIntBytes _)(Inet.SO.SendBufferSize.apply) :::
+      so("so-reuse-address")(_ getBoolean _)(Inet.SO.ReuseAddress.apply) :::
+      so("so-traffic-class")(_ getInt _)(Inet.SO.TrafficClass.apply) :::
+      so("tcp-keep-alive")(_ getBoolean _)(Tcp.SO.KeepAlive.apply) :::
+      so("tcp-oob-inline")(_ getBoolean _)(Tcp.SO.OOBInline.apply) :::
+      so("tcp-no-delay")(_ getBoolean _)(Tcp.SO.TcpNoDelay.apply)
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -5,14 +5,13 @@
 package akka.http.javadsl
 
 import java.util.{ Optional, Collection => JCollection }
-
 import akka.annotation.{ ApiMayChange, DoNotInherit }
 import akka.http.scaladsl
 import akka.japi.Util
 import akka.stream.TLSClientAuth
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
-import javax.net.ssl.{ SSLContext, SSLEngine, SSLParameters }
 
+import javax.net.ssl.{ SSLContext, SSLEngine, SSLParameters }
 import scala.compat.java8.OptionConverters
 
 object ConnectionContext {
@@ -106,6 +105,9 @@ abstract class ConnectionContext {
 @DoNotInherit
 abstract class HttpConnectionContext extends akka.http.javadsl.ConnectionContext {
   override final def isSecure = false
+
+  @Deprecated
+  @deprecated("Not always available", since = "10.2.0")
   override def sslConfig: Option[AkkaSSLConfig] = None
 }
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/Http.scala
@@ -38,7 +38,7 @@ object Http extends ExtensionId[Http] with ExtensionIdProvider {
 }
 
 class Http(system: ExtendedActorSystem) extends akka.actor.Extension {
-  import akka.dispatch.ExecutionContexts.{ sameThreadExecutionContext => ec }
+  import akka.dispatch.ExecutionContexts.{ parasitic => ec }
 
   import language.implicitConversions
   private implicit def completionStageCovariant[T, U >: T](in: CompletionStage[T]): CompletionStage[U] = in.asInstanceOf[CompletionStage[U]]

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ServerBinding.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ServerBinding.scala
@@ -78,7 +78,7 @@ class ServerBinding private[http] (delegate: akka.http.scaladsl.Http.ServerBindi
 
   def terminate(hardDeadline: java.time.Duration): CompletionStage[HttpTerminated] = {
     delegate.terminate(FiniteDuration.apply(hardDeadline.toMillis, TimeUnit.MILLISECONDS))
-      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.sameThreadExecutionContext)
+      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.parasitic)
       .toJava
   }
 
@@ -92,7 +92,7 @@ class ServerBinding private[http] (delegate: akka.http.scaladsl.Http.ServerBindi
    */
   def whenTerminationSignalIssued: CompletionStage[java.time.Duration] =
     delegate.whenTerminationSignalIssued
-      .map(deadline => deadline.time.asJava)(ExecutionContexts.sameThreadExecutionContext)
+      .map(deadline => deadline.time.asJava)(ExecutionContexts.parasitic)
       .toJava
 
   /**
@@ -109,7 +109,7 @@ class ServerBinding private[http] (delegate: akka.http.scaladsl.Http.ServerBindi
    */
   def whenTerminated: CompletionStage[HttpTerminated] =
     delegate.whenTerminated
-      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.sameThreadExecutionContext)
+      .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.parasitic)
       .toJava
 
   /**

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ServerBuilder.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ServerBuilder.scala
@@ -185,6 +185,6 @@ object ServerBuilder {
     def connectionSource(): Source[IncomingConnection, CompletionStage[ServerBinding]] =
       http.bindImpl(interface, port, context.asScala, settings.asScala, log)
         .map(new IncomingConnection(_))
-        .mapMaterializedValue(_.map(new ServerBinding(_))(ExecutionContexts.sameThreadExecutionContext).toJava).asJava
+        .mapMaterializedValue(_.map(new ServerBinding(_))(ExecutionContexts.parasitic).toJava).asJava
   }
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -77,6 +77,7 @@ object ConnectionContext {
       case Some((host, port)) => createSSLEngine(host, port)
     }: Option[(String, Int)] => SSLEngine))
 
+  @nowarn("msg=deprecated")
   @deprecated("use httpsClient, httpsServer, or the lower-level SSLEngine-based constructor", "10.2.0")
   def https(
     sslContext:          SSLContext,
@@ -113,6 +114,7 @@ final class HttpsConnectionContext private[http] (private[http] val sslContextDa
   extends akka.http.javadsl.HttpsConnectionContext with ConnectionContext {
   protected[http] override final def defaultPort: Int = 443
 
+  @nowarn("msg=deprecated")
   @deprecated("prefer ConnectionContext.httpsClient or ConnectionContext.httpsServer", "10.2.0")
   def this(
     sslContext:          SSLContext,
@@ -149,7 +151,7 @@ sealed class HttpConnectionContext extends akka.http.javadsl.HttpConnectionConte
   protected[http] override final def defaultPort: Int = 80
 }
 
-final object HttpConnectionContext extends HttpConnectionContext {
+object HttpConnectionContext extends HttpConnectionContext {
   /** Java API */
   def getInstance() = this
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -5,12 +5,10 @@
 package akka.http.scaladsl.model
 
 import java.util.OptionalLong
-
 import language.implicitConversions
 import java.io.File
 import java.nio.file.{ Files, Path }
 import java.lang.{ Iterable => JIterable }
-
 import scala.util.control.NonFatal
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -28,10 +26,10 @@ import akka.http.impl.util.JavaMapping.Implicits._
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 import java.util.concurrent.CompletionStage
-
 import akka.actor.ClassicActorSystemProvider
 import akka.annotation.{ DoNotInherit, InternalApi }
 
+import scala.annotation.nowarn
 import scala.compat.java8.FutureConverters
 
 /**
@@ -76,7 +74,7 @@ sealed trait HttpEntity extends jm.HttpEntity {
    */
   def toStrict(timeout: FiniteDuration)(implicit fm: Materializer): Future[HttpEntity.Strict] = {
     import akka.http.impl.util._
-    val config = fm.asInstanceOf[ActorMaterializer].system.settings.config
+    val config = fm.system.settings.config
     toStrict(timeout, config.getPossiblyInfiniteBytes("akka.http.parsing.max-to-strict-bytes"))
   }
 
@@ -638,6 +636,7 @@ object HttpEntity {
       private var maxBytes = -1L
       private var bytesLeft = Long.MaxValue
 
+      @nowarn("msg=deprecated") // we need getFirst semantics
       override def preStart(): Unit = {
         _attributes.getFirst[SizeLimit] match {
           case Some(limit: SizeLimit) if limit.isDisabled =>

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -453,9 +453,9 @@ object HttpRequest {
           s"Cannot establish effective URI of request to `$uri`, request has a relative URI and $detail",
           "consider setting `akka.http.server.default-host-header`")
       val Host(hostHeaderHost, hostHeaderPort) = hostHeader match {
-        case OptionVal.None                 => if (defaultHostHeader.isEmpty) fail("is missing a `Host` header") else defaultHostHeader
         case OptionVal.Some(x) if x.isEmpty => if (defaultHostHeader.isEmpty) fail("an empty `Host` header") else defaultHostHeader
         case OptionVal.Some(x)              => x
+        case _                              => if (defaultHostHeader.isEmpty) fail("is missing a `Host` header") else defaultHostHeader
       }
       val defaultScheme =
         if (isWebsocket) Uri.websocketScheme(securedConnection)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -514,7 +514,7 @@ object Multipart {
                    _additionalHeaders:           Iterable[akka.http.javadsl.model.HttpHeader]): Multipart.FormData.BodyPart = {
           val _headers = _additionalHeaders.to(immutable.Seq) map {
             case h: akka.http.scaladsl.model.HttpHeader => h
-            case other                                  => throw new IllegalStateException(s"Unexpected type: $other") // compiler completeness check pleaser
+            case _                                      => throw new IllegalStateException("Unexpected type") // compiler completeness check pleaser
           }
           apply(_name, _entity, _additionalDispositionParams, _headers)
         }
@@ -528,7 +528,7 @@ object Multipart {
                          _additionalHeaders:           Iterable[akka.http.javadsl.model.HttpHeader]): Multipart.FormData.BodyPart.Strict = {
           val _headers = _additionalHeaders.to(immutable.Seq) map {
             case h: akka.http.scaladsl.model.HttpHeader => h
-            case other                                  => throw new IllegalStateException(s"Unexpected type: $other") // compiler completeness check pleaser
+            case _                                      => throw new IllegalStateException("Unexpected type") // compiler completeness check pleaser
           }
           Strict(_name, _entity, _additionalDispositionParams, _headers)
         }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -512,7 +512,10 @@ object Multipart {
         def create(_name: String, _entity: BodyPartEntity,
                    _additionalDispositionParams: Map[String, String],
                    _additionalHeaders:           Iterable[akka.http.javadsl.model.HttpHeader]): Multipart.FormData.BodyPart = {
-          val _headers = _additionalHeaders.to(immutable.Seq) map { case h: akka.http.scaladsl.model.HttpHeader => h }
+          val _headers = _additionalHeaders.to(immutable.Seq) map {
+            case h: akka.http.scaladsl.model.HttpHeader => h
+            case other                                  => throw new IllegalStateException(s"Unexpected type: $other") // compiler completeness check pleaser
+          }
           apply(_name, _entity, _additionalDispositionParams, _headers)
         }
       }
@@ -523,7 +526,10 @@ object Multipart {
         def createStrict(_name: String, _entity: HttpEntity.Strict,
                          _additionalDispositionParams: Map[String, String],
                          _additionalHeaders:           Iterable[akka.http.javadsl.model.HttpHeader]): Multipart.FormData.BodyPart.Strict = {
-          val _headers = _additionalHeaders.to(immutable.Seq) map { case h: akka.http.scaladsl.model.HttpHeader => h }
+          val _headers = _additionalHeaders.to(immutable.Seq) map {
+            case h: akka.http.scaladsl.model.HttpHeader => h
+            case other                                  => throw new IllegalStateException(s"Unexpected type: $other") // compiler completeness check pleaser
+          }
           Strict(_name, _entity, _additionalDispositionParams, _headers)
         }
       }

--- a/akka-http-core/src/test/java/akka/http/JavaTestServer.java
+++ b/akka-http-core/src/test/java/akka/http/JavaTestServer.java
@@ -14,8 +14,6 @@ import akka.http.javadsl.model.ws.Message;
 import akka.http.javadsl.model.ws.TextMessage;
 import akka.http.javadsl.model.ws.WebSocket;
 import akka.japi.JavaPartialFunction;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Source;
 

--- a/akka-http-core/src/test/java/akka/http/javadsl/GracefulTerminationCompileTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/GracefulTerminationCompileTest.java
@@ -8,8 +8,6 @@ import akka.actor.ActorSystem;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.japi.function.Function;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;

--- a/akka-http-core/src/test/java/akka/http/javadsl/settings/ParserSettingsTest.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/settings/ParserSettingsTest.java
@@ -10,6 +10,7 @@ import org.scalatestplus.junit.JUnitSuite;
 
 public class ParserSettingsTest extends JUnitSuite {
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCreateWithActorSystem() {
         ActorSystem sys = ActorSystem.create("test");

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HostConnectionPoolSpec.scala
@@ -763,7 +763,7 @@ class HostConnectionPoolSpec extends AkkaSpecWithMaterializer(
             super.onUpstreamFailure(ex)
           }
 
-          override def onDownstreamFinish(): Unit = failStage(new RuntimeException("was cancelled"))
+          override def onDownstreamFinish(cause: Throwable): Unit = failStage(new RuntimeException("was cancelled", cause))
         }
         setHandlers(reqIn, reqOut, new MonitorMessage(reqIn, reqOut))
         setHandlers(resIn, resOut, new MonitorMessage(resIn, resOut))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/HttpsProxyGraphStageSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/HttpsProxyGraphStageSpec.scala
@@ -197,9 +197,9 @@ class HttpsProxyGraphStageSpec extends AkkaSpecWithMaterializer {
 
         val flowUnderTest = proxyGraphStage.join(proxyFlow)
 
-        val (source, sink) = TestSource.probe[ByteString]
+        val (source, sink) = TestSource[ByteString]()
           .via(flowUnderTest)
-          .toMat(TestSink.probe)(Keep.both)
+          .toMat(TestSink())(Keep.both)
           .run()
 
         fn(source, flowInProbe, flowOutProbe, sink)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/NewConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/NewConnectionPoolSpec.scala
@@ -119,7 +119,7 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
         case (Success(x), 43) => requestUri(x) should endWith("/b")
         case x                => fail(x.toString)
       }
-      Seq(r1, r2).map(t => connNr(t._1.get)) should contain allOf (1, 2)
+      Seq(r1, r2).map(t => connNr(t._1.get)) should contain allElementsOf Seq(1, 2)
     }
 
     "open a second connection if the request on the first one is dispatch but not yet completed" in new TestSetup {
@@ -228,7 +228,7 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
 
       val crashingEntity =
         Source.fromIterator(() => Iterator.fill(10)(ByteString("abc")))
-          .concat(Source.fromFuture(errorOnConnection1.future))
+          .concat(Source.future(errorOnConnection1.future))
           .log("response-entity-stream")
           .addAttributes(Attributes.logLevels(Logging.InfoLevel, Logging.InfoLevel, Logging.InfoLevel))
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/PrepareResponseSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/PrepareResponseSpec.scala
@@ -9,7 +9,7 @@ import akka.http.impl.engine.parsing.ParserOutput
 import akka.http.impl.engine.parsing.ParserOutput.{ EntityChunk, EntityStreamError, StreamedEntityCreator, StrictEntityCreator }
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ParserSettings
-import akka.stream.{ ActorMaterializer, Attributes }
+import akka.stream.Attributes
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
 import akka.util.ByteString
@@ -48,8 +48,6 @@ class PrepareResponseSpec extends AkkaSpec {
   "The PrepareRequest stage" should {
 
     "not lose demand that comes in while streaming entity" in {
-      implicit val mat: ActorMaterializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]()
 
@@ -93,8 +91,6 @@ class PrepareResponseSpec extends AkkaSpec {
     }
 
     "not lose demand that comes in while handling strict entity" in {
-      implicit val mat: ActorMaterializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]()
 
@@ -129,8 +125,6 @@ class PrepareResponseSpec extends AkkaSpec {
     "complete entity stream then complete stage when downstream cancels" in {
       // to make it possible to cancel a big file download for example
       // without downloading the entire response first
-      implicit val mat: ActorMaterializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]()
 
@@ -170,8 +164,6 @@ class PrepareResponseSpec extends AkkaSpec {
     }
 
     "complete stage when downstream cancels before end of strict request has arrived" in {
-      implicit val mat: ActorMaterializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]()
 
@@ -198,7 +190,6 @@ class PrepareResponseSpec extends AkkaSpec {
     }
 
     "cancel entire stage when the entity stream is canceled" in {
-      implicit val mat: ActorMaterializer = ActorMaterializer()
 
       val inProbe = TestPublisher.manualProbe[ParserOutput.ResponseOutput]()
       val responseProbe = TestSubscriber.manualProbe[HttpResponse]()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/ResponseParsingMergeSpec.scala
@@ -13,7 +13,7 @@ import akka.http.scaladsl.settings.ParserSettings
 import akka.stream.TLSProtocol.SessionBytes
 import akka.stream.scaladsl.{ GraphDSL, RunnableGraph, Sink, Source }
 import akka.stream.testkit.{ TestPublisher, TestSubscriber }
-import akka.stream.{ ActorMaterializer, Attributes, ClosedShape }
+import akka.stream.{ Attributes, ClosedShape }
 import akka.testkit.AkkaSpec
 import akka.util.ByteString
 
@@ -24,8 +24,6 @@ class ResponseParsingMergeSpec extends AkkaSpec {
   "The ResponseParsingMerge stage" should {
 
     "not lose entity truncation errors on upstream finish" in {
-      implicit val mat: ActorMaterializer = ActorMaterializer()
-
       val inBypassProbe = TestPublisher.manualProbe[OutgoingConnectionBlueprint.BypassData]()
       val inSessionBytesProbe = TestPublisher.manualProbe[SessionBytes]()
       val responseProbe = TestSubscriber.manualProbe[List[ParserOutput.ResponseOutput]]()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/parsing/RequestParserSpec.scala
@@ -11,7 +11,6 @@ import scala.concurrent.duration._
 import com.typesafe.config.{ Config, ConfigFactory }
 import akka.util.ByteString
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.stream.TLSProtocol._
 import org.scalatest.matchers.Matcher
@@ -48,7 +47,6 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
   import system.dispatcher
 
   val BOLT = HttpMethod.custom("BOLT", safe = false, idempotent = true, requestEntityAcceptance = Expected)
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   s"The request parsing logic should (mode: $mode)" - {
     "properly parse a request" - {
@@ -776,7 +774,7 @@ abstract class RequestParserSpec(mode: String, newLine: String) extends AnyFreeS
         }
         .concatSubstreams
         .flatMapConcat { x =>
-          Source.fromFuture {
+          Source.future {
             x match {
               case Right(request) => compactEntity(request.entity).fast.map(x => Right(request.withEntity(x)))
               case Left(error)    => FastFuture.successful(Left(error))

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/RequestRendererSpec.scala
@@ -18,7 +18,6 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.impl.util._
 import akka.stream.scaladsl._
-import akka.stream.ActorMaterializer
 import HttpEntity._
 import HttpMethods._
 import akka.testkit._
@@ -31,8 +30,6 @@ class RequestRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfterA
     akka.loglevel = WARNING""")
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
-
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   "The request preparation logic should" - {
     "properly render an unchunked" - {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/rendering/ResponseRendererSpec.scala
@@ -17,7 +17,6 @@ import akka.http.scaladsl.model.headers._
 import akka.http.impl.util._
 import akka.util.ByteString
 import akka.stream.scaladsl._
-import akka.stream.ActorMaterializer
 import HttpEntity._
 import akka.http.impl.engine.rendering.ResponseRenderingContext.CloseRequested
 import akka.http.impl.util.Rendering.CrLf
@@ -34,7 +33,6 @@ class ResponseRendererSpec extends AnyFreeSpec with Matchers with BeforeAndAfter
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName, testConf)
 
   val ServerOnTheMove = StatusCodes.custom(330, "Server on the move")
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   "The response preparation logic should properly render" - {
     "a response with no body," - {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerBug21008Spec.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.model.HttpEntity.Chunked
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.{ ContentType, HttpRequest, HttpResponse }
 import akka.http.scaladsl.model.MediaTypes._
-import akka.stream.Materializer
 import akka.stream.testkit.Utils.{ TE, _ }
 import akka.testkit._
 import org.scalatest.Inside
@@ -25,7 +24,6 @@ class HttpServerBug21008Spec extends AkkaSpecWithMaterializer(
 
     "not cause internal graph failures when consuming a `100 Continue` entity triggers a failure" in assertAllStagesStopped(new HttpServerTestSetupBase {
       override implicit def system = HttpServerBug21008Spec.this.system
-      override implicit def materializer: Materializer = HttpServerBug21008Spec.this.materializer
 
       send("""POST / HTTP/1.1
              |Host: example.com

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -5,9 +5,7 @@
 package akka.http.impl.engine.server
 
 import scala.annotation.nowarn
-
 import java.net.{ InetAddress, InetSocketAddress }
-
 import akka.event.LoggingAdapter
 import akka.http.ParsingErrorHandler
 import akka.http.impl.engine.ws.ByteStringSinkProbe
@@ -23,6 +21,7 @@ import akka.stream.scaladsl._
 import akka.stream.testkit.Utils.assertAllStagesStopped
 import akka.stream.testkit._
 import akka.stream.Attributes
+import akka.stream.Materializer
 import akka.stream.Outlet
 import akka.stream.SourceShape
 import akka.stream.stage.GraphStage
@@ -47,6 +46,7 @@ class HttpServerSpec extends AkkaSpec(
      akka.http.server.log-unencrypted-network-bytes = 100
      akka.http.server.request-timeout = infinite
   """) with Inside with WithLogCapturing { spec =>
+  implicit val materializer = Materializer.createMaterializer(system)
 
   "The server implementation" should {
     "deliver an empty request as soon as all headers are received" in assertAllStagesStopped(new TestSetup {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -46,7 +46,7 @@ class HttpServerSpec extends AkkaSpec(
      akka.http.server.log-unencrypted-network-bytes = 100
      akka.http.server.request-timeout = infinite
   """) with Inside with WithLogCapturing { spec =>
-  implicit val materializer = Materializer.createMaterializer(system)
+  implicit val materializer: Materializer = Materializer.createMaterializer(system)
 
   "The server implementation" should {
     "deliver an empty request as soon as all headers are received" in assertAllStagesStopped(new TestSetup {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -22,7 +22,6 @@ import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.scaladsl._
 import akka.stream.testkit.Utils.assertAllStagesStopped
 import akka.stream.testkit._
-import akka.stream.ActorMaterializer
 import akka.stream.Attributes
 import akka.stream.Outlet
 import akka.stream.SourceShape
@@ -48,7 +47,6 @@ class HttpServerSpec extends AkkaSpec(
      akka.http.server.log-unencrypted-network-bytes = 100
      akka.http.server.request-timeout = infinite
   """) with Inside with WithLogCapturing { spec =>
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   "The server implementation" should {
     "deliver an empty request as soon as all headers are received" in assertAllStagesStopped(new TestSetup {
@@ -1583,7 +1581,6 @@ class HttpServerSpec extends AkkaSpec(
   }
   class TestSetup(maxContentLength: Int = -1) extends HttpServerTestSetupBase {
     implicit def system = spec.system
-    implicit def materializer = spec.materializer
 
     override def settings = {
       val s = super.settings

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerTestSetupBase.scala
@@ -21,7 +21,6 @@ import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
 
 abstract class HttpServerTestSetupBase {
   implicit def system: ActorSystem
-  implicit def materializer: Materializer
 
   val requests = TestSubscriber.probe[HttpRequest]()
   val responses = TestPublisher.probe[HttpResponse]()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerWithExplicitSchedulerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerWithExplicitSchedulerSpec.scala
@@ -7,6 +7,7 @@ package akka.http.impl.engine.server
 import akka.http.impl.util._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{ Connection, `Timeout-Access` }
+import akka.stream.Materializer
 import akka.stream.testkit.Utils.assertAllStagesStopped
 import akka.testkit.ExplicitlyTriggeredScheduler
 import org.scalatest.Inside
@@ -164,7 +165,7 @@ class HttpServerWithExplicitSchedulerSpec extends AkkaSpecWithMaterializer(
 
   class TestSetup(maxContentLength: Int = -1) extends HttpServerTestSetupBase {
     implicit def system = spec.system
-    implicit def materializer = spec.materializer
+    implicit def materializer: Materializer = spec.materializer
     lazy val scheduler = spec.system.scheduler.asInstanceOf[ExplicitlyTriggeredScheduler]
 
     override def settings = {

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/PrepareRequestsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/PrepareRequestsSpec.scala
@@ -9,7 +9,7 @@ import akka.http.impl.engine.parsing.ParserOutput.{ StrictEntityCreator, EntityS
 import akka.http.impl.engine.server.HttpServerBluePrint.PrepareRequests
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ServerSettings
-import akka.stream.{ Attributes, ActorMaterializer }
+import akka.stream.Attributes
 import akka.stream.scaladsl.{ Sink, Source, Flow }
 import akka.stream.testkit.{ TestSubscriber, TestPublisher }
 import akka.testkit._
@@ -55,7 +55,6 @@ class PrepareRequestsSpec extends AkkaSpec {
   "The PrepareRequest stage" should {
 
     "not fail when there is demand from both streamed entity consumption and regular flow" in {
-      implicit val materializer: ActorMaterializer = ActorMaterializer()
       // covers bug #19623 where a reply before the streamed
       // body has been consumed causes pull/push twice
       val inProbe = TestPublisher.manualProbe[ParserOutput.RequestOutput]()
@@ -115,8 +114,6 @@ class PrepareRequestsSpec extends AkkaSpec {
     }
 
     "not complete running entity stream when upstream cancels" in {
-      implicit val materializer: ActorMaterializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.RequestOutput]()
       val upstreamProbe = TestSubscriber.manualProbe[HttpRequest]()
 
@@ -166,8 +163,6 @@ class PrepareRequestsSpec extends AkkaSpec {
 
     "complete stage if chunked stream is completed without reaching end of chunks" in {
       // a bit unsure about this, but to document the assumption
-      implicit val materializer: ActorMaterializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.RequestOutput]()
       val upstreamProbe = TestSubscriber.manualProbe[HttpRequest]()
 
@@ -207,8 +202,6 @@ class PrepareRequestsSpec extends AkkaSpec {
     }
 
     "cancel the stage when the entity stream is canceled" in {
-      implicit val materializer: ActorMaterializer = ActorMaterializer()
-
       val inProbe = TestPublisher.manualProbe[ParserOutput.RequestOutput]()
       val upstreamProbe = TestSubscriber.manualProbe[HttpRequest]()
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/ByteStringSinkProbe.scala
@@ -54,7 +54,7 @@ private[http] object ByteStringSinkProbe {
       }
       def expectNoBytes(): Unit = {
         ensureRequested()
-        probe.expectNoMsg()
+        probe.expectNoMessage()
       }
       def expectNoBytes(timeout: FiniteDuration): Unit = {
         ensureRequested()

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/EchoTestClientApp.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/EchoTestClientApp.scala
@@ -11,7 +11,6 @@ import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.ws.{ TextMessage, BinaryMessage, Message }
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.util.ByteString
 
@@ -24,7 +23,6 @@ import scala.util.{ Failure, Success }
 object EchoTestClientApp extends App {
   implicit val system: ActorSystem = ActorSystem()
   import system.dispatcher
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   def delayedCompletion(delay: FiniteDuration): Source[Nothing, NotUsed] =
     Source.single(1)

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSClientAutobahnTest.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSClientAutobahnTest.scala
@@ -10,7 +10,6 @@ import scala.concurrent.Future
 import scala.util.{ Failure, Success, Try }
 import spray.json._
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri
@@ -19,7 +18,6 @@ import akka.http.scaladsl.model.ws._
 object WSClientAutobahnTest extends App {
   implicit val system: ActorSystem = ActorSystem()
   import system.dispatcher
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   val Agent = "akka-http"
   val Parallelism = 4

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSServerAutobahnTest.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WSServerAutobahnTest.scala
@@ -14,14 +14,12 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.AttributeKeys.webSocketUpgrade
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.ws.Message
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 
 import scala.io.StdIn
 
 object WSServerAutobahnTest extends App {
   implicit val system: ActorSystem = ActorSystem("WSServerTest")
-  implicit val fm: ActorMaterializer = ActorMaterializer()
 
   val host = System.getProperty("akka.ws-host", "127.0.0.1")
   val port = System.getProperty("akka.ws-port", "9001").toInt

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/WebSocketServerSpec.scala
@@ -4,6 +4,7 @@
 
 package akka.http.impl.engine.ws
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.ws._
 import akka.http.scaladsl.model.AttributeKeys.webSocketUpgrade
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
@@ -11,6 +12,7 @@ import akka.stream.testkit.Utils
 import akka.util.ByteString
 import akka.http.impl.engine.server.HttpServerTestSetupBase
 import akka.http.impl.util.AkkaSpecWithMaterializer
+import akka.stream.Materializer
 
 import scala.concurrent.duration._
 
@@ -177,8 +179,8 @@ class WebSocketServerSpec extends AkkaSpecWithMaterializer("akka.http.server.web
   }
 
   class TestSetup extends HttpServerTestSetupBase with WSTestSetupBase {
-    implicit def system = spec.system
-    implicit def materializer = spec.materializer
+    implicit def system: ActorSystem = spec.system
+    implicit def materializer: Materializer = spec.materializer
 
     def expectBytes(length: Int): ByteString = netOut.expectBytes(length)
     def expectBytes(bytes: ByteString): Unit = netOut.expectBytes(bytes)

--- a/akka-http-core/src/test/scala/akka/http/impl/util/AkkaSpecWithMaterializer.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/AkkaSpecWithMaterializer.scala
@@ -6,7 +6,7 @@ package akka.http.impl.util
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.{ ActorMaterializer, Materializer, SystemMaterializer }
+import akka.stream.{ Materializer, SystemMaterializer }
 import akka.testkit.AkkaSpec
 import akka.testkit.EventFilter
 import com.typesafe.config.ConfigFactory
@@ -33,7 +33,7 @@ abstract class AkkaSpecWithMaterializer(configOverrides: String)
       // shutdown materializer first, otherwise it will only be shutdown during
       // main system guardian being shutdown which will be after the logging has
       // reverted to stdout logging that cannot be intercepted
-      materializer.asInstanceOf[ActorMaterializer].shutdown()
+      materializer.shutdown()
       Http().shutdownAllConnectionPools()
       // materializer shutdown is async but cannot be watched
       Thread.sleep(10)

--- a/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/One2OneBidiFlowSpec.scala
@@ -7,7 +7,6 @@ package akka.http.impl.util
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.NotUsed
-import akka.stream.{ ActorMaterializer, Materializer }
 import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.stream.testkit.Utils._
 import akka.stream.testkit._
@@ -18,7 +17,6 @@ import akka.testkit._
 import org.scalatest.concurrent.Eventually
 
 class One2OneBidiFlowSpec extends AkkaSpec with Eventually {
-  implicit val materializer: Materializer = ActorMaterializer()
 
   "A One2OneBidiFlow" must {
 

--- a/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/util/StreamUtilsSpec.scala
@@ -4,7 +4,7 @@
 
 package akka.http.impl.util
 
-import akka.stream.{ ActorMaterializer, Attributes, Materializer }
+import akka.stream.Attributes
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.ByteString
 import akka.testkit._
@@ -14,7 +14,6 @@ import scala.concurrent.duration._
 import scala.util.Failure
 
 class StreamUtilsSpec extends AkkaSpec with ScalaFutures {
-  implicit val materializer: Materializer = ActorMaterializer()
 
   "captureTermination" should {
     "signal completion" when {

--- a/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/ConnectHttpSpec.scala
@@ -9,9 +9,12 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.annotation.nowarn
+
 class ConnectHttpSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   val httpContext = ConnectionContext.noEncryption()
+  @nowarn("msg=deprecated")
   val httpsContext = ConnectionContext.https(null)
 
   val successResponse = HttpResponse.create().withStatus(200)

--- a/akka-http-core/src/test/scala/akka/http/javadsl/ConnectionContextSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/ConnectionContextSpec.scala
@@ -6,11 +6,13 @@ package akka.http.javadsl
 
 import java.util.{ Collections, Optional }
 import javax.net.ssl.SSLContext
-
 import akka.stream.TLSClientAuth
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.annotation.nowarn
+
+@nowarn("msg=deprecated")
 class ConnectionContextSpec extends AnyWordSpec with Matchers {
 
   "ConnectionContext.https" should {

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/JavaApiSpec.scala
@@ -43,11 +43,11 @@ class JavaApiSpec extends AnyFreeSpec with Matchers {
       }
       "pathSegments" in {
         Uri.create("/abc/def/ghi/jkl")
-          .pathSegments().asScala.toSeq must contain inOrderOnly ("abc", "def", "ghi", "jkl")
+          .pathSegments().asScala.toSeq must contain inOrderElementsOf Seq("abc", "def", "ghi", "jkl")
       }
       "access parameterMap" in {
         Uri.create("/abc?name=blub&age=28")
-          .query().toMap.asScala must contain allOf ("name" -> "blub", "age" -> "28")
+          .query().toMap.asScala must contain allElementsOf Seq("name" -> "blub", "age" -> "28")
       }
       "access parameters" in {
         val mutable.Seq(param1, param2, param3) =

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientServerSpec.scala
@@ -717,6 +717,7 @@ Host: example.com
 
       // Disable hostname verification as ExampleHttpContexts.exampleClientContext sets hostname as akka.example.org
       val sslConfigSettings = SSLConfigSettings().withLoose(SSLLooseConfig().withDisableHostnameVerification(true))
+      @nowarn("msg=deprecated")
       val sslConfig = AkkaSSLConfig.apply().withSettings(sslConfigSettings)
       val sslContext = {
         val certStore = KeyStore.getInstance(KeyStore.getDefaultType)

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientSpec.scala
@@ -7,7 +7,6 @@ package akka.http.scaladsl
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.HttpMethods._
-import akka.stream.ActorMaterializer
 import com.typesafe.config.{ Config, ConfigFactory }
 import scala.concurrent.duration._
 import scala.concurrent.Await
@@ -25,7 +24,6 @@ class ClientSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     akka.log-dead-letters = OFF
     akka.http.server.request-timeout = infinite""")
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName, testConf)
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
 

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
@@ -74,7 +74,7 @@ class ClientTransportWithCustomResolverSpec extends AkkaSpecWithMaterializer("ak
       assertThrows[TimeoutException](Await.result(resolverCalled.future, 3.seconds.dilated))
 
       // resolving kicks in when a request comes along
-      sourceQueue.offer(HttpRequest(POST, s"http://$hostnameToFind:$portToFind/") -> ())
+      sourceQueue.offer((HttpRequest(POST, s"http://$hostnameToFind:$portToFind/"), ()))
       Await.result(resolverCalled.future, 3.seconds.dilated) shouldBe Done
       val resp = Await.result(sinkQueue.pull(), 3.seconds.dilated).value._1.get
       resp.status shouldBe StatusCodes.OK

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/ClientTransportWithCustomResolverSpec.scala
@@ -74,7 +74,7 @@ class ClientTransportWithCustomResolverSpec extends AkkaSpecWithMaterializer("ak
       assertThrows[TimeoutException](Await.result(resolverCalled.future, 3.seconds.dilated))
 
       // resolving kicks in when a request comes along
-      sourceQueue.offer((HttpRequest(POST, s"http://$hostnameToFind:$portToFind/"), ()))
+      sourceQueue.offer(HttpRequest(POST, s"http://$hostnameToFind:$portToFind/") -> ())
       Await.result(resolverCalled.future, 3.seconds.dilated) shouldBe Done
       val resp = Await.result(sinkQueue.pull(), 3.seconds.dilated).value._1.get
       resp.status shouldBe StatusCodes.OK

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/GracefulTerminationSpec.scala
@@ -15,7 +15,7 @@ import akka.http.scaladsl.model.headers.{ Connection, HttpEncodings, `Content-En
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.settings.{ ConnectionPoolSettings, ServerSettings }
 import akka.stream.scaladsl._
-import akka.stream.testkit.TestSubscriber.{ OnComplete, OnError }
+import akka.stream.testkit.TestSubscriber.OnError
 import akka.stream.testkit.scaladsl.{ StreamTestKit, TestSink }
 import akka.stream.{ Server => _, _ }
 import akka.testkit._
@@ -90,7 +90,7 @@ class GracefulTerminationSpec
             // start reading the response
             val responseEntity = r1.futureValue.entity.dataBytes
               .via(Framing.delimiter(ByteString(","), 20))
-              .runWith(TestSink.probe[ByteString])(SystemMaterializer(clientSystem).materializer)
+              .runWith(TestSink[ByteString]())(SystemMaterializer(clientSystem).materializer)
             responseEntity.requestNext().utf8String should ===("reply1")
 
             val termination = serverBinding.terminate(hardDeadline = 1.second)
@@ -120,7 +120,7 @@ class GracefulTerminationSpec
       // start reading the response
       val response = r1.futureValue.entity.dataBytes
         .via(Framing.delimiter(ByteString(","), 20))
-        .runWith(TestSink.probe[ByteString])
+        .runWith(TestSink[ByteString]())
       response.requestNext().utf8String should ===("reply1")
 
       try {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestClient.scala
@@ -11,7 +11,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.util.{ Failure, Success }
 import akka.actor.{ ActorSystem, UnhandledMessage }
-import akka.stream.{ ActorMaterializer, IOResult }
+import akka.stream.IOResult
 import akka.stream.scaladsl.{ FileIO, Sink, Source }
 import akka.http.scaladsl.model._
 import akka.http.impl.util._
@@ -26,7 +26,6 @@ object TestClient extends App {
     akka.log-dead-letters = off
     akka.io.tcp.trace-logging = off""")
   implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
-  implicit val fm: ActorMaterializer = ActorMaterializer()
   import system.dispatcher
 
   installEventStreamLoggerFor[UnhandledMessage]

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TestServer.scala
@@ -6,7 +6,6 @@ package akka.http.scaladsl
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
-
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
@@ -14,11 +13,10 @@ import akka.http.scaladsl.model.AttributeKeys.webSocketUpgrade
 import akka.http.scaladsl.model.ws._
 import akka.stream._
 import akka.stream.scaladsl.{ Flow, Source }
-
 import com.typesafe.config.{ Config, ConfigFactory }
-
 import HttpMethods._
 
+import scala.annotation.nowarn
 import scala.io.StdIn
 
 object TestServer extends App {
@@ -32,10 +30,12 @@ object TestServer extends App {
     """)
   implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
 
+  @nowarn("msg=deprecated")
   val settings = ActorMaterializerSettings(system)
     .withFuzzing(false)
     //    .withSyncProcessingLimit(Int.MaxValue)
     .withInputBuffer(128, 128)
+  @nowarn("msg=deprecated")
   implicit val fm: ActorMaterializer = ActorMaterializer(settings)
   try {
     val binding = Http().newServerAt("localhost", 9001).bindSync {

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/TightRequestTimeoutSpec.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl._
-import akka.stream.{ OverflowStrategy, ActorMaterializer }
+import akka.stream.OverflowStrategy
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
@@ -27,7 +27,6 @@ class TightRequestTimeoutSpec extends AnyWordSpec with Matchers with BeforeAndAf
     akka.http.server.request-timeout = 10ms""")
 
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName, testConf)
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
   implicit val patience: PatienceConfig = PatienceConfig(3.seconds.dilated)
 
   override def afterAll() = TestKit.shutdownActorSystem(system)

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/HttpEntitySpec.scala
@@ -82,7 +82,7 @@ class HttpEntitySpec extends AkkaSpecWithMaterializer {
       "Infinite data stream" in {
         val neverCompleted = Promise[ByteString]()
         intercept[TimeoutException] {
-          Await.result(Default(tpe, 42, Source.fromFuture(neverCompleted.future)).toStrict(100.millis), awaitAtMost)
+          Await.result(Default(tpe, 42, Source.future(neverCompleted.future)).toStrict(100.millis), awaitAtMost)
         }.getMessage should be("HttpEntity.toStrict timed out after 100 milliseconds while still waiting for outstanding data")
       }
     }

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/settings/ConnectionPoolSettingsSpec.scala
@@ -11,6 +11,8 @@ import akka.testkit.AkkaSpec
 import akka.http.scaladsl.model.headers.`User-Agent`
 import com.typesafe.config.ConfigFactory
 
+import scala.annotation.nowarn
+
 class ConnectionPoolSettingsSpec extends AkkaSpec {
   "ConnectionPoolSettings" should {
     "use akka.http.client settings by default" in {
@@ -148,6 +150,7 @@ class ConnectionPoolSettingsSpec extends AkkaSpec {
       settings.minConnections shouldEqual 2
     }
 
+    @nowarn("msg=never used")
     def expectError(configString: String): String = Try(config(configString)) match {
       case Failure(cause) => cause.getMessage
       case Success(_)     => fail("Expected a failure when max-open-requests is not a power of 2")

--- a/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
+++ b/akka-http-core/src/test/scala/io/akka/integrationtest/http/HttpModelIntegrationSpec.scala
@@ -13,7 +13,6 @@ import akka.util.ByteString
 import akka.actor.ActorSystem
 import akka.http.ccompat._
 import akka.http.scaladsl.model._
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl._
 import akka.testkit._
 import headers._
@@ -45,8 +44,6 @@ class HttpModelIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndA
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName, testConf)
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
-
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   "External HTTP libraries" should {
 

--- a/akka-http-marshallers-java/akka-http-jackson/src/main/java/akka/http/javadsl/marshallers/jackson/Jackson.java
+++ b/akka-http-marshallers-java/akka-http-jackson/src/main/java/akka/http/javadsl/marshallers/jackson/Jackson.java
@@ -19,10 +19,11 @@ import akka.util.ByteString;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 public class Jackson {
   private static final ObjectMapper defaultObjectMapper =
-    new ObjectMapper().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
+      JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
 
   /**
    * INTERNAL API

--- a/akka-http-marshallers-java/akka-http-jackson/src/test/java/akka/http/javadsl/marshallers/jackson/JacksonTest.java
+++ b/akka-http-marshallers-java/akka-http-jackson/src/test/java/akka/http/javadsl/marshallers/jackson/JacksonTest.java
@@ -4,6 +4,7 @@
 
 package akka.http.javadsl.marshallers.jackson;
 
+import akka.stream.SystemMaterializer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.typesafe.config.Config;
@@ -19,7 +20,6 @@ import akka.http.javadsl.server.ExceptionHandler;
 import akka.http.javadsl.server.Route;
 import akka.http.javadsl.settings.RoutingSettings;
 import akka.http.javadsl.testkit.JUnitRouteTest;
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 import org.junit.Test;
@@ -53,7 +53,7 @@ public class JacksonTest extends JUnitRouteTest {
   public void failingToUnmarshallShouldProvideFailureDetails() throws Exception {
     ActorSystem sys = ActorSystem.create("test");
     try {
-      Materializer materializer = ActorMaterializer.create(sys);
+      Materializer materializer = SystemMaterializer.get(sys).materializer();
       CompletionStage<SomeData> unmarshalled = Jackson.unmarshaller(SomeData.class).unmarshal(invalidEntity, system());
 
 

--- a/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
+++ b/akka-http-marshallers-scala/akka-http-spray-json/src/test/scala/akka/http/scaladsl/marshallers/sprayjson/SprayJsonSupportSpec.scala
@@ -10,7 +10,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.MessageEntity
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream.ActorMaterializer
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import spray.json.{ JsArray, JsString, JsValue }
@@ -25,7 +24,6 @@ class SprayJsonSupportSpec extends AnyWordSpec with Matchers with ScalaFutures {
 
   implicit val exampleFormat: RootJsonFormat[Example] = jsonFormat1(Example.apply)
   implicit val sys: ActorSystem = ActorSystem("SprayJsonSupportSpec")
-  implicit val mat: ActorMaterializer = ActorMaterializer()
   implicit val ec: ExecutionContext = sys.dispatcher
 
   val TestString = "Contains all UTF-8 characters: 2-byte: £, 3-byte: ﾖ, 4-byte: 😁, 4-byte as a literal surrogate pair: \uD83D\uDE01"

--- a/akka-http-scalafix/scalafix-rules/src/main/scala/akka/http/fix/MigrateToServerBuilder.scala
+++ b/akka-http-scalafix/scalafix-rules/src/main/scala/akka/http/fix/MigrateToServerBuilder.scala
@@ -81,7 +81,7 @@ class MigrateToServerBuilder extends SemanticRule("MigrateToServerBuilder") {
       } ++
         named.map {
           case q"$name = $expr" => name.asInstanceOf[Term.Name].value -> expr
-          case other            => throw new IllegalStateException(s"Unexpected term $other") // compiler completeness check pleaser
+          case _                => throw new IllegalStateException("Unexpected term") // compiler completeness check pleaser
         }
       ).toMap
     }

--- a/akka-http-scalafix/scalafix-rules/src/main/scala/akka/http/fix/MigrateToServerBuilder.scala
+++ b/akka-http-scalafix/scalafix-rules/src/main/scala/akka/http/fix/MigrateToServerBuilder.scala
@@ -81,6 +81,7 @@ class MigrateToServerBuilder extends SemanticRule("MigrateToServerBuilder") {
       } ++
         named.map {
           case q"$name = $expr" => name.asInstanceOf[Term.Name].value -> expr
+          case other            => throw new IllegalStateException(s"Unexpected term $other") // compiler completeness check pleaser
         }
       ).toMap
     }

--- a/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/TestRouteResult.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/javadsl/testkit/TestRouteResult.scala
@@ -33,13 +33,15 @@ import scala.annotation.varargs
 abstract class TestRouteResult(_result: Future[RouteResult], awaitAtMost: FiniteDuration)(implicit ec: ExecutionContext, materializer: Materializer) {
 
   private def _response = _result.awaitResult(awaitAtMost) match {
-    case scaladsl.server.RouteResult.Complete(r)          => r
+    case scaladsl.server.RouteResult.Complete(r) => r
     case scaladsl.server.RouteResult.Rejected(rejections) => doFail("Expected route to complete, but was instead rejected with " + rejections)
+    case other => throw new IllegalArgumentException(s"Unexpected result: $other") // compiler completeness check pleaser
   }
 
   private def _rejections = _result.awaitResult(awaitAtMost) match {
     case scaladsl.server.RouteResult.Complete(r)  => doFail("Request was not rejected, response was " + r)
     case scaladsl.server.RouteResult.Rejected(ex) => ex
+    case other                                    => throw new IllegalArgumentException(s"Unexpected result: $other") // compiler completeness check pleaser
   }
 
   /**

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSProbe.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSProbe.scala
@@ -128,7 +128,7 @@ object WSProbe {
         case _ => throw new AssertionError(s"""Expected BinaryMessage("$bytes") but got TextMessage""")
       }
 
-      def expectNoMessage(): Unit = subscriber.expectNoMsg()
+      def expectNoMessage(): Unit = subscriber.expectNoMessage()
       def expectNoMessage(max: FiniteDuration): Unit = subscriber.expectNoMessage(max)
 
       def expectCompletion(): Unit = subscriber.expectComplete()

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSTestRequestBuilding.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/WSTestRequestBuilding.scala
@@ -5,15 +5,19 @@
 package akka.http.scaladsl.testkit
 
 import akka.http.impl.engine.server.InternalCustomHeader
-import akka.http.scaladsl.model.headers.{ UpgradeProtocol, Upgrade, `Sec-WebSocket-Protocol` }
-import akka.http.scaladsl.model.{ StatusCodes, HttpResponse, HttpRequest, Uri }
-import akka.http.scaladsl.model.ws.{ UpgradeToWebSocket, WebSocketUpgrade, Message }
+import akka.http.scaladsl.model.headers.{ Upgrade, UpgradeProtocol, `Sec-WebSocket-Protocol` }
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes, Uri }
+import akka.http.scaladsl.model.ws.{ Message, UpgradeToWebSocket, WebSocketUpgrade }
 import akka.http.scaladsl.model.AttributeKeys.webSocketUpgrade
+
 import scala.collection.immutable
-import akka.stream.{ Materializer, Graph, FlowShape }
+import akka.stream.{ FlowShape, Graph, Materializer }
 import akka.stream.scaladsl.Flow
 
+import scala.annotation.nowarn
+
 trait WSTestRequestBuilding {
+  @nowarn("msg=deprecated")
   def WS(uri: Uri, clientSideHandler: Flow[Message, Message, Any], subprotocols: Seq[String] = Nil)(implicit materializer: Materializer): HttpRequest = {
     val upgrade = new InternalCustomHeader("UpgradeToWebSocketTestHeader") with UpgradeToWebSocket with WebSocketUpgrade {
       def requestedProtocols: immutable.Seq[String] = subprotocols.toList

--- a/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java
+++ b/akka-http-tests/src/main/java/akka/http/javadsl/server/examples/petstore/PetStoreExample.java
@@ -12,7 +12,6 @@ import akka.http.javadsl.marshallers.jackson.Jackson;
 import akka.http.javadsl.model.StatusCodes;
 //#imports
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
 
 import java.io.IOException;
 //#imports

--- a/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/HttpAPIsTest.java
@@ -29,11 +29,13 @@ public class HttpAPIsTest extends JUnitRouteTest {
     // fails if there are no test cases
   }
 
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "deprecation"})
   public void compileOnly() throws Exception {
     final Http http = Http.get(system());
 
     final ConnectionContext connectionContext = ConnectionContext.https(SSLContext.getDefault());
+    final ConnectionContext clientConnectionContext = ConnectionContext.httpsClient(SSLContext.getDefault());
+    final ConnectionContext serverConnectionContext = ConnectionContext.httpsServer(SSLContext.getDefault());
     final HttpConnectionContext httpContext = ConnectionContext.noEncryption();
     final HttpsConnectionContext httpsContext = ConnectionContext.https(SSLContext.getDefault());
 
@@ -116,7 +118,7 @@ public class HttpAPIsTest extends JUnitRouteTest {
     connect.effectiveHttpsConnectionContext(http.defaultClientHttpsContext()); // usage by us internally
   }
 
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "deprecation"})
   public void compileOnlyBinding() throws Exception {
     final Http http = Http.get(system());
     final HttpsConnectionContext httpsConnectionContext = null;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/MinimalHttpApp.java
@@ -12,6 +12,10 @@ import akka.http.scaladsl.Http;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Deprecated: See akka.http.javadsl.server.HttpApp
+ */
+@Deprecated
 public class MinimalHttpApp extends HttpApp {
 
   CompletableFuture<Done> shutdownTrigger = new CompletableFuture<>();

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/SneakHttpApp.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/SneakHttpApp.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+@SuppressWarnings("deprecation")
 public class SneakHttpApp extends MinimalHttpApp {
 
   AtomicBoolean postServerShutdownCalled = new AtomicBoolean(false);

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/CodingDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/CodingDirectivesTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import static akka.http.javadsl.server.Directives.*;
 
+@SuppressWarnings("deprecation")
 public class CodingDirectivesTest extends JUnitRouteTest {
 
   @Test

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/MiscDirectivesTest.java
@@ -52,6 +52,7 @@ public class MiscDirectivesTest extends JUnitRouteTest {
       .assertEntity("Path too long!");
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testClientIpExtraction() throws UnknownHostException {
     TestRoute route = testRoute(extractClientIP(ip -> complete(ip.toString())));

--- a/akka-http-tests/src/test/java/akka/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/unmarshalling/sse/EventStreamUnmarshallingTest.java
@@ -18,8 +18,8 @@ package akka.http.javadsl.unmarshalling.sse;
 
 import akka.actor.ActorSystem;
 import akka.http.javadsl.model.HttpEntity;
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.SystemMaterializer;
 import akka.stream.javadsl.Sink;
 import akka.http.javadsl.model.sse.ServerSentEvent;
 import akka.http.scaladsl.unmarshalling.sse.EventStreamUnmarshallingSpec;
@@ -36,7 +36,7 @@ public class EventStreamUnmarshallingTest extends JUnitSuite {
     public void testFromEventsStream() throws Exception {
         ActorSystem system = ActorSystem.create();
         try {
-            Materializer mat = ActorMaterializer.create(system);
+            Materializer mat = SystemMaterializer.get(system).materializer();
 
             List<ServerSentEvent> events = EventStreamUnmarshallingSpec.eventsAsJava();
             HttpEntity entity = EventStreamUnmarshallingSpec.entity();

--- a/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/javadsl/server/HttpAppSpec.scala
@@ -19,9 +19,11 @@ import akka.testkit.EventFilter
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, Future }
 
+@nowarn("msg=deprecated")
 class HttpAppSpec extends AkkaSpecWithMaterializer with RequestBuilding with Eventually {
   import system.dispatcher
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/CustomMediaTypesSpec.scala
@@ -8,7 +8,6 @@ import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.MediaType.WithFixedCharset
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives
-import akka.stream.ActorMaterializer
 import akka.testkit._
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
@@ -16,8 +15,6 @@ import scala.concurrent.duration._
 
 class CustomMediaTypesSpec extends AkkaSpec with ScalaFutures
   with Directives with RequestBuilding {
-
-  implicit val mat: ActorMaterializer = ActorMaterializer()
 
   "Http" should {
     "find media types in a set if they differ in casing" in {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/FormDataSpec.scala
@@ -4,14 +4,12 @@
 
 package akka.http.scaladsl
 
-import akka.stream.ActorMaterializer
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model._
 import akka.testkit.AkkaSpec
 
 class FormDataSpec extends AkkaSpec {
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
   import system.dispatcher
 
   val formData = FormData(Map("surname" -> "Smith", "age" -> "42"))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/RouteJavaScalaDslConversionSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/RouteJavaScalaDslConversionSpec.scala
@@ -5,10 +5,12 @@
 package akka.http.scaladsl
 
 import java.util.function.Supplier
-
 import akka.http.javadsl.server.Route
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.annotation.nowarn
+
+@nowarn("msg=never used")
 class RouteJavaScalaDslConversionSpec extends AnyWordSpec {
 
   "Routes" must {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/TestSingleRequest.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/TestSingleRequest.scala
@@ -8,7 +8,6 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.util.ByteString
 import com.typesafe.config.{ ConfigFactory, Config }
 import akka.actor.ActorSystem
-import akka.stream._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.io.StdIn
@@ -20,7 +19,6 @@ object TestSingleRequest extends App {
     akka.stream.materializer.debug.fuzzing-mode = off
     """)
   implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
   import system.dispatcher
 
   val url = StdIn.readLine("url? ")

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CodecSpecSupport.scala
@@ -6,7 +6,6 @@ package akka.http.scaladsl.coding
 
 import org.scalatest.{ BeforeAndAfterAll, Suite }
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.matchers.should.Matchers
@@ -71,7 +70,6 @@ voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita ka
 est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy e""".replace("\r\n", "\n")
 
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   override def afterAll() = TestKit.shutdownActorSystem(system)
 }

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -12,7 +12,6 @@ import akka.http.scaladsl.model.MediaTypes._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.MarshallingTestUtils
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -26,7 +25,6 @@ import org.scalatest.matchers.should.Matchers
 
 class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with MultipartMarshallers with MarshallingTestUtils {
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
   import system.dispatcher
 
   override val testConfig = ConfigFactory.load()

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/ConnectionTestApp.scala
@@ -8,9 +8,10 @@ import akka.actor._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
 import akka.stream.scaladsl.{ Flow, Sink, Source }
-import akka.stream.{ ActorMaterializer, OverflowStrategy }
+import akka.stream.OverflowStrategy
 import com.typesafe.config.{ Config, ConfigFactory }
 
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.io.StdIn
 import scala.util.{ Failure, Success, Try }
@@ -29,10 +30,10 @@ object ConnectionTestApp {
 
   implicit val system: ActorSystem = ActorSystem("ConnectionTest", testConf)
   import system.dispatcher
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   val clientFlow = Http().superPool[Int]()
 
+  @nowarn("msg=deprecated")
   val sourceActor = {
     // Our superPool expects (HttpRequest, Int) as input
     val source = Source.actorRef[(HttpRequest, Int)](10000, OverflowStrategy.dropNew).buffer(20000, OverflowStrategy.fail)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -11,7 +11,6 @@ import akka.event.Logging
 import akka.http.impl.util.WithLogCapturing
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.testkit.Utils.assertAllStagesStopped
 import akka.testkit.TestKit
@@ -39,7 +38,6 @@ abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String
       http.host-connection-pool.base-connection-backoff = 0 ms
     }""").withFallback(ConfigFactory.load())
   implicit val system: ActorSystem = ActorSystem("DontLeakActorsOnFailingConnectionSpecs-" + poolImplementation, config)
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   val log = Logging(system, getClass)(LogSource.fromClass)
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/DontLeakActorsOnFailingConnectionSpecs.scala
@@ -5,12 +5,12 @@
 package akka.http.scaladsl.server
 
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
-
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.impl.util.WithLogCapturing
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.testkit.Utils.assertAllStagesStopped
 import akka.testkit.TestKit
@@ -38,6 +38,7 @@ abstract class DontLeakActorsOnFailingConnectionSpecs(poolImplementation: String
       http.host-connection-pool.base-connection-backoff = 0 ms
     }""").withFallback(ConfigFactory.load())
   implicit val system: ActorSystem = ActorSystem("DontLeakActorsOnFailingConnectionSpecs-" + poolImplementation, config)
+  implicit val materializer: Materializer = Materializer.createMaterializer(system)
 
   val log = Logging(system, getClass)(LogSource.fromClass)
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/EntityStreamingSpec.scala
@@ -118,7 +118,7 @@ class EntityStreamingSpec extends RoutingSpec with ScalaFutures {
 
     // flatten the Future[Source[]] into a Source[]:
     val source: Source[Tweet, Future[NotUsed]] =
-      Source.fromFutureSource(unmarshalled)
+      Source.futureSource(unmarshalled)
 
     //#json-streaming-client-example
     // tests ------------------------------------------------------------

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/HttpAppSpec.scala
@@ -9,7 +9,6 @@ import java.net.ServerSocket
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.net.SocketException
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.http.impl.util.AkkaSpecWithMaterializer
@@ -22,6 +21,7 @@ import akka.testkit.EventFilter
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContext, Future, Promise }
 import scala.util.Try
@@ -29,6 +29,7 @@ import scala.util.Try
 class HttpAppSpec extends AkkaSpecWithMaterializer with RequestBuilding with Eventually {
   import system.dispatcher
 
+  @nowarn("msg=deprecated")
   class MinimalApp extends HttpApp {
 
     val shutdownPromise = Promise[Done]()

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -13,7 +13,6 @@ import akka.http.scaladsl.model.HttpEntity.Chunk
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{ HttpEncoding, HttpEncodings, `Content-Encoding` }
 import akka.http.scaladsl.server.Directives._
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Flow, Source }
 import akka.testkit.TestKit
 import akka.util.ByteString
@@ -45,7 +44,6 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
     """)
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
   val random = new scala.util.Random(42)
 
   implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(5, Millis))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -13,9 +13,11 @@ import akka.http.scaladsl.model.HttpEntity.Chunk
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{ HttpEncoding, HttpEncodings, `Content-Encoding` }
 import akka.http.scaladsl.server.Directives._
+import akka.stream.Materializer
 import akka.stream.scaladsl.{ Flow, Source }
 import akka.testkit.TestKit
 import akka.util.ByteString
+
 import scala.annotation.nowarn
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
@@ -44,6 +46,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
     """)
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
+  implicit val materializer = Materializer.createMaterializer(system)
   val random = new scala.util.Random(42)
 
   implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(5, Millis))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/SizeLimitSpec.scala
@@ -46,7 +46,7 @@ class SizeLimitSpec extends AnyWordSpec with Matchers with RequestBuilding with 
     """)
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName, testConf)
   import system.dispatcher
-  implicit val materializer = Materializer.createMaterializer(system)
+  implicit val materializer: Materializer = Materializer.createMaterializer(system)
   val random = new scala.util.Random(42)
 
   implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(5, Millis))

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TcpLeakApp.scala
@@ -9,7 +9,7 @@ import java.net.InetSocketAddress
 import akka.actor.{ ActorSystem, ActorSystemImpl }
 import akka.event.Logging
 import akka.stream.scaladsl._
-import akka.stream.{ ActorAttributes, ActorMaterializer }
+import akka.stream.ActorAttributes
 import akka.util.ByteString
 import com.typesafe.config.{ Config, ConfigFactory }
 import scala.io.StdIn
@@ -21,7 +21,6 @@ object TcpLeakApp extends App {
     akka.log-dead-letters = on
     akka.io.tcp.trace-logging = on""")
   implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
-  implicit val fm: ActorMaterializer = ActorMaterializer()
 
   import system.dispatcher
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/TestServer.scala
@@ -10,7 +10,6 @@ import akka.http.scaladsl.model.{ HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.directives.Credentials
 import com.typesafe.config.{ Config, ConfigFactory }
 import akka.actor.ActorSystem
-import akka.stream._
 import akka.stream.scaladsl._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.common.EntityStreamingSupport
@@ -30,7 +29,6 @@ object TestServer extends App {
 
   implicit val system: ActorSystem = ActorSystem("ServerTest", testConf)
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   import spray.json.DefaultJsonProtocol._
   import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/FileUploadDirectivesSpec.scala
@@ -5,7 +5,6 @@
 package akka.http.scaladsl.server.directives
 
 import java.io.File
-
 import akka.NotUsed
 import akka.http.scaladsl.model.{ Multipart, _ }
 import akka.http.scaladsl.server.{ MissingFormFieldRejection, Route, RoutingSpec }
@@ -15,6 +14,7 @@ import akka.util.ByteString
 import akka.testkit._
 import org.scalatest.concurrent.Eventually
 
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -485,6 +485,7 @@ class MockFailingWritePath extends java.nio.file.Path { selfPath =>
   import java.nio.file.{ AccessMode, CopyOption, DirectoryStream, FileStore, FileSystem, LinkOption, OpenOption, Path, PathMatcher, WatchEvent, WatchKey, WatchService }
   import java.{ lang, util }
 
+  @nowarn("msg=never used")
   override def getFileSystem: FileSystem =
     new FileSystem {
       override def provider(): FileSystemProvider = new FileSystemProvider {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/directives/HeaderDirectivesSpec.scala
@@ -8,11 +8,13 @@ import akka.http.scaladsl.model._
 import headers._
 import akka.http.scaladsl.server._
 import directives.HeaderDirectivesSpec.XCustomHeader
-
 import org.scalatest.Inside
+
+import scala.annotation.nowarn
 import scala.reflect.ClassTag
 import scala.util.Try
 
+@nowarn("msg=deprecated")
 class HeaderDirectivesSpec extends RoutingSpec with Inside {
 
   "The headerValuePF directive" should {

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/UnmarshallingSpec.scala
@@ -11,7 +11,6 @@ import org.scalatest.BeforeAndAfterAll
 import akka.http.scaladsl.testkit.ScalatestUtils
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.MediaType.WithFixedCharset
-import akka.stream.ActorMaterializer
 import akka.http.scaladsl.model._
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
@@ -24,7 +23,6 @@ import org.scalatest.matchers.should.Matchers
 
 class UnmarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with ScalatestUtils {
   implicit val system: ActorSystem = ActorSystem(getClass.getSimpleName)
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   override val testConfig = ConfigFactory.load()
 

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/BaseUnmarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/BaseUnmarshallingSpec.scala
@@ -10,6 +10,8 @@ package sse
 import akka.actor.ActorSystem
 import akka.stream.{ ActorMaterializer, Materializer }
 import org.scalatest.{ BeforeAndAfterAll, Suite }
+
+import scala.annotation.nowarn
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
@@ -18,6 +20,7 @@ trait BaseUnmarshallingSpec extends BeforeAndAfterAll { this: Suite =>
   protected implicit val system: ActorSystem =
     ActorSystem()
 
+  @nowarn("msg=deprecated")
   protected implicit val mat: Materializer =
     ActorMaterializer()
 

--- a/akka-http/src/main/java/akka/http/javadsl/coding/Coder.java
+++ b/akka-http/src/main/java/akka/http/javadsl/coding/Coder.java
@@ -8,9 +8,6 @@ import java.util.concurrent.CompletionStage;
 
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
-import akka.http.scaladsl.coding.Deflate$;
-import akka.http.scaladsl.coding.Gzip$;
-import akka.http.scaladsl.coding.NoCoding$;
 import akka.stream.Materializer;
 import akka.util.ByteString;
 import scala.compat.java8.FutureConverters;
@@ -18,12 +15,13 @@ import scala.compat.java8.FutureConverters;
 /**
  * A coder is an implementation of the predefined encoders/decoders defined for HTTP.
  */
+@SuppressWarnings({"deprecation", "removal"})
 public enum Coder {
-    NoCoding(NoCoding$.MODULE$), Deflate(Deflate$.MODULE$), Gzip(Gzip$.MODULE$),
-    DeflateLevel1(Deflate$.MODULE$.withLevel(1)),
-    DeflateLevel9(Deflate$.MODULE$.withLevel(9)),
-    GzipLevel1(Gzip$.MODULE$.withLevel(1)),
-    GzipLevel9(Gzip$.MODULE$.withLevel(9));
+    NoCoding(akka.http.scaladsl.coding.NoCoding$.MODULE$), Deflate(akka.http.scaladsl.coding.Deflate$.MODULE$), Gzip(akka.http.scaladsl.coding.Gzip$.MODULE$),
+    DeflateLevel1(akka.http.scaladsl.coding.Deflate$.MODULE$.withLevel(1)),
+    DeflateLevel9(akka.http.scaladsl.coding.Deflate$.MODULE$.withLevel(9)),
+    GzipLevel1(akka.http.scaladsl.coding.Gzip$.MODULE$.withLevel(1)),
+    GzipLevel9(akka.http.scaladsl.coding.Gzip$.MODULE$.withLevel(9));
 
     private akka.http.scaladsl.coding.Coder underlying;
 

--- a/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
+++ b/akka-http/src/main/java/akka/http/javadsl/server/HttpApp.java
@@ -11,7 +11,6 @@ import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.settings.ServerSettings;
-import akka.stream.ActorMaterializer;
 import com.typesafe.config.ConfigFactory;
 
 import java.io.IOException;
@@ -92,7 +91,6 @@ public abstract class HttpApp extends AllDirectives {
 
     final ActorSystem theSystem = system.orElseGet(() -> ActorSystem.create(Logging.simpleName(this).replaceAll("\\$", "")));
     systemReference.set(theSystem);
-    final ActorMaterializer materializer = ActorMaterializer.create(theSystem);
 
     CompletionStage<ServerBinding> bindingFuture = Http
       .get(theSystem)

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RequestContext.scala
@@ -49,18 +49,18 @@ class RequestContext private (val delegate: scaladsl.server.RequestContext) {
 
   def complete[T](value: T, marshaller: Marshaller[T, HttpResponse]): CompletionStage[RouteResult] = {
     delegate.complete(ToResponseMarshallable(value)(marshaller))
-      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext).toJava
+      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).toJava
   }
 
   def completeWith(response: HttpResponse): CompletionStage[RouteResult] = {
     delegate.complete(response.asScala)
-      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext).toJava
+      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).toJava
   }
 
   @varargs def reject(rejections: Rejection*): CompletionStage[RouteResult] = {
     val scalaRejections = rejections.map(_.asScala)
     delegate.reject(scalaRejections: _*)
-      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext).toJava
+      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).toJava
   }
 
   def redirect(uri: Uri, redirectionType: StatusCode): CompletionStage[RouteResult] = {
@@ -69,7 +69,7 @@ class RequestContext private (val delegate: scaladsl.server.RequestContext) {
 
   def fail(error: Throwable): CompletionStage[RouteResult] =
     delegate.fail(error)
-      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext).toJava
+      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).toJava
 
   def withRequest(req: HttpRequest): RequestContext = wrap(delegate.withRequest(req.asScala))
   def withExecutionContext(ec: ExecutionContextExecutor): RequestContext = wrap(delegate.withExecutionContext(ec))

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
@@ -24,8 +24,6 @@ import scala.collection.immutable
 private[http] object RoutingJavaMapping {
 
   object Implicits {
-    import scala.language.implicitConversions
-
     implicit def convertToScala[J](j: J)(implicit mapping: J2SMapping[J]): mapping.S = mapping.toScala(j)
     implicit def convertSeqToScala[J](j: Seq[J])(implicit mapping: J2SMapping[J]): immutable.Seq[mapping.S] =
       j.map(mapping.toScala(_)).toList

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
@@ -84,17 +84,17 @@ abstract class BasicDirectives {
 
   def mapRouteResultFuture(f: JFunction[CompletionStage[RouteResult], CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
     D.mapRouteResultFuture(stage =>
-      f(toJava(stage.fast.map(_.asJava)(ExecutionContexts.sameThreadExecutionContext))).toScala.fast.map(_.asScala)(ExecutionContexts.sameThreadExecutionContext)) {
+      f(toJava(stage.fast.map(_.asJava)(ExecutionContexts.parasitic))).toScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) {
       inner.get.delegate
     }
   }
 
   def mapRouteResultWith(f: JFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.mapRouteResultWith(r => f(r.asJava).toScala.fast.map(_.asScala)(ExecutionContexts.sameThreadExecutionContext)) { inner.get.delegate }
+    D.mapRouteResultWith(r => f(r.asJava).toScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) { inner.get.delegate }
   }
 
   def mapRouteResultWithPF(f: PartialFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.mapRouteResultWith(r => f(r.asJava).toScala.fast.map(_.asScala)(ExecutionContexts.sameThreadExecutionContext)) { inner.get.delegate }
+    D.mapRouteResultWith(r => f(r.asJava).toScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) { inner.get.delegate }
   }
 
   /**
@@ -148,7 +148,7 @@ abstract class BasicDirectives {
   }
 
   def recoverRejectionsWith(f: JFunction[JIterable[Rejection], CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.recoverRejectionsWith(rs => f.apply(Util.javaArrayList(rs.map(_.asJava))).toScala.fast.map(_.asScala)(ExecutionContexts.sameThreadExecutionContext)) { inner.get.delegate }
+    D.recoverRejectionsWith(rs => f.apply(Util.javaArrayList(rs.map(_.asJava))).toScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) { inner.get.delegate }
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -42,6 +42,7 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
     alternative match {
       case adapt: RouteAdapter =>
         RouteAdapter(delegate ~ adapt.delegate)
+      case other => throw new IllegalStateException(s"Unexpected type of alternative: $other") // compiler completeness check pleaser
     }
 
   override def seal(): Route = RouteAdapter(scaladsl.server.Route.seal(delegate))

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -5,7 +5,6 @@
 package akka.http.javadsl.server.directives
 
 import java.util.concurrent.{ CompletionException, CompletionStage }
-
 import akka.dispatch.ExecutionContexts
 import akka.http.javadsl.marshalling.Marshaller
 
@@ -22,13 +21,14 @@ import akka.http.scaladsl.server.RouteResult
 import akka.http.scaladsl.server.directives.{ RouteDirectives => D }
 import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.util.FastFuture._
+
 import scala.concurrent.ExecutionContext
 
 abstract class RouteDirectives extends RespondWithDirectives {
   import RoutingJavaMapping.Implicits._
 
   // Don't try this at home – we only use it here for the java -> scala conversions
-  private implicit val conversionExecutionContext: ExecutionContext = ExecutionContexts.sameThreadExecutionContext
+  private implicit val conversionExecutionContext: ExecutionContext = ExecutionContexts.parasitic
 
   /**
    * Java-specific call added so you can chain together multiple alternate routes using comma,

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
@@ -32,7 +32,7 @@ trait Encoder {
     mapper.transformDataBytes(t, Flow.fromGraph(singleUseEncoderFlow()))
 
   def encoderFlow: Flow[ByteString, ByteString, NotUsed] =
-    Flow.setup { (_, _) => Flow.fromGraph(singleUseEncoderFlow()) }
+    Flow.fromMaterializer { (_, _) => Flow.fromGraph(singleUseEncoderFlow()) }
       .mapMaterializedValue(_ => NotUsed)
 
   @InternalApi
@@ -65,6 +65,7 @@ object Encoder {
   val DefaultFilter: HttpMessage => Boolean = {
     case req: HttpRequest                    => isCompressible(req)
     case res @ HttpResponse(status, _, _, _) => isCompressible(res) && status.allowsEntity
+    case other                               => throw new IllegalStateException(s"Unexpected type of request key: $other") // compiler completeness check pleaser
   }
   private[coding] def isCompressible(msg: HttpMessage): Boolean =
     msg.entity.contentType.mediaType.isCompressible

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
@@ -65,7 +65,7 @@ object Encoder {
   val DefaultFilter: HttpMessage => Boolean = {
     case req: HttpRequest                    => isCompressible(req)
     case res @ HttpResponse(status, _, _, _) => isCompressible(res) && status.allowsEntity
-    case other                               => throw new IllegalStateException(s"Unexpected type of request key: $other") // compiler completeness check pleaser
+    case _                                   => throw new IllegalStateException("Unexpected type of request key") // compiler completeness check pleaser
   }
   private[coding] def isCompressible(msg: HttpMessage): Boolean =
     msg.entity.contentType.mediaType.isCompressible

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/GzipCompressor.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/GzipCompressor.scala
@@ -5,14 +5,16 @@
 package akka.http.scaladsl.coding
 
 import java.util.zip.{ CRC32, Deflater, Inflater, ZipException }
-
 import akka.annotation.InternalApi
 import akka.stream.Attributes
 import akka.stream.impl.io.ByteStringParser
 import akka.stream.impl.io.ByteStringParser.{ ParseResult, ParseStep }
 import akka.util.ByteString
 
+import scala.annotation.nowarn
+
 /** Internal API */
+@nowarn("msg=deprecated")
 @InternalApi
 private[coding] class GzipCompressor(compressionLevel: Int) extends DeflateCompressor(compressionLevel) {
   override protected lazy val deflater = new Deflater(compressionLevel, true)
@@ -60,7 +62,7 @@ private[coding] object GzipCompressor {
 private[coding] class GzipDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
   override def createLogic(attr: Attributes) = new ParsingLogic {
     private[this] val inflater = new Inflater(true)
-    private[this] var crc32: CRC32 = new CRC32
+    private[this] val crc32: CRC32 = new CRC32
 
     trait Step extends ParseStep[ByteString] {
       override def onTruncation(): Unit = failStage(new ZipException("Truncated GZIP stream"))

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/ExceptionHandler.scala
@@ -8,7 +8,6 @@ import scala.util.control.NonFatal
 import akka.http.scaladsl.settings.RoutingSettings
 import akka.http.scaladsl.model._
 import StatusCodes._
-import scala.language.implicitConversions
 
 trait ExceptionHandler extends ExceptionHandler.PF {
 

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/BasicDirectives.scala
@@ -17,7 +17,7 @@ import scala.collection.immutable
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.Uri.Path
 import akka.util.ConstantFun.scalaIdentityFunction
-import akka.stream.{ ActorMaterializerHelper, Materializer }
+import akka.stream.Materializer
 import akka.http.scaladsl.settings.{ ParserSettings, RoutingSettings }
 import akka.http.scaladsl.server.util.Tuple
 import akka.http.scaladsl.util.FastFuture
@@ -260,7 +260,7 @@ trait BasicDirectives {
    * @group basic
    */
   def extractActorSystem: Directive1[ActorSystem] = extract { ctx =>
-    ActorMaterializerHelper.downcast(ctx.materializer).system
+    ctx.materializer.system
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala
@@ -5,10 +5,9 @@
 package akka.http.scaladsl.server.directives
 
 import java.io.File
-
 import akka.Done
 import akka.annotation.ApiMayChange
-import akka.http.impl.util.StreamUtils
+import akka.dispatch.ExecutionContexts
 import akka.http.scaladsl.server.{ Directive, Directive1, MissingFormFieldRejection }
 import akka.http.scaladsl.model.{ ContentType, Multipart }
 import akka.util.ByteString
@@ -52,8 +51,7 @@ trait FileUploadDirectives {
           val uploadedF: Future[(FileInfo, File)] =
             bytes
               .runWith(FileIO.toPath(dest.toPath))
-              .flatMap(StreamUtils.handleIOResult)
-              .map(_ => (fileInfo, dest))
+              .map(_ => (fileInfo, dest))(ExecutionContexts.parasitic)
               .recoverWith {
                 case ex =>
                   dest.delete()
@@ -76,7 +74,6 @@ trait FileUploadDirectives {
     entity(as[Multipart.FormData]).flatMap { formData =>
       extractRequestContext.flatMap { ctx =>
         implicit val mat = ctx.materializer
-        implicit val ec = ctx.executionContext
 
         val uploaded: Source[(FileInfo, File), Any] = formData.parts
           .mapConcat { part =>
@@ -91,8 +88,7 @@ trait FileUploadDirectives {
             val dest = destFn(fileInfo)
 
             part.entity.dataBytes.runWith(FileIO.toPath(dest.toPath))
-              .flatMap(StreamUtils.handleIOResult)
-              .map(_ => (fileInfo, dest))
+              .map(_ => (fileInfo, dest))(ExecutionContexts.parasitic)
           }
 
         val uploadedF = uploaded.runWith(Sink.seq[(FileInfo, File)])

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MiscDirectives.scala
@@ -10,6 +10,8 @@ import akka.http.scaladsl.server.directives.BasicDirectives._
 import akka.http.scaladsl.server.RequestEntityExpectedRejection
 import headers._
 
+import scala.annotation.nowarn
+
 /**
  * @groupname misc Miscellaneous directives
  * @groupprio misc 140
@@ -107,6 +109,7 @@ object MiscDirectives extends MiscDirectives {
   import RouteDirectives._
   import RouteResult._
 
+  @nowarn("msg=deprecated")
   private val _extractClientIP: Directive1[RemoteAddress] =
     headerValuePF { case `X-Forwarded-For`(Seq(address, _*)) => address } |
       headerValuePF { case `X-Real-Ip`(address) => address } |

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/MultipartUnmarshallers.scala
@@ -14,7 +14,6 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.settings.ParserSettings
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.http.scaladsl.util.FastFuture
-import akka.stream.ActorMaterializerHelper
 import akka.stream.scaladsl._
 
 import scala.collection.immutable
@@ -74,7 +73,7 @@ trait MultipartUnmarshallers {
               FastFuture.failed(new RuntimeException("Content-Type with a multipart media type must have a 'boundary' parameter"))
             case Some(boundary) =>
               import BodyPartParser._
-              val effectiveParserSettings = Option(parserSettings).getOrElse(ParserSettings(ActorMaterializerHelper.downcast(mat).system))
+              val effectiveParserSettings = Option(parserSettings).getOrElse(ParserSettings(mat.system))
               val parser = new BodyPartParser(defaultContentType, boundary, log, effectiveParserSettings)
 
               entity match {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import akka.http.impl.util.{ ExampleHttpContexts, WithLogCapturing }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives
-import akka.stream.{ ActorMaterializer, Materializer }
 import akka.testkit._
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
@@ -36,7 +35,6 @@ class H2SpecIntegrationSpec extends AkkaSpec(
   """) with Directives with ScalaFutures with WithLogCapturing {
 
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val mat: Materializer = ActorMaterializer()
 
   override def expectedTestDuration = 5.minutes // because slow jenkins, generally finishes below 1 or 2 minutes
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2cUpgradeSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/H2cUpgradeSpec.scala
@@ -51,7 +51,7 @@ class H2cUpgradeSpec extends AkkaSpecWithMaterializer("""
       testWith(settings)
     }
 
-    def testWith(settings: String) = {
+    def testWith(settings: String): Unit = {
       val upgradeRequest =
         s"""GET / HTTP/1.1
 Host: localhost

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -404,7 +404,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         val chunksIn =
           user.expectResponse()
             .entity.asInstanceOf[Chunked]
-            .chunks.runWith(TestSink.probe[ChunkStreamPart](system.classicSystem))
+            .chunks.runWith(TestSink[ChunkStreamPart]()(system.classicSystem))
         val data1 = ByteString("abcdef")
         network.sendDATA(TheStreamId, endStream = false, data1)
         chunksIn.request(2)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
@@ -32,9 +32,9 @@ class Http2ServerDemuxSpec extends AkkaSpecWithMaterializer("""
       )
       val bidi = BidiFlow.fromGraph(new Http2ServerDemux(settings, initialRemoteSettings, upgraded = true))
 
-      val ((substreamProducer, (frameConsumer, frameProducer)), substreamConsumer) = TestSource.probe[Http2SubStream]
-        .viaMat(bidi.joinMat(Flow.fromSinkAndSourceMat(TestSink.probe[FrameEvent], TestSource.probe[FrameEvent])(Keep.both))(Keep.right))(Keep.both)
-        .toMat(TestSink.probe[Http2SubStream])(Keep.both)
+      val ((substreamProducer, (frameConsumer, frameProducer)), substreamConsumer) = TestSource[Http2SubStream]()
+        .viaMat(bidi.joinMat(Flow.fromSinkAndSourceMat(TestSink[FrameEvent](), TestSource[FrameEvent]())(Keep.both))(Keep.right))(Keep.both)
+        .toMat(TestSink[Http2SubStream]())(Keep.both)
         .run()
 
       frameConsumer.request(1000)
@@ -53,11 +53,11 @@ class Http2ServerDemuxSpec extends AkkaSpecWithMaterializer("""
         Map.empty
       ))
 
-      frameConsumer.expectNext shouldBe an[SettingsFrame]
+      frameConsumer.expectNext() shouldBe an[SettingsFrame]
       // The client could send an 'ack' here, but doesn't need to
       // frameProducer.sendNext(SettingsAckFrame(frame.asInstanceOf[SettingsFrame].settings))
 
-      frameConsumer.expectNext shouldBe (response)
+      frameConsumer.expectNext() shouldBe (response)
     }
   }
 }

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ProtocolSwitchSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/ProtocolSwitchSpec.scala
@@ -4,12 +4,10 @@
 
 package akka.http.impl.engine.http2
 
-import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.{ Future, Promise }
 import akka.Done
 import akka.http.impl.engine.server.ServerTerminator
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
-import akka.stream.Materializer
 import akka.stream.OverflowStrategy
 import akka.stream.QueueOfferResult.Enqueued
 import akka.stream.TLSProtocol._
@@ -27,7 +25,6 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 class ProtocolSwitchSpec extends AkkaSpec {
-  implicit val mat: Materializer = ActorMaterializer()
 
   override implicit val patience: PatienceConfig = PatienceConfig(timeout = Span(2, Seconds), interval = Span(50, Milliseconds))
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -53,11 +53,12 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
               data = Right(data),
               correlationAttributes = Map.empty
             )
+          case other => throw new IllegalStateException(s"Unexpected frame: $other") // compiler completeness check pleaser
         }
         .map(parseRequest)
         .runWith(Sink.head)
         .futureValue
-      catch { case ex => throw ex.getCause } // unpack futureValue exceptions
+      catch { case ex: Throwable => throw ex.getCause } // unpack futureValue exceptions
     }
 
     def shouldThrowMalformedRequest[T](block: => T): Exception = {

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -53,7 +53,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
               data = Right(data),
               correlationAttributes = Map.empty
             )
-          case other => throw new IllegalStateException(s"Unexpected frame: $other") // compiler completeness check pleaser
+          case _ => throw new IllegalStateException("Unexpected frame") // compiler completeness check pleaser
         }
         .map(parseRequest)
         .runWith(Sink.head)

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/TelemetrySpiSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/TelemetrySpiSpec.scala
@@ -32,6 +32,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 
 import java.util.UUID
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Failure
@@ -132,6 +133,7 @@ abstract class TelemetrySpiSpec(useTls: Boolean) extends AkkaSpecWithMaterialize
 
       val (serverBinding, http2ClientFow) = bindAndConnect(probe)
 
+      @nowarn("msg=deprecated")
       val (requestQueue, _) =
         Source.queue(10, OverflowStrategy.fail)
           .viaMat(http2ClientFow)(Keep.left)
@@ -199,6 +201,7 @@ abstract class TelemetrySpiSpec(useTls: Boolean) extends AkkaSpecWithMaterialize
       telemetryProbe.expectMsg("bind-seen")
 
       val responseProbe = TestProbe()
+      @nowarn("msg=deprecated")
       val (requestQueue, _) =
         Source.queue(10, OverflowStrategy.fail)
           .viaMat(http2ClientFlow)(Keep.left)

--- a/docs/src/test/java/docs/http/javadsl/ComposeDirectivesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/ComposeDirectivesExampleTest.java
@@ -14,7 +14,6 @@ import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.PathMatcher1;
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
 
 import static akka.http.javadsl.common.PartialApplication.*;

--- a/docs/src/test/java/docs/http/javadsl/CustomStatusCodesExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/CustomStatusCodesExampleTest.java
@@ -80,7 +80,7 @@ public class CustomStatusCodesExampleTest extends JUnitRouteTest {
     final HttpResponse response = Http.get(system)
       .singleRequest(HttpRequest
         .GET("http://" + host + ":" + port + "/"),
-        ConnectionContext.https(SSLContext.getDefault()),
+        ConnectionContext.httpsClient(SSLContext.getDefault()),
         clientSettings,
         system.log())
       .toCompletableFuture()

--- a/docs/src/test/java/docs/http/javadsl/Http2Test.java
+++ b/docs/src/test/java/docs/http/javadsl/Http2Test.java
@@ -18,7 +18,6 @@ import static akka.http.javadsl.model.AttributeKeys.trailer;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.japi.function.Function;
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 //#bindAndHandleSecure
@@ -36,7 +35,6 @@ class Http2Test {
   void testBindAndHandleAsync() {
     Function<HttpRequest, CompletionStage<HttpResponse>> asyncHandler = r -> CompletableFuture.completedFuture(HttpResponse.create());
     ActorSystem system = ActorSystem.create();
-    Materializer materializer = ActorMaterializer.create(system);
     HttpsConnectionContext httpsConnectionContext = null;
 
     //#bindAndHandleSecure

--- a/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
+++ b/docs/src/test/java/docs/http/javadsl/HttpClientExampleDocTest.java
@@ -40,7 +40,7 @@ import scala.concurrent.duration.FiniteDuration;
 import akka.actor.AbstractActor;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
-import static akka.pattern.PatternsCS.pipe;
+import static akka.pattern.Patterns.pipe;
 
 //#single-request-in-actor-example
 

--- a/docs/src/test/java/docs/http/javadsl/UnmarshalTest.java
+++ b/docs/src/test/java/docs/http/javadsl/UnmarshalTest.java
@@ -7,9 +7,6 @@ package docs.http.javadsl;
 import static org.junit.Assert.assertEquals;
 import akka.http.javadsl.testkit.JUnitRouteTest;
 
-import akka.util.ByteString;
-import akka.stream.ActorMaterializer;
-import akka.stream.Materializer;
 import org.junit.Test;
 
 //#imports

--- a/docs/src/test/java/docs/http/javadsl/WebSocketClientExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/WebSocketClientExampleTest.java
@@ -18,8 +18,8 @@ import akka.http.javadsl.model.ws.WebSocketRequest;
 import akka.http.javadsl.model.ws.WebSocketUpgradeResponse;
 import akka.http.javadsl.settings.ClientConnectionSettings;
 import akka.japi.Pair;
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
+import akka.stream.SystemMaterializer;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
@@ -37,9 +37,9 @@ public class WebSocketClientExampleTest {
   // compile only test
   public void testSingleWebSocketRequest() {
     //#single-WebSocket-request
-    ActorSystem system = ActorSystem.create();
-    Materializer materializer = ActorMaterializer.create(system);
-    Http http = Http.get(system);
+    final ActorSystem system = ActorSystem.create();
+    final Materializer materializer = SystemMaterializer.get(system).materializer();
+    final Http http = Http.get(system);
 
     // print each incoming text message
     // would throw exception on non strict or binary message
@@ -92,7 +92,7 @@ public class WebSocketClientExampleTest {
   public void halfClosedWebSocketClosingExample() {
 
     final ActorSystem system = ActorSystem.create();
-    final Materializer materializer = ActorMaterializer.create(system);
+    final Materializer materializer = SystemMaterializer.get(system).materializer();
     final Http http = Http.get(system);
 
     //#half-closed-WebSocket-closing
@@ -114,7 +114,7 @@ public class WebSocketClientExampleTest {
 
   public void halfClosedWebSocketWorkingExample() {
     final ActorSystem system = ActorSystem.create();
-    final Materializer materializer = ActorMaterializer.create(system);
+    final Materializer materializer = SystemMaterializer.get(system).materializer();
     final Http http = Http.get(system);
 
     //#half-closed-WebSocket-working
@@ -140,7 +140,7 @@ public class WebSocketClientExampleTest {
 
   public void halfClosedWebSocketFiniteWorkingExample() {
     final ActorSystem system = ActorSystem.create();
-    final Materializer materializer = ActorMaterializer.create(system);
+    final Materializer materializer = SystemMaterializer.get(system).materializer();
     final Http http = Http.get(system);
 
     //#half-closed-WebSocket-finite
@@ -189,7 +189,7 @@ public class WebSocketClientExampleTest {
   public void testWebSocketClientFlow() {
     //#WebSocket-client-flow
     ActorSystem system = ActorSystem.create();
-    Materializer materializer = ActorMaterializer.create(system);
+    Materializer materializer = SystemMaterializer.get(system).materializer();
     Http http = Http.get(system);
 
     // print each incoming text message
@@ -246,7 +246,7 @@ public class WebSocketClientExampleTest {
     //#https-proxy-singleWebSocket-request-example
 
     final ActorSystem system = ActorSystem.create();
-    final Materializer materializer = ActorMaterializer.create(system);
+    final Materializer materializer = SystemMaterializer.get(system).materializer();
 
     final Flow<Message, Message, NotUsed> flow =
       Flow.fromSinkAndSource(
@@ -274,7 +274,7 @@ public class WebSocketClientExampleTest {
   public void testSingleWebSocketRequestWithHttpsProxyExampleWithAuth() {
 
     final ActorSystem system = ActorSystem.create();
-    final Materializer materializer = ActorMaterializer.create(system);
+    final Materializer materializer = SystemMaterializer.get(system).materializer();
 
     final Flow<Message, Message, NotUsed> flow =
       Flow.fromSinkAndSource(
@@ -302,7 +302,7 @@ public class WebSocketClientExampleTest {
         materializer);
 
     //#auth-https-proxy-singleWebSocket-request-example
-}
-
-
   }
+
+
+}

--- a/docs/src/test/java/docs/http/javadsl/server/AkkaHttp1020MigrationExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/AkkaHttp1020MigrationExample.java
@@ -9,7 +9,6 @@ import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import static akka.http.javadsl.server.Directives.*;
 import akka.http.javadsl.server.Route;
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 @SuppressWarnings("deprecation")
@@ -19,7 +18,7 @@ public class AkkaHttp1020MigrationExample {
             //#old-binding
             // only worked with classic actor system
             akka.actor.ActorSystem system = akka.actor.ActorSystem.create("TheSystem");
-            Materializer mat = ActorMaterializer.create(system);
+            Materializer mat = akka.stream.ActorMaterializer.create(system);
             Route route = get(() -> complete("Hello World!"));
             Http.get(system).bindAndHandle(route.flow(system), ConnectHttp.toHost("localhost", 8080), mat);
             //#old-binding

--- a/docs/src/test/java/docs/http/javadsl/server/HttpsServerExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/HttpsServerExampleTest.java
@@ -6,7 +6,6 @@ package docs.http.javadsl.server;
 
 import akka.actor.ActorSystem;
 import akka.http.javadsl.ConnectionContext;
-import com.typesafe.sslconfig.akka.AkkaSSLConfig;
 import org.junit.Test;
 import org.scalatestplus.junit.JUnitSuite;
 

--- a/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
+++ b/docs/src/test/java/docs/http/javadsl/server/WebSocketCoreExample.java
@@ -26,7 +26,6 @@ import akka.http.scaladsl.model.AttributeKeys;
 import akka.japi.JavaPartialFunction;
 import akka.japi.function.Function;
 
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Source;

--- a/docs/src/test/java/docs/http/javadsl/server/directives/BasicDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/BasicDirectivesExamplesTest.java
@@ -24,8 +24,8 @@ import akka.http.javadsl.settings.RoutingSettings;
 import akka.http.javadsl.testkit.JUnitRouteTest;
 import akka.http.javadsl.server.*;
 import akka.japi.pf.PFBuilder;
-import akka.stream.ActorMaterializer;
 import akka.stream.ActorMaterializerSettings;
+import akka.stream.Materializer;
 import akka.stream.javadsl.FileIO;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
@@ -287,11 +287,13 @@ public class BasicDirectivesExamplesTest extends JUnitRouteTest {
     //#extractLog
   }
 
+  // FIXME rewrite to not use deprecated ActorMaterializerSettings/ActorMaterializer and update docs
+  @SuppressWarnings("deprecation")
   @Test
   public void testWithMaterializer() {
     //#withMaterializer
     final ActorMaterializerSettings settings = ActorMaterializerSettings.create(system());
-    final ActorMaterializer special = ActorMaterializer.create(settings, system(), "special");
+    final Materializer special = akka.stream.ActorMaterializer.create(settings, system(), "special");
 
     final Route sample = path("sample", () ->
       extractMaterializer(mat ->
@@ -1040,7 +1042,7 @@ public class BasicDirectivesExamplesTest extends JUnitRouteTest {
     });
 
     // tests:
-    final Iterator iterator = Arrays.asList(
+    final Iterator<ByteString> iterator = Arrays.asList(
       ByteString.fromString("1"),
       ByteString.fromString("2"),
       ByteString.fromString("3")).iterator();
@@ -1062,7 +1064,7 @@ public class BasicDirectivesExamplesTest extends JUnitRouteTest {
     );
 
     // tests:
-    final Iterator iterator = Arrays.asList(
+    final Iterator<ByteString> iterator = Arrays.asList(
       ByteString.fromString("1"),
       ByteString.fromString("2"),
       ByteString.fromString("3")).iterator();
@@ -1090,7 +1092,7 @@ public class BasicDirectivesExamplesTest extends JUnitRouteTest {
     );
 
     // tests:
-    final Iterator iterator = Arrays.asList(
+    final Iterator<ByteString> iterator = Arrays.asList(
       ByteString.fromString("1"),
       ByteString.fromString("2"),
       ByteString.fromString("3")).iterator();

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CodingDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CodingDirectivesExamplesTest.java
@@ -55,6 +55,7 @@ import static akka.http.javadsl.server.Directives.withPrecompressedMediaTypeSupp
 
 //#withPrecompressedMediaTypeSupport
 
+@SuppressWarnings("deprecation")
 public class CodingDirectivesExamplesTest extends JUnitRouteTest {
 
   @Test

--- a/docs/src/test/java/docs/http/javadsl/server/directives/CookieDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/CookieDirectivesExamplesTest.java
@@ -96,6 +96,7 @@ public class CookieDirectivesExamplesTest extends JUnitRouteTest {
         Optional.empty(),
         false,
         false,
+        Optional.empty(),
         Optional.empty()));
 
     testRoute(route).run(HttpRequest.GET("/"))

--- a/docs/src/test/java/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
+++ b/docs/src/test/java/docs/http/javadsl/server/directives/FutureDirectivesExamplesTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import scala.concurrent.duration.FiniteDuration;
 
 import static akka.http.javadsl.server.PathMatchers.*;
-import static scala.compat.java8.JFunction.func;
 
 //#onComplete
 import static akka.http.javadsl.server.Directives.complete;
@@ -58,7 +57,7 @@ public class FutureDirectivesExamplesTest extends JUnitRouteTest {
                 (a, b) -> onComplete(
                         () -> CompletableFuture.supplyAsync(() -> a / b),
                         maybeResult -> maybeResult
-                                .map(func(result -> complete("The result was " + result)))
+                                .map(result -> complete("The result was " + result))
                                 .recover(new PFBuilder<Throwable, Route>()
                                         .matchAny(ex -> complete(StatusCodes.InternalServerError(),
                                                 "An error occurred: " + ex.getMessage())
@@ -137,15 +136,15 @@ public class FutureDirectivesExamplesTest extends JUnitRouteTest {
         // import static akka.http.javadsl.server.PathMatchers.*;
 
         final int maxFailures = 1;
-        final FiniteDuration callTimeout = FiniteDuration.create(5, TimeUnit.SECONDS);
-        final FiniteDuration resetTimeout = FiniteDuration.create(1, TimeUnit.SECONDS);
+        final Duration callTimeout = Duration.ofSeconds(5);
+        final Duration resetTimeout = Duration.ofSeconds(1);
         final CircuitBreaker breaker = CircuitBreaker.create(system().scheduler(), maxFailures, callTimeout, resetTimeout);
 
         final Route route = path(segment("divide").slash(integerSegment()).slash(integerSegment()),
                 (a, b) -> onCompleteWithBreaker(breaker,
                         () -> CompletableFuture.supplyAsync(() -> a / b),
                         maybeResult -> maybeResult
-                                .map(func(result -> complete("The result was " + result)))
+                                .map(result -> complete("The result was " + result))
                                 .recover(new PFBuilder<Throwable, Route>()
                                         .matchAny(ex -> complete(StatusCodes.InternalServerError(),
                                                 "An error occurred: " + ex.toString())

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -26,7 +26,7 @@ object Common extends AutoPlugin {
     ),
     scalacOptions ++= onlyOnScala2(Seq("-Xlint")).value,
     javacOptions ++=
-      Seq("-encoding", "UTF-8") ++ onlyOnJdk8("-source", "1.8") ++ onlyAfterJdk8("--release", "8"),
+      Seq("-encoding", "UTF-8", "-Xlint:deprecation") ++ onlyOnJdk8("-source", "1.8") ++ onlyAfterJdk8("--release", "8"),
     // restrict to 'compile' scope because otherwise it is also passed to
     // javadoc and -target is not valid there.
     // https://github.com/sbt/sbt/issues/1785
@@ -36,8 +36,10 @@ object Common extends AutoPlugin {
 
     // in test code we often use destructing assignment, which now produces an exhaustiveness warning
     // when the type is asserted
-    Test / compile / scalacOptions += "-Wconf:msg=match may not be exhaustive:s",
-    Test / compile / scalacOptions += "-Wconf:cat=lint-infer-any:s",
+    Test / compile / scalacOptions ++=
+      Seq("-Wconf:msg=match may not be exhaustive:s",
+      "-Wconf:cat=lint-infer-any:s"
+      ),
 
     mimaReportSignatureProblems := true,
     Global / parallelExecution := sys.props.getOrElse("akka.http.parallelExecution", "true") != "false"

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -19,16 +19,19 @@ object Common extends AutoPlugin {
         "-encoding", "UTF-8", // yes, this is 2 args
         "-release", "8",
         "-unchecked",
-        // Silence deprecation notices for changes introduced in Scala 2.12
-        // Can be removed when we drop support for Scala 2.12:
-        "-Wconf:msg=object JavaConverters in package collection is deprecated:s",
         "-Wconf:msg=is deprecated \\(since 2\\.13\\.:s") ++
       (if (scalaVersion.value.startsWith("2."))
         // Scala 2.x
-        Seq("-Ywarn-dead-code")
+        Seq("-Ywarn-dead-code",
+          // Silence deprecation notices for changes introduced in Scala 2.12
+          // Can be removed when we drop support for Scala 2.12:
+          "-Wconf:msg=object JavaConverters in package collection is deprecated:s",
+        )
       else
         // Scala 3
-        Seq.empty),
+        Seq(
+          "-Wconf:msg=does not suppress any warnings:s" // some are warnings in 2.12
+        )),
     scalacOptions ++= onlyOnScala2(Seq("-Xlint")).value,
     javacOptions ++=
       Seq("-encoding", "UTF-8", "-Xlint:deprecation") ++ onlyOnJdk8("-source", "1.8") ++ onlyAfterJdk8("--release", "8"),


### PR DESCRIPTION
Mainly
 * Deprecated ActorMaterializer usage, fixed or silenced
 * Scala 2.13 completeness check, most fixed, test unnapplies left
 * IOResul deprecation in Akka 2.6, special handling removed
 * Misc others silenced with annotations
 * Switching from deprecated akka-stream methods to the new ones (since we no longer support Akka 2.5)