### PR TITLE
docs: Fix sample Akka 2.10.5 versions

### DIFF
--- a/samples/akka-http-quickstart-java/pom.xml
+++ b/samples/akka-http-quickstart-java/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0</version>
 
     <properties>
-        <akka.version>2.10.0</akka.version>
+        <akka.version>2.10.5</akka.version>
         <akka-http.version>10.7.1</akka-http.version>
         <scala.binary.version>2.13</scala.binary.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/samples/akka-http-quickstart-scala/build.sbt
+++ b/samples/akka-http-quickstart-scala/build.sbt
@@ -1,5 +1,5 @@
 lazy val akkaHttpVersion = sys.props.getOrElse("akka-http.version", "10.7.1")
-lazy val akkaVersion    = "2.10.0"
+lazy val akkaVersion    = "2.10.5"
 
 ThisBuild / resolvers += "lightbend-akka".at("https://dl.cloudsmith.io/basic/lightbend/akka/maven/")
 ThisBuild / credentials ++= {


### PR DESCRIPTION
Akka HTTP pulls in 2.10.5 but samples was on 2.10.0 so was failing in https://github.com/akka/akka-http/actions/workflows/check-samples.yml