### PR TITLE
chore: Mark SSE encode method as internal stable

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/sse/ServerSentEvent.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/sse/ServerSentEvent.scala
@@ -7,8 +7,9 @@ package scaladsl
 package model
 package sse
 
-import java.nio.charset.StandardCharsets.UTF_8
+import akka.annotation.InternalStableApi
 
+import java.nio.charset.StandardCharsets.UTF_8
 import akka.http.javadsl.model
 import akka.util.ByteString
 
@@ -88,6 +89,7 @@ final case class ServerSentEvent(
   require(id.forall(noNewLine), "id must not contain \\n or \\r!")
   require(retry.forall(_ > 0), "retry must be a positive number!")
 
+  @InternalStableApi
   private[scaladsl] def encode = {
     def s = { // Performance fun fact: change this to val and get an ~30% performance penalty!!!
       // Why 8? "data:" == 5 + \n\n (1 data (at least) and 1 ending) == 2 and then we add 1 extra to allocate


### PR DESCRIPTION
Used by the Akka SDK