### PR TITLE
ci: remove name from JVM selection again

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         SCALA_VERSION: [2.12, 2.13, 3.1]
-        JDK_VERSION: ["temurin:1.8", "temurin:1.11", "temurin:1.17"]
+        JDK_VERSION: ["1.8", "1.11", "1.17"]
+        include:
+          - JDK_VERSION: 1.8
+            JVM_NAME: temurin:1.8
+          - JDK_VERSION: 1.11
+            JVM_NAME: temurin:1.11
+          - JDK_VERSION: 1.17
+            JVM_NAME: temurin:1.17
         AKKA_VERSION: [main, default]
 
     steps:
@@ -31,7 +38,7 @@ jobs:
       - name: Set up JDK ${{ matrix.JDK_VERSION }}
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: ${{ matrix.JDK_VERSION }}
+          jvm: ${{ matrix.JVM_NAME }}
 
       - name: Cache Build Target
         uses: actions/cache@v3.0.11

--- a/.github/workflows/publish-test-reports.yml
+++ b/.github/workflows/publish-test-reports.yml
@@ -16,15 +16,15 @@ jobs:
       fail-fast: false
       matrix:
         SCALA_VERSION: [ 2.12, 2.13 ]
-        JDK_VERSION: [ "temurin:1.8", "temurin:1.11" ]
+        JDK_VERSION: ["1.8", "1.11", "1.17"]
     steps:
       # https://github.com/dorny/test-reporter/releases/tag/v1.6.0
       - uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226
         # avoid excessive notification spam, fail-on-error seems broken https://github.com/dorny/test-reporter/issues/161
         continue-on-error: true
         with:
-          artifact: test-results-${{ matrix.JDK_VERSION }}-${{ matrix.SCALA_VERSION }}
-          name: Test Results Details / Scala ${{ matrix.SCALA_VERSION }} on JDK ${{ matrix.JDK_VERSION }}
+          artifact: 'test-results-${{ matrix.JDK_VERSION }}-${{ matrix.SCALA_VERSION }}'
+          name: 'Test Results Details / Scala ${{ matrix.SCALA_VERSION }} on JDK ${{ matrix.JDK_VERSION }}'
           fail-on-error: false
           path: '**/target/test-reports/*.xml'
           reporter: java-junit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 8
+      - name: Set up JDK 1.11
         uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:1.11.0.9 # align with akka/akka

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK 1.11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11.0.9 # align with akka/akka
+          jvm: temurin:1.11.0.17 # align with akka/akka
 
       - name: Install graphviz
         run: sudo apt-get install -y graphviz
@@ -54,7 +54,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:11
+          jvm: temurin:1.11
 
       - name: Publish Documentation
         run: |

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.8
+          jvm: temurin:1.17
 
       - name: Cache Build Target
         uses: actions/cache@v3.0.11

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -47,9 +47,16 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-      matrix:
+      matrix: # align with publish-test-reports.yml
         SCALA_VERSION: [2.12, 2.13, 3.1]
-        JDK_VERSION: ["temurin:1.8", "temurin:1.11"]
+        JDK_VERSION: ["1.8", "1.11", "1.17"]
+        include:
+          - JDK_VERSION: 1.8
+            JVM_NAME: temurin:1.8
+          - JDK_VERSION: 1.11
+            JVM_NAME: temurin:1.11
+          - JDK_VERSION: 1.17
+            JVM_NAME: temurin:1.17
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -62,7 +69,7 @@ jobs:
       - name: Set up JDK ${{ matrix.JDK_VERSION }}
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: ${{ matrix.JDK_VERSION }}
+          jvm: ${{ matrix.JVM_NAME }}
 
       - name: Cache Build Target
         uses: actions/cache@v3.0.11


### PR DESCRIPTION
The filenames for uploads may not contain `:`, splitting out the JVM name.

References #4191 