### PR TITLE
ci: send email for failing nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,3 +58,19 @@ jobs:
         with:
           name: 'test-results-${{ matrix.JDK_VERSION }}-${{ matrix.SCALA_VERSION }}-${{ matrix.AKKA_VERSION }}'
           path: '**/target/test-reports/*.xml'
+
+      - name: Email on failure
+        if: ${{ failure() }}
+        # https://github.com/dawidd6/action-send-mail/releases/tag/v3.7.1
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+          subject: "Failed: ${{ github.workflow }} / ${{ github.job }}"
+          to: ${{secrets.MAIL_SEND_TO}}
+          from: Akka HTTP CI
+          body: |
+            Job ${{ github.job }} in workflow ${{ github.workflow }} of ${{github.repository}} failed!
+            https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
Same setup as in akka/akka.
Applicable secrets are available.