### PR TITLE
chore: fix fossa excludes using paths

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,10 +1,8 @@
 version: 3
 # https://github.com/fossas/fossa-cli/blob/master/docs/references/files/fossa-yml.md
 
-targets:
+paths:
   # exclude non-distributed projects from dependency scanning
   exclude:
-    - type: scala
-      path: akka-http-bench-jmh
-    - type: scala
-      path: akka-http-compatibility-tests
+    - akka-http-bench-jmh
+    - akka-http-compatibility-tests


### PR DESCRIPTION
Fossa was not skipping the excluded targets. Couldn't figure out why or how to make target excludes work here. Switch to path excludes (as we're using for akka).

`fossa analyze --output` before:

```
18 projects scanned;  1 skipped,  17 succeeded,  0 failed,  17 analysis warnings

* scala project in "/Users/peter/dev/akka/akka-http/akka-http-bench-jmh/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-bill-of-materials/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-caching/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-compatibility-tests/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-core/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-java/akka-http-jackson/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-java/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-scala/akka-http-spray-json/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-scala/akka-http-xml/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-scala/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-scalafix/scalafix-rules/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-testkit/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-tests/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http2-support/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-parsing/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/docs/target/scala-2.13/": skipped (non-production path filtering)
```

With path excludes it skips the excluded projects:

```
18 projects scanned;  3 skipped,  15 succeeded,  0 failed,  15 analysis warnings

* scala project in "/Users/peter/dev/akka/akka-http/akka-http-bill-of-materials/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-caching/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-core/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-java/akka-http-jackson/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-java/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-scala/akka-http-spray-json/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-scala/akka-http-xml/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-marshallers-scala/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-scalafix/scalafix-rules/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-testkit/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-tests/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http2-support/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-parsing/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/target/scala-2.13/": succeeded with 1 warning
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-bench-jmh/target/scala-2.13/": skipped (exclusion filters)
* scala project in "/Users/peter/dev/akka/akka-http/akka-http-compatibility-tests/target/scala-2.13/": skipped (exclusion filters)
* scala project in "/Users/peter/dev/akka/akka-http/docs/target/scala-2.13/": skipped (non-production path filtering)
```
