### PR TITLE
bump: update scalatest to 3.2.19, scalacheck to 1.18.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
       val junitIntf    = "com.github.sbt"    % "junit-interface" % "0.13.3"            % "test" // MIT
 
       val scalatest               = "org.scalatest"     %% "scalatest"       % scalaTestVersion          % "test" // ApacheV2
-      val scalatestplusScalacheck = "org.scalatestplus" %% "scalacheck-1-16" % (scalaTestVersion + ".0") % "test"
+      val scalatestplusScalacheck = "org.scalatestplus" %% "scalacheck-1-18" % (scalaTestVersion + ".0") % "test"
       val scalatestplusJUnit      = "org.scalatestplus" %% "junit-4-13"      % (scalaTestVersion + ".0") % "test"
 
       // HTTP/2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,9 +19,9 @@ object Dependencies {
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
   val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v${h2specVersion}/${h2specName}.zip"
 
-  val scalaTestVersion = "3.2.12"
+  val scalaTestVersion = "3.2.19"
   val specs2Version = "4.10.6"
-  val scalaCheckVersion = "1.15.4"
+  val scalaCheckVersion = "1.18.0"
 
   val scalafixVersion = _root_.scalafix.sbt.BuildInfo.scalafixVersion // grab from plugin
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
 
   val scalaTestVersion = "3.2.19"
   val specs2Version = "4.10.6"
-  val scalaCheckVersion = "1.18.0"
+  val scalaCheckVersion = "1.18.1"
 
   val scalafixVersion = _root_.scalafix.sbt.BuildInfo.scalafixVersion // grab from plugin
 


### PR DESCRIPTION
Superseds https://github.com/akka/akka-http/pull/4414, including the scalacheck bump.