### PR TITLE
add config support for RouteTestTimeout via application.conf

### DIFF
--- a/akka-http-testkit/src/main/resources/reference.conf
+++ b/akka-http-testkit/src/main/resources/reference.conf
@@ -1,1 +1,2 @@
 akka.http.testkit.marshalling.timeout = 1 s
+akka.http.testkit.routes.timeout = 1 s

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestTimeout.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTestTimeout.scala
@@ -6,10 +6,14 @@ package akka.http.scaladsl.testkit
 
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
-import akka.testkit._
+import akka.http.impl.util.enhanceConfig
 
 case class RouteTestTimeout(duration: FiniteDuration)
 
 object RouteTestTimeout {
-  implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(1.second.dilated)
+
+  implicit def default(implicit system: ActorSystem): RouteTestTimeout = {
+    val routesTimeout = system.settings.config.getFiniteDuration("akka.http.testkit.routes.timeout")
+    RouteTestTimeout(routesTimeout)
+  }
 }


### PR DESCRIPTION
This PR add support to changing the `RouteTestTimeout` with providing the override of the `akka.http.testkit.routes.timeout` from the typesafe config, in this way we can change the default timeout directly from the configuration instead of overriding the timeout directly from the code.

References #4238
