### PR TITLE
ci: Remove linting flag from JavaDoc runs

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -55,6 +55,8 @@ object Common extends AutoPlugin {
         Seq.empty
       }),
 
+    Compile / doc / javacOptions := javacOptions.value.filterNot(_ == "-Xlint:deprecation"),
+
     mimaReportSignatureProblems := true,
     Global / parallelExecution := sys.props.getOrElse("akka.http.parallelExecution", "true") != "false"
   )


### PR DESCRIPTION
JavaDoc started failing in CI when updating to later JDKs for the `-Xlint:deprecation` flag.
https://github.com/akka/akka-http/actions/runs/3513685314/jobs/5886797573#step:5:362