### PR TITLE
chore: Fix failing HTTP/2 retry test

### DIFF
--- a/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
+++ b/akka-http2-support/src/test/scala/akka/http/impl/engine/http2/Http2PersistentClientSpec.scala
@@ -262,8 +262,15 @@ abstract class Http2PersistentClientSpec(tls: Boolean) extends AkkaSpecWithMater
           if (withBackoff) {
             // not immediate when using backoff, 4 retries before failing, backoff is 300-800ms (so at least 1.2s)
             client.responsesIn.expectNoMessage(clientSettings.http2Settings.baseConnectionBackoff * 4)
+            // total max backoff for 4 tries with the random factor could actually worst case be something
+            // like 600 + 800 + 800 + 800 - those 1200 ms = 1800 ms, but no way to pass a timeout to expectError
+            awaitAssert({
+              client.responsesIn.expectError()
+            }, 1800.millis)
+          } else {
+            // directly
+            client.responsesIn.expectError()
           }
-          client.responsesIn.expectError()
           client.requestsOut.expectCancellation()
 
         }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Max retry timespan was underestimated

References #4205 
