### PR TITLE
fix: Align better with RFC 8288 by quoting strings with colon 

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LinkValue.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/LinkValue.scala
@@ -40,7 +40,9 @@ object LinkParam {
 }
 
 object LinkParams {
-  private val reserved = CharPredicate(" ,;")
+  // Note rfc5988 only lists " ,;" but we add : to align with rfc8288 which quotes anything not a token as defined
+  // in rfc7230 (but without having to parse token)
+  private val reserved = CharPredicate(" ,;:")
 
   // A few convenience rels
   val next = rel("next")

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -424,7 +424,7 @@ class HttpHeaderSpec extends AnyFreeSpec with Matchers {
         .renderedTo("""<http://example.com/TheBook/chapter2>; rel=previous; title="previous chapter"""")
 
       """Link: </>; rel="http://example.net/foo"""" =!= Link(Uri("/"), LinkParams.rel("http://example.net/foo"))
-        .renderedTo("</>; rel=http://example.net/foo")
+        .renderedTo("""</>; rel="http://example.net/foo"""")
 
       """Link: <http://example.org/>; rel="start http://example.net/relation/other"""" =!= Link(
         Uri("http://example.org/"),

--- a/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/model/parser/HttpHeaderSpec.scala
@@ -432,6 +432,9 @@ class HttpHeaderSpec extends AnyFreeSpec with Matchers {
 
       // only one 'rel=' is allowed, http://tools.ietf.org/html/rfc5988#section-5.3 requires any subsequent ones to be skipped
       "Link: </>; rel=prev; rel=next" =!=> "</>; rel=prev"
+
+      // make sure we still parse unquoted rel uri
+      """Link: <http://example.org/>; rel=http://example.net/relation/other""" =!=> """<http://example.org/>; rel="http://example.net/relation/other""""
     }
 
     "Origin" in {


### PR DESCRIPTION
Refs #4264

Instead of the suggested always quoting I went for additional quoting when colon in string, keeping it closer to original behavior and also trading one more char check for two additional bytes in each Link/rel entry.