### PR TITLE
chore: remove references to Gitter and other outdated things

### DIFF
--- a/.github/ISSUE_TEMPLATE/---question.md
+++ b/.github/ISSUE_TEMPLATE/---question.md
@@ -4,4 +4,4 @@ about: Please use https://discuss.akka.io for questions
 
 ---
 
-Please use https://discuss.akka.io or https://gitter.im/akka/akka for questions instead of posting them to the issue tracker.
+Please use https://discuss.akka.io for questions instead of posting them to the issue tracker.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,7 @@ You're always welcome to submit your PR straight away and start the discussion (
 
 # The Akka Community
 
-In case of questions about the contribution process or for discussion of specific issues please visit the [akka/dev gitter chat](https://gitter.im/akka/dev).
-
-You may also check out these [other resources](https://akka.io/get-involved/).
+Check out these [resources](https://akka.io/get-involved/).
 
 # Navigating around the project & codebase
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Community
 You can join these groups and chats to discuss and ask Akka related questions:
 
 - Forums: [discuss.akka.io](https://discuss.akka.io)
-- Chat room about *using* Akka HTTP: [![gitter: akka/akka][gitter-user-badge]][gitter-user]
 - Q&A: [![stackoverflow: #akka-http][stackoverflow-badge]][stackoverflow]
 - Issue tracker: [![github: akka/akka-http][github-issues-badge]][github-issues] (Please use the issue
   tracker for bugs and reasonable feature requests. Please ask usage questions on the other channels.)
@@ -44,18 +43,11 @@ In addition to that, you may enjoy following:
 - The [news](https://akka.io/blog/news-archive.html) section of the page, which is updated whenever a new version is released
 - The [Akka Team Blog](https://akka.io/blog)
 - [@akkateam](https://twitter.com/akkateam) on Twitter
-- Projects built with Akka HTTP: [![Built with Akka HTTP][scaladex-badge]][scaladex-projects]
 
-[groups-user-badge]:   https://img.shields.io/badge/group%3A-akka--user-blue.svg?style=flat-square
-[groups-user]:         https://groups.google.com/forum/#!forum/akka-user
-[gitter-user-badge]:   https://img.shields.io/badge/gitter%3A-akka%2Fakka-blue.svg?style=flat-square
-[gitter-user]:         https://gitter.im/akka/akka
 [stackoverflow-badge]: https://img.shields.io/badge/stackoverflow%3A-akka--http-blue.svg?style=flat-square
 [stackoverflow]:       https://stackoverflow.com/questions/tagged/akka-http
 [github-issues-badge]: https://img.shields.io/badge/github%3A-issues-blue.svg?style=flat-square
 [github-issues]:       https://github.com/akka/akka-http/issues
-[scaladex-badge]:      https://index.scala-lang.org/count.svg?q=dependencies:akka/akka-http*&subject=scaladex:&color=blue&style=flat-square
-[scaladex-projects]:   https://index.scala-lang.org/search?q=dependencies:akka/akka-http*
 
 Contributing
 ------------
@@ -65,14 +57,7 @@ If you see an issue that you'd like to see fixed, the best way to make it happen
 For ideas of where to contribute, [tickets marked as "help wanted"](https://github.com/akka/akka-http/labels/help%20wanted) are a good starting point.
 
 Refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file for more details about the workflow,
-and general hints on how to prepare your pull request. You can also ask for clarifications or guidance in GitHub issues directly,
-or in the [akka/dev][gitter-dev] chat if a more real-time communication would be of benefit.
-
-A chat room is available for all questions related to *developing and contributing* to Akka:
-[![gitter: akka/dev][gitter-dev-badge]][gitter-dev]
-
-[gitter-dev-badge]: https://img.shields.io/badge/gitter%3A-akka%2Fdev-blue.svg?style=flat-square
-[gitter-dev]:       https://gitter.im/akka/dev
+and general hints on how to prepare your pull request. You can also ask for clarifications or guidance in GitHub issues directly.
 
 Maintenance
 -----------

--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -61,7 +61,6 @@ For important patch releases, and only if critical issues have been fixed:
 
 - [ ] Send a release notification to [Lightbend discuss](https://discuss.akka.io)
 - [ ] Tweet using the [@akkateam](https://twitter.com/akkateam/) account (or ask someone to) about the new release
-- [ ] Announce on [Gitter akka/akka](https://gitter.im/akka/akka)
 - [ ] Announce internally (with links to Tweet, discuss)
 
 For minor or major releases:

--- a/docs/src/main/paradox/migration-guide/migration-from-old-http-javadsl.md
+++ b/docs/src/main/paradox/migration-guide/migration-from-old-http-javadsl.md
@@ -62,8 +62,5 @@ This has been made more consistent than previously, across all overloads and Fut
 
 ## Migration help
 
-As always, feel free to reach out via the [akka-user](https://groups.google.com/forum/#!searchin/akka-user/) mailing list or gitter channels,
-to seek help or guidance when migrating from the old APIs. 
-
 For Lightbend subscription owners it is possible to reach out to the core team for help in the migration by asking specific 
 questions via the [Lightbend customer portal](https://portal.lightbend.com/account/login).

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -23,10 +23,6 @@ project-info {
         text: "Lightbend Discuss"
         url: "https://discuss.lightbend.com/tags/c/akka/akka-http"
       }
-      {
-        text: "akka/akka Gitter channel"
-        url: "https://gitter.im/akka/akka"
-      }
     ]
   }
   akka-http: ${project-info.shared-info} {


### PR DESCRIPTION
Just happened to notice we still offer Gitter as a channel in some places.