### PR TITLE
Removed jm.CustomHeader from TlsSessionInfo heirarchy

### DIFF
--- a/akka-http-core/src/main/java/akka/http/javadsl/model/headers/TlsSessionInfo.java
+++ b/akka-http-core/src/main/java/akka/http/javadsl/model/headers/TlsSessionInfo.java
@@ -4,6 +4,8 @@
 
 package akka.http.javadsl.model.headers;
 
+import akka.http.scaladsl.model.HttpHeader;
+
 import javax.net.ssl.SSLSession;
 
 /**
@@ -13,7 +15,7 @@ import javax.net.ssl.SSLSession;
  * This header will only be added if it enabled in the configuration by setting
  * <code>akka.http.[client|server].parsing.tls-session-info-header = on</code>.
  */
-public abstract class TlsSessionInfo extends CustomHeader {
+public abstract class TlsSessionInfo extends HttpHeader {
     /**
      * @return the SSLSession this message was received over.
      */

--- a/akka-http-core/src/main/mima-filters/10.6.3.backwards.excludes/tls-session-info.excludes
+++ b/akka-http-core/src/main/mima-filters/10.6.3.backwards.excludes/tls-session-info.excludes
@@ -1,0 +1,3 @@
+# changed type hierarchy but should not affect users
+ProblemFilters.exclude[MissingTypesProblem]("akka.http.javadsl.model.headers.TlsSessionInfo")
+ProblemFilters.exclude[MissingTypesProblem]("akka.http.scaladsl.model.headers.Tls$minusSession$minusInfo")


### PR DESCRIPTION
Fixes #4426.

When `TlsSessionInfo` was added, the only way to mark it as a header that should not be rendered was to implement `CustomHeader`, and then implement a method called `suppressRendering` to return `true`.

Obviously, this semantically didn't make sense since it's not a custom header, but not long after, a much better, more robust and semantically reasonable mechanism to ensure it didn't get rendered was provided in:

https://github.com/akka/akka/commit/a93a73ef5b0f8f56ffb99548b77a7f3fa297a594

This added `renderInRequests` and `renderInResponses` flags to headers, along with the traits `RequestHeader`, `ResponseHeader`, and `SyntheticHeader`. The Scala `Tls-Session-Info` class was modified to implement `SyntheticHeader` instead of the Scala `CustomHeader` trait, but the author forgot to modify the Java `TlsSessionInfo` class to no longer extend the Java `CustomHeader` class.

This didn't cause any real issue at the time, because there was nowhere that the Java `CustomHeader` class was returned or accepted by any API calls, or treated specially in anyway. That was, until #4348, which caused the modelled header lookup method to throw an exception, instead of return `None`, when the header is not present, if it extends the Java `CustomHeader` class.

So, this change removes `CustomHeader` from the superclass heirarchy of `TlsSessionInfo`, and instead makes it implement the Scala `HttpHeader` class directly, like all other headers. As far as I can tell, this should cause no issues, as `CustomHeader` is otherwise still not treated specially anywhere or exposed in any API. It would only cause an issue if some end user code tried to assign it to a `CustomHeader` typed variable, which I don't see any reason to ever do that.