### PR TITLE
chore: exclude ScalaFix support from vulnerability scanning

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -6,3 +6,4 @@ paths:
   exclude:
     - akka-http-bench-jmh
     - akka-http-compatibility-tests
+    - akka-http-scalafix


### PR DESCRIPTION
The vulnerability scanning detects outdated libraries in the ScalaFix support.
As this is not used when running Akka HTTP-based systems, we can exclude it from scanning.