### PR TITLE
chore: Drop scala java8 compat

### DIFF
--- a/akka-http-core/src/main/java/akka/http/impl/util/Util.java
+++ b/akka-http-core/src/main/java/akka/http/impl/util/Util.java
@@ -4,10 +4,11 @@
 
 package akka.http.impl.util;
 
-import scala.compat.java8.OptionConverters;
 import scala.None$;
 import scala.collection.immutable.Map$;
 import scala.collection.immutable.Seq;
+import scala.jdk.javaapi.OptionConverters;
+
 import akka.stream.scaladsl.Source;
 import akka.http.ccompat.MapHelpers;
 

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/ContentRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/ContentRange.java
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.ContentRange$;
 import java.util.Optional;
 import java.util.OptionalLong;
 
-import scala.jdk.javaapi.OptionConverters;
+import scala.Option;
 
 public abstract class ContentRange {
     public abstract boolean isByteContentRange();
@@ -31,7 +31,7 @@ public abstract class ContentRange {
     }
     @SuppressWarnings("unchecked")
     public static ContentRange create(long first, long last, OptionalLong instanceLength) {
-        return ContentRange$.MODULE$.apply(first, last, OptionConverters.toScala(instanceLength).map(length -> (Object)length));
+        return ContentRange$.MODULE$.apply(first, last, (instanceLength.isPresent() ? Option.apply(instanceLength.getAsLong()) : Option.empty()));
     }
     public static ContentRange createUnsatisfiable(long length) {
         return new akka.http.scaladsl.model.ContentRange.Unsatisfiable(length);

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/ContentRange.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/ContentRange.java
@@ -8,7 +8,8 @@ import akka.http.scaladsl.model.ContentRange$;
 
 import java.util.Optional;
 import java.util.OptionalLong;
-import scala.compat.java8.OptionConverters;
+
+import scala.jdk.javaapi.OptionConverters;
 
 public abstract class ContentRange {
     public abstract boolean isByteContentRange();
@@ -30,7 +31,7 @@ public abstract class ContentRange {
     }
     @SuppressWarnings("unchecked")
     public static ContentRange create(long first, long last, OptionalLong instanceLength) {
-        return ContentRange$.MODULE$.apply(first, last, OptionConverters.toScala(instanceLength));
+        return ContentRange$.MODULE$.apply(first, last, OptionConverters.toScala(instanceLength).map(length -> (Object)length));
     }
     public static ContentRange createUnsatisfiable(long length) {
         return new akka.http.scaladsl.model.ContentRange.Unsatisfiable(length);

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/RemoteAddress.java
@@ -9,7 +9,8 @@ import java.net.InetSocketAddress;
 import java.util.Optional;
 
 import akka.http.javadsl.model.headers.HttpEncodingRanges;
-import scala.compat.java8.OptionConverters;
+
+import scala.jdk.javaapi.OptionConverters;
 
 public abstract class RemoteAddress {
     public abstract boolean isUnknown();

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
@@ -4,6 +4,7 @@
 
 package akka.http.javadsl.model.headers;
 
+import scala.Some;
 import scala.jdk.javaapi.OptionConverters;
 
 import java.util.Optional;
@@ -19,7 +20,7 @@ public final class CacheDirectives {
         return new akka.http.scaladsl.model.headers.CacheDirectives.max$minusstale(OptionConverters.toScala(Optional.empty()));
     }
     public static CacheDirective MAX_STALE(long deltaSeconds) {
-        return new akka.http.scaladsl.model.headers.CacheDirectives.max$minusstale(OptionConverters.toScala(OptionalLong.of(deltaSeconds)).map(delta -> (Object)delta));
+        return new akka.http.scaladsl.model.headers.CacheDirectives.max$minusstale(new Some<>(deltaSeconds));
     }
     public static CacheDirective MIN_FRESH(long deltaSeconds) {
         return new akka.http.scaladsl.model.headers.CacheDirectives.min$minusfresh(deltaSeconds);

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/CacheDirectives.java
@@ -4,7 +4,7 @@
 
 package akka.http.javadsl.model.headers;
 
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -19,7 +19,7 @@ public final class CacheDirectives {
         return new akka.http.scaladsl.model.headers.CacheDirectives.max$minusstale(OptionConverters.toScala(Optional.empty()));
     }
     public static CacheDirective MAX_STALE(long deltaSeconds) {
-        return new akka.http.scaladsl.model.headers.CacheDirectives.max$minusstale(OptionConverters.toScala(OptionalLong.of(deltaSeconds)));
+        return new akka.http.scaladsl.model.headers.CacheDirectives.max$minusstale(OptionConverters.toScala(OptionalLong.of(deltaSeconds)).map(delta -> (Object)delta));
     }
     public static CacheDirective MIN_FRESH(long deltaSeconds) {
         return new akka.http.scaladsl.model.headers.CacheDirectives.min$minusfresh(deltaSeconds);

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCookie.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/HttpCookie.java
@@ -7,7 +7,8 @@ package akka.http.javadsl.model.headers;
 import akka.annotation.DoNotInherit;
 import akka.http.javadsl.model.DateTime;
 import akka.http.impl.util.Util;
-import scala.compat.java8.OptionConverters;
+
+import scala.jdk.javaapi.OptionConverters;
 
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -62,7 +63,7 @@ public abstract class HttpCookie {
         return new akka.http.scaladsl.model.headers.HttpCookie(
                 name, value,
                 Util.<DateTime, akka.http.scaladsl.model.DateTime>convertOptionalToScala(expires),
-                OptionConverters.toScala(maxAge),
+                OptionConverters.toScala(maxAge).map(age -> (Object)age),
                 OptionConverters.toScala(domain),
                 OptionConverters.toScala(path),
                 secure,
@@ -85,7 +86,7 @@ public abstract class HttpCookie {
         return new akka.http.scaladsl.model.headers.HttpCookie(
                 name, value,
                 Util.<DateTime, akka.http.scaladsl.model.DateTime>convertOptionalToScala(expires),
-                OptionConverters.toScala(maxAge),
+                OptionConverters.toScala(maxAge).map(age -> (Object)age),
                 OptionConverters.toScala(domain),
                 OptionConverters.toScala(path),
                 secure,

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/sse/ServerSentEvent.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/sse/ServerSentEvent.java
@@ -28,9 +28,9 @@ import scala.Option;
  */
 public abstract class ServerSentEvent {
 
-    private static final Option<String> stringNone = OptionConverters.toScala(Optional.empty());
+    private static final Option<String> stringNone = Option.empty();
 
-    private static final Option<Object> intNone = OptionConverters.toScala(OptionalInt.empty()).map(emptyIntOption -> (Object)emptyIntOption);
+    private static final Option<Object> intNone = Option.empty();
 
 
     /**

--- a/akka-http-core/src/main/java/akka/http/javadsl/model/sse/ServerSentEvent.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/sse/ServerSentEvent.java
@@ -18,8 +18,9 @@ package akka.http.javadsl.model.sse;
 
 import java.util.Optional;
 import java.util.OptionalInt;
+
+import scala.jdk.javaapi.OptionConverters;
 import scala.Option;
-import static scala.compat.java8.OptionConverters.toScala;
 
 /**
  * Representation of a server-sent event. According to the specification, an empty data field
@@ -27,9 +28,9 @@ import static scala.compat.java8.OptionConverters.toScala;
  */
 public abstract class ServerSentEvent {
 
-    private static final Option<String> stringNone =  toScala(Optional.empty());
+    private static final Option<String> stringNone = OptionConverters.toScala(Optional.empty());
 
-    private static final Option<Object> intNone = toScala(OptionalInt.empty());
+    private static final Option<Object> intNone = OptionConverters.toScala(OptionalInt.empty()).map(emptyIntOption -> (Object)emptyIntOption);
 
 
     /**
@@ -92,7 +93,7 @@ public abstract class ServerSentEvent {
                                          Optional<String> id,
                                          OptionalInt retry) {
         return akka.http.scaladsl.model.sse.ServerSentEvent.apply(
-                data, toScala(type), toScala(id), toScala(retry)
+                data, OptionConverters.toScala(type), OptionConverters.toScala(id), OptionConverters.toScala(retry).map(retryInt -> (Object) retryInt)
         );
     }
 

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/OutgoingConnectionBuilderImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/OutgoingConnectionBuilderImpl.scala
@@ -130,8 +130,8 @@ private[akka] object OutgoingConnectionBuilderImpl {
       new JavaAdapter(actual.logTo(logger).asInstanceOf[Impl])
 
     private def javaFlow(flow: Flow[HttpRequest, HttpResponse, Future[OutgoingConnection]]): JFlow[javadsl.model.HttpRequest, javadsl.model.HttpResponse, CompletionStage[javadsl.OutgoingConnection]] = {
-      import scala.compat.java8.FutureConverters.toJava
-      javaFlowKeepMatVal(flow.mapMaterializedValue(f => toJava(f.map(oc => new javadsl.OutgoingConnection(oc))(ExecutionContexts.parasitic))))
+      import scala.jdk.FutureConverters._
+      javaFlowKeepMatVal(flow.mapMaterializedValue(f => f.map(oc => new javadsl.OutgoingConnection(oc))(ExecutionContexts.parasitic).asJava))
     }
 
     private def javaFlowKeepMatVal[M](flow: Flow[HttpRequest, HttpResponse, M]): JFlow[javadsl.model.HttpRequest, javadsl.model.HttpResponse, M] =

--- a/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/JavaMapping.scala
@@ -13,7 +13,8 @@ import akka.japi.Pair
 import akka.stream.{ FlowShape, Graph, javadsl, scaladsl }
 
 import scala.collection.immutable
-import scala.compat.java8.{ FutureConverters, OptionConverters }
+import scala.jdk.FutureConverters._
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 import akka.NotUsed
 import akka.annotation.InternalApi
@@ -115,8 +116,8 @@ private[http] object JavaMapping {
     }
   implicit def option[_J, _S](implicit mapping: JavaMapping[_J, _S]): JavaMapping[Optional[_J], Option[_S]] =
     new JavaMapping[Optional[_J], Option[_S]] {
-      def toScala(javaObject: Optional[_J]): Option[_S] = OptionConverters.toScala(javaObject).map(mapping.toScala)
-      def toJava(scalaObject: Option[_S]): Optional[_J] = OptionConverters.toJava(scalaObject.map(mapping.toJava))
+      def toScala(javaObject: Optional[_J]): Option[_S] = javaObject.toScala.map(mapping.toScala)
+      def toJava(scalaObject: Option[_S]): Optional[_J] = scalaObject.map(mapping.toJava).toJava
     }
 
   implicit def flowMapping[JIn, SIn, JOut, SOut, JM, SM](implicit inMapping: JavaMapping[JIn, SIn], outMapping: JavaMapping[JOut, SOut], matValueMapping: JavaMapping[JM, SM]): JavaMapping[javadsl.Flow[JIn, JOut, JM], scaladsl.Flow[SIn, SOut, SM]] =
@@ -161,8 +162,8 @@ private[http] object JavaMapping {
 
   implicit def futureMapping[_J, _S](implicit mapping: JavaMapping[_J, _S], ec: ExecutionContext): JavaMapping[CompletionStage[_J], Future[_S]] =
     new JavaMapping[CompletionStage[_J], Future[_S]] {
-      def toJava(scalaObject: Future[_S]): CompletionStage[_J] = FutureConverters.toJava(scalaObject.map(mapping.toJava))
-      def toScala(javaObject: CompletionStage[_J]): Future[_S] = FutureConverters.toScala(javaObject).map(mapping.toScala)
+      def toJava(scalaObject: Future[_S]): CompletionStage[_J] = scalaObject.map(mapping.toJava).asJava
+      def toScala(javaObject: CompletionStage[_J]): Future[_S] = javaObject.asScala.map(mapping.toScala)
     }
 
   implicit object StringIdentity extends Identity[String]

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ClientTransport.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ClientTransport.scala
@@ -83,8 +83,8 @@ object ClientTransport {
    *               to an [[InetSocketAddress]]
    */
   def withCustomResolver(lookup: BiFunction[String, Int, CompletionStage[InetSocketAddress]]): ClientTransport = {
-    import scala.compat.java8.FutureConverters._
-    scaladsl.ClientTransport.withCustomResolver((host, port) => lookup.apply(host, port).toScala).asJava
+    import scala.jdk.FutureConverters._
+    scaladsl.ClientTransport.withCustomResolver((host, port) => lookup.apply(host, port).asScala).asJava
   }
 
   def fromScala(scalaTransport: scaladsl.ClientTransport): ClientTransport =

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectHttp.scala
@@ -7,7 +7,7 @@ package akka.http.javadsl
 import java.util.Locale
 import java.util.Optional
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.http.javadsl.model.Uri
@@ -21,11 +21,11 @@ abstract class ConnectHttp {
   def connectionContext: Optional[HttpsConnectionContext]
 
   final def effectiveHttpsConnectionContext(fallbackContext: HttpsConnectionContext): HttpsConnectionContext =
-    connectionContext.asScala
+    connectionContext.toScala
       .getOrElse(fallbackContext)
 
   final def effectiveConnectionContext(fallbackContext: ConnectionContext): ConnectionContext =
-    connectionContext.asScala // Optional doesn't deal well with covariance
+    connectionContext.toScala // Optional doesn't deal well with covariance
       .getOrElse(fallbackContext)
 
   override def toString = s"ConnectHttp($host,$port,$isHttps,$connectionContext)"

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ConnectionContext.scala
@@ -4,14 +4,10 @@
 
 package akka.http.javadsl
 
-import java.util.{ Optional, Collection => JCollection }
 import akka.annotation.{ ApiMayChange, DoNotInherit }
 import akka.http.scaladsl
-import akka.japi.Util
-import akka.stream.TLSClientAuth
 
 import javax.net.ssl.{ SSLContext, SSLEngine }
-import scala.compat.java8.OptionConverters
 
 object ConnectionContext {
   //#https-server-context-creation

--- a/akka-http-core/src/main/scala/akka/http/javadsl/IncomingConnection.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/IncomingConnection.scala
@@ -5,6 +5,7 @@
 package akka.http.javadsl
 
 import java.net.InetSocketAddress
+
 import akka.NotUsed
 import akka.japi.function.Function
 import akka.stream.Materializer
@@ -12,8 +13,9 @@ import akka.stream.javadsl.Flow
 import akka.http.javadsl.model._
 import akka.http.scaladsl.{ model => sm }
 import java.util.concurrent.CompletionStage
+
 import scala.concurrent.Future
-import scala.compat.java8.FutureConverters._
+import scala.jdk.FutureConverters._
 
 /**
  * Represents one accepted incoming HTTP connection.
@@ -53,11 +55,11 @@ class IncomingConnection private[http] (delegate: akka.http.scaladsl.Http.Incomi
    * Handles the connection with the given handler function.
    */
   def handleWithAsyncHandler(handler: Function[HttpRequest, CompletionStage[HttpResponse]], materializer: Materializer): Unit =
-    delegate.handleWithAsyncHandler(handler.apply(_).toScala.asInstanceOf[Future[sm.HttpResponse]])(materializer)
+    delegate.handleWithAsyncHandler(handler.apply(_).asScala.asInstanceOf[Future[sm.HttpResponse]])(materializer)
 
   /**
    * Handles the connection with the given handler function.
    */
   def handleWithAsyncHandler(handler: Function[HttpRequest, CompletionStage[HttpResponse]], parallelism: Int, materializer: Materializer): Unit =
-    delegate.handleWithAsyncHandler(handler.apply(_).toScala.asInstanceOf[Future[sm.HttpResponse]], parallelism)(materializer)
+    delegate.handleWithAsyncHandler(handler.apply(_).asScala.asInstanceOf[Future[sm.HttpResponse]], parallelism)(materializer)
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/ServerBinding.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/ServerBinding.scala
@@ -7,14 +7,14 @@ package akka.http.javadsl
 import java.net.InetSocketAddress
 import java.util.concurrent.{ CompletionStage, TimeUnit }
 
-import akka.Done
+import akka.actor.ClassicActorSystemProvider
 import akka.annotation.DoNotInherit
 import akka.dispatch.ExecutionContexts
+import akka.Done
 import akka.util.JavaDurationConverters._
 
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
-import akka.actor.ClassicActorSystemProvider
+import scala.jdk.FutureConverters._
 
 /**
  * Represents a prospective HTTP server binding.
@@ -32,7 +32,7 @@ class ServerBinding private[http] (delegate: akka.http.scaladsl.Http.ServerBindi
    * The produced [[java.util.concurrent.CompletionStage]] is fulfilled when the unbinding has been completed.
    */
   def unbind(): CompletionStage[Done] =
-    delegate.unbind().toJava
+    delegate.unbind().asJava
 
   /**
    * Triggers "graceful" termination request being handled on this connection.
@@ -79,7 +79,7 @@ class ServerBinding private[http] (delegate: akka.http.scaladsl.Http.ServerBindi
   def terminate(hardDeadline: java.time.Duration): CompletionStage[HttpTerminated] = {
     delegate.terminate(FiniteDuration.apply(hardDeadline.toMillis, TimeUnit.MILLISECONDS))
       .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.parasitic)
-      .toJava
+      .asJava
   }
 
   /**
@@ -93,7 +93,7 @@ class ServerBinding private[http] (delegate: akka.http.scaladsl.Http.ServerBindi
   def whenTerminationSignalIssued: CompletionStage[java.time.Duration] =
     delegate.whenTerminationSignalIssued
       .map(deadline => deadline.time.asJava)(ExecutionContexts.parasitic)
-      .toJava
+      .asJava
 
   /**
    * This completion stage completes when the termination process, as initiated by an [[terminate]] call has completed.
@@ -110,7 +110,7 @@ class ServerBinding private[http] (delegate: akka.http.scaladsl.Http.ServerBindi
   def whenTerminated: CompletionStage[HttpTerminated] =
     delegate.whenTerminated
       .map(_.asInstanceOf[HttpTerminated])(ExecutionContexts.parasitic)
-      .toJava
+      .asJava
 
   /**
    * Adds this `ServerBinding` to the actor system's coordinated shutdown, so that [[unbind]] and [[terminate]] get

--- a/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/model/ws/Message.scala
@@ -13,7 +13,7 @@ import akka.stream.javadsl.Source
 import akka.util.ByteString
 
 import scala.concurrent.duration._
-import scala.compat.java8.FutureConverters._
+import scala.jdk.FutureConverters._
 
 /**
  * Represents a WebSocket message. A message can either be a binary message or a text message.
@@ -87,7 +87,7 @@ object TextMessage {
 
       def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.TextMessage.Strict] = asScala
         .toStrict(timeoutMillis.millis)(materializer)
-        .toJava
+        .asJava
 
       def asScala: sm.ws.TextMessage = sm.ws.TextMessage.Strict(text)
     }
@@ -102,7 +102,7 @@ object TextMessage {
 
       def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.TextMessage.Strict] = asScala
         .toStrict(timeoutMillis.millis)(materializer)
-        .toJava
+        .asJava
 
       def asScala: sm.ws.TextMessage = sm.ws.TextMessage(textStream.asScala)
     }
@@ -148,7 +148,7 @@ object BinaryMessage {
 
       def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.BinaryMessage.Strict] = asScala
         .toStrict(timeoutMillis.millis)(materializer)
-        .toJava
+        .asJava
 
       def asScala: sm.ws.BinaryMessage = sm.ws.BinaryMessage.Strict(data)
     }
@@ -164,7 +164,7 @@ object BinaryMessage {
 
       def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[sm.ws.BinaryMessage.Strict] = asScala
         .toStrict(timeoutMillis.millis)(materializer)
-        .toJava
+        .asJava
 
       def asScala: sm.ws.BinaryMessage = sm.ws.BinaryMessage(dataStream.asScala)
     }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ClientConnectionSettings.scala
@@ -19,9 +19,8 @@ import com.typesafe.config.Config
 import akka.http.impl.util.JavaMapping.Implicits._
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.OptionConverters
-import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.jdk.OptionConverters._
 
 /**
  * Public API but not intended for subclassing
@@ -34,15 +33,15 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
   final def getParserSettings: ParserSettings = parserSettings
   final def getIdleTimeout: Duration = idleTimeout
   final def getSocketOptions: java.lang.Iterable[SocketOption] = socketOptions.asJava
-  final def getUserAgentHeader: Optional[UserAgent] = OptionConverters.toJava(userAgentHeader)
-  final def getLogUnencryptedNetworkBytes: Optional[Int] = OptionConverters.toJava(logUnencryptedNetworkBytes)
+  final def getUserAgentHeader: Optional[UserAgent] = userAgentHeader.toJava.map(_.asJava)
+  final def getLogUnencryptedNetworkBytes: Optional[Int] = logUnencryptedNetworkBytes.toJava
   final def getStreamCancellationDelay: FiniteDuration = streamCancellationDelay
   final def getRequestHeaderSizeHint: Int = requestHeaderSizeHint
   final def getWebsocketSettings: WebSocketSettings = websocketSettings
   final def getWebsocketRandomFactory: Supplier[Random] = new Supplier[Random] {
     override def get(): Random = websocketRandomFactory()
   }
-  final def getLocalAddress: Optional[InetSocketAddress] = OptionConverters.toJava(localAddress)
+  final def getLocalAddress: Optional[InetSocketAddress] = localAddress.toJava
 
   /** The underlying transport used to connect to hosts. By default [[ClientTransport.TCP]] is used. */
   @ApiMayChange
@@ -57,15 +56,15 @@ abstract class ClientConnectionSettings private[akka] () { self: ClientConnectio
 
   // Java API versions of mutators
 
-  def withUserAgentHeader(newValue: Optional[UserAgent]): ClientConnectionSettings = self.copy(userAgentHeader = newValue.asScala.map(_.asScala))
-  def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ClientConnectionSettings = self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
+  def withUserAgentHeader(newValue: Optional[UserAgent]): ClientConnectionSettings = self.copy(userAgentHeader = newValue.toScala.map(_.asScala))
+  def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ClientConnectionSettings = self.copy(logUnencryptedNetworkBytes = newValue.toScala)
   def withWebsocketRandomFactory(newValue: java.util.function.Supplier[Random]): ClientConnectionSettings = self.copy(websocketSettings = websocketSettings.withRandomFactoryFactory(new Supplier[Random] {
     override def get(): Random = newValue.get()
   }))
   def withWebsocketSettings(newValue: WebSocketSettings): ClientConnectionSettings = self.copy(websocketSettings = newValue.asScala)
   def withSocketOptions(newValue: java.lang.Iterable[SocketOption]): ClientConnectionSettings = self.copy(socketOptions = newValue.asScala.toList)
   def withParserSettings(newValue: ParserSettings): ClientConnectionSettings = self.copy(parserSettings = newValue.asScala)
-  def withLocalAddress(newValue: Optional[InetSocketAddress]): ClientConnectionSettings = self.copy(localAddress = OptionConverters.toScala(newValue))
+  def withLocalAddress(newValue: Optional[InetSocketAddress]): ClientConnectionSettings = self.copy(localAddress = newValue.toScala)
 
   @ApiMayChange
   def withTransport(newValue: ClientTransport): ClientConnectionSettings = self.copy(transport = newValue.asScala)

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ServerSettings.scala
@@ -17,9 +17,8 @@ import akka.http.impl.util.JavaMapping.Implicits._
 import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.OptionConverters
-import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.jdk.OptionConverters._
 
 /**
  * Public API but not intended for subclassing
@@ -60,7 +59,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
 
   // ---
 
-  def withServerHeader(newValue: Optional[Server]): ServerSettings = self.copy(serverHeader = newValue.asScala.map(_.asScala))
+  def withServerHeader(newValue: Optional[Server]): ServerSettings = self.copy(serverHeader = newValue.toScala.map(_.asScala))
   def withPreviewServerSettings(newValue: PreviewServerSettings): ServerSettings = self.copy(previewServerSettings = newValue.asScala)
   def withTimeouts(newValue: ServerSettings.Timeouts): ServerSettings = self.copy(timeouts = newValue.asScala)
   def withMaxConnections(newValue: Int): ServerSettings = self.copy(maxConnections = newValue)
@@ -80,7 +79,7 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
     override def get(): Random = newValue.get()
   }))
   def withWebsocketSettings(newValue: WebSocketSettings): ServerSettings = self.copy(websocketSettings = newValue.asScala)
-  def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ServerSettings = self.copy(logUnencryptedNetworkBytes = OptionConverters.toScala(newValue))
+  def withLogUnencryptedNetworkBytes(newValue: Optional[Int]): ServerSettings = self.copy(logUnencryptedNetworkBytes = newValue.toScala)
   def withHttp2Settings(newValue: Http2ServerSettings): ServerSettings = self.copy(http2Settings = newValue.asScala)
   def withDefaultHttpPort(newValue: Int): ServerSettings = self.copy(defaultHttpPort = newValue)
   def withDefaultHttpsPort(newValue: Int): ServerSettings = self.copy(defaultHttpPort = newValue)

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/ConnectionContext.scala
@@ -13,7 +13,7 @@ import javax.net.ssl._
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 trait ConnectionContext extends akka.http.javadsl.ConnectionContext {
   /** INTERNAL API */

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/Http.scala
@@ -39,11 +39,10 @@ import scala.annotation.nowarn
 import com.typesafe.config.Config
 
 import scala.concurrent._
+import scala.concurrent.duration._
+import scala.jdk.FutureConverters._
 import scala.util.{ Success, Try }
 import scala.util.control.NonFatal
-import scala.compat.java8.FutureConverters._
-import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.concurrent.duration._
 
 /**
  * Akka extension for HTTP which serves as the main entry point into akka-http.
@@ -1064,7 +1063,7 @@ object Http extends ExtensionId[HttpExt] with ExtensionIdProvider {
 
     private[http] def toJava = new akka.http.javadsl.HostConnectionPool {
       override def setup = HostConnectionPool.this.setup
-      def shutdown(): CompletionStage[Done] = HostConnectionPool.this.shutdown().toJava
+      def shutdown(): CompletionStage[Done] = HostConnectionPool.this.shutdown().asJava
     }
 
     override def productArity: Int = 1

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentRange.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ContentRange.scala
@@ -5,9 +5,11 @@
 package akka.http.scaladsl.model
 
 import java.util.{ OptionalLong, Optional }
+
 import akka.http.impl.util.{ Rendering, ValueRenderable }
 import akka.http.javadsl.{ model => jm }
-import scala.compat.java8.OptionConverters._
+
+import scala.jdk.OptionConverters._
 
 sealed trait ContentRange extends jm.ContentRange with ValueRenderable {
   // default implementations to override
@@ -24,7 +26,7 @@ sealed trait ByteContentRange extends ContentRange {
   /** Java API */
   def isByteContentRange: Boolean = true
   /** Java API */
-  def getInstanceLength: OptionalLong = instanceLength.asPrimitive
+  def getInstanceLength: OptionalLong = instanceLength.toJavaPrimitive
 }
 
 // http://tools.ietf.org/html/rfc7233#section-4.2

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpEntity.scala
@@ -4,16 +4,24 @@
 
 package akka.http.scaladsl.model
 
-import java.util.OptionalLong
 import language.implicitConversions
+
 import java.io.File
 import java.nio.file.{ Files, Path }
 import java.lang.{ Iterable => JIterable }
-import scala.util.control.NonFatal
+import java.util.concurrent.CompletionStage
+import java.util.OptionalLong
+
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.collection.immutable
-import akka.util.ByteString
+import scala.jdk.OptionConverters._
+import scala.jdk.FutureConverters._
+import scala.util.control.NonFatal
+
+import akka.actor.ClassicActorSystemProvider
+import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.stream.scaladsl._
 import akka.stream.stage._
 import akka.stream._
@@ -22,15 +30,7 @@ import akka.http.scaladsl.util.FastFuture
 import akka.http.javadsl.{ model => jm }
 import akka.http.impl.util.{ JavaMapping, StreamUtils }
 import akka.http.impl.util.JavaMapping.Implicits._
-
-import scala.compat.java8.OptionConverters._
-import scala.compat.java8.FutureConverters._
-import java.util.concurrent.CompletionStage
-import akka.actor.ClassicActorSystemProvider
-import akka.annotation.{ DoNotInherit, InternalApi }
-
-import scala.annotation.nowarn
-import scala.compat.java8.FutureConverters
+import akka.util.ByteString
 
 /**
  * Models the entity (aka "body" or "content") of an HTTP message.
@@ -179,7 +179,7 @@ sealed trait HttpEntity extends jm.HttpEntity {
     stream.javadsl.Source.fromGraph(dataBytes.asInstanceOf[Source[ByteString, AnyRef]])
 
   /** Java API */
-  override def getContentLengthOption: OptionalLong = contentLengthOption.asPrimitive
+  override def getContentLengthOption: OptionalLong = contentLengthOption.toJavaPrimitive
 
   // default implementations, should be overridden
   override def isCloseDelimited: Boolean = false
@@ -190,19 +190,19 @@ sealed trait HttpEntity extends jm.HttpEntity {
 
   /** Java API */
   override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.HttpEntity.Strict] =
-    toStrict(timeoutMillis.millis)(materializer).toJava
+    toStrict(timeoutMillis.millis)(materializer).asJava
 
   /** Java API */
   override def toStrict(timeoutMillis: Long, maxBytes: Long, materializer: Materializer): CompletionStage[jm.HttpEntity.Strict] =
-    toStrict(timeoutMillis.millis, maxBytes)(materializer).toJava
+    toStrict(timeoutMillis.millis, maxBytes)(materializer).asJava
 
   /** Java API */
   override def toStrict(timeoutMillis: Long, system: ClassicActorSystemProvider): CompletionStage[jm.HttpEntity.Strict] =
-    toStrict(timeoutMillis.millis)(SystemMaterializer(system).materializer).toJava
+    toStrict(timeoutMillis.millis)(SystemMaterializer(system).materializer).asJava
 
   /** Java API */
   override def toStrict(timeoutMillis: Long, maxBytes: Long, system: ClassicActorSystemProvider): CompletionStage[jm.HttpEntity.Strict] =
-    toStrict(timeoutMillis.millis, maxBytes)(SystemMaterializer(system).materializer).toJava
+    toStrict(timeoutMillis.millis, maxBytes)(SystemMaterializer(system).materializer).asJava
 
   /** Java API */
   override def withContentType(contentType: jm.ContentType): HttpEntity = {
@@ -702,7 +702,7 @@ object HttpEntity {
      * This future completes successfully once the underlying entity stream has been
      * successfully drained (and fails otherwise).
      */
-    def completionStage: CompletionStage[Done] = FutureConverters.toJava(f)
+    def completionStage: CompletionStage[Done] = f.asJava
   }
 
   /** Adds Scala DSL idiomatic methods to [[HttpEntity]], e.g. versions of methods with an implicit [[Materializer]]. */

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpMessage.scala
@@ -12,11 +12,15 @@ import java.nio.file.Path
 import java.lang.{ Iterable => JIterable }
 import java.util.Optional
 import java.util.concurrent.{ CompletionStage, Executor }
-import scala.compat.java8.FutureConverters
+
+import scala.annotation.tailrec
+import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.collection.immutable
+import scala.jdk.FutureConverters._
 import scala.reflect.{ ClassTag, classTag }
+
 import akka.Done
 import akka.actor.ClassicActorSystemProvider
 import akka.parboiled2.CharUtils
@@ -26,11 +30,8 @@ import akka.http.impl.util._
 import akka.http.javadsl.model.headers.CustomHeader
 import akka.http.javadsl.{ model => jm }
 import akka.http.scaladsl.util.FastFuture._
-import headers._
 
-import scala.annotation.tailrec
-import scala.compat.java8.FutureConverters._
-import scala.concurrent.duration._
+import headers._
 
 /**
  * Common base class of HttpRequest and HttpResponse.
@@ -239,21 +240,21 @@ sealed trait HttpMessage extends jm.HttpMessage {
   /** Java API */
   def toStrict(timeoutMillis: Long, ec: Executor, materializer: Materializer): CompletionStage[Self] = {
     val ex = ExecutionContext.fromExecutor(ec)
-    toStrict(timeoutMillis.millis)(ex, materializer).toJava
+    toStrict(timeoutMillis.millis)(ex, materializer).asJava
   }
   /** Java API */
   def toStrict(timeoutMillis: Long, maxBytes: Long, ec: Executor, materializer: Materializer): CompletionStage[Self] = {
     val ex = ExecutionContext.fromExecutor(ec)
-    toStrict(timeoutMillis.millis, maxBytes)(ex, materializer).toJava
+    toStrict(timeoutMillis.millis, maxBytes)(ex, materializer).asJava
   }
 
   /** Java API */
   def toStrict(timeoutMillis: Long, system: ClassicActorSystemProvider): CompletionStage[Self] =
-    toStrict(timeoutMillis.millis)(system.classicSystem.dispatcher, SystemMaterializer(system).materializer).toJava
+    toStrict(timeoutMillis.millis)(system.classicSystem.dispatcher, SystemMaterializer(system).materializer).asJava
 
   /** Java API */
   def toStrict(timeoutMillis: Long, maxBytes: Long, system: ClassicActorSystemProvider): CompletionStage[Self] =
-    toStrict(timeoutMillis.millis, maxBytes)(system.classicSystem.dispatcher, SystemMaterializer(system).materializer).toJava
+    toStrict(timeoutMillis.millis, maxBytes)(system.classicSystem.dispatcher, SystemMaterializer(system).materializer).asJava
 }
 
 object HttpMessage {
@@ -279,7 +280,7 @@ object HttpMessage {
      * This future completes successfully once the underlying entity stream has been
      * successfully drained (and fails otherwise).
      */
-    def completionStage: CompletionStage[Done] = FutureConverters.toJava(f)
+    def completionStage: CompletionStage[Done] = f.asJava
   }
   val AlreadyDiscardedEntity = new DiscardedEntity(Future.successful(Done))
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Multipart.scala
@@ -3,34 +3,32 @@
  */
 
 package akka.http.scaladsl.model
+
 import java.io.File
 import java.nio.file.Path
 import java.util.Optional
-
-import akka.http.impl.util.{ DefaultNoLogging, Util }
+import java.util.concurrent.CompletionStage
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.Future
 import scala.collection.immutable
 import scala.collection.JavaConverters._
+import scala.jdk.FutureConverters._
 import scala.util.{ Failure, Success, Try }
+
+import akka.annotation.InternalApi
 import akka.event.LoggingAdapter
+import akka.http.impl.util.{ DefaultNoLogging, Util }
 import akka.util.ConstantFun
 import akka.stream.Materializer
 import akka.stream.javadsl.{ Source => JSource }
 import akka.stream.scaladsl._
-import akka.http.ccompat._
 import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.model.headers._
 import akka.http.impl.engine.rendering.BodyPartRenderer
 import akka.http.javadsl.{ model => jm }
 import FastFuture._
 import akka.http.impl.util.JavaMapping.Implicits._
-
-import scala.compat.java8.FutureConverters._
-import java.util.concurrent.CompletionStage
-
-import akka.annotation.InternalApi
 
 /**
  * The model of multipart content for media-types `multipart/\*` (general multipart content),
@@ -89,7 +87,7 @@ sealed trait Multipart extends jm.Multipart {
 
   /** Java API */
   def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[_ <: jm.Multipart.Strict] =
-    toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).toJava
+    toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).asJava
 }
 
 object Multipart {
@@ -190,7 +188,7 @@ object Multipart {
 
     /** Java API */
     def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[_ <: jm.Multipart.BodyPart.Strict] =
-      toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).toJava
+      toStrict(FiniteDuration(timeoutMillis, concurrent.duration.MILLISECONDS))(materializer).asJava
   }
 
   object BodyPart {
@@ -231,7 +229,7 @@ object Multipart {
 
     /** Java API */
     override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.General.Strict] =
-      super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[jm.Multipart.General.Strict]].toJava
+      super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[jm.Multipart.General.Strict]].asJava
   }
   object General {
     def apply(mediaType: MediaType.Multipart, parts: BodyPart.Strict*): Strict = Strict(mediaType, parts.toVector)
@@ -277,7 +275,7 @@ object Multipart {
 
       /** Java API */
       override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.General.BodyPart.Strict] =
-        super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[jm.Multipart.General.BodyPart.Strict]].toJava
+        super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[jm.Multipart.General.BodyPart.Strict]].asJava
 
       private[BodyPart] def tryCreateFormDataBodyPart[T](f: (String, Map[String, String], immutable.Seq[HttpHeader]) => T): Try[T] = {
         val params = dispositionParams
@@ -342,7 +340,7 @@ object Multipart {
 
     /** Java API */
     override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.FormData.Strict] =
-      super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[jm.Multipart.FormData.Strict]].toJava
+      super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[jm.Multipart.FormData.Strict]].asJava
   }
   object FormData {
     def apply(parts: Multipart.FormData.BodyPart.Strict*): Multipart.FormData.Strict = Strict(parts.toVector)
@@ -465,7 +463,7 @@ object Multipart {
 
       /** Java API */
       override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.FormData.BodyPart.Strict] =
-        super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[jm.Multipart.FormData.BodyPart.Strict]].toJava
+        super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[jm.Multipart.FormData.BodyPart.Strict]].asJava
     }
     object BodyPart {
       def apply(_name: String, _entity: BodyPartEntity,
@@ -554,7 +552,7 @@ object Multipart {
 
     /** Java API */
     override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.ByteRanges.Strict] =
-      super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[jm.Multipart.ByteRanges.Strict]].toJava
+      super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[jm.Multipart.ByteRanges.Strict]].asJava
   }
   object ByteRanges {
     def apply(parts: Multipart.ByteRanges.BodyPart.Strict*): Strict = Strict(parts.toVector)
@@ -629,7 +627,7 @@ object Multipart {
 
       /** Java API */
       override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[jm.Multipart.ByteRanges.BodyPart.Strict] =
-        super.toStrict(timeoutMillis, materializer).toScala.asInstanceOf[Future[jm.Multipart.ByteRanges.BodyPart.Strict]].toJava
+        super.toStrict(timeoutMillis, materializer).asScala.asInstanceOf[Future[jm.Multipart.ByteRanges.BodyPart.Strict]].asJava
     }
     object BodyPart {
       def apply(_contentRange: ContentRange, _entity: BodyPartEntity, _rangeUnit: RangeUnit = RangeUnits.Bytes,

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCookie.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/headers/HttpCookie.scala
@@ -4,16 +4,16 @@
 
 package akka.http.scaladsl.model.headers
 
-import akka.http.impl.model.parser.CharacterClasses
-import akka.parboiled2.CharPredicate
 import java.util.{ Optional, OptionalLong }
 
+import akka.http.impl.model.parser.CharacterClasses
 import akka.http.scaladsl.model.DateTime
 import akka.http.impl.util._
 import akka.http.javadsl.{ model => jm }
 import akka.http.impl.util.JavaMapping.Implicits._
+import akka.parboiled2.CharPredicate
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 /**
  * for a full definition of the http cookie header fields, see
@@ -163,17 +163,17 @@ final class HttpCookie private[http] (
   }
 
   /** Java API */
-  def getSameSite: Optional[jm.headers.SameSite] = sameSite.map(_.asJava).asJava
+  def getSameSite: Optional[jm.headers.SameSite] = sameSite.map(_.asJava).toJava
   /** Java API */
-  def getExtension: Optional[String] = extension.asJava
+  def getExtension: Optional[String] = extension.toJava
   /** Java API */
-  def getPath: Optional[String] = path.asJava
+  def getPath: Optional[String] = path.toJava
   /** Java API */
-  def getDomain: Optional[String] = domain.asJava
+  def getDomain: Optional[String] = domain.toJava
   /** Java API */
-  def getMaxAge: OptionalLong = maxAge.asPrimitive
+  def getMaxAge: OptionalLong = maxAge.toJavaPrimitive
   /** Java API */
-  def getExpires: Optional[jm.DateTime] = expires.map(_.asJava).asJava
+  def getExpires: Optional[jm.DateTime] = expires.map(_.asJava).toJava
 
   def withName(name: String): HttpCookie = copy(name = name)
   def withValue(value: String): HttpCookie = copy(value = value)
@@ -193,7 +193,7 @@ final class HttpCookie private[http] (
   def withSameSite(sameSite: Option[SameSite]) = copy(sameSite = sameSite)
   /** Java API */
   def withSameSite(sameSite: jm.headers.SameSite): HttpCookie = copy(sameSite = Option(sameSite.asScala()))
-  def withSameSite(sameSite: Optional[jm.headers.SameSite]): HttpCookie = copy(sameSite = sameSite.asScala.map(_.asScala()))
+  def withSameSite(sameSite: Optional[jm.headers.SameSite]): HttpCookie = copy(sameSite = sameSite.toScala.map(_.asScala()))
 
   def withExtension(extension: String): HttpCookie = copy(extension = Some(extension))
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/sse/ServerSentEvent.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/sse/ServerSentEvent.scala
@@ -7,11 +7,13 @@ package scaladsl
 package model
 package sse
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import akka.http.javadsl.model
 import akka.util.ByteString
-import java.nio.charset.StandardCharsets.UTF_8
+
 import scala.annotation.tailrec
-import scala.compat.java8.OptionConverters.RichOptionForJava8
+import scala.jdk.OptionConverters._
 
 object ServerSentEvent {
 
@@ -125,9 +127,9 @@ final case class ServerSentEvent(
 
   override def getData = data
 
-  override def getEventType = eventType.asJava
+  override def getEventType = eventType.toJava
 
-  override def getId = id.asJava
+  override def getId = id.toJava
 
-  override def getRetry = retry.asPrimitive
+  override def getRetry = retry.toJavaPrimitive
 }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ws/Message.scala
@@ -12,7 +12,7 @@ import akka.util.{ ByteString, ByteStringBuilder }
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.compat.java8.FutureConverters._
+import scala.jdk.FutureConverters._
 
 //#message-model
 /**
@@ -48,7 +48,7 @@ sealed trait TextMessage extends akka.http.javadsl.model.ws.TextMessage with Mes
   /** Java API */
   override def getStreamedText: javadsl.Source[String, _] = textStream.asJava
   override def asScala: TextMessage = this
-  override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[TextMessage.Strict] = toStrict(timeoutMillis.millis)(materializer).toJava
+  override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[TextMessage.Strict] = toStrict(timeoutMillis.millis)(materializer).asJava
 }
 //#message-model
 object TextMessage {
@@ -106,7 +106,7 @@ sealed trait BinaryMessage extends akka.http.javadsl.model.ws.BinaryMessage with
   /** Java API */
   override def getStreamedData: javadsl.Source[ByteString, _] = dataStream.asJava
   override def asScala: BinaryMessage = this
-  override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[BinaryMessage.Strict] = toStrict(timeoutMillis.millis)(materializer).toJava
+  override def toStrict(timeoutMillis: Long, materializer: Materializer): CompletionStage[BinaryMessage.Strict] = toStrict(timeoutMillis.millis)(materializer).asJava
 }
 //#message-model
 object BinaryMessage {

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -18,7 +18,7 @@ import akka.http.scaladsl.{ settings => js }
 import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.OptionConverters
+import scala.jdk.OptionConverters._
 
 /**
  * Public API but not intended for subclassing
@@ -77,14 +77,22 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   override def getConflictingContentTypeHeaderProcessingMode = this.conflictingContentTypeHeaderProcessingMode
 
   override def getCustomMethods = new Function[String, Optional[akka.http.javadsl.model.HttpMethod]] {
-    override def apply(t: String) = OptionConverters.toJava(self.customMethods(t))
+    override def apply(t: String) = {
+      val method: Option[akka.http.javadsl.model.HttpMethod] = self.customMethods(t)
+      method.toJava
+    }
   }
   override def getCustomStatusCodes = new Function[Int, Optional[akka.http.javadsl.model.StatusCode]] {
-    override def apply(t: Int) = OptionConverters.toJava(self.customStatusCodes(t))
+    override def apply(t: Int) = {
+      val code: Option[akka.http.javadsl.model.StatusCode] = self.customStatusCodes(t)
+      code.toJava
+    }
   }
   override def getCustomMediaTypes = new akka.japi.function.Function2[String, String, Optional[akka.http.javadsl.model.MediaType]] {
-    override def apply(mainType: String, subType: String): Optional[model.MediaType] =
-      OptionConverters.toJava(self.customMediaTypes(mainType, subType))
+    override def apply(mainType: String, subType: String): Optional[model.MediaType] = {
+      val mediaType: Option[akka.http.javadsl.model.MediaType] = self.customMediaTypes(mainType, subType)
+      mediaType.toJava
+    }
   }
   def getModeledHeaderParsing: Boolean = this.modeledHeaderParsing
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ServerSettings.scala
@@ -21,8 +21,8 @@ import com.typesafe.config.Config
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.compat.java8.OptionConverters
 import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.jdk.OptionConverters._
 import scala.language.implicitConversions
 
 /**
@@ -70,12 +70,12 @@ abstract class ServerSettings private[akka] () extends akka.http.javadsl.setting
   override def getResponseHeaderSizeHint = this.responseHeaderSizeHint
   override def getVerboseErrorMessages = this.verboseErrorMessages
   override def getSocketOptions = this.socketOptions.asJava
-  override def getServerHeader = OptionConverters.toJava(this.serverHeader.map(_.asJava))
+  override def getServerHeader = this.serverHeader.map(_.asJava).toJava
   override def getTimeouts = this.timeouts
   override def getRawRequestUriHeader = this.rawRequestUriHeader
   override def getRemoteAddressHeader = this.remoteAddressHeader
   override def getRemoteAddressAttribute: Boolean = this.remoteAddressAttribute
-  override def getLogUnencryptedNetworkBytes = OptionConverters.toJava(this.logUnencryptedNetworkBytes)
+  override def getLogUnencryptedNetworkBytes = this.logUnencryptedNetworkBytes.toJava
   @Deprecated @deprecated("Kept for binary compatibility; Use websocketSettings.getRandomFactory instead", since = "10.2.0")
   override def getWebsocketRandomFactory = new Supplier[Random] {
     override def get(): Random = self.websocketRandomFactory()

--- a/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/javadsl/model/MultipartsSpec.scala
@@ -10,15 +10,16 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.jdk.FutureConverters._
+
 import org.scalatest.{ BeforeAndAfterAll, Inside }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 import akka.actor.ActorSystem
 import akka.stream.SystemMaterializer
 import akka.stream.javadsl.Source
 import akka.testkit._
-
-import scala.compat.java8.FutureConverters
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
 class MultipartsSpec extends AnyWordSpec with Matchers with Inside with BeforeAndAfterAll {
 
@@ -35,7 +36,7 @@ class MultipartsSpec extends AnyWordSpec with Matchers with Inside with BeforeAn
         Multiparts.createFormDataBodyPart("foo", HttpEntities.create("FOO")),
         Multiparts.createFormDataBodyPart("bar", HttpEntities.create("BAR")))
       val strictCS = streamed.toStrict(1000, materializer)
-      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second.dilated)
+      val strict = Await.result(strictCS.asScala, 1.second.dilated)
 
       strict shouldEqual akka.http.scaladsl.model.Multipart.FormData(
         Map("foo" -> akka.http.scaladsl.model.HttpEntity("FOO"), "bar" -> akka.http.scaladsl.model.HttpEntity("BAR")))
@@ -46,7 +47,7 @@ class MultipartsSpec extends AnyWordSpec with Matchers with Inside with BeforeAn
         Multiparts.createFormDataBodyPart("bar", HttpEntities.create("BAR"))
       )))
       val strictCS = streamed.toStrict(1000, materializer)
-      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second.dilated)
+      val strict = Await.result(strictCS.asScala, 1.second.dilated)
       strict shouldEqual akka.http.scaladsl.model.Multipart.FormData(
         Map("foo" -> akka.http.scaladsl.model.HttpEntity("FOO"), "bar" -> akka.http.scaladsl.model.HttpEntity("BAR")))
     }
@@ -58,7 +59,7 @@ class MultipartsSpec extends AnyWordSpec with Matchers with Inside with BeforeAn
       fields.put("foo", HttpEntities.create("FOO"))
       val streamed = Multiparts.createFormDataFromFields(fields)
       val strictCS = streamed.toStrict(1000, materializer)
-      val strict = Await.result(FutureConverters.toScala(strictCS), 1.second.dilated)
+      val strict = Await.result(strictCS.asScala, 1.second.dilated)
 
       strict shouldEqual akka.http.scaladsl.model.Multipart.FormData(
         Map("foo" -> akka.http.scaladsl.model.HttpEntity("FOO")))

--- a/akka-http-jwt/src/main/scala/akka/http/jwt/internal/JwtClaimsImpl.scala
+++ b/akka-http-jwt/src/main/scala/akka/http/jwt/internal/JwtClaimsImpl.scala
@@ -7,11 +7,13 @@ package akka.http.jwt.internal
 import akka.annotation.InternalApi
 import akka.http.jwt.scaladsl.server.directives.JwtClaims
 import akka.http.jwt.javadsl.server.directives.{ JwtClaims => JavaJwtClaims }
+
 import spray.json.{ JsArray, JsBoolean, JsNumber, JsObject, JsString, JsValue }
 
 import java.util.Optional
-import scala.compat.java8.OptionConverters.RichOptionForJava8
+
 import scala.jdk.CollectionConverters.SeqHasAsJava
+import scala.jdk.OptionConverters._
 
 /**
  * INTERNAL API
@@ -44,17 +46,17 @@ private[jwt] final case class JwtClaimsImpl(claims: JsObject) extends JwtClaims 
   override def rawClaim(name: String): Option[JsValue] = claims.fields.get(name)
 
   // JAVA API
-  override def getIntClaim(name: String): Optional[Int] = intClaim(name).asJava
+  override def getIntClaim(name: String): Optional[Int] = intClaim(name).toJava
 
-  override def getLongClaim(name: String): Optional[Long] = longClaim(name).asJava
+  override def getLongClaim(name: String): Optional[Long] = longClaim(name).toJava
 
-  override def getDoubleClaim(name: String): Optional[Double] = doubleClaim(name).asJava
+  override def getDoubleClaim(name: String): Optional[Double] = doubleClaim(name).toJava
 
-  override def getStringClaim(name: String): Optional[String] = stringClaim(name).asJava
+  override def getStringClaim(name: String): Optional[String] = stringClaim(name).toJava
 
   override def getStringClaims(name: String): java.util.List[String] = stringClaims(name).asJava
 
-  override def getBooleanClaim(name: String): Optional[Boolean] = booleanClaim(name).asJava
+  override def getBooleanClaim(name: String): Optional[Boolean] = booleanClaim(name).toJava
 
-  override def getRawClaim(name: String): Optional[String] = rawClaim(name).map(_.toString).asJava
+  override def getRawClaim(name: String): Optional[String] = rawClaim(name).map(_.toString).toJava
 }

--- a/akka-http/src/main/java/akka/http/javadsl/coding/Coder.java
+++ b/akka-http/src/main/java/akka/http/javadsl/coding/Coder.java
@@ -10,7 +10,8 @@ import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.stream.Materializer;
 import akka.util.ByteString;
-import scala.compat.java8.FutureConverters;
+
+import scala.jdk.javaapi.FutureConverters;
 
 /**
  * A coder is an implementation of the predefined encoders/decoders defined for HTTP.
@@ -54,7 +55,7 @@ public enum Coder {
     }
 
     public CompletionStage<ByteString> decode(ByteString input, Materializer mat) {
-        return FutureConverters.toJava(underlying.decode(input, mat));
+        return FutureConverters.asJava(underlying.decode(input, mat));
     }
     public akka.http.scaladsl.coding.Coder _underlyingScalaCoder() {
         return underlying;

--- a/akka-http/src/main/mima-filters/10.6.3.backwards.excludes/4418-drop-java8-compat.excludes
+++ b/akka-http/src/main/mima-filters/10.6.3.backwards.excludes/4418-drop-java8-compat.excludes
@@ -1,0 +1,3 @@
+# Drop scala java8 compat
+ProblemFilters.exclude[MissingClassProblem]("akka.http.javadsl.server.RoutingJavaMapping$ConvertCompletionStage")
+ProblemFilters.exclude[MissingClassProblem]("akka.http.javadsl.server.RoutingJavaMapping$ConvertCompletionStage$")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
@@ -4,24 +4,24 @@
 
 package akka.http.javadsl.server
 
+import akka.annotation.DoNotInherit
 import akka.http.impl.util.JavaMapping
 import akka.http.scaladsl.server.ContentNegotiator.Alternative
 import akka.http.scaladsl.server._
 import akka.http.javadsl.model._
 import akka.http.javadsl.model.headers.{ ByteRange, HttpChallenge, HttpEncoding }
-
-import java.util.Optional
-import java.util.function.{ Function => JFunction }
-import java.lang.{ Iterable => JIterable }
-import akka.annotation.DoNotInherit
 import akka.http.scaladsl
 import akka.japi.Util
 import akka.pattern.CircuitBreakerOpenException
 
+import java.lang.{ Iterable => JIterable }
+import java.util.Optional
+import java.util.function.{ Function => JFunction }
 import java.util.{ List => JList }
-import scala.compat.java8.OptionConverters._
+
 import scala.collection.immutable
 import scala.collection.JavaConverters._
+import scala.jdk.OptionConverters._
 
 /**
  * A rejection encapsulates a specific reason why a Route was not able to handle a request. Rejections are gathered
@@ -368,7 +368,7 @@ object Rejections {
   def malformedQueryParam(parameterName: String, errorMsg: String): MalformedQueryParamRejection =
     s.MalformedQueryParamRejection(parameterName, errorMsg)
   def malformedQueryParam(parameterName: String, errorMsg: String, cause: Optional[Throwable]): MalformedQueryParamRejection =
-    s.MalformedQueryParamRejection(parameterName, errorMsg, cause.asScala)
+    s.MalformedQueryParamRejection(parameterName, errorMsg, cause.toScala)
 
   def missingFormField(fieldName: String): MissingFormFieldRejection =
     s.MissingFormFieldRejection(fieldName)
@@ -376,7 +376,7 @@ object Rejections {
   def malformedFormField(fieldName: String, errorMsg: String): MalformedFormFieldRejection =
     s.MalformedFormFieldRejection(fieldName, errorMsg)
   def malformedFormField(fieldName: String, errorMsg: String, cause: Optional[Throwable]): s.MalformedFormFieldRejection =
-    s.MalformedFormFieldRejection(fieldName, errorMsg, cause.asScala)
+    s.MalformedFormFieldRejection(fieldName, errorMsg, cause.toScala)
 
   def missingHeader(headerName: String): MissingHeaderRejection =
     s.MissingHeaderRejection(headerName)
@@ -384,14 +384,14 @@ object Rejections {
   def malformedHeader(headerName: String, errorMsg: String): MalformedHeaderRejection =
     s.MalformedHeaderRejection(headerName, errorMsg)
   def malformedHeader(headerName: String, errorMsg: String, cause: Optional[Throwable]): s.MalformedHeaderRejection =
-    s.MalformedHeaderRejection(headerName, errorMsg, cause.asScala)
+    s.MalformedHeaderRejection(headerName, errorMsg, cause.toScala)
 
   def unsupportedRequestContentType(
     supported:   java.lang.Iterable[MediaType],
     contentType: Optional[ContentType]): UnsupportedRequestContentTypeRejection =
     s.UnsupportedRequestContentTypeRejection(
       supported = supported.asScala.map((m: MediaType) => scaladsl.model.ContentTypeRange(m.asScala)).toSet,
-      contentType = contentType.asScala.map((c: ContentType) => c.asScala))
+      contentType = contentType.toScala.map((c: ContentType) => c.asScala))
 
   // for backwards compatibility
   def unsupportedRequestContentType(supported: java.lang.Iterable[MediaType]): UnsupportedRequestContentTypeRejection =
@@ -442,7 +442,7 @@ object Rejections {
   def validationRejection(message: String) =
     s.ValidationRejection(message)
   def validationRejection(message: String, cause: Optional[Throwable]) =
-    s.ValidationRejection(message, cause.asScala)
+    s.ValidationRejection(message, cause.toScala)
 
   def transformationRejection(f: java.util.function.Function[java.util.List[Rejection], java.util.List[Rejection]]) =
     s.TransformationRejection(rejections => f.apply(rejections.map(_.asJava).asJava).asScala.toVector.map(_.asScala)) // TODO this is maddness

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RequestContext.scala
@@ -4,30 +4,29 @@
 
 package akka.http.javadsl.server
 
+import akka.annotation.InternalApi
+import akka.event.LoggingAdapter
 import akka.http.javadsl.marshalling.Marshaller
 import akka.http.javadsl.model.HttpRequest
-import akka.http.scaladsl.util.FastFuture._
-
-import scala.concurrent.ExecutionContextExecutor
-import akka.stream.Materializer
-import akka.event.LoggingAdapter
 import akka.http.javadsl.settings.RoutingSettings
 import akka.http.javadsl.settings.ParserSettings
 import akka.http.javadsl.model.HttpResponse
 import akka.http.javadsl.model.StatusCode
 import akka.http.javadsl.model.Uri
 import akka.http.javadsl.model.headers.Location
+import akka.http.scaladsl.util.FastFuture._
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.impl.util.JavaMapping.Implicits._
+import akka.stream.Materializer
+
 import java.util.concurrent.CompletionStage
 import java.util.function.{ Function => JFunction }
 
-import akka.annotation.InternalApi
-import akka.http.scaladsl
-import akka.http.impl.util.JavaMapping.Implicits._
-import akka.http.scaladsl.marshalling.ToResponseMarshallable
-
-import scala.compat.java8.FutureConverters._
 import scala.annotation.varargs
-import akka.http.scaladsl.model.Uri.Path
+import scala.concurrent.ExecutionContextExecutor
+import scala.jdk.FutureConverters._
 
 class RequestContext private (val delegate: scaladsl.server.RequestContext) {
   import RequestContext._
@@ -49,18 +48,18 @@ class RequestContext private (val delegate: scaladsl.server.RequestContext) {
 
   def complete[T](value: T, marshaller: Marshaller[T, HttpResponse]): CompletionStage[RouteResult] = {
     delegate.complete(ToResponseMarshallable(value)(marshaller))
-      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).toJava
+      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).asJava
   }
 
   def completeWith(response: HttpResponse): CompletionStage[RouteResult] = {
     delegate.complete(response.asScala)
-      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).toJava
+      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).asJava
   }
 
   @varargs def reject(rejections: Rejection*): CompletionStage[RouteResult] = {
     val scalaRejections = rejections.map(_.asScala)
     delegate.reject(scalaRejections: _*)
-      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).toJava
+      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).asJava
   }
 
   def redirect(uri: Uri, redirectionType: StatusCode): CompletionStage[RouteResult] = {
@@ -69,7 +68,7 @@ class RequestContext private (val delegate: scaladsl.server.RequestContext) {
 
   def fail(error: Throwable): CompletionStage[RouteResult] =
     delegate.fail(error)
-      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).toJava
+      .fast.map(r => r: RouteResult)(akka.dispatch.ExecutionContexts.parasitic).asJava
 
   def withRequest(req: HttpRequest): RequestContext = wrap(delegate.withRequest(req.asScala))
   def withExecutionContext(ec: ExecutionContextExecutor): RequestContext = wrap(delegate.withExecutionContext(ec))

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RoutingJavaMapping.scala
@@ -77,9 +77,5 @@ private[http] object RoutingJavaMapping {
   //  val javaToScalaHttpEntity extends Inherited[javadsl.model.HttpEntity, scaladsl.model.HttpEntity]
   //  val javaToScalaResponseEntity extends Inherited[javadsl.model.ResponseEntity, scaladsl.model.ResponseEntity]
 
-  implicit final class ConvertCompletionStage[T](val stage: CompletionStage[T]) extends AnyVal {
-    import scala.compat.java8.FutureConverters._
-    def asScala = stage.toScala
-  }
 }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/AttributeDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/AttributeDirectives.scala
@@ -10,7 +10,7 @@ import akka.http.javadsl.model.AttributeKey
 import akka.http.javadsl.server.Route
 import akka.http.scaladsl.server.directives.{ AttributeDirectives => D }
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 abstract class AttributeDirectives extends HeaderDirectives {
   import akka.http.impl.util.JavaMapping._
@@ -30,7 +30,7 @@ abstract class AttributeDirectives extends HeaderDirectives {
    */
   def optionalAttribute[T](key: AttributeKey[T], inner: jf.Function[Optional[T], Route]) = RouteAdapter {
     D.optionalAttribute(toScala(key)) { value =>
-      inner.apply(value.asJava).delegate
+      inner.apply(value.toJava).delegate
     }
   }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
@@ -39,8 +39,8 @@ import akka.dispatch.ExecutionContexts
 import akka.event.LoggingAdapter
 import akka.http.javadsl.server
 
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.FutureConverters._
 
 abstract class BasicDirectives {
   import akka.http.impl.util.JavaMapping.Implicits._
@@ -84,17 +84,17 @@ abstract class BasicDirectives {
 
   def mapRouteResultFuture(f: JFunction[CompletionStage[RouteResult], CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
     D.mapRouteResultFuture(stage =>
-      f(toJava(stage.fast.map(_.asJava)(ExecutionContexts.parasitic))).toScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) {
+      f(stage.fast.map(_.asJava)(ExecutionContexts.parasitic).asJava).asScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) {
       inner.get.delegate
     }
   }
 
   def mapRouteResultWith(f: JFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.mapRouteResultWith(r => f(r.asJava).toScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) { inner.get.delegate }
+    D.mapRouteResultWith(r => f(r.asJava).asScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) { inner.get.delegate }
   }
 
   def mapRouteResultWithPF(f: PartialFunction[RouteResult, CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.mapRouteResultWith(r => f(r.asJava).toScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) { inner.get.delegate }
+    D.mapRouteResultWith(r => f(r.asJava).asScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) { inner.get.delegate }
   }
 
   /**
@@ -148,7 +148,7 @@ abstract class BasicDirectives {
   }
 
   def recoverRejectionsWith(f: JFunction[JIterable[Rejection], CompletionStage[RouteResult]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.recoverRejectionsWith(rs => f.apply(Util.javaArrayList(rs.map(_.asJava))).toScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) { inner.get.delegate }
+    D.recoverRejectionsWith(rs => f.apply(Util.javaArrayList(rs.map(_.asJava))).asScala.fast.map(_.asScala)(ExecutionContexts.parasitic)) { inner.get.delegate }
   }
 
   /**

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/CacheConditionDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/CacheConditionDirectives.scala
@@ -8,7 +8,7 @@ package directives
 import java.util.Optional
 import java.util.function.Supplier
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 import akka.http.javadsl.model.DateTime
 import akka.http.javadsl.model.headers.EntityTag
@@ -74,7 +74,7 @@ abstract class CacheConditionDirectives extends BasicDirectives {
    * must be on a deeper level in your route structure in order to function correctly.
    */
   def conditional(eTag: Optional[EntityTag], lastModified: Optional[DateTime], inner: Supplier[Route]): Route = RouteAdapter {
-    D.conditional(eTag.asScala.map((e: EntityTag) => e.asScala), lastModified.asScala.map((d: DateTime) => d.asScala)) { inner.get.delegate }
+    D.conditional(eTag.toScala.map((e: EntityTag) => e.asScala), lastModified.asScala.map((d: DateTime) => d.asScala)) { inner.get.delegate }
   }
 
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FormFieldDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FormFieldDirectives.scala
@@ -19,7 +19,7 @@ import akka.http.javadsl.server.Route
 import akka.http.scaladsl.server.{ Directives => D }
 import akka.http.scaladsl.server.directives.ParameterDirectives._
 
-import scala.compat.java8.OptionConverters
+import scala.jdk.OptionConverters._
 
 abstract class FormFieldDirectives extends FileUploadDirectives {
 
@@ -31,7 +31,7 @@ abstract class FormFieldDirectives extends FileUploadDirectives {
   @CorrespondsTo("formField")
   def formFieldOptional(name: String, inner: JFunction[Optional[String], Route]): Route = RouteAdapter(
     D.formField(name.optional) { value =>
-      inner.apply(value.asJava).delegate
+      inner.apply(value.toJava).delegate
     })
 
   @CorrespondsTo("formFieldSeq")
@@ -53,7 +53,7 @@ abstract class FormFieldDirectives extends FileUploadDirectives {
     import t.asScala
     RouteAdapter(
       D.formField(name.as[T].optional) { value =>
-        inner.apply(OptionConverters.toJava(value)).delegate
+        inner.apply(value.toJava).delegate
       })
   }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/FutureDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/FutureDirectives.scala
@@ -11,13 +11,13 @@ import java.util.function.Supplier
 
 import akka.http.javadsl.marshalling.Marshaller
 import akka.http.javadsl.model.RequestEntity
-
-import scala.compat.java8.FutureConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.Try
 import akka.http.javadsl.server.Route
 import akka.http.scaladsl.server.directives.{ CompleteOrRecoverWithMagnet, FutureDirectives => D }
 import akka.pattern.CircuitBreaker
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.FutureConverters._
+import scala.util.Try
 
 abstract class FutureDirectives extends FormFieldDirectives {
 
@@ -28,7 +28,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def onComplete[T](f: Supplier[CompletionStage[T]], inner: JFunction[Try[T], Route]) = RouteAdapter {
-    D.onComplete(f.get.toScala.recover(unwrapCompletionException)) { value =>
+    D.onComplete(f.get.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -40,7 +40,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def onComplete[T](cs: CompletionStage[T], inner: JFunction[Try[T], Route]) = RouteAdapter {
-    D.onComplete(cs.toScala.recover(unwrapCompletionException)) { value =>
+    D.onComplete(cs.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -56,7 +56,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def onCompleteWithBreaker[T](breaker: CircuitBreaker, f: Supplier[CompletionStage[T]], inner: JFunction[Try[T], Route]) = RouteAdapter {
-    D.onCompleteWithBreaker(breaker)(f.get.toScala.recover(unwrapCompletionException)) { value =>
+    D.onCompleteWithBreaker(breaker)(f.get.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -70,7 +70,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def onSuccess[T](f: Supplier[CompletionStage[T]], inner: JFunction[T, Route]) = RouteAdapter {
-    D.onSuccess(f.get.toScala.recover(unwrapCompletionException)) { value =>
+    D.onSuccess(f.get.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -84,7 +84,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def onSuccess[T](cs: CompletionStage[T], inner: JFunction[T, Route]) = RouteAdapter {
-    D.onSuccess(cs.toScala.recover(unwrapCompletionException)) { value =>
+    D.onSuccess(cs.asScala.recover(unwrapCompletionException)) { value =>
       inner(value).delegate
     }
   }
@@ -99,7 +99,7 @@ abstract class FutureDirectives extends FormFieldDirectives {
    * @group future
    */
   def completeOrRecoverWith[T](f: Supplier[CompletionStage[T]], marshaller: Marshaller[T, RequestEntity], inner: JFunction[Throwable, Route]): Route = RouteAdapter {
-    val magnet = CompleteOrRecoverWithMagnet(f.get.toScala)(Marshaller.asScalaEntityMarshaller(marshaller))
+    val magnet = CompleteOrRecoverWithMagnet(f.get.asScala)(Marshaller.asScalaEntityMarshaller(marshaller))
     D.completeOrRecoverWith(magnet) { ex => inner(ex).delegate }
   }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/HeaderDirectives.scala
@@ -8,16 +8,13 @@ import java.util.Optional
 import java.util.{ function => jf }
 
 import akka.actor.ReflectiveDynamicAccess
-
-import scala.compat.java8.OptionConverters
-import scala.compat.java8.OptionConverters._
-import akka.http.impl.util.JavaMapping.Implicits._
 import akka.http.javadsl.model.headers.{ HttpOriginRange, HttpOriginRanges }
 import akka.http.javadsl.model.HttpHeader
 import akka.http.javadsl.server.Route
 import akka.http.scaladsl.model.headers.{ ModeledCustomHeader, ModeledCustomHeaderCompanion }
 import akka.http.scaladsl.server.directives.{ HeaderMagnet, HeaderDirectives => D }
 
+import scala.jdk.OptionConverters._
 import scala.reflect.ClassTag
 import scala.util.{ Failure, Success }
 
@@ -50,7 +47,7 @@ abstract class HeaderDirectives extends FutureDirectives {
    * with a [[akka.http.javadsl.server.MalformedHeaderRejection]].
    */
   def headerValue[T](f: jf.Function[HttpHeader, Optional[T]], inner: jf.Function[T, Route]) = RouteAdapter {
-    D.headerValue(h => f.apply(h).asScala) { value =>
+    D.headerValue(h => f.apply(h).toScala) { value =>
       inner.apply(value).delegate
     }
   }
@@ -113,8 +110,8 @@ abstract class HeaderDirectives extends FutureDirectives {
    * with a [[akka.http.javadsl.server.MalformedHeaderRejection]].
    */
   def optionalHeaderValue[T](f: jf.Function[HttpHeader, Optional[T]], inner: jf.Function[Optional[T], Route]) = RouteAdapter {
-    D.optionalHeaderValue(h => f.apply(h).asScala) { value =>
-      inner.apply(value.asJava).delegate
+    D.optionalHeaderValue(h => f.apply(h).toScala) { value =>
+      inner.apply(value.toJava).delegate
     }
   }
 
@@ -125,7 +122,7 @@ abstract class HeaderDirectives extends FutureDirectives {
    */
   def optionalHeaderValuePF[T](pf: PartialFunction[HttpHeader, T], inner: jf.Function[Optional[T], Route]) = RouteAdapter {
     D.optionalHeaderValuePF(pf) { value =>
-      inner.apply(value.asJava).delegate
+      inner.apply(value.toJava).delegate
     }
   }
 
@@ -134,7 +131,7 @@ abstract class HeaderDirectives extends FutureDirectives {
    */
   def optionalHeaderValueByName(headerName: String, inner: jf.Function[Optional[String], Route]) = RouteAdapter {
     D.optionalHeaderValueByName(headerName) { value =>
-      inner.apply(value.asJava).delegate
+      inner.apply(value.toJava).delegate
     }
   }
 
@@ -148,7 +145,7 @@ abstract class HeaderDirectives extends FutureDirectives {
     // TODO needs instance of check if it's a modeled header and then magically locate companion
     D.optionalHeaderValueByType(HeaderMagnet.fromClassNormalJavaHeader(t).asInstanceOf[ScalaHeaderMagnet]) { value =>
       val valueT = value.asInstanceOf[Option[T]] // we know this is safe because T <: HttpHeader
-      inner.apply(OptionConverters.toJava[T](valueT)).delegate
+      inner.apply(valueT.toJava).delegate
     }
   }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/ParameterDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/ParameterDirectives.scala
@@ -14,7 +14,7 @@ import akka.http.scaladsl.server.directives.ParameterDirectives._
 import akka.http.scaladsl.server.directives.{ ParameterDirectives => D }
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters._
 
 abstract class ParameterDirectives extends MiscDirectives {
 
@@ -26,7 +26,7 @@ abstract class ParameterDirectives extends MiscDirectives {
   @CorrespondsTo("parameter")
   def parameterOptional(name: String, inner: java.util.function.Function[Optional[String], Route]): Route = RouteAdapter(
     D.parameter(name.optional) { value =>
-      inner.apply(value.asJava).delegate
+      inner.apply(value.toJava).delegate
     })
 
   @CorrespondsTo("parameter")
@@ -56,7 +56,7 @@ abstract class ParameterDirectives extends MiscDirectives {
     import t.asScala
     RouteAdapter(
       D.parameter(name.as[T].optional) { value =>
-        inner.apply(value.asJava).delegate
+        inner.apply(value.toJava).delegate
       })
   }
 

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -23,6 +23,7 @@ import akka.http.scaladsl.util.FastFuture
 import akka.http.scaladsl.util.FastFuture._
 
 import scala.concurrent.ExecutionContext
+import scala.jdk.FutureConverters._
 
 abstract class RouteDirectives extends RespondWithDirectives {
   import RoutingJavaMapping.Implicits._

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/SecurityDirectives.scala
@@ -9,8 +9,6 @@ import java.util.concurrent.CompletionStage
 import java.util.function.{ Function => JFunction }
 import java.util.function.Supplier
 
-import scala.compat.java8.FutureConverters._
-import scala.compat.java8.OptionConverters._
 import akka.http.javadsl.model.headers.HttpChallenge
 import akka.http.javadsl.model.headers.HttpCredentials
 import akka.http.javadsl.server.{ Route, RequestContext }
@@ -18,6 +16,8 @@ import akka.http.scaladsl
 import akka.http.scaladsl.server.{ Directives => D }
 
 import scala.concurrent.{ ExecutionContextExecutor, Future }
+import scala.jdk.FutureConverters._
+import scala.jdk.OptionConverters._
 
 object SecurityDirectives {
   /**
@@ -53,7 +53,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
    */
   def extractCredentials(inner: JFunction[Optional[HttpCredentials], Route]): Route = RouteAdapter {
     D.extractCredentials { cred =>
-      inner.apply(cred.map(_.asJava).asJava).delegate // TODO attempt to not need map()
+      inner.apply(cred.map(_.asJava).toJava).delegate // TODO attempt to not need map()
     }
   }
 
@@ -66,7 +66,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
    */
   def authenticateBasic[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], Optional[T]],
                            inner: JFunction[T, Route]): Route = RouteAdapter {
-    D.authenticateBasic(realm, c => authenticator.apply(toJava(c)).asScala) { t =>
+    D.authenticateBasic(realm, c => authenticator.apply(toJava(c)).toScala) { t =>
       inner.apply(t).delegate
     }
   }
@@ -102,7 +102,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
       case credentials =>
         val jCredentials = toJava(credentials)
         if (authenticator isDefinedAt jCredentials) {
-          authenticator(jCredentials).toScala.map(Some(_))
+          authenticator(jCredentials).asScala.map(Some(_))
         } else {
           Future.successful(None)
         }
@@ -125,8 +125,8 @@ abstract class SecurityDirectives extends SchemeDirectives {
   @CorrespondsTo("authenticateBasic")
   def authenticateBasicOptional[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], Optional[T]],
                                    inner: JFunction[Optional[T], Route]): Route = RouteAdapter {
-    D.authenticateBasic(realm, c => authenticator.apply(toJava(c)).asScala).optional { t =>
-      inner.apply(t.asJava).delegate
+    D.authenticateBasic(realm, c => authenticator.apply(toJava(c)).toScala).optional { t =>
+      inner.apply(t.toJava).delegate
     }
   }
 
@@ -140,7 +140,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
   def authenticateBasicAsync[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], CompletionStage[Optional[T]]],
                                 inner: JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      D.authenticateBasicAsync(realm, c => authenticator.apply(toJava(c)).toScala.map(_.asScala)) { t =>
+      D.authenticateBasicAsync(realm, c => authenticator.apply(toJava(c)).asScala.map(_.toScala)) { t =>
         inner.apply(t).delegate
       }
     }
@@ -157,8 +157,8 @@ abstract class SecurityDirectives extends SchemeDirectives {
   def authenticateBasicAsyncOptional[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], CompletionStage[Optional[T]]],
                                         inner: JFunction[Optional[T], Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      D.authenticateBasicAsync(realm, c => authenticator.apply(toJava(c)).toScala.map(_.asScala)).optional { t =>
-        inner.apply(t.asJava).delegate
+      D.authenticateBasicAsync(realm, c => authenticator.apply(toJava(c)).asScala.map(_.toScala)).optional { t =>
+        inner.apply(t.toJava).delegate
       }
     }
   }
@@ -172,7 +172,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
    */
   def authenticateOAuth2[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], Optional[T]],
                             inner: JFunction[T, Route]): Route = RouteAdapter {
-    D.authenticateOAuth2(realm, c => authenticator.apply(toJava(c)).asScala) { t =>
+    D.authenticateOAuth2(realm, c => authenticator.apply(toJava(c)).toScala) { t =>
       inner.apply(t).delegate
     }
   }
@@ -187,8 +187,8 @@ abstract class SecurityDirectives extends SchemeDirectives {
   @CorrespondsTo("authenticateOAuth2")
   def authenticateOAuth2Optional[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], Optional[T]],
                                     inner: JFunction[Optional[T], Route]): Route = RouteAdapter {
-    D.authenticateOAuth2(realm, c => authenticator.apply(toJava(c)).asScala).optional { t =>
-      inner.apply(t.asJava).delegate
+    D.authenticateOAuth2(realm, c => authenticator.apply(toJava(c)).toScala).optional { t =>
+      inner.apply(t.toJava).delegate
     }
   }
 
@@ -202,7 +202,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
   def authenticateOAuth2Async[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], CompletionStage[Optional[T]]],
                                  inner: JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      D.authenticateOAuth2Async(realm, c => authenticator.apply(toJava(c)).toScala.map(_.asScala)) { t =>
+      D.authenticateOAuth2Async(realm, c => authenticator.apply(toJava(c)).asScala.map(_.toScala)) { t =>
         inner.apply(t).delegate
       }
     }
@@ -219,8 +219,8 @@ abstract class SecurityDirectives extends SchemeDirectives {
   def authenticateOAuth2AsyncOptional[T](realm: String, authenticator: JFunction[Optional[ProvidedCredentials], CompletionStage[Optional[T]]],
                                          inner: JFunction[Optional[T], Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
-      D.authenticateOAuth2Async(realm, c => authenticator.apply(toJava(c)).toScala.map(_.asScala)).optional { t =>
-        inner.apply(t.asJava).delegate
+      D.authenticateOAuth2Async(realm, c => authenticator.apply(toJava(c)).asScala.map(_.toScala)).optional { t =>
+        inner.apply(t.toJava).delegate
       }
     }
   }
@@ -236,7 +236,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
     inner:         JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
       val scalaAuthenticator = { (cred: Option[scaladsl.model.headers.HttpCredentials]) =>
-        authenticator.apply(cred.map(_.asJava).asJava).toScala.map(_.left.map(_.asScala))
+        authenticator.apply(cred.map(_.asJava).toJava).asScala.map(_.left.map(_.asScala))
       }
 
       D.authenticateOrRejectWithChallenge(scalaAuthenticator) { t =>
@@ -255,7 +255,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
     inner:         JFunction[T, Route]): Route = RouteAdapter {
     D.extractExecutionContext { implicit ctx =>
       val scalaAuthenticator = { (cred: Option[scaladsl.model.headers.HttpCredentials]) =>
-        authenticator.apply(cred.filter(c.isInstance).map(_.asJava).asJava.asInstanceOf[Optional[C]]).toScala.map(_.left.map(_.asScala)) // TODO make sure cast is safe
+        authenticator.apply(cred.filter(c.isInstance).map(_.asJava).toJava.asInstanceOf[Optional[C]]).asScala.map(_.left.map(_.asScala)) // TODO make sure cast is safe
       }
 
       D.authenticateOrRejectWithChallenge(scalaAuthenticator) { t =>
@@ -288,7 +288,7 @@ abstract class SecurityDirectives extends SchemeDirectives {
    * If the check fails the route is rejected with an [[akka.http.javadsl.server.AuthorizationFailedRejection]].
    */
   def authorizeAsync(check: Supplier[CompletionStage[Boolean]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.authorizeAsync(check.get().toScala) {
+    D.authorizeAsync(check.get().asScala) {
       inner.get().delegate
     }
   }
@@ -300,6 +300,6 @@ abstract class SecurityDirectives extends SchemeDirectives {
    */
   @CorrespondsTo("authorizeAsync")
   def authorizeAsyncWithRequestContext(check: akka.japi.function.Function[RequestContext, CompletionStage[Boolean]], inner: Supplier[Route]): Route = RouteAdapter {
-    D.authorizeAsync(rc => check(RequestContext.wrap(rc)).toScala)(inner.get().delegate)
+    D.authorizeAsync(rc => check(RequestContext.wrap(rc)).asScala)(inner.get().delegate)
   }
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/Unmarshaller.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/unmarshalling/Unmarshaller.scala
@@ -22,8 +22,8 @@ import akka.util.ByteString
 import scala.annotation.nowarn
 
 import scala.collection.JavaConverters._
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
+import scala.jdk.FutureConverters._
 
 object Unmarshaller extends akka.http.javadsl.unmarshalling.Unmarshallers {
   implicit def fromScala[A, B](scalaUnmarshaller: unmarshalling.Unmarshaller[A, B]): Unmarshaller[A, B] =
@@ -41,7 +41,7 @@ object Unmarshaller extends akka.http.javadsl.unmarshalling.Unmarshallers {
    * Creates an unmarshaller from an asynchronous Java function.
    */
   override def async[A, B](f: java.util.function.Function[A, CompletionStage[B]]): Unmarshaller[A, B] =
-    unmarshalling.Unmarshaller[A, B] { ctx => a => f(a).toScala
+    unmarshalling.Unmarshaller[A, B] { ctx => a => f(a).asScala
     }
 
   /**
@@ -123,7 +123,7 @@ abstract class Unmarshaller[-A, B] extends UnmarshallerBase[A, B] {
   /**
    * Apply this Unmarshaller to the given value.
    */
-  def unmarshal(value: A, ec: ExecutionContext, mat: Materializer): CompletionStage[B] = asScala.apply(value)(ec, mat).toJava
+  def unmarshal(value: A, ec: ExecutionContext, mat: Materializer): CompletionStage[B] = asScala.apply(value)(ec, mat).asJava
 
   /**
    * Apply this Unmarshaller to the given value. Uses the default materializer [[ExecutionContext]].
@@ -150,7 +150,7 @@ abstract class Unmarshaller[-A, B] extends UnmarshallerBase[A, B] {
   def thenApply[C](f: java.util.function.Function[B, C]): Unmarshaller[A, C] = asScala.map(f.apply)
 
   def flatMap[C](f: java.util.function.Function[B, CompletionStage[C]]): Unmarshaller[A, C] =
-    asScala.flatMap { ctx => mat => b => f.apply(b).toScala }
+    asScala.flatMap { ctx => mat => b => f.apply(b).asScala }
 
   def flatMap[C](u: Unmarshaller[_ >: B, C]): Unmarshaller[A, C] =
     asScala.flatMap { ctx => mat => b => u.asScala.apply(b)(ctx, mat) }

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.model.headers.{ HttpOrigin => SHttpOrigin }
 import java.util.{ List => JList }
 import scala.collection.JavaConverters._
 import scala.collection.immutable
-import scala.compat.java8.OptionConverters
+import scala.jdk.OptionConverters._
 import scala.runtime.AbstractFunction1
 
 /**
@@ -32,7 +32,7 @@ import scala.runtime.AbstractFunction1
 trait Rejection extends akka.http.javadsl.server.Rejection
 
 trait RejectionWithOptionalCause extends Rejection {
-  final def getCause: Optional[Throwable] = OptionConverters.toJava(cause)
+  final def getCause: Optional[Throwable] = cause.toJava
   def cause: Option[Throwable]
 }
 
@@ -348,7 +348,7 @@ final case class CorsRejection(description: String) extends jserver.CorsRejectio
 
 final case class TlsClientUnverifiedRejection(description: String) extends jserver.TlsClientUnverifiedRejection with Rejection
 final case class TlsClientIdentityRejection(description: String, requiredExpression: String, certificateCN: Option[String], certificateSANs: Seq[String]) extends jserver.TlsClientIdentityRejection with Rejection {
-  override def getCertificateCN: Optional[String] = certificateCN.asJava
+  override def getCertificateCN: Optional[String] = certificateCN.toJava
 
   override def getCertificateSANs: JList[String] = certificateSANs.asJava
 }


### PR DESCRIPTION
Fixes https://github.com/akka/akka-http/issues/4417

Imports seem inconsistent, so its a best-effort. Should maybe auto-alignt in a separate pr?

Is there maybe a better way to avoid the "map to object", like this one?
```
.map(length -> (Object)length));
```