### PR TITLE
Revert parboiled upper/lowercase changes for performance

### DIFF
--- a/akka-parsing/src/main/scala/akka/parboiled2/CharUtils.scala
+++ b/akka-parsing/src/main/scala/akka/parboiled2/CharUtils.scala
@@ -171,13 +171,13 @@ object CharUtils {
    * Efficiently lower-cases the given character.
    * Note: only works for 7-bit ASCII letters.
    */
-  def toLowerCase(c: Char): Char = if (CharPredicate.UpperAlpha(c)) (c + 0x20).toChar else c
+  def toLowerCase(c: Char): Char = if (c >= 'A' && c <= 'Z') (c + 0x20).toChar else c
 
   /**
    * Efficiently upper-cases the given character.
    * Note: only works for 7-bit ASCII letters.
    */
-  def toUpperCase(c: Char): Char = if (CharPredicate.LowerAlpha(c)) (c + 0x20).toChar else c
+  def toUpperCase(c: Char): Char = if (c >= 'a' && c <= 'z') (c + 0x20).toChar else c
 
   def escape(c: Char): String =
     c match {


### PR DESCRIPTION
We already had this optimization but it got lost in the Scala 3 support work. Fixes a 10% throughput regression for Scala 2.13 after the Scala 3 support was added.