### PR TITLE
#4265  Replace echo.websocket.org -> ws.ifelse.io

### DIFF
--- a/akka-http-core/src/test/java/akka/http/javadsl/WSEchoTestClientApp.java
+++ b/akka-http-core/src/test/java/akka/http/javadsl/WSEchoTestClientApp.java
@@ -69,7 +69,7 @@ public class WSEchoTestClientApp {
 
             CompletionStage<List<String>> result =
                 Http.get(system).singleWebSocketRequest(
-                    WebSocketRequest.create("ws://echo.websocket.org"),
+                    WebSocketRequest.create("ws://ws.ifelse.io"),
                     echoClient,
                     materializer
                 ).second();

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/ws/EchoTestClientApp.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/ws/EchoTestClientApp.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Future
 import scala.util.{ Failure, Success }
 
 /**
- * An example App that runs a quick test against the websocket server at wss://echo.websocket.org
+ * An example App that runs a quick test against the websocket server at wss://ws.ifelse.io
  */
 object EchoTestClientApp extends App {
   implicit val system: ActorSystem = ActorSystem()
@@ -52,7 +52,7 @@ object EchoTestClientApp extends App {
 
   def echoClient = Flow.fromSinkAndSourceMat(sink, source)(Keep.left)
 
-  val (upgrade, res) = Http().singleWebSocketRequest("wss://echo.websocket.org", echoClient)
+  val (upgrade, res) = Http().singleWebSocketRequest("wss://ws.ifelse.io", echoClient)
   res onComplete {
     case Success(res) =>
       println("Run successful. Got these elements:")

--- a/docs/src/test/java/docs/http/javadsl/WebSocketClientExampleTest.java
+++ b/docs/src/test/java/docs/http/javadsl/WebSocketClientExampleTest.java
@@ -59,7 +59,7 @@ public class WebSocketClientExampleTest {
 
     final Pair<CompletionStage<WebSocketUpgradeResponse>, CompletionStage<Done>> pair =
       http.singleWebSocketRequest(
-        WebSocketRequest.create("ws://echo.websocket.org"),
+        WebSocketRequest.create("ws://ws.ifelse.io"),
         flow,
         materializer
       );
@@ -205,7 +205,7 @@ public class WebSocketClientExampleTest {
 
 
     Flow<Message, Message, CompletionStage<WebSocketUpgradeResponse>> webSocketFlow =
-      http.webSocketClientFlow(WebSocketRequest.create("ws://echo.websocket.org"));
+      http.webSocketClientFlow(WebSocketRequest.create("ws://ws.ifelse.io"));
 
 
     Pair<CompletionStage<WebSocketUpgradeResponse>, CompletionStage<Done>> pair =

--- a/docs/src/test/scala/docs/http/scaladsl/SingleWebSocketRequest.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/SingleWebSocketRequest.scala
@@ -39,7 +39,7 @@ object SingleWebSocketRequest {
     // completes or fails when the connection succeeds or fails
     // and closed is a Future[Done] representing the stream completion from above
     val (upgradeResponse, closed) =
-      Http().singleWebSocketRequest(WebSocketRequest("ws://echo.websocket.org"), flow)
+      Http().singleWebSocketRequest(WebSocketRequest("ws://ws.ifelse.io"), flow)
 
     val connected = upgradeResponse.map { upgrade =>
       // just like a regular http request we can access response status which is available via upgrade.response.status

--- a/docs/src/test/scala/docs/http/scaladsl/WebSocketClientFlow.scala
+++ b/docs/src/test/scala/docs/http/scaladsl/WebSocketClientFlow.scala
@@ -32,7 +32,7 @@ object WebSocketClientFlow {
     val outgoing = Source.single(TextMessage("hello world!"))
 
     // flow to use (note: not re-usable!)
-    val webSocketFlow = Http().webSocketClientFlow(WebSocketRequest("ws://echo.websocket.org"))
+    val webSocketFlow = Http().webSocketClientFlow(WebSocketRequest("ws://ws.ifelse.io"))
 
     // the materialized value is a tuple with
     // upgradeResponse is a Future[WebSocketUpgradeResponse] that


### PR DESCRIPTION
- Replaced usages of `ws://echo.websocket.org` echo websocket that is no longer available, with `ws://ws.ifelse.io` that is currently available.

References #4265 
