### PR TITLE
bump: Jackson 2.15.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,8 +11,8 @@ import scala.language.implicitConversions
 object Dependencies {
   import DependencyHelpers._
 
-  val jacksonDatabindVersion = "2.13.4.2"
-  val jacksonXmlVersion = "2.13.4"
+  val jacksonDatabindVersion = "2.15.2"
+  val jacksonXmlVersion = "2.15.2"
   val junitVersion = "4.13.2"
   val h2specVersion = "1.5.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"


### PR DESCRIPTION
Use same Jackson version as in upcoming Akka 2.9. Targeting next minor release.