### PR TITLE
docs: remove docs referencing external CORS lib

### DIFF
--- a/docs/src/main/paradox/extensions.md
+++ b/docs/src/main/paradox/extensions.md
@@ -7,7 +7,6 @@ Among those, we want to highlight the following:
 - [akka-http-json](https://github.com/hseeberger/akka-http-json): Integrate some of the best JSON libs in Scala with Akka HTTP
 - [swagger-akka-http](https://github.com/swagger-akka-http/swagger-akka-http): A Scala/Java library for generating Open API (a.k.a. Swagger) from annotated Akka HTTP code
 - [Guardrail](https://github.com/twilio/guardrail): Guardrail is a code generation tool, capable of reading from OpenAPI/Swagger specification files and generating Akka HTTP code
-- [akka-http-cors](https://github.com/lomigmegard/akka-http-cors): Akka Http directives implementing the CORS specifications defined by W3C
 - [akka-http-session](https://github.com/softwaremill/akka-http-session): Web & mobile client-side akka-http sessions, with optional JWT support
 - [sttp](https://github.com/softwaremill/sttp): Library that provides a clean, programmer-friendly API to define HTTP requests and execute them using one of the wrapped backends, akka-http among them.
 


### PR DESCRIPTION
Add-on to https://github.com/akka/akka-http/pull/4343