### PR TITLE
chore: Exclude samples from FOSSA scanning

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -10,3 +10,4 @@ paths:
     - akka-http-scalafix
     - akka-http-tests
     - native-image-tests
+    - samples


### PR DESCRIPTION
We don't need FOSSA to scan the projects in the samples directory, so configure FOSSA to ignore that directory

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References lightbend/akka-meta/issues/488
