### PR TITLE
ci: permit checks write for test reporting

### DIFF
--- a/.github/workflows/publish-test-reports.yml
+++ b/.github/workflows/publish-test-reports.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  # required to attach test details https://github.com/dorny/test-reporter/issues/149#issuecomment-1004820190
+  checks: write
 
 jobs:
   publish-test-results:


### PR DESCRIPTION
See the error in https://github.com/akka/akka-http/actions/runs/3530396634/jobs/5922344320#step:2:749

References #4189 