### PR TITLE
fix: Invalid HTTP2 request headers should lead to bad request responses

### DIFF
--- a/akka-http-core/src/main/mima-filters/10.4.0.backwards.excludes/4226-bad-header-http2-response.excludes
+++ b/akka-http-core/src/main/mima-filters/10.4.0.backwards.excludes/4226-bad-header-http2-response.excludes
@@ -1,0 +1,6 @@
+# internals only
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.FrameEvent#ParsedHeadersFrame.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.FrameEvent#ParsedHeadersFrame.this")
+ProblemFilters.exclude[MissingTypesProblem]("akka.http.impl.engine.http2.FrameEvent$ParsedHeadersFrame$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.http.impl.engine.http2.FrameEvent#ParsedHeadersFrame.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.http.impl.engine.http2.FrameEvent#ParsedHeadersFrame.unapply")

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/FrameEvent.scala
@@ -8,6 +8,7 @@ import akka.annotation.InternalApi
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2.Http2Protocol.FrameType
 import akka.http.impl.engine.http2.Http2Protocol.SettingIdentifier
+import akka.http.scaladsl.model.ErrorInfo
 import akka.util.ByteString
 
 import scala.collection.immutable
@@ -99,12 +100,15 @@ private[http] object FrameEvent {
   /**
    * Convenience (logical) representation of a parsed HEADERS frame with zero, one or
    * many CONTINUATIONS Frames into a single, decompressed object.
+   *
+   * @param headerParseErrorDetails Only used server side, passes header errors from decompression into error response logic
    */
   final case class ParsedHeadersFrame(
-    streamId:      Int,
-    endStream:     Boolean,
-    keyValuePairs: Seq[(String, AnyRef)],
-    priorityInfo:  Option[PriorityFrame]
+    streamId:                Int,
+    endStream:               Boolean,
+    keyValuePairs:           Seq[(String, AnyRef)],
+    priorityInfo:            Option[PriorityFrame],
+    headerParseErrorDetails: Option[ErrorInfo]
   ) extends StreamFrameEvent
 
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/FrameLogger.scala
@@ -70,7 +70,7 @@ private[http2] object FrameLogger {
         case GoAwayFrame(lastStreamId, errorCode, debug) =>
           LogEntry(0, "GOAY", s"lastStreamId = $lastStreamId, errorCode = $errorCode, debug = ${debug.utf8String}")
 
-        case ParsedHeadersFrame(streamId, endStream, kvPairs, prio) =>
+        case ParsedHeadersFrame(streamId, endStream, kvPairs, prio, _) =>
           val prioInfo = if (prio.isDefined) display(entryForFrame(prio.get)) + " " else ""
           val kvInfo = kvPairs.map {
             case (key, value) => s"$key -> $value"

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -271,7 +271,7 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
       nextStateStream:       IncomingStreamBuffer => StreamState,
       correlationAttributes: Map[AttributeKey[_], _]             = Map.empty): StreamState =
       event match {
-        case frame @ ParsedHeadersFrame(streamId, endStream, _, _) =>
+        case frame @ ParsedHeadersFrame(streamId, endStream, _, _, _) =>
           if (endStream) {
             dispatchSubstream(frame, Left(ByteString.empty), correlationAttributes)
             nextStateEmpty
@@ -778,7 +778,7 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
         case HttpEntity.LastChunk(_, headers) =>
           if (headers.nonEmpty && !trailer.isEmpty)
             log.warning("Found both an attribute with trailing headers, and headers in the `LastChunk`. This is not supported.")
-          trailer = OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, HttpMessageRendering.renderHeaders(headers, log, isServer, shouldRenderAutoHeaders = false, dateHeaderRendering = DateHeaderRendering.Unavailable), None))
+          trailer = OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, HttpMessageRendering.renderHeaders(headers, log, isServer, shouldRenderAutoHeaders = false, dateHeaderRendering = DateHeaderRendering.Unavailable), None, None))
         case _ => throw new IllegalArgumentException("Unexpected stream element") // compiler completeness check pleaser
       }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/HttpMessageRendering.scala
@@ -78,10 +78,10 @@ private[http2] sealed abstract class MessageRendering[R <: HttpMessage] extends 
     HttpMessageRendering.renderHeaders(r.headers, headerPairs, peerIdHeader, log, isServer = r.isResponse, shouldRenderAutoHeaders = true, dateHeaderRendering)
 
     val streamId = nextStreamId(r)
-    val headersFrame = ParsedHeadersFrame(streamId, endStream = r.entity.isKnownEmpty, headerPairs.result(), None)
+    val headersFrame = ParsedHeadersFrame(streamId, endStream = r.entity.isKnownEmpty, headerPairs.result(), None, None)
     val trailingHeadersFrame =
       r.attribute(AttributeKeys.trailer) match {
-        case Some(trailer) if trailer.headers.nonEmpty => OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, trailer.headers, None))
+        case Some(trailer) if trailer.headers.nonEmpty => OptionVal.Some(ParsedHeadersFrame(streamId, endStream = true, trailer.headers, None, None))
         case _                                         => OptionVal.None
       }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestErrorFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestErrorFlow.scala
@@ -49,8 +49,6 @@ private[http2] final class RequestErrorFlow extends GraphStage[BidiShape[HttpRes
         grab(requestIn) match {
           case RequestParsing.OkRequest(request) => push(requestOut, request)
           case notOk: RequestParsing.BadRequest =>
-            // FIXME is emit safe here?
-            // FIXME details vs summary?
             emit(responseOut, HttpResponse(StatusCodes.BadRequest, entity = notOk.info.summary).addAttribute(Http2.streamId, notOk.streamId))
             pull(requestIn)
         }
@@ -59,7 +57,6 @@ private[http2] final class RequestErrorFlow extends GraphStage[BidiShape[HttpRes
       override def onPull(): Unit = pull(requestIn)
     })
     setHandlers(responseIn, responseOut, new InHandler with OutHandler {
-      // FIXME did we detach so we need to check if we can push?
       override def onPush(): Unit = push(responseOut, grab(responseIn))
       override def onPull(): Unit = if (!hasBeenPulled(responseIn)) pull(responseIn)
     })

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestErrorFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestErrorFlow.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.http.impl.engine.http2
+
+import akka.NotUsed
+import akka.annotation.InternalApi
+import akka.http.impl.engine.http2.RequestParsing.ParseRequestResult
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
+import akka.stream.Attributes
+import akka.stream.BidiShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.scaladsl.BidiFlow
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[http2] object RequestErrorFlow {
+
+  private val _bidiFlow = BidiFlow.fromGraph(new RequestErrorFlow)
+  def apply(): BidiFlow[HttpResponse, HttpResponse, ParseRequestResult, HttpRequest, NotUsed] = _bidiFlow
+
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[http2] final class RequestErrorFlow extends GraphStage[BidiShape[HttpResponse, HttpResponse, ParseRequestResult, HttpRequest]] {
+
+  val requestIn = Inlet[ParseRequestResult]("requestIn")
+  val requestOut = Outlet[HttpRequest]("requestOut")
+  val responseIn = Inlet[HttpResponse]("responseIn")
+  val responseOut = Outlet[HttpResponse]("responseOut")
+
+  override val shape: BidiShape[HttpResponse, HttpResponse, ParseRequestResult, HttpRequest] = BidiShape(responseIn, responseOut, requestIn, requestOut)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    setHandlers(requestIn, requestOut, new InHandler with OutHandler {
+      override def onPush(): Unit = {
+        grab(requestIn) match {
+          case RequestParsing.OkRequest(request) => push(requestOut, request)
+          case notOk: RequestParsing.BadRequest =>
+            // FIXME is emit safe here?
+            // FIXME details vs summary?
+            emit(responseOut, HttpResponse(StatusCodes.BadRequest, entity = notOk.info.summary).addAttribute(Http2.streamId, notOk.streamId))
+            pull(requestIn)
+        }
+      }
+
+      override def onPull(): Unit = pull(requestIn)
+    })
+    setHandlers(responseIn, responseOut, new InHandler with OutHandler {
+      // FIXME did we detach so we need to check if we can push?
+      override def onPush(): Unit = push(responseOut, grab(responseIn))
+      override def onPull(): Unit = if (!hasBeenPulled(responseIn)) pull(responseIn)
+    })
+
+  }
+}

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestErrorFlow.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/RequestErrorFlow.scala
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.http.impl.engine.http2
 
 import akka.NotUsed

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/client/ResponseParsing.scala
@@ -6,6 +6,7 @@ package akka.http.impl.engine.http2
 package client
 
 import akka.annotation.InternalApi
+import akka.http.impl.engine.http2.Http2Compliance.Http2ProtocolException
 import akka.http.impl.engine.http2.RequestParsing._
 import akka.http.impl.engine.parsing.HttpHeaderParser
 import akka.http.impl.engine.server.HttpAttributes
@@ -15,8 +16,8 @@ import akka.http.scaladsl.model.headers.`Tls-Session-Info`
 import akka.http.scaladsl.settings.ParserSettings
 import akka.stream.Attributes
 import akka.util.OptionVal
-import javax.net.ssl.SSLSession
 
+import javax.net.ssl.SSLSession
 import scala.annotation.tailrec
 import scala.collection.immutable.VectorBuilder
 
@@ -75,23 +76,23 @@ private[http2] object ResponseParsing {
           if (contentType.isEmpty)
             rec(remainingHeaders.tail, status, OptionVal.Some(contentTypeValue), contentLength, seenRegularHeader, headers)
           else
-            malformedRequest("HTTP message must not contain more than one content-type header")
+            malformedResponse("HTTP message must not contain more than one content-type header")
 
         case ("content-type", ct: String) =>
           if (contentType.isEmpty) {
-            val contentTypeValue = ContentType.parse(ct).right.getOrElse(malformedRequest(s"Invalid content-type: '$ct'"))
+            val contentTypeValue = ContentType.parse(ct).right.getOrElse(malformedResponse(s"Invalid content-type: '$ct'"))
             rec(remainingHeaders.tail, status, OptionVal.Some(contentTypeValue), contentLength, seenRegularHeader, headers)
-          } else malformedRequest("HTTP message must not contain more than one content-type header")
+          } else malformedResponse("HTTP message must not contain more than one content-type header")
 
         case ("content-length", length: String) =>
           if (contentLength == -1) {
             val contentLengthValue = length.toLong
-            if (contentLengthValue < 0) malformedRequest("HTTP message must not contain a negative content-length header")
+            if (contentLengthValue < 0) malformedResponse("HTTP message must not contain a negative content-length header")
             rec(remainingHeaders.tail, status, contentType, contentLengthValue, seenRegularHeader, headers)
-          } else malformedRequest("HTTP message must not contain more than one content-length header")
+          } else malformedResponse("HTTP message must not contain more than one content-length header")
 
         case (name, _) if name.startsWith(":") =>
-          malformedRequest(s"Unexpected pseudo-header '$name' in response")
+          malformedResponse(s"Unexpected pseudo-header '$name' in response")
 
         case (_, httpHeader: HttpHeader) =>
           rec(remainingHeaders.tail, status, contentType, contentLength, seenRegularHeader = true, headers += httpHeader)
@@ -106,4 +107,7 @@ private[http2] object ResponseParsing {
 
     rec(subStream.initialHeaders.keyValuePairs)
   }
+
+  private def malformedResponse(msg: String): Nothing =
+    throw throw new Http2ProtocolException(s"Malformed response: $msg")
 }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderCompression.scala
@@ -37,7 +37,7 @@ private[http2] object HeaderCompression extends GraphStage[FlowShape[FrameEvent,
       case ack @ SettingsAckFrame(s) =>
         applySettings(s)
         push(eventsOut, ack)
-      case ParsedHeadersFrame(streamId, endStream, kvs, prioInfo) =>
+      case ParsedHeadersFrame(streamId, endStream, kvs, prioInfo, _) =>
         // When ending the stream without any payload, use a DATA frame rather than
         // a HEADERS frame to work around https://github.com/golang/go/issues/47851.
         if (endStream && kvs.isEmpty) push(eventsOut, DataFrame(streamId, endStream, ByteString.empty))

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -11,6 +11,7 @@ import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2.RequestParsing.parseHeaderPair
 import akka.http.impl.engine.http2._
 import akka.http.impl.engine.parsing.HttpHeaderParser
+import akka.http.scaladsl.model.ParsingException
 import akka.http.scaladsl.settings.ParserSettings
 import akka.http.shaded.com.twitter.hpack.HeaderListener
 import akka.stream._
@@ -82,9 +83,12 @@ private[http2] final class HeaderDecompression(masterHeaderParser: HttpHeaderPar
         decoder.decode(ByteStringInputStream(payload), Receiver)
         decoder.endHeaderBlock() // TODO: do we have to check the result here?
 
-        push(eventsOut, ParsedHeadersFrame(streamId, endStream, headers.result(), prioInfo))
+        push(eventsOut, ParsedHeadersFrame(streamId, endStream, headers.result(), prioInfo, None))
       } catch {
-        case ex: IOException =>
+        case ex: ParsingException =>
+          // push details further and let RequestErrorFlow handle responding with bad request
+          push(eventsOut, ParsedHeadersFrame(streamId, endStream, Seq.empty, prioInfo, Some(ex.info)))
+        case _: IOException =>
           // this is signalled by the decoder when it failed, we want to react to this by rendering a GOAWAY frame
           fail(eventsOut, new Http2Compliance.Http2ProtocolException(ErrorCode.COMPRESSION_ERROR, "Decompression failed."))
       }

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/Http2HeaderParsing.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/Http2HeaderParsing.scala
@@ -5,7 +5,8 @@
 package akka.http.impl.engine.http2.hpack
 
 import akka.annotation.InternalApi
-import akka.http.impl.engine.http2.RequestParsing.malformedRequest
+import akka.http.impl.engine.http2.RequestParsing
+import akka.http.impl.engine.http2.RequestParsing.parseError
 import akka.http.scaladsl.model
 import akka.http.scaladsl.model.HttpHeader.ParsingResult
 import model.{ HttpHeader, HttpMethod, HttpMethods, IllegalUriException, ParsingException, StatusCode, Uri }
@@ -26,7 +27,7 @@ private[akka] object Http2HeaderParsing {
     override def parse(name: String, value: String, parserSettings: ParserSettings): HttpMethod =
       HttpMethods.getForKey(value)
         .orElse(parserSettings.customMethods(value))
-        .getOrElse(malformedRequest(s"Unknown HTTP method: '$value'"))
+        .getOrElse(RequestParsing.parseError(s"Unknown HTTP method: '$value'", ":method"))
   }
   object PathAndQuery extends HeaderParser[(Uri.Path, Option[String])](":path") {
     override def parse(name: String, value: String, parserSettings: ParserSettings): (Uri.Path, Option[String]) =
@@ -50,7 +51,11 @@ private[akka] object Http2HeaderParsing {
   }
   object ContentType extends HeaderParser[model.ContentType]("content-type") {
     override def parse(name: String, value: String, parserSettings: ParserSettings): model.ContentType =
-      model.ContentType.parse(value).right.getOrElse(malformedRequest(s"Invalid content-type: '$value'"))
+      model.ContentType.parse(value) match {
+        case Right(tpe) => tpe
+        case Left(_) =>
+          parseError(s"Invalid content-type: '$value'", "content-type")
+      }
   }
   object ContentLength extends Verbatim("content-length")
   object Cookie extends Verbatim("cookie")

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
@@ -7,7 +7,7 @@ package akka.http.impl.engine.http2
 import akka.http.impl.engine.HttpIdleTimeoutException
 import akka.http.impl.engine.ws.ByteStringSinkProbe
 import akka.http.impl.util.{ AkkaSpecWithMaterializer, ExampleHttpContexts }
-import akka.http.scaladsl.model.{ AttributeKey, ContentTypes, HttpEntity, HttpHeader, HttpMethod, HttpMethods, HttpRequest, HttpResponse, RequestResponseAssociation, StatusCode, StatusCodes, Uri, headers }
+import akka.http.scaladsl.model.{ AttributeKey, ContentTypes, HttpEntity, HttpHeader, HttpMethod, HttpMethods, HttpProtocols, HttpRequest, HttpResponse, RequestResponseAssociation, StatusCode, StatusCodes, Uri, headers }
 import akka.http.scaladsl.model.headers.HttpEncodings
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.unmarshalling.Unmarshal
@@ -110,6 +110,17 @@ class Http2ClientServerSpec extends AkkaSpecWithMaterializer(
       clientRequestsOut.expectCancellation()
       // expect idle timeout exception to propagate to user
       clientResponsesIn.expectError() shouldBe a[HttpIdleTimeoutException]
+    }
+
+    "return bad request response when header parsing fails" in new TestSetup {
+      val badRequest = HttpRequest(
+        // easiest valid way to cause parsing to fail - unknown method
+        method = HttpMethod.custom("UNKNOWN_TO_SERVER"),
+        uri = "http://www.example.com/test"
+      )
+      sendClientRequest(badRequest)
+      val response = expectClientResponse()
+      response.status should be(StatusCodes.BadRequest)
     }
   }
 

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2ServerDemuxSpec.scala
@@ -45,7 +45,7 @@ class Http2ServerDemuxSpec extends AkkaSpecWithMaterializer("""
       // The request is taken from the HTTP/1.1 request that had the Upgrade
       // header and is passed to the handler code 'directly', bypassing the demux stage,
       // so the first thing the demux stage sees of this request is the response:
-      val response = ParsedHeadersFrame(streamId = 1, endStream = true, Seq((":status", "200")), None)
+      val response = ParsedHeadersFrame(streamId = 1, endStream = true, Seq((":status", "200")), None, None)
       substreamProducer.sendNext(new Http2SubStream(
         response,
         OptionVal.None,

--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/RequestParsingSpec.scala
@@ -13,6 +13,7 @@ import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.{ ByteString, OptionVal }
 import org.scalatest.{ Inside, Inspectors }
 import FrameEvent._
+import akka.http.impl.engine.http2.RequestParsing.ParseRequestResult
 import akka.http.impl.engine.http2.hpack.HeaderDecompression
 import akka.http.impl.engine.server.HttpAttributes
 import akka.http.impl.util.AkkaSpecWithMaterializer
@@ -26,11 +27,11 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
     /** Helper to test parsing */
     def parse(
       keyValuePairs:  Seq[(String, String)],
-      data:           Source[ByteString, Any] = Source.empty,
-      attributes:     Attributes              = Attributes(),
-      uriParsingMode: Uri.ParsingMode         = Uri.ParsingMode.Relaxed,
-      settings:       ServerSettings          = ServerSettings(system)
-    ): HttpRequest = {
+      data:           Source[ByteString, Any],
+      attributes:     Attributes,
+      uriParsingMode: Uri.ParsingMode,
+      settings:       ServerSettings
+    ): RequestParsing.ParseRequestResult = {
       val (serverSettings, parserSettings) = {
         val ps = settings.parserSettings.withUriParsingMode(uriParsingMode)
         (settings.withParserSettings(ps), ps)
@@ -40,10 +41,9 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       val encoder = new HPackEncodingSupport {}
       val frame = HeadersFrame(1, data == Source.empty, endHeaders = true, encoder.encodeHeaderPairs(keyValuePairs), None)
 
-      val parseRequest: Http2SubStream => HttpRequest =
-        RequestParsing.parseRequest(headerParser, serverSettings, attributes)
+      val parseRequest: Http2SubStream => ParseRequestResult = RequestParsing.parseRequest(headerParser, serverSettings, attributes)
 
-      try Source.single(frame)
+      Source.single(frame)
         .via(new HeaderDecompression(headerParser, parserSettings))
         .map { // emulate demux
           case headers: ParsedHeadersFrame =>
@@ -58,14 +58,29 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
         .map(parseRequest)
         .runWith(Sink.head)
         .futureValue
-      catch { case ex: Throwable => throw ex.getCause } // unpack futureValue exceptions
     }
 
-    def shouldThrowMalformedRequest[T](block: => T): Exception = {
-      val thrown = the[RuntimeException] thrownBy block
-      thrown.getMessage should startWith("Malformed request: ")
-      thrown
-    }
+    def parseExpectOk(
+      keyValuePairs:  Seq[(String, String)],
+      data:           Source[ByteString, Any] = Source.empty,
+      attributes:     Attributes              = Attributes(),
+      uriParsingMode: Uri.ParsingMode         = Uri.ParsingMode.Relaxed,
+      settings:       ServerSettings          = ServerSettings(system)): HttpRequest =
+      parse(keyValuePairs, data, attributes, uriParsingMode, settings) match {
+        case RequestParsing.OkRequest(req)      => req
+        case RequestParsing.BadRequest(info, _) => fail(s"Failed parsing request: $info")
+      }
+
+    def parseExpectError[T](
+      keyValuePairs:  Seq[(String, String)],
+      data:           Source[ByteString, Any] = Source.empty,
+      attributes:     Attributes              = Attributes(),
+      uriParsingMode: Uri.ParsingMode         = Uri.ParsingMode.Relaxed,
+      settings:       ServerSettings          = ServerSettings(system)): ErrorInfo =
+      parse(keyValuePairs, data, attributes, uriParsingMode, settings) match {
+        case RequestParsing.OkRequest(req)      => fail("Unexpectedly succeeded parsing request")
+        case RequestParsing.BadRequest(info, _) => info
+      }
 
     "follow RFC7540" should {
 
@@ -75,14 +90,14 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       // appear in requests.
 
       "not accept response pseudo-header fields in a request" in {
-        val thrown = shouldThrowMalformedRequest(parse(
+        val info = parseExpectError(
           keyValuePairs = Vector(
             ":scheme" -> "https",
             ":method" -> "GET",
             ":path" -> "/",
             ":status" -> "200"
-          )))
-        thrown.getMessage should ===("Malformed request: Pseudo-header ':status' is for responses only; it cannot appear in a request")
+          ))
+        info.summary should ===("Malformed request: Pseudo-header ':status' is for responses only; it cannot appear in a request")
       }
 
       // All pseudo-header fields MUST appear in the header block before
@@ -100,7 +115,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
           // Insert the Foo header so it occurs before at least one pseudo-header
           val (before, after) = pseudoHeaders.splitAt(insertPoint)
           val modified = before ++ Vector("Foo" -> "bar") ++ after
-          shouldThrowMalformedRequest(parse(modified))
+          parseExpectError(modified)
         }
       }
 
@@ -110,34 +125,32 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       // be treated as malformed...
 
       "not accept connection-specific headers" in {
-        shouldThrowMalformedRequest {
-          // Add Connection header to indicate that Foo is a connection-specific header
-          parse(Vector(
-            ":method" -> "GET",
-            ":scheme" -> "https",
-            ":path" -> "/",
-            "Connection" -> "foo",
-            "Foo" -> "bar"
-          ))
-        }
+        // Add Connection header to indicate that Foo is a connection-specific header
+        parseExpectError(Vector(
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          ":path" -> "/",
+          "Connection" -> "foo",
+          "Foo" -> "bar"
+        ))
       }
 
       "not accept TE with other values than 'trailers'" in {
-        shouldThrowMalformedRequest {
-          // The only exception to this is the TE header field, which MAY be
-          // present in an HTTP/2 request; when it is, it MUST NOT contain any
-          // value other than "trailers".
-          parse(Vector(
-            ":method" -> "GET",
-            ":scheme" -> "https",
-            ":path" -> "/",
-            "TE" -> "chunked",
-          ))
-        }
+
+        // The only exception to this is the TE header field, which MAY be
+        // present in an HTTP/2 request; when it is, it MUST NOT contain any
+        // value other than "trailers".
+        parseExpectError(Vector(
+          ":method" -> "GET",
+          ":scheme" -> "https",
+          ":path" -> "/",
+          "TE" -> "chunked",
+        ))
+
       }
 
       "accept TE with 'trailers' as value" in {
-        parse(Vector(
+        parseExpectOk(Vector(
           ":method" -> "GET",
           ":scheme" -> "https",
           ":path" -> "/",
@@ -153,7 +166,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       "parse the ':method' pseudo-header correctly" in {
         val methods = Seq("GET", "POST", "DELETE", "OPTIONS")
         forAll(methods) { (method: String) =>
-          val request: HttpRequest = parse(
+          val request: HttpRequest = parseExpectOk(
             keyValuePairs = Vector(
               ":method" -> method,
               ":scheme" -> "https",
@@ -176,7 +189,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
         // can't be constructed with any other schemes.
         val schemes = Seq("http", "https", "ws", "wss")
         forAll(schemes) { (scheme: String) =>
-          val request: HttpRequest = parse(
+          val request: HttpRequest = parseExpectOk(
             keyValuePairs = Vector(
               ":method" -> "POST",
               ":scheme" -> scheme,
@@ -203,7 +216,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
           )
           forAll(authorities) {
             case (authority, host, optPort) =>
-              val request: HttpRequest = parse(
+              val request: HttpRequest = parseExpectOk(
                 keyValuePairs = Vector(
                   ":method" -> "POST",
                   ":scheme" -> "https",
@@ -219,14 +232,14 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
 
           val authorities = Seq("?", " ", "@", ":")
           forAll(authorities) { authority =>
-            val thrown = the[ParsingException] thrownBy (parse(
+            val info = parseExpectError(
               keyValuePairs = Vector(
                 ":method" -> "POST",
                 ":scheme" -> "https",
                 ":authority" -> authority,
                 ":path" -> "/"
-              )))
-            thrown.getMessage should include("http2-authority-pseudo-header")
+              ))
+            info.summary should include("http2-authority-pseudo-header")
           }
         }
       }
@@ -248,14 +261,14 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
         val schemes = Seq("http", "https")
         forAll(schemes) { (scheme: String) =>
           forAll(authorities) { (authority: String) =>
-            val exception = the[Exception] thrownBy (parse(
+            val info = parseExpectError(
               keyValuePairs = Vector(
                 ":method" -> "POST",
                 ":scheme" -> scheme,
                 ":authority" -> authority,
                 ":path" -> "/"
-              )))
-            exception.getMessage should startWith("Illegal http2-authority-pseudo-header")
+              ))
+            info.summary should startWith("Illegal http2-authority-pseudo-header")
           }
         }
       }
@@ -268,8 +281,11 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       "follow RFC3986 for the ':path' pseudo-header" should {
 
         def parsePath(path: String, uriParsingMode: Uri.ParsingMode = Uri.ParsingMode.Relaxed): Uri = {
-          parse(Seq(":method" -> "GET", ":scheme" -> "https", ":path" -> path), uriParsingMode = uriParsingMode).uri
+          parseExpectOk(Seq(":method" -> "GET", ":scheme" -> "https", ":path" -> path), uriParsingMode = uriParsingMode).uri
         }
+
+        def parsePathExpectError(path: String, uriParsingMode: Uri.ParsingMode = Uri.ParsingMode.Relaxed): ErrorInfo =
+          parseExpectError(Seq(":method" -> "GET", ":scheme" -> "https", ":path" -> path), uriParsingMode = uriParsingMode)
 
         // sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
         //             / "*" / "+" / "," / ";" / "="
@@ -334,8 +350,8 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
             "http://localhost/foo"
           )
           forAll(invalidAbsolutePaths) { (absPath: String) =>
-            val exception = the[ParsingException] thrownBy (parsePath(absPath))
-            exception.getMessage should include("http2-path-pseudo-header")
+            val info = parsePathExpectError(absPath)
+            info.summary should include("http2-path-pseudo-header")
           }
         }
 
@@ -345,8 +361,8 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
             "//", "//x"
           )
           forAll(invalidAbsolutePaths) { (absPath: String) =>
-            val exception = the[ParsingException] thrownBy (parsePath(absPath, uriParsingMode = Uri.ParsingMode.Strict))
-            exception.getMessage should include("http2-path-pseudo-header")
+            val info = parsePathExpectError(absPath, uriParsingMode = Uri.ParsingMode.Strict)
+            info.summary should include("http2-path-pseudo-header")
           }
         }
 
@@ -387,10 +403,11 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
           val invalidQueries: Seq[String] = Seq(
             ":", "/", "?", "#", "[", "]", "@", " "
           )
+
           forAll(absolutePaths.take(3)) {
             case (inputPath, _) =>
               forAll(invalidQueries) { (query: String) =>
-                shouldThrowMalformedRequest(parsePath(inputPath + "?" + query, uriParsingMode = Uri.ParsingMode.Strict))
+                parsePathExpectError(inputPath + "?" + query, uriParsingMode = Uri.ParsingMode.Strict)
               }
           }
         }
@@ -401,7 +418,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       // value '*' for the ":path" pseudo-header field.
 
       "handle a ':path' with an asterisk" in pendingUntilFixed {
-        val request: HttpRequest = parse(
+        val request: HttpRequest = parseExpectOk(
           keyValuePairs = Vector(
             ":method" -> "OPTIONS",
             ":scheme" -> "http",
@@ -413,15 +430,15 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       // [The ":path"] pseudo-header field MUST NOT be empty for "http" or "https"
       // URIs...
 
-      "reject empty ':path' pseudo-headers for http and https" in pendingUntilFixed {
+      "reject empty ':path' pseudo-headers for http and https" in {
         val schemes = Seq("http", "https")
         forAll(schemes) { (scheme: String) =>
-          shouldThrowMalformedRequest(parse(
+          parseExpectError(
             keyValuePairs = Vector(
               ":method" -> "POST",
               ":scheme" -> scheme,
               ":path" -> ""
-            )))
+            ))
         }
       }
 
@@ -442,13 +459,13 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       "reject requests without a mandatory pseudo-headers" in {
         val mandatoryPseudoHeaders = Seq(":method", ":scheme", ":path")
         forAll(mandatoryPseudoHeaders) { (name: String) =>
-          val thrown = shouldThrowMalformedRequest(parse(
+          val info = parseExpectError(
             keyValuePairs = Vector(
               ":scheme" -> "https",
               ":method" -> "GET",
               ":path" -> "/"
-            ).filter(_._1 != name)))
-          thrown.getMessage should ===(s"Malformed request: Mandatory pseudo-header '$name' missing")
+            ).filter(_._1 != name))
+          info.summary should ===(s"Malformed request: Mandatory pseudo-header '$name' missing")
         }
       }
 
@@ -456,14 +473,14 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
         val pseudoHeaders = Seq(":method" -> "POST", ":scheme" -> "http", ":path" -> "/other", ":authority" -> "example.org")
         forAll(pseudoHeaders) {
           case (name: String, alternative: String) =>
-            val thrown = shouldThrowMalformedRequest(parse(
+            val info = parseExpectError(
               keyValuePairs = Vector(
                 ":scheme" -> "https",
                 ":method" -> "GET",
                 ":authority" -> "akka.io",
                 ":path" -> "/"
-              ) :+ (name -> alternative)))
-            thrown.getMessage should ===(s"Malformed request: Pseudo-header '$name' must not occur more than once")
+              ) :+ (name -> alternative))
+            info.summary should ===(s"Malformed request: Pseudo-header '$name' must not occur more than once")
         }
       }
 
@@ -484,7 +501,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
         )
         forAll(cookieHeaders) {
           case (inValues, outValue) =>
-            val httpRequest: HttpRequest = parse(
+            val httpRequest: HttpRequest = parseExpectOk(
               Vector(
                 ":method" -> "GET",
                 ":scheme" -> "https",
@@ -502,7 +519,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       // 8.1.3.  Examples
 
       "parse GET example" in {
-        val request: HttpRequest = parse(
+        val request: HttpRequest = parseExpectOk(
           keyValuePairs = Vector(
             ":method" -> "GET",
             ":scheme" -> "https",
@@ -527,7 +544,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
       }
 
       "parse POST example" in {
-        val request: HttpRequest = parse(
+        val request: HttpRequest = parseExpectOk(
           keyValuePairs = Vector(
             ":method" -> "POST",
             ":scheme" -> "https",
@@ -564,7 +581,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
     // Tests that don't come from an RFC document...
 
     "parse GET https://localhost:8000/ correctly" in {
-      val request: HttpRequest = parse(
+      val request: HttpRequest = parseExpectOk(
         keyValuePairs = Vector(
           ":method" -> "GET",
           ":scheme" -> "https",
@@ -584,7 +601,7 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
     }
 
     "reject requests with multiple content length headers" in {
-      val thrown = shouldThrowMalformedRequest(parse(
+      val info = parseExpectError(
         keyValuePairs = Vector(
           ":method" -> "GET",
           ":scheme" -> "https",
@@ -592,12 +609,12 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
           ":path" -> "/",
           "content-length" -> "123",
           "content-length" -> "124",
-        )))
-      thrown.getMessage should ===(s"Malformed request: HTTP message must not contain more than one content-length header")
+        ))
+      info.summary should ===(s"Malformed request: HTTP message must not contain more than one content-length header")
     }
 
     "reject requests with multiple content type headers" in {
-      val thrown = shouldThrowMalformedRequest(parse(
+      val info = parseExpectError(
         keyValuePairs = Vector(
           ":method" -> "GET",
           ":scheme" -> "https",
@@ -605,19 +622,19 @@ class RequestParsingSpec extends AkkaSpecWithMaterializer with Inside with Inspe
           ":path" -> "/",
           "content-type" -> "text/json",
           "content-type" -> "text/json",
-        )))
-      thrown.getMessage should ===(s"Malformed request: HTTP message must not contain more than one content-type header")
+        ))
+      info.summary should ===(s"Malformed request: HTTP message must not contain more than one content-type header")
     }
 
     "reject requests with too many headers" in {
       val maxHeaderCount = ServerSettings(system).parserSettings.maxHeaderCount
-      val thrown = shouldThrowMalformedRequest(parse((0 to (maxHeaderCount + 1)).map(n => s"x-my-header-$n" -> n.toString).toVector))
-      thrown.getMessage should ===(s"Malformed request: HTTP message contains more than the configured limit of $maxHeaderCount headers")
+      val info = parseExpectError((0 to (maxHeaderCount + 1)).map(n => s"x-my-header-$n" -> n.toString).toVector)
+      info.summary should ===(s"Malformed request: HTTP message contains more than the configured limit of $maxHeaderCount headers")
     }
 
     "add remote address request attribute if enabled" in {
       val theAddress = InetAddress.getByName("127.5.2.1")
-      val request: HttpRequest = parse(
+      val request: HttpRequest = parseExpectOk(
         keyValuePairs = Vector(
           ":method" -> "GET",
           ":scheme" -> "https",


### PR DESCRIPTION
References #4226
Also fixes https://github.com/akka/akka-http/issues/2394
