### PR TITLE
chore: Reintroduce a way for tests to invoke a route without error handler 

### DIFF
--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -4,7 +4,7 @@
 
 package akka.http.scaladsl.testkit
 
-import akka.actor.ActorSystem
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
@@ -205,8 +205,21 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
       }
   }
 }
-private[http] object RouteTest {
-  def runRouteClientServer(request: HttpRequest, route: Route, serverSettings: ServerSettings)(implicit system: ActorSystem): Future[HttpResponse] = {
+object RouteTest {
+
+  /**
+   * Turn the route into a function for testing, but do not handle exceptions in any way, instead, they are bubbled
+   * out as is to the caller.
+   */
+  def toFunctionPassThroughExceptions(route: Route)(implicit system: ClassicActorSystemProvider): HttpRequest => Future[HttpResponse] = {
+    val routingLog = RoutingLog(system.classicSystem.log)
+    val routingSettings = RoutingSettings(system)
+    val parserSettings = ParserSettings.forServer
+    implicit val ec: ExecutionContextExecutor = system.classicSystem.dispatcher
+    Route.createAsyncHandler(route, routingLog, routingSettings, parserSettings)
+  }
+
+  private[http] def runRouteClientServer(request: HttpRequest, route: Route, serverSettings: ServerSettings)(implicit system: ActorSystem): Future[HttpResponse] = {
     import system.dispatcher
     for {
       binding <- Http().newServerAt("127.0.0.1", 0).withSettings(settings = serverSettings).bind(route)

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/RouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/RouteTestSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.http.scaladsl.testkit
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.client.RequestBuilding.Get
+import akka.testkit.TestKit
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class RouteTestSpec extends AnyWordSpec with Matchers with ScalaFutures {
+
+  "RouteTest" should {
+
+    "allow for pass through of exceptions in tests" in {
+      implicit val system: ActorSystem = ActorSystem()
+      try {
+        import akka.http.scaladsl.server.directives.MethodDirectives._
+        val route = get {
+          throw new RuntimeException("BOOM")
+        }
+
+        val routeF = RouteTest.toFunctionPassThroughExceptions(route)
+        intercept[RuntimeException] {
+          routeF(Get("/whatever"))
+        }.getMessage shouldBe "BOOM"
+
+      } finally {
+        TestKit.shutdownActorSystem(system)
+      }
+    }
+  }
+
+}

--- a/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/RouteTestSpec.scala
+++ b/akka-http-testkit/src/test/scala/akka/http/scaladsl/testkit/RouteTestSpec.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.http.scaladsl.testkit
 
 import akka.actor.ActorSystem

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -105,7 +105,7 @@ object Route {
     createAsyncHandler(seal(route), routingLog, routingSettings, effectiveParserSettings)(effectiveEC, materializer)
   }
 
-  private def createAsyncHandler(sealedRoute: Route, routingLog: RoutingLog, routingSettings: RoutingSettings, parserSettings: ParserSettings)(implicit ec: ExecutionContextExecutor, mat: Materializer): HttpRequest => Future[HttpResponse] = {
+  private[akka] def createAsyncHandler(sealedRoute: Route, routingLog: RoutingLog, routingSettings: RoutingSettings, parserSettings: ParserSettings)(implicit ec: ExecutionContextExecutor, mat: Materializer): HttpRequest => Future[HttpResponse] = {
     request =>
       sealedRoute(new RequestContextImpl(request, routingLog.requestLog(request), routingSettings, parserSettings)).fast
         .map {


### PR DESCRIPTION
References #4142