### PR TITLE
fix: HTTP/2 connection unusable after a bad request response

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -98,8 +98,8 @@ private[http2] final class HeaderDecompression(masterHeaderParser: HttpHeaderPar
           headerLimitExceeded(s"Decoded header list for stream $streamId exceeded configured maximum of ${http2Settings.maxHeaderListSize} bytes")
         else parseError match {
           // push details further and let RequestErrorFlow handle responding with bad request
-          case Some(info) => push(eventsOut, ParsedHeadersFrame(streamId, endStream, Seq.empty, prioInfo, Some(info)))
-          case None       => push(eventsOut, ParsedHeadersFrame(streamId, endStream, headers.result(), prioInfo, None))
+          case Some(_) => push(eventsOut, ParsedHeadersFrame(streamId, endStream, Seq.empty, prioInfo, parseError))
+          case None    => push(eventsOut, ParsedHeadersFrame(streamId, endStream, headers.result(), prioInfo, None))
         }
       } catch {
         case _: IOException =>

--- a/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/engine/http2/hpack/HeaderDecompression.scala
@@ -11,7 +11,7 @@ import akka.http.impl.engine.http2.Http2Protocol.ErrorCode
 import akka.http.impl.engine.http2.RequestParsing.parseHeaderPair
 import akka.http.impl.engine.http2._
 import akka.http.impl.engine.parsing.HttpHeaderParser
-import akka.http.scaladsl.model.ParsingException
+import akka.http.scaladsl.model.{ ErrorInfo, ParsingException }
 import akka.http.scaladsl.settings.{ Http2CommonSettings, ParserSettings }
 import akka.http.shaded.com.twitter.hpack.HeaderListener
 import akka.stream._
@@ -51,6 +51,7 @@ private[http2] final class HeaderDecompression(masterHeaderParser: HttpHeaderPar
 
     def parseAndEmit(streamId: Int, endStream: Boolean, payload: ByteString, prioInfo: Option[PriorityFrame]): Unit = {
       val headers = new VectorBuilder[(String, AnyRef)]
+      var parseError: Option[ErrorInfo] = None
       object Receiver extends HeaderListener {
         def addHeader(name: String, value: String, parsed: AnyRef, sensitive: Boolean): AnyRef = {
           if (parsed ne null) {
@@ -63,20 +64,28 @@ private[http2] final class HeaderDecompression(masterHeaderParser: HttpHeaderPar
               parsed
             }
 
-            name match {
-              case "content-type"   => handle(ContentType.parse(name, value, parserSettings))
-              case ":authority"     => handle(Authority.parse(name, value, parserSettings))
-              case ":path"          => handle(PathAndQuery.parse(name, value, parserSettings))
-              case ":method"        => handle(Method.parse(name, value, parserSettings))
-              case ":scheme"        => handle(Scheme.parse(name, value, parserSettings))
-              case "content-length" => handle(ContentLength.parse(name, value, parserSettings))
-              case "cookie"         => handle(Cookie.parse(name, value, parserSettings))
-              case x if x(0) == ':' => handle(value)
-              case _ =>
-                // cannot use OtherHeader.parse because that doesn't has access to header parser
-                val header = parseHeaderPair(httpHeaderParser, name, value)
-                RequestParsing.validateHeader(header)
-                handle(header)
+            try {
+              name match {
+                case "content-type"   => handle(ContentType.parse(name, value, parserSettings))
+                case ":authority"     => handle(Authority.parse(name, value, parserSettings))
+                case ":path"          => handle(PathAndQuery.parse(name, value, parserSettings))
+                case ":method"        => handle(Method.parse(name, value, parserSettings))
+                case ":scheme"        => handle(Scheme.parse(name, value, parserSettings))
+                case "content-length" => handle(ContentLength.parse(name, value, parserSettings))
+                case "cookie"         => handle(Cookie.parse(name, value, parserSettings))
+                case x if x(0) == ':' => handle(value)
+                case _ =>
+                  // cannot use OtherHeader.parse because that doesn't has access to header parser
+                  val header = parseHeaderPair(httpHeaderParser, name, value)
+                  RequestParsing.validateHeader(header)
+                  handle(header)
+              }
+            } catch {
+              case ex: ParsingException =>
+                // the remainder of the block still has to be decoded to keep the HPACK dynamic table in sync
+                // with the peer, so remember the first error rather than letting it abort decoding
+                if (parseError.isEmpty) parseError = Some(ex.info)
+                null // nothing is cached for this header, so a later reference to it fails again
             }
           }
         }
@@ -87,13 +96,12 @@ private[http2] final class HeaderDecompression(masterHeaderParser: HttpHeaderPar
         // here, so not checking would hand a request with arbitrary headers missing to the application
         if (decoder.endHeaderBlock())
           headerLimitExceeded(s"Decoded header list for stream $streamId exceeded configured maximum of ${http2Settings.maxHeaderListSize} bytes")
-        else
-          push(eventsOut, ParsedHeadersFrame(streamId, endStream, headers.result(), prioInfo, None))
-      } catch {
-        case ex: ParsingException =>
-          decoder.endHeaderBlock() // decoding was aborted midway, reset the accumulated header list size
+        else parseError match {
           // push details further and let RequestErrorFlow handle responding with bad request
-          push(eventsOut, ParsedHeadersFrame(streamId, endStream, Seq.empty, prioInfo, Some(ex.info)))
+          case Some(info) => push(eventsOut, ParsedHeadersFrame(streamId, endStream, Seq.empty, prioInfo, Some(info)))
+          case None       => push(eventsOut, ParsedHeadersFrame(streamId, endStream, headers.result(), prioInfo, None))
+        }
+      } catch {
         case _: IOException =>
           // this is signalled by the decoder when it failed, we want to react to this by rendering a GOAWAY frame
           fail(eventsOut, new Http2Compliance.Http2ProtocolException(ErrorCode.COMPRESSION_ERROR, "Decompression failed."))

--- a/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
+++ b/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/Http2ClientServerSpec.scala
@@ -122,6 +122,33 @@ class Http2ClientServerSpec extends AkkaSpecWithMaterializer(
       val response = expectClientResponse()
       response.status should be(StatusCodes.BadRequest)
     }
+
+    "keep the connection usable after a bad request response" in new TestSetup {
+      // Parsing fails on the ':method' pseudo header, but the headers after it still entered the client's
+      // HPACK dynamic table. Unless the server decodes them too, the tables drift apart and every later
+      // request on the connection resolves its indices against the wrong entries.
+      sendClientRequest(HttpRequest(
+        method = HttpMethod.custom("UNKNOWN_TO_SERVER"),
+        uri = "http://www.example.com/test",
+        headers = headers.`Accept-Encoding`(HttpEncodings.gzip) :: Nil
+      ).addAttribute(requestIdAttr, RequestId("bad")))
+      expectClientResponse().status should be(StatusCodes.BadRequest)
+
+      // encoded largely as references into the dynamic table built up by the request above
+      sendClientRequest(HttpRequest(
+        uri = "http://www.example.com/test",
+        headers = headers.`Accept-Encoding`(HttpEncodings.gzip) :: Nil
+      ).addAttribute(requestIdAttr, RequestId("good")))
+
+      val serverRequest = expectServerRequest()
+      serverRequest.request.uri.path.toString shouldBe "/test"
+      serverRequest.request.header[headers.`Accept-Encoding`] should not be empty
+      serverRequest.sendResponse(HttpResponse(entity = "pong"))
+
+      val ok = expectClientResponse()
+      ok.attribute(requestIdAttr).get.id shouldBe "good"
+      Unmarshal(ok.entity).to[String].futureValue shouldBe "pong"
+    }
   }
 
   case class ServerRequest(request: HttpRequest, promise: Promise[HttpResponse]) {

--- a/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/hpack/HeaderDecompressionSpec.scala
+++ b/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/hpack/HeaderDecompressionSpec.scala
@@ -51,6 +51,28 @@ class HeaderDecompressionSpec extends AkkaSpecWithMaterializer {
       second.keyValuePairs.collectFirst { case ("x-marker", v) => v.toString } shouldBe Some("x-marker: hello")
     }
 
+    "only report the first of several parse errors in a header block, but still process every header" in {
+      val encoder = new HPackEncodingSupport {}
+
+      // both 'connection' and 'transfer-encoding' are forbidden in HTTP/2, each triggers its own
+      // ParsingException while decoding the same block
+      val rejected = encoder.encodeHeaderPairs(
+        pseudoHeaders("/one") ++ Seq("connection" -> "close", "transfer-encoding" -> "chunked", "x-marker" -> "hello"))
+      // encoded almost entirely as references into the dynamic table built up by the block above
+      val accepted = encoder.encodeHeaderPairs(pseudoHeaders("/one") :+ ("x-marker" -> "hello"))
+
+      val Seq(first, second) = decompress(ServerSettings(system), rejected, accepted)
+
+      first.headerParseErrorDetails.map(_.summary) shouldBe
+        Some("Malformed request: Header 'Connection' must not be used with HTTP/2")
+
+      // the dynamic table still reflects every header of the rejected block, including the ones after
+      // the first error, so later blocks referencing them decode correctly
+      second.headerParseErrorDetails shouldBe empty
+      second.keyValuePairs.collectFirst { case (":path", (path, _)) => path.toString } shouldBe Some("/one")
+      second.keyValuePairs.collectFirst { case ("x-marker", v) => v.toString } shouldBe Some("x-marker: hello")
+    }
+
     "not carry the decoded header list size of a rejected header block over to the next block" in {
       val settings = ServerSettings(system).mapHttp2Settings(_.withMaxHeaderListSize(200))
       val encoder = new HPackEncodingSupport {}

--- a/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/hpack/HeaderDecompressionSpec.scala
+++ b/akka-http2-tests/src/test/scala/akka/http/impl/engine/http2/hpack/HeaderDecompressionSpec.scala
@@ -10,18 +10,50 @@ import akka.http.impl.engine.parsing.HttpHeaderParser
 import akka.http.impl.util.AkkaSpecWithMaterializer
 import akka.http.scaladsl.settings.ServerSettings
 import akka.stream.scaladsl.{ Sink, Source }
+import akka.util.ByteString
 
 class HeaderDecompressionSpec extends AkkaSpecWithMaterializer {
 
+  def pseudoHeaders(path: String): Seq[(String, String)] =
+    Seq(":method" -> "GET", ":scheme" -> "http", ":path" -> path, ":authority" -> "www.example.com")
+
+  /** Runs the blocks through a single decompression stage, as they would arrive on one connection */
+  def decompress(settings: ServerSettings, blocks: ByteString*): Seq[ParsedHeadersFrame] = {
+    val parserSettings = settings.parserSettings
+    Source(blocks.zipWithIndex.map {
+      case (block, idx) => HeadersFrame(1 + idx * 2, endStream = true, endHeaders = true, block, None)
+    }.toList)
+      .via(new HeaderDecompression(HttpHeaderParser(parserSettings, log), parserSettings, settings.http2Settings))
+      .runWith(Sink.seq).futureValue
+      .map(_.asInstanceOf[ParsedHeadersFrame])
+  }
+
   "HeaderDecompression" should {
+
+    "keep the HPACK dynamic table in sync when a header block is rejected" in {
+      val encoder = new HPackEncodingSupport {}
+
+      // 'connection' is not allowed in HTTP/2 and is rejected, but the headers after it still enter the
+      // peer's dynamic table. If decoding stops at the rejected header the tables drift apart, and every
+      // later block on the connection resolves its indices against the wrong entries.
+      val rejected = encoder.encodeHeaderPairs(
+        pseudoHeaders("/one") ++ Seq("connection" -> "close", "x-marker" -> "hello"))
+      // encoded almost entirely as references into the dynamic table built up by the block above
+      val accepted = encoder.encodeHeaderPairs(pseudoHeaders("/one") :+ ("x-marker" -> "hello"))
+
+      val Seq(first, second) = decompress(ServerSettings(system), rejected, accepted)
+
+      first.headerParseErrorDetails.map(_.summary) shouldBe
+        Some("Malformed request: Header 'Connection' must not be used with HTTP/2")
+
+      second.headerParseErrorDetails shouldBe empty
+      second.keyValuePairs.collectFirst { case (":path", (path, _)) => path.toString } shouldBe Some("/one")
+      second.keyValuePairs.collectFirst { case ("x-marker", v) => v.toString } shouldBe Some("x-marker: hello")
+    }
 
     "not carry the decoded header list size of a rejected header block over to the next block" in {
       val settings = ServerSettings(system).mapHttp2Settings(_.withMaxHeaderListSize(200))
-      val parserSettings = settings.parserSettings
       val encoder = new HPackEncodingSupport {}
-
-      def pseudoHeaders(path: String): Seq[(String, String)] =
-        Seq(":method" -> "GET", ":scheme" -> "http", ":path" -> path, ":authority" -> "www.example.com")
 
       // 'connection' is not allowed in HTTP/2 so decoding is aborted when it is reached, after roughly 150
       // bytes of header list have already been counted. It is encoded as 'never indexed' so that the abort
@@ -31,13 +63,7 @@ class HeaderDecompressionSpec extends AkkaSpecWithMaterializer {
           encoder.encodeNeverIndexedHeader("connection", "close")
       val accepted = encoder.encodeHeaderPairs(pseudoHeaders("/two"))
 
-      val frames = Source(List(
-        HeadersFrame(1, endStream = true, endHeaders = true, rejected, None),
-        HeadersFrame(3, endStream = true, endHeaders = true, accepted, None)))
-        .via(new HeaderDecompression(HttpHeaderParser(parserSettings, log), parserSettings, settings.http2Settings))
-        .runWith(Sink.seq).futureValue
-
-      val Seq(first: ParsedHeadersFrame, second: ParsedHeadersFrame) = frames
+      val Seq(first, second) = decompress(settings, rejected, accepted)
 
       first.headerParseErrorDetails.map(_.summary) shouldBe Some("Malformed request: Header 'Connection' must not be used with HTTP/2")
       second.headerParseErrorDetails shouldBe empty


### PR DESCRIPTION
A header that fails validation, such as `Connection` or an unknown `:method`, aborted decoding of the whole block. The remaining headers never entered our HPACK dynamic table while the peer's encoder had already added them, so every later header block on the connection resolved its indices against the wrong entries. Header parse errors are now collected in the header listener so the block is always decoded to completion.