### PR TITLE
chore: api may change removals for 10.6

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/javadsl/ClientTransport.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ClientTransport.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletionStage
 import java.util.function.BiFunction
 
 import akka.actor.ActorSystem
-import akka.annotation.ApiMayChange
 import akka.http.impl.util.JavaMapping
 import akka.http.impl.util.JavaMapping.Implicits._
 import akka.http.impl.util.JavaMapping._
@@ -21,19 +20,17 @@ import akka.util.ByteString
 import scala.concurrent.Future
 
 /**
- * (Still unstable) SPI for implementors of custom client transports.
+ * SPI for implementors of custom client transports.
  */
 // #client-transport-definition
-@ApiMayChange
 abstract class ClientTransport {
   def connectTo(host: String, port: Int, settings: ClientConnectionSettings, system: ActorSystem): Flow[ByteString, ByteString, CompletionStage[OutgoingConnection]]
 }
 // #client-transport-definition
 
 /**
- * (Still unstable) entry point to create or access predefined client transports.
+ * Entry point to create or access predefined client transports.
  */
-@ApiMayChange
 object ClientTransport {
   def TCP: ClientTransport = scaladsl.ClientTransport.TCP.asJava
 

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/RequestResponseAssociation.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/RequestResponseAssociation.scala
@@ -6,12 +6,9 @@ package akka.http.javadsl.model
 
 import java.util.concurrent.CompletableFuture
 
-import akka.annotation.ApiMayChange
-
 /**
  * A marker trait for attribute values that should be (automatically) carried over from request to response.
  */
-@ApiMayChange
 trait RequestResponseAssociation
 
 /**

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ClientTransport.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ClientTransport.scala
@@ -6,7 +6,6 @@ package akka.http.scaladsl
 
 import java.net.InetSocketAddress
 import akka.actor.ActorSystem
-import akka.annotation.ApiMayChange
 import akka.http.impl.engine.client.HttpsProxyGraphStage
 import akka.http.scaladsl.Http.OutgoingConnection
 import akka.http.scaladsl.model.headers.HttpCredentials
@@ -21,19 +20,17 @@ import scala.concurrent.{ ExecutionContext, Future }
 /**
  * Abstraction to allow the creation of alternative transports to run HTTP on.
  *
- * (Still unstable) SPI for implementors of custom client transports.
+ * SPI for implementors of custom client transports.
  */
 // #client-transport-definition
-@ApiMayChange
 trait ClientTransport {
   def connectTo(host: String, port: Int, settings: ClientConnectionSettings)(implicit system: ActorSystem): Flow[ByteString, ByteString, Future[OutgoingConnection]]
 }
 // #client-transport-definition
 
 /**
- * (Still unstable) entry point to create or access predefined client transports.
+ * Entry point to create or access predefined client transports.
  */
-@ApiMayChange
 object ClientTransport {
   val TCP: ClientTransport = TCPTransport
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/RequestResponseAssociation.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/RequestResponseAssociation.scala
@@ -4,7 +4,6 @@
 
 package akka.http.scaladsl.model
 
-import akka.annotation.ApiMayChange
 import akka.annotation.InternalStableApi
 
 import scala.concurrent.Promise
@@ -12,14 +11,12 @@ import scala.concurrent.Promise
 /**
  * A marker trait for attribute values that should be (automatically) carried over from request to response.
  */
-@ApiMayChange
 @InternalStableApi
 trait RequestResponseAssociation extends akka.http.javadsl.model.RequestResponseAssociation
 
 /**
  * A simple value holder class implementing RequestResponseAssociation.
  */
-@ApiMayChange
 final case class SimpleRequestResponseAttribute[T](value: T) extends RequestResponseAssociation
 
 /**

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
@@ -6,7 +6,6 @@ package akka.http.javadsl.server
 
 import java.util.function.{ BiFunction, Function, Supplier }
 
-import akka.annotation.ApiMayChange
 import akka.http.javadsl.server.directives.FramedEntityStreamingDirectives
 import scala.annotation.nowarn
 
@@ -43,7 +42,6 @@ object Directives extends AllDirectives {
    * @param inner the inner route Producer
    * @return the resulting route
    */
-  @ApiMayChange
   def anyOf(first: Function[Supplier[Route], Route], second: Function[Supplier[Route], Route], inner: Supplier[Route]): Route = {
     first.apply(inner).orElse(second.apply(inner))
   }
@@ -60,7 +58,6 @@ object Directives extends AllDirectives {
    * @tparam A the type of the parameter the directives extract and the inner route takes
    * @return the resulting route
    */
-  @ApiMayChange
   def anyOf[A](first: Function[Function[A, Route], Route], second: Function[Function[A, Route], Route], inner: Function[A, Route]): Route = {
     first.apply(inner).orElse(second.apply(inner))
   }
@@ -74,7 +71,6 @@ object Directives extends AllDirectives {
    * @param inner the inner route function
    * @return the resulting route
    */
-  @ApiMayChange
   def allOf(first: Function[Supplier[Route], Route], second: Function[Supplier[Route], Route], inner: Supplier[Route]): Route = {
     first.apply(new Supplier[Route] {
       override def get(): Route =
@@ -93,7 +89,6 @@ object Directives extends AllDirectives {
    * @tparam B the type extracted from the second directive
    * @return the resulting route
    */
-  @ApiMayChange
   def allOf[A, B](first: Function[Function[A, Route], Route], second: Function[Function[B, Route], Route], inner: BiFunction[A, B, Route]): Route = {
     first.apply(new Function[A, Route] {
       override def apply(a: A): Route =
@@ -114,7 +109,6 @@ object Directives extends AllDirectives {
    * @tparam A the type extracted from the second directive
    * @return the resulting route
    */
-  @ApiMayChange
   def allOf[A](first: Function[Supplier[Route], Route], second: Function[Function[A, Route], Route], inner: Function[A, Route]): Route = {
     first.apply(new Supplier[Route] {
       override def get(): Route =

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FileUploadDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FileUploadDirectives.scala
@@ -25,7 +25,6 @@ abstract class FileUploadDirectives extends FileAndResourceDirectives {
    * field the request will be rejected, if there are multiple file parts with the same name, the first one will be
    * used and the subsequent ones ignored.
    */
-  @ApiMayChange
   def storeUploadedFile(fieldName: String, destFn: JFunction[FileInfo, File], inner: BiFunction[FileInfo, File, Route]): Route = RouteAdapter {
     D.storeUploadedFile(fieldName, destFn.apply) { case (info, file) => inner.apply(info, file).delegate }
   }
@@ -35,7 +34,6 @@ abstract class FileUploadDirectives extends FileAndResourceDirectives {
    * If there is an error writing to disk the request will be failed with the thrown exception, if there is no such
    * field the request will be rejected. Stored files are cleaned up on exit but not on failure.
    */
-  @ApiMayChange
   def storeUploadedFiles(fieldName: String, destFn: JFunction[FileInfo, File], inner: JFunction[JList[JMap.Entry[FileInfo, File]], Route]): Route = RouteAdapter {
     D.storeUploadedFiles(fieldName, destFn.apply) { files =>
       val entries = files.map { case (info, src) => new SimpleImmutableEntry(fileInfoToJava(info), src) }
@@ -59,7 +57,6 @@ abstract class FileUploadDirectives extends FileAndResourceDirectives {
    * Files are buffered into temporary files on disk so in-memory buffers don't overflow. The temporary
    * files are cleaned up once materialized, or on exit if the stream is not consumed.
    */
-  @ApiMayChange
   def fileUploadAll(fieldName: String, inner: JFunction[JList[JMap.Entry[FileInfo, Source[ByteString, Any]]], Route]): Route = RouteAdapter {
     D.fileUploadAll(fieldName) { files =>
       val entries = files.map { case (info, src) => new SimpleImmutableEntry(fileInfoToJava(info), src.asJava) }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/FileUploadDirectives.scala
@@ -5,7 +5,6 @@
 package akka.http.scaladsl.server.directives
 
 import akka.Done
-import akka.annotation.ApiMayChange
 import akka.dispatch.ExecutionContexts
 import akka.http.javadsl
 import akka.http.scaladsl.model.ContentType
@@ -43,7 +42,6 @@ trait FileUploadDirectives {
    *
    * @group fileupload
    */
-  @ApiMayChange
   def storeUploadedFile(fieldName: String, destFn: FileInfo => File): Directive[(FileInfo, File)] =
     extractRequestContext.flatMap { ctx =>
       import ctx.executionContext
@@ -74,7 +72,6 @@ trait FileUploadDirectives {
    *
    * @group fileupload
    */
-  @ApiMayChange
   def storeUploadedFiles(fieldName: String, destFn: FileInfo => File): Directive1[immutable.Seq[(FileInfo, File)]] =
     entity(as[Multipart.FormData]).flatMap { formData =>
       extractRequestContext.flatMap { ctx =>
@@ -161,7 +158,6 @@ trait FileUploadDirectives {
    *
    * @group fileupload
    */
-  @ApiMayChange
   def fileUploadAll(fieldName: String): Directive1[immutable.Seq[(FileInfo, Source[ByteString, Any])]] =
     extractRequestContext.flatMap { ctx =>
       implicit val ec = ctx.executionContext

--- a/docs/src/main/paradox/client-side/client-transport.md
+++ b/docs/src/main/paradox/client-side/client-transport.md
@@ -1,6 +1,6 @@
 # Pluggable Client Transports / HTTP(S) proxy Support
 
-The client side infrastructure has support to plug different transport mechanisms underneath (the API may still change in the future). A client side
+The client side infrastructure has support to plug different transport mechanisms underneath. A client side
 transport is represented by an instance of
 @scala[@scaladoc[akka.http.scaladsl.ClientTransport](akka.http.scaladsl.ClientTransport)]@java[@javadoc[akka.http.javadsl.ClientTransport](akka.http.javadsl.ClientTransport)]:
 


### PR DESCRIPTION
Some APIs that has been around long enough that they should be marked stable and some that are used internally and will not change.