### PR TITLE
chore: configure Fossa scanning

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,10 @@
+version: 3
+# https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md
+
+targets:
+  # exclude non-distributed projects from dependency scanning
+  exclude:
+    - type: scala
+      path: akka-http-bench-jmh
+    - type: scala
+      path: akka-http-compatibility-tests


### PR DESCRIPTION
Exclude non-distributed modules from scanning by Fossa.