### PR TITLE
docs: New centralized security page

### DIFF
--- a/docs/src/main/paradox/security.md
+++ b/docs/src/main/paradox/security.md
@@ -1,5 +1,10 @@
 # Security Announcements
 
+@@@note
+
+Security announcements has moved to a shared page for all Akka projects and can now be found at [akka.io/security](https://akka.io/security) 
+@@@
+
 ## Receiving Security Advisories
 The best way to receive any and all security announcements is to subscribe to the [Akka security list](https://groups.google.com/forum/#!forum/akka-security).
 


### PR DESCRIPTION
Leaving existing announcement pages for now (but they have been duplicated to akka.io).