### PR TITLE
build: bump h2spec and make possible to run on non x86

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,6 +366,19 @@ the plaintext traffic in Wireshark: you can set its `InterceptorPort` to
 the same value as the `ReturnPort` and then sniff the loopback interface and
 filter on that port.
 
+### h2spec (HTTP/2 conformance testing)
+
+The `H2SpecIntegrationSpec` test uses [h2spec](https://github.com/summerwind/h2spec) to validate
+HTTP/2 conformance. On amd64 platforms, the binary is downloaded automatically. On other architectures
+(e.g. Apple Silicon), you need to install it locally using Go:
+
+```
+go install github.com/summerwind/h2spec/cmd/h2spec@latest
+```
+
+The build checks both `PATH` and `~/go/bin`, so it should be found automatically.
+If h2spec is not available, the tests will be skipped rather than fail.
+
 ### golang
 
 When testing against a Go application, running with the environment variable

--- a/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -98,13 +98,16 @@ class H2SpecIntegrationSpec extends AkkaSpec(
       "5.5",
       "6.1",
       "6.3",
+      "6.5",
       "6.5.2",
       "6.9",
       "6.9.1",
       "6.10",
+      "8.1",
       "8.1.2",
       "8.1.2.1",
       "8.1.2.2",
+      "8.1.2.3",
       "8.1.2.6"
     )
 
@@ -158,7 +161,7 @@ class H2SpecIntegrationSpec extends AkkaSpec(
         "-p", port.toString,
         "-j", junitOutput.getPath
       ) ++
-        specSectionNumber.toList.flatMap(number => Seq("-s", number))
+        specSectionNumber.toList.map(number => s"http2/$number")
 
       log.debug(s"Executing h2spec: $command")
       val aggregateTckLogs = ProcessLogger(
@@ -182,7 +185,10 @@ class H2SpecIntegrationSpec extends AkkaSpec(
       exitedWith should be(0)
     }
 
-    def executable =
-      System.getProperty("h2spec.path").ensuring(_ != null, "h2spec.path property not defined")
+    def executable: String = {
+      val path = System.getProperty("h2spec.path")
+      if (path != null && new File(path).canExecute) path
+      else throw new org.scalatest.exceptions.TestCanceledException("h2spec not available - install it locally, see CONTRIBUTING.md", 0)
+    }
   }
 }

--- a/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/H2SpecIntegrationSpec.scala
+++ b/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/H2SpecIntegrationSpec.scala
@@ -91,18 +91,15 @@ class H2SpecIntegrationSpec extends AkkaSpec(
     /** Cases that are known to fail, but we haven't triaged yet */
     val pendingTestCases = Seq(
       "4.2",
-      "4.3",
       "5.1",
       "5.1.1",
       "5.1.2",
       "5.5",
       "6.1",
-      "6.3",
       "6.5",
       "6.5.2",
       "6.9",
       "6.9.1",
-      "6.10",
       "8.1",
       "8.1.2",
       "8.1.2.1",

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import akka._
 import AkkaDependency._
-import Dependencies.{h2specExe, h2specName}
+import Dependencies.{h2specExe, h2specExt, h2specName}
 import com.typesafe.sbt.MultiJvmPlugin.autoImport.MultiJvm
 import java.nio.file.Files
 import java.nio.file.attribute.{PosixFileAttributeView, PosixFilePermission}
@@ -211,7 +211,31 @@ lazy val http2Tests = project("akka-http2-tests")
   .settings(Dependencies.http2Tests)
   .settings {
     lazy val h2specPath = Def.task {
-      (Test / target).value / h2specName / h2specExe
+      // Check for a locally installed h2spec (needed for non-amd64 platforms like Apple Silicon)
+      val fromPath: Option[File] = {
+        // Check PATH
+        val onPath = scala.util.Try {
+          val path = scala.sys.process.Process(Seq("which", h2specExe)).!!.trim
+          val f = new File(path)
+          if (f.canExecute) Some(f) else None
+        }.getOrElse(None)
+        // Check common Go bin location
+        onPath.orElse {
+          val goDefault = new File(System.getProperty("user.home"), s"go/bin/$h2specExe")
+          if (goDefault.canExecute) Some(goDefault) else None
+        }
+      }
+
+      // Only fall back to the downloaded amd64 binary when on amd64
+      val isAmd64 = System.getProperty("os.arch") == "amd64" || System.getProperty("os.arch") == "x86_64"
+      fromPath.getOrElse(
+        if (isAmd64) (Test / target).value / h2specName / h2specExe
+        else {
+          streams.value.log.warn("h2spec not found on PATH and no prebuilt binary available for " + System.getProperty("os.arch") + ". " +
+            "Install h2spec locally: go install github.com/summerwind/h2spec/cmd/h2spec@latest")
+          (Test / target).value / "h2spec-not-available"
+        }
+      )
     }
     Seq(
       Test / run / fork := true,
@@ -222,11 +246,20 @@ lazy val http2Tests = project("akka-http2-tests")
         val log = streams.value.log
         val h2spec = h2specPath.value
 
-        if (!h2spec.exists) {
+        if (!h2spec.exists && h2spec.getName != "h2spec-not-available") {
           log.info("Extracting h2spec to " + h2spec)
 
-          for (zip <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = "zip")))
-            IO.unzip(zip, (Test / target).value)
+          val targetDir = (Test / target).value
+          for (archive <- (Test / update).value.select(artifact = artifactFilter(name = h2specName, extension = h2specExt))) {
+            if (h2specExt == "zip")
+              IO.unzip(archive, targetDir)
+            else {
+              // tar.gz: extract into h2specName subdirectory to match expected path
+              val extractDir = targetDir / h2specName
+              IO.createDirectory(extractDir)
+              scala.sys.process.Process(Seq("tar", "xzf", archive.getAbsolutePath, "-C", extractDir.getAbsolutePath)).!
+            }
+          }
 
           // Set the executable bit on the expected path to fail if it doesn't exist
           for (view <- Option(Files.getFileAttributeView(h2spec.toPath, classOf[PosixFileAttributeView]))) {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,10 +17,13 @@ object Dependencies {
   val jacksonDatabindVersion = "2.18.4"
   val jacksonXmlVersion = jacksonDatabindVersion
   val junitVersion = "4.13.2"
-  val h2specVersion = "1.5.0"
+  val h2specVersion = "2.6.0"
   val h2specName = s"h2spec_${DependencyHelpers.osName}_amd64"
   val h2specExe = "h2spec" + DependencyHelpers.exeIfWindows
-  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v${h2specVersion}/${h2specName}.zip"
+  // sbt resolves .tar.gz as extension "gz"
+  val h2specExt = if (DependencyHelpers.osName == "windows") "zip" else "gz"
+  private val h2specArchiveExt = if (DependencyHelpers.osName == "windows") "zip" else "tar.gz"
+  val h2specUrl = s"https://github.com/summerwind/h2spec/releases/download/v${h2specVersion}/${h2specName}.$h2specArchiveExt"
 
   val scalaTestVersion = "3.2.19"
   val specs2Version = "4.10.6"


### PR DESCRIPTION
Previously it has been impossible to run all the HTTP2 tests because hardcoded to only do x86.

This PR
  - Upgrades h2spec from 1.5.0 to 2.6.0 (latest)
  - enable a few h2spec test cases that now pass
  - Makes h2spec tests runnable on non-x86 platforms (e.g. Apple Silicon) by checking for a locally installed h2spec binary before falling back to the downloaded amd64
   binary
  - Tests skip gracefully when h2spec is not available instead of failing
  - Adapts test CLI flags for h2spec v2.x (http2/<section> positional arg instead of -s)
  - Adds install instructions for h2spec to CONTRIBUTING.md

On amd64 (CI), behavior is unchanged — the binary is downloaded automatically. On other architectures, developers can install h2spec via `go install github.com/summerwind/h2spec/cmd/h2spec@latest`.