### PR TITLE
Fixed docs for http2 ping-timeout

### DIFF
--- a/akka-http-core/src/main/resources/reference.conf
+++ b/akka-http-core/src/main/resources/reference.conf
@@ -307,7 +307,8 @@ akka.http {
       ping-interval = 0s
 
       # Fail the connection if a sent ping is not acknowledged within this timeout.
-      # When zero the ping-interval is used, if set the value must be evenly divisible by less than or equal to the ping-interval.
+      # When set to zero, the ping-interval is used. Otherwise, the value must be less than or equal to the ping-interval, and must be a
+      # divisor of the ping-interval.
       ping-timeout = 0s
 
       # Limit the number of RSTs a client is allowed to do on one connection, per interval
@@ -486,7 +487,8 @@ akka.http {
       ping-interval = 0s
 
       # Fail the connection if a sent ping is not acknowledged within this timeout.
-      # When zero the ping-interval is used, if set the value must be evenly divisible by less than or equal to the ping-interval.
+      # When set to zero, the ping-interval is used. Otherwise, the value must be less than or equal to the ping-interval, and must be a
+      # divisor of the ping-interval.
       ping-timeout = 0s
 
       # The maximum number of times a connections is attempted

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/Http2ServerSettings.scala
@@ -46,7 +46,7 @@ private[http] object Http2CommonSettings {
     if (pingInterval > Duration.Zero && pingTimeout > Duration.Zero) {
       require(
         pingTimeout <= pingInterval && pingInterval.toMillis % pingTimeout.toMillis == 0,
-        s"ping-timeout must be less than and evenly divisible by the ping-interval ($pingInterval)")
+        s"ping-timeout must be less than or equal to and a divisor of the ping-interval ($pingInterval)")
     }
   }
 }


### PR DESCRIPTION
This fixes the documentation and error message to be correct for ping-timeout vs ping-interval configuration. It was back to front (ping-timeout must be a divisor of, not divisible by, ping-interval), and the wording was hard to grok.