### PR TITLE
chore: Improve request/response stream logging

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Blueprint.scala
@@ -105,7 +105,7 @@ private[http] object Http2Blueprint {
     val masterHttpHeaderParser = HttpHeaderParser(settings.parserSettings, log) // FIXME: reuse for framing
     telemetry.serverConnection atop
       httpLayer(settings, log, dateHeaderRendering) atopKeepRight
-      serverDemux(settings.http2Settings, initialDemuxerSettings, upgraded) atop
+      serverDemux(settings.http2Settings, initialDemuxerSettings, upgraded, Some(log)) atop
       FrameLogger.logFramesIfEnabled(settings.http2Settings.logFrames) atop // enable for debugging
       hpackCoding(masterHttpHeaderParser, settings.parserSettings) atop
       framing(settings.http2Settings, log) atop
@@ -197,8 +197,8 @@ private[http] object Http2Blueprint {
    * Creates substreams for every stream and manages stream state machines
    * and handles priorization (TODO: later)
    */
-  def serverDemux(settings: Http2ServerSettings, initialDemuxerSettings: immutable.Seq[Setting], upgraded: Boolean): BidiFlow[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream, ServerTerminator] =
-    BidiFlow.fromGraph(new Http2ServerDemux(settings, initialDemuxerSettings, upgraded))
+  def serverDemux(settings: Http2ServerSettings, initialDemuxerSettings: immutable.Seq[Setting], upgraded: Boolean, log: Option[LoggingAdapter] = None): BidiFlow[Http2SubStream, FrameEvent, FrameEvent, Http2SubStream, ServerTerminator] =
+    BidiFlow.fromGraph(new Http2ServerDemux(settings, initialDemuxerSettings, upgraded, log))
 
   /**
    * Creates substreams for every stream and manages stream state machines

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2Demux.scala
@@ -5,6 +5,7 @@
 package akka.http.impl.engine.http2
 
 import akka.annotation.InternalApi
+import akka.event.LoggingAdapter
 import akka.http.impl.engine.http2.FrameEvent._
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2.Http2Protocol.ErrorCode.FLOW_CONTROL_ERROR
@@ -57,7 +58,7 @@ private[http2] class Http2ClientDemux(http2Settings: Http2ClientSettings, master
  * INTERNAL API
  */
 @InternalApi
-private[http2] class Http2ServerDemux(http2Settings: Http2ServerSettings, initialRemoteSettings: immutable.Seq[Setting], upgraded: Boolean)
+private[http2] class Http2ServerDemux(http2Settings: Http2ServerSettings, initialRemoteSettings: immutable.Seq[Setting], upgraded: Boolean, override val streamFailureLogOverride: Option[LoggingAdapter] = None)
   extends Http2Demux(http2Settings, initialRemoteSettings, upgraded, isServer = true) {
   // We don't provide access to incoming trailing request headers on the server side
   def wrapTrailingHeaders(headers: ParsedHeadersFrame): Option[ChunkStreamPart] = None
@@ -211,10 +212,13 @@ private[http2] abstract class Http2Demux(http2Settings: Http2CommonSettings, ini
 
   def wrapTrailingHeaders(headers: ParsedHeadersFrame): Option[HttpEntity.ChunkStreamPart]
   def completionTimeout: FiniteDuration
+  def streamFailureLogOverride: Option[LoggingAdapter] = None
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, ServerTerminator) = {
     object Logic extends TimerGraphStageLogic(shape) with Http2MultiplexerSupport with Http2StreamHandling with GenericOutletSupport with StageLogging with LogHelper with ServerTerminator {
       logic =>
+
+      override def streamFailureLog: LoggingAdapter = stage.streamFailureLogOverride.getOrElse(log)
 
       import Http2Demux.CompletionTimeout
       import Http2Demux.GoAwayGracePeriod

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -37,6 +37,8 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
   def pushGOAWAY(errorCode: ErrorCode, debug: String): Unit
   def dispatchSubstream(initialHeaders: ParsedHeadersFrame, data: Either[ByteString, Source[Any, Any]], correlationAttributes: Map[AttributeKey[_], _]): Unit
   def isUpgraded: Boolean
+  /** LoggingAdapter to use for response stream failure messages. Defaults to the stage log. */
+  def streamFailureLog: akka.event.LoggingAdapter = log
 
   def wrapTrailingHeaders(headers: ParsedHeadersFrame): Option[HttpEntity.ChunkStreamPart]
 
@@ -799,7 +801,8 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
       }
     }
     override def onUpstreamFailure(ex: Throwable): Unit = {
-      log.error(ex, s"Substream $streamId failed with $ex")
+      val streamKind = if (isServer) "HTTP/2 Response" else "HTTP/2 Request"
+      streamFailureLog.warning(ex, s"$streamKind stream for [stream $streamId] failed with '${ex.getMessage}'. Resetting stream.")
       multiplexer.pushControlFrame(RstStreamFrame(streamId, Http2Protocol.ErrorCode.INTERNAL_ERROR))
       handleOutgoingFailed(streamId, ex)
       cleanupStream()

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/server/HttpServerBluePrint.scala
@@ -458,7 +458,7 @@ private[http] object HttpServerBluePrint {
               val (newEntity, fut) = HttpEntity.captureTermination(e)
               fut.onComplete {
                 case Failure(ex) =>
-                  log.error(ex, s"Response stream for [${requestStart.debugString}] failed with '${ex.getMessage}'. Aborting connection.")
+                  log.warning(ex, s"Response stream for [${requestStart.debugString}] failed with '${ex.getMessage}'. Aborting connection.")
                 case _ => // ignore
               }(ExecutionContext.parasitic)
               newEntity

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/client/NewConnectionPoolSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/client/NewConnectionPoolSpec.scala
@@ -264,7 +264,7 @@ class NewConnectionPoolSpec extends AkkaSpecWithMaterializer("""
       val handlerSetter = Await.result(laterHandler.future, 1.second.dilated)
 
       // now fail the first one, expecting the server-side error message
-      EventFilter[RuntimeException](message = "Response stream for [GET /a] failed with 'Woops, slipped on a slippery slope.'. Aborting connection.", occurrences = 1) intercept {
+      EventFilter.warning(message = "Response stream for [GET /a] failed with 'Woops, slipped on a slippery slope.'. Aborting connection.", occurrences = 1) intercept {
         errorOnConnection1.failure(new RuntimeException("Woops, slipped on a slippery slope."))
       }
 

--- a/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/impl/engine/server/HttpServerSpec.scala
@@ -942,7 +942,7 @@ class HttpServerSpec extends AkkaSpec(
       netOut.expectComplete()
     })
 
-    "log error and reset connection when the response stream fails" in assertAllStagesStopped(new TestSetup {
+    "log warning and reset connection when the response stream fails" in assertAllStagesStopped(new TestSetup {
 
       send("""POST /inject-meteor HTTP/1.1
              |Host: example.com
@@ -966,7 +966,7 @@ class HttpServerSpec extends AkkaSpec(
       dataOutProbe.sendNext(ByteString("Hello"))
       netOut.expectUtf8EncodedString("5\r\nHello\r\n")
 
-      EventFilter.error("Response stream for [POST /inject-meteor] failed with 'Meteor wiped data center'. Aborting connection.", occurrences = 1).intercept {
+      EventFilter.warning("Response stream for [POST /inject-meteor] failed with 'Meteor wiped data center'. Aborting connection.", occurrences = 1).intercept {
         dataOutProbe.sendError(new RuntimeException("Meteor wiped data center"))
       }
 

--- a/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -524,7 +524,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         requestStream.expectRequest()
       }
       "send RST_STREAM when request entity data stream fails immediately" in new StreamingRequestSent {
-        EventFilter[RuntimeException](pattern = "Substream 1 failed with .*", occurrences = 1).intercept {
+        EventFilter.warning(pattern = "HTTP/2 Request stream for \\[stream 1\\] failed with '.*'. Resetting stream\\.", occurrences = 1).intercept {
           requestStream.sendError(new RuntimeException("boom"))
           network.expectRST_STREAM(streamId, ErrorCode.INTERNAL_ERROR)
         }
@@ -534,7 +534,7 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         requestStream.sendNext(ByteString("abc"))
         network.expectDATA(streamId, false, ByteString("abc"))
 
-        EventFilter[RuntimeException](pattern = "Substream 1 failed with .*", occurrences = 1).intercept {
+        EventFilter.warning(pattern = "HTTP/2 Request stream for \\[stream 1\\] failed with '.*'. Resetting stream\\.", occurrences = 1).intercept {
           requestStream.sendError(new RuntimeException("boom"))
           network.expectRST_STREAM(streamId, ErrorCode.INTERNAL_ERROR)
         }

--- a/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
+++ b/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/Http2ServerSpec.scala
@@ -820,7 +820,7 @@ class Http2ServerSpec extends AkkaSpecWithMaterializer("""
 
         class MyProblem extends RuntimeException
 
-        EventFilter[MyProblem](pattern = "Substream 1 failed with .*", occurrences = 1).intercept {
+        EventFilter.warning(pattern = "HTTP/2 Response stream for \\[stream 1\\] failed with '.*'. Resetting stream\\.", occurrences = 1).intercept {
           entityDataOut.sendError(new MyProblem)
           network.expectRST_STREAM(1, ErrorCode.INTERNAL_ERROR)
         }


### PR DESCRIPTION
 * If a custom logger for the server is set, use that for stream failures
 * Request/response stream failures are not critical, use warning level instead of error
 * Rephrase the HTTP/2 log slightly to make it clear what kind of stream that failed