### PR TITLE
chore: reduce to weekly full matrix validation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
-name: Nightly Builds
+name: Weekly Builds
 
 on:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 2 * * 2"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Running the full matrix of builds every day seems to be a waste of energy as the JVM and Scala versions are very stable nowadays.