### PR TITLE
docs: replace magnet pattern URLs with correct one

### DIFF
--- a/docs/src/main/paradox/routing-dsl/directives/debugging-directives/logRequest.md
+++ b/docs/src/main/paradox/routing-dsl/directives/debugging-directives/logRequest.md
@@ -14,7 +14,7 @@ def logRequest(magnet: LoggingMagnet[HttpRequest => Unit]): Directive0
 
 The signature shown is simplified, the real signature uses magnets. <a id="^1" href="#1">[1]</a>
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/debugging-directives/logRequestResult.md
+++ b/docs/src/main/paradox/routing-dsl/directives/debugging-directives/logRequestResult.md
@@ -12,7 +12,7 @@ def logRequestResult(show: HttpRequest => RouteResult => Option[LogEntry])(impli
 
 The signature shown is simplified, the real signature uses magnets. <a id="^1" href="#1">[1]</a>
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/debugging-directives/logResult.md
+++ b/docs/src/main/paradox/routing-dsl/directives/debugging-directives/logResult.md
@@ -14,7 +14,7 @@ def logResult(magnet: LoggingMagnet[RouteResult => Unit]): Directive0
 
 The signature shown is simplified, the real signature uses magnets. <a id="^1" href="#1">[1]</a>
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFields.md
+++ b/docs/src/main/paradox/routing-dsl/directives/form-field-directives/formFields.md
@@ -18,7 +18,7 @@ def formFields(fields: <FieldDef[T_0]> :: ... <FieldDef[T_i]> ... :: HNil): Dire
 The signature shown is simplified and written in pseudo-syntax, the real signature uses magnets. <a id="^1" href="#1">[1]</a> The type
 `<FieldDef>` doesn't really exist but consists of the syntactic variants as shown in the description and the examples.
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 ## Description
 

--- a/docs/src/main/paradox/routing-dsl/directives/future-directives/onSuccess.md
+++ b/docs/src/main/paradox/routing-dsl/directives/future-directives/onSuccess.md
@@ -12,7 +12,7 @@ def onSuccess(hlistFuture: Future[T_0 :: ... T_i ... :: HNil]): Directive[T_0 ::
 
 The signature shown is simplified and written in pseudo-syntax, the real signature uses magnets. <a id="^1" href="#1">[1]</a>.
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/header-directives/headerValueByType.md
+++ b/docs/src/main/paradox/routing-dsl/directives/header-directives/headerValueByType.md
@@ -9,7 +9,7 @@ def headerValueByType[T <: HttpHeader: ClassTag](): Directive1[T]
 
 The signature shown is simplified, the real signature uses magnets. <a id="^1" href="#1">[1]</a>
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/header-directives/optionalHeaderValueByType.md
+++ b/docs/src/main/paradox/routing-dsl/directives/header-directives/optionalHeaderValueByType.md
@@ -9,7 +9,7 @@ def optionalHeaderValueByType[T <: HttpHeader: ClassTag](): Directive1[Option[T]
 
 The signature shown is simplified, the real signature uses magnets. <a id="^1" href="#1">[1]</a>
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
+++ b/docs/src/main/paradox/routing-dsl/directives/parameter-directives/parameters.md
@@ -15,7 +15,7 @@ def parameters(params: <ParamDef[T_0]> :: ... <ParamDef[T_i]> ... :: HNil): Dire
 The signature shown is simplified and written in pseudo-syntax, the real signature uses magnets. <a id="^1" href="#1">[1]</a> The type
 `<ParamDef>` doesn't really exist but consists of the syntactic variants as shown in the description and the examples.
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/range-directives/withRangeSupport.md
+++ b/docs/src/main/paradox/routing-dsl/directives/range-directives/withRangeSupport.md
@@ -10,7 +10,7 @@ def withRangeSupport(rangeCountLimit: Int, rangeCoalescingThreshold:Long): Direc
 
 The signature shown is simplified, the real signature uses magnets. <a id="^1" href="#1">[1]</a>
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 @@@
 

--- a/docs/src/main/paradox/routing-dsl/directives/route-directives/complete.md
+++ b/docs/src/main/paradox/routing-dsl/directives/route-directives/complete.md
@@ -15,7 +15,7 @@ def complete[T :Marshaller](status: Int, headers: Seq[HttpHeader], value: T): St
 
 The signature shown is simplified, the real signature uses magnets. <a id="^1" href="#1">[1]</a>
 
-> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](http://spray.io/blog/2012-12-13-the-magnet-pattern/) for an explanation of magnet-based overloading.
+> <a id="1" href="#^1">[1]</a> See [The Magnet Pattern](https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html) for an explanation of magnet-based overloading.
 
 @@@
 


### PR DESCRIPTION
This is a simple PR that replaces the links to the magnet pattern blog post with the correct one.
The previous link, `http://spray.io/blog/2012-12-13-the-magnet-pattern/`, is no longer valid - it seems that the `spray.io` domain was transferred to some other party (a Korean company from the looks of it).
I found the blog post via Google at https://spray.readthedocs.io/en/latest/blog/2012-12-13-the-magnet-pattern.html, so I thought I'd go ahead and submit a fix to the docs so other people don't get confused.