### PR TITLE
fix: Fail-over to UTF-8 if Accept-Charset is invalid

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/marshalling/MarshallingSpec.scala
@@ -33,6 +33,11 @@ class MarshallingSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
     "StringMarshaller should marshal strings to `text/plain` content in UTF-8" in {
       marshal("Ha“llo") shouldEqual HttpEntity("Ha“llo")
     }
+    "StringMarshaller should marshal strings to `text/plain` content in UTF-8 when specified request accept-charset is invalid" in {
+      val response = marshalToResponse("Hallo", HttpRequest().withHeaders(Vector(`Accept-Charset`(HttpCharsetRange(HttpCharset("asd")(Nil))))))
+      response.entity.contentType.charsetOption should be(Some(HttpCharsets.`UTF-8`))
+    }
+
     "DoneMarshaller should enable marshalling of akka.Done" in {
       marshal(akka.Done) shouldEqual HttpEntity("")
     }


### PR DESCRIPTION
References #4295

Follows the suggestion in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Charset and falls back to UTF-8 when the requested Accept-Charset is not a valid charset (instead of failing with a NIO exception and logging noise)