### PR TITLE
chore: renovate GH workflows

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * 6' # At 00:00 on saturdays
 
+permissions:
+  contents: read
+
 jobs:
   fossa:
     name: Fossa

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,27 +3,27 @@ name: Dependency License Scanning
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0' # At 00:00 on Sunday
+    - cron: '0 0 * * 6' # At 00:00 on saturdays
 
 jobs:
   fossa:
     name: Fossa
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/akka-http'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.11
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -26,11 +26,17 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.17
 
-      - name: FOSSA policy check
-        run: |-
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
-          fossa analyze && fossa test
-        env:
-          FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"
+      - name: "fossa analyze"
+        # https://github.com/fossas/fossa-action/releases/tag/v1.3.1
+        uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f
+        with:
+          api-key: ${{secrets.FOSSA_API_KEY}}
+
+      - name: "fossa test"
+        # https://github.com/fossas/fossa-action/releases/tag/v1.3.1
+        uses: fossas/fossa-action@f61a4c0c263690f2ddb54b9822a719c25a7b608f
+        with:
+          api-key: ${{secrets.FOSSA_API_KEY}}
+          run-tests: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   compile-and-test:
     name: Compile and test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,32 +8,30 @@ on:
 jobs:
   compile-and-test:
     name: Compile and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         SCALA_VERSION: [2.12, 2.13, 3.1]
-        JABBA_JDK: [8, 11, 17]
+        TEMURIN_JDK: [8, 11, 17]
         AKKA_VERSION: [main, default]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
-      - name: Set up JDK ${{ matrix.JABBA_JDK }}
-        uses: olafurpg/setup-scala@v10
-        env:
-          JABBA_INDEX: 'https://github.com/typelevel/jdk-index/raw/main/index.json'
-        with:
-          java-version: temurin@${{ matrix.JABBA_JDK }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK ${{ matrix.TEMURIN_JDK }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:${{ matrix.TEMURIN_JDK }}
 
       - name: Cache Build Target
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: project/**/target
           key: build-target-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/**/*.scala') }}
@@ -45,7 +43,7 @@ jobs:
         run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 -Dakka.http.build.akka.version=${{ matrix.AKKA_VERSION }} ++${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues test
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2  # upload test results
+        uses: actions/upload-artifact@v3.1.1
         if: success() || failure()        # run this step even if previous step failed
         with:
           name: test-results-${{ matrix.JABBA_JDK }}-${{ matrix.SCALA_VERSION }}-${{ matrix.AKKA_VERSION }}

--- a/.github/workflows/publish-test-reports.yml
+++ b/.github/workflows/publish-test-reports.yml
@@ -7,19 +7,20 @@ on:
 jobs:
   publish-test-results:
     name: "Publish details with dorny-test-reporter"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         SCALA_VERSION: [ 2.12, 2.13 ]
-        JABBA_JDK: [ 1.8, 1.11 ]
+        TEMURIN_JDK: [ 1.8, 1.11 ]
     steps:
-      - uses: dorny/test-reporter@v1
+      # https://github.com/dorny/test-reporter/releases/tag/v1.6.0
+      - uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226
         # avoid excessive notification spam, fail-on-error seems broken https://github.com/dorny/test-reporter/issues/161
         continue-on-error: true
         with:
-          artifact: test-results-${{ matrix.JABBA_JDK }}-${{ matrix.SCALA_VERSION }}
-          name: Test Results Details / Scala ${{ matrix.SCALA_VERSION }} on JDK ${{ matrix.JABBA_JDK }}
+          artifact: test-results-${{ matrix.TEMURIN_JDK }}-${{ matrix.SCALA_VERSION }}
+          name: Test Results Details / Scala ${{ matrix.SCALA_VERSION }} on JDK ${{ matrix.TEMURIN_JDK }}
           fail-on-error: false
           path: '**/target/test-reports/*.xml'
           reporter: java-junit

--- a/.github/workflows/publish-test-reports.yml
+++ b/.github/workflows/publish-test-reports.yml
@@ -4,6 +4,10 @@ on:
     workflows: ['Validate and test']                     # runs after CI workflow
     types:
       - completed
+
+permissions:
+  contents: read
+
 jobs:
   publish-test-results:
     name: "Publish details with dorny-test-reporter"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,20 +8,20 @@ on:
 jobs:
   publish-artifacts:
     name: Publish artifacts to Sonatype
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 8
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.8
 
       - name: Install graphviz
         run: sudo apt-get install -y graphviz
@@ -36,20 +36,20 @@ jobs:
 
   publish-docs:
     name: Publish documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.11
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:11
 
       - name: Publish Documentation
         run: eval "$(ssh-agent -s)" && echo $SCP_SECRET | base64 -d > /tmp/id_rsa && chmod 600 /tmp/id_rsa && ssh-add /tmp/id_rsa && sbt -jvm-opts .jvmopts-ghactions -Dakka.genjavadoc.enabled=true publishRsync

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
     tags: [ v* ]
 
+permissions:
+  contents: read
+
 jobs:
   publish-artifacts:
     name: Publish artifacts to Sonatype

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -6,6 +6,9 @@ on:
     branches: [ main ]
     tags-ignore: [ v* ]
 
+permissions:
+  contents: read
+
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
   group: ci-${{ github.ref }}

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -14,21 +14,21 @@ concurrency:
 jobs:
   formatting-check:
     name: Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Scala on JDK 8
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.8
+        uses: actions/checkout@v3.1.0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: adopt:1.8
 
       - name: Cache Build Target
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: project/**/target
           key: build-target-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/**/*.scala') }}
@@ -41,28 +41,28 @@ jobs:
 
   compile-and-test:
     name: Compile and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         SCALA_VERSION: [2.12, 2.13, 3.1]
-        JABBA_JDK: [1.8, 1.11]
+        TEMURIN_JDK: [1.8, 1.11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
-      - name: Set up JDK ${{ matrix.JABBA_JDK }}
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@${{ matrix.JABBA_JDK }}
-
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK ${{ matrix.TEMURIN_JDK }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: temurin:${{ matrix.TEMURIN_JDK }}
 
       - name: Cache Build Target
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: project/**/target
           key: build-target-${{ hashFiles('**/*.sbt', 'project/build.properties', 'project/**/*.scala') }}
@@ -81,7 +81,7 @@ jobs:
         run: sbt -Dakka.http.parallelExecution=false -Dakka.test.timefactor=2 ++${{ matrix.SCALA_VERSION }} mimaReportBinaryIssues test
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2  # upload test results
+        uses: actions/upload-artifact@v3.1.1
         if: success() || failure()        # run this step even if previous step failed
         with:
           name: test-results-${{ matrix.JABBA_JDK }}-${{ matrix.SCALA_VERSION }}


### PR DESCRIPTION
`nightly` used Temurin JDK builds via Jabba. This switches to Temurin everywhere.

References https://github.com/akka/akka/pull/31730
