### PR TITLE
chore: Treat HTTP/2 RST_STREAM(NO_ERROR) on an outgoing stream as graceful cancel

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/Http2StreamHandling.scala
@@ -802,8 +802,15 @@ private[http2] trait Http2StreamHandling extends GraphStageLogic with LogHelper 
     }
     override def onUpstreamFailure(ex: Throwable): Unit = {
       val streamKind = if (isServer) "HTTP/2 Response" else "HTTP/2 Request"
-      streamFailureLog.warning(ex, s"$streamKind stream for [stream $streamId] failed with '${ex.getMessage}'. Resetting stream.")
-      multiplexer.pushControlFrame(RstStreamFrame(streamId, Http2Protocol.ErrorCode.INTERNAL_ERROR))
+      ex match {
+        case pcse: PeerClosedStreamException if pcse.numericErrorCode == Http2Protocol.ErrorCode.NO_ERROR.id =>
+          // peer aborted transmission gracefully (NO_ERROR), cancel the stream rather than treating it as an error
+          streamFailureLog.debug(s"$streamKind stream for [stream $streamId] was cancelled with NO_ERROR. Cancelling stream.")
+          multiplexer.pushControlFrame(RstStreamFrame(streamId, Http2Protocol.ErrorCode.CANCEL))
+        case _ =>
+          streamFailureLog.warning(ex, s"$streamKind stream for [stream $streamId] failed with '${ex.getMessage}'. Resetting stream.")
+          multiplexer.pushControlFrame(RstStreamFrame(streamId, Http2Protocol.ErrorCode.INTERNAL_ERROR))
+      }
       handleOutgoingFailed(streamId, ex)
       cleanupStream()
     }

--- a/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
+++ b/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/Http2ClientSpec.scala
@@ -22,6 +22,7 @@ import akka.http.scaladsl.model.HttpEntity.Chunked
 import akka.http.scaladsl.model.HttpEntity.LastChunk
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.http2.PeerClosedStreamException
 import akka.http.scaladsl.model.headers.CacheDirectives._
 import akka.http.scaladsl.model.headers.{ RawHeader, `Access-Control-Allow-Origin`, `Cache-Control`, `Content-Length`, `Content-Type` }
 import akka.http.scaladsl.settings.ClientConnectionSettings
@@ -537,6 +538,19 @@ class Http2ClientSpec extends AkkaSpecWithMaterializer("""
         EventFilter.warning(pattern = "HTTP/2 Request stream for \\[stream 1\\] failed with '.*'. Resetting stream\\.", occurrences = 1).intercept {
           requestStream.sendError(new RuntimeException("boom"))
           network.expectRST_STREAM(streamId, ErrorCode.INTERNAL_ERROR)
+        }
+      }
+
+      "treat request entity failing with PeerClosedStreamException(NO_ERROR) as a graceful cancellation" in new StreamingRequestSent {
+        requestStream.sendNext(ByteString("abc"))
+        network.expectDATA(streamId, false, ByteString("abc"))
+
+        // The request entity source fails with a NO_ERROR PeerClosedStreamException, i.e. a graceful
+        // "stop sending" signal. That is not an error, so it should not be logged as a warning and
+        // should be forwarded as CANCEL rather than INTERNAL_ERROR.
+        EventFilter.warning(pattern = "HTTP/2 Request stream for \\[stream 1\\] failed with '.*'. Resetting stream\\.", occurrences = 0).intercept {
+          requestStream.sendError(new PeerClosedStreamException(19251, ErrorCode.NO_ERROR))
+          network.expectRST_STREAM(streamId, ErrorCode.CANCEL)
         }
       }
     }


### PR DESCRIPTION
When a request/response entity source fails with a PeerClosedStreamException carrying NO_ERROR, reset the outgoing stream with CANCEL and log at debug instead of resetting with
INTERNAL_ERROR and logging a warning.

This removes noisy warnings and misleading error resets in proxy scenarios where a peer gracefully aborts a stream (e.g. gRPC clients/linkerd).