### PR TITLE
bump: Scalafix 0.13.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 addSbtPlugin("io.akka" % "sbt-paradox-akka" % "24.10.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.2")
 addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % "2.0.0")
 


### PR DESCRIPTION
Project doesn't load on my machine without this bump, because there is no Scala 2.13.15 version of the plugin (how can CI be green?)