### PR TITLE
Fail on attempt to look up custom modelled headers

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/HttpMessage.java
@@ -57,6 +57,8 @@ public interface HttpMessage {
     /**
      * Try to find the first header of the given class and return
      * Optional.of(header), otherwise this method returns an empty Optional.
+     *
+     * @throws IllegalArgumentException if headerClass is a custom header.
      */
     <T extends HttpHeader> Optional<T> getHeader(Class<T> headerClass);
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
@@ -10,6 +10,7 @@ import scala.util.{ Failure, Success }
 import akka.parboiled2.ParseError
 import akka.http.impl.util.ToStringRenderable
 import akka.http.impl.model.parser.{ CharacterClasses, HeaderParser }
+import akka.http.javadsl.model.headers.CustomHeader
 import akka.http.javadsl.{ model => jm }
 import akka.http.scaladsl.model.headers._
 import akka.util.OptionVal

--- a/docs/src/main/paradox/common/http-model.md
+++ b/docs/src/main/paradox/common/http-model.md
@@ -378,9 +378,17 @@ Java
 :   @@snip [CustomHeaderExampleTest.java](/docs/src/test/java/docs/http/javadsl/CustomHeaderExampleTest.java) { #header-value-pf }
 
 @@@ note { .group-scala }
+Custom headers do not work with the `header[T]` method on @apidoc[HttpMessage].
+@@@
+
+@@@ note { .group-scala }
 When defining custom headers, it is better to extend @apidoc[ModeledCustomHeader] instead of its parent @apidoc[CustomHeader].
 Custom headers that extend @apidoc[ModeledCustomHeader] automatically comply with the pattern matching semantics that usually apply to built-in
 types (such as matching a custom header against a @apidoc[RawHeader] in routing layers of Akka HTTP applications).
+@@@
+
+@@@ note { .group-java }
+Custom headers do not work with the `getHeader(Class)` method on @javadoc[HttpMessage].
 @@@
 
 @@@ note { .group-java }

--- a/docs/src/main/paradox/common/http-model.md
+++ b/docs/src/main/paradox/common/http-model.md
@@ -388,7 +388,7 @@ types (such as matching a custom header against a @apidoc[RawHeader] in routing 
 @@@
 
 @@@ note { .group-java }
-Custom headers do not work with the `getHeader(Class)` method on @javadoc[HttpMessage].
+Custom headers do not work with the `getHeader(Class)` method on @apidoc[HttpMessage].
 @@@
 
 @@@ note { .group-java }


### PR DESCRIPTION
See #1102.

Throws an `IllegalArgumentException` if an attempt is used to lookup a modelled custom header by class from an `HttpRequest`.

While ideally, the best thing would be to support registering modelled headers, until that gets implemented, I think it's important to make sure users know when they try to lookup a custom header using an unsupported method that it's not supported. This will save a lot of heartache.

Things I'm not sure about this change:

* Performance - it adds an `isAssignableFrom` to every `HttpRequest.header[T]` call when the header is not present.
* Whether there are any places where we depend on the request returning `None`, eg, if we have methods that try this first, and then fallback to using a method that is supported for custom headers. I couldn't find anything.

It's also important to be aware that this could introduce a regression in situations where not returning the header doesn't matter - eg if the header is an unused feature, or a feature where that isn't important and no one cares that it's not working. Or, in the case of https://github.com/akka/akka-grpc/issues/1897, it turns a bug (gRPC compression is never negotiated, but requests still succeed) into a much more serious bug (all requests fail).