### PR TITLE
fix: end Inflater/Deflater on cancellation, not just normal stream completion

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/StreamUtils.scala
@@ -33,7 +33,10 @@ private[http] object StreamUtils {
    * input has been read it will call `finish` once to determine the final ByteString to post to the output.
    * Empty ByteStrings are discarded.
    */
-  def byteStringTransformer(f: ByteString => ByteString, finish: () => ByteString): GraphStage[FlowShape[ByteString, ByteString]] = new SimpleLinearGraphStage[ByteString] {
+  def byteStringTransformer(
+    f:       ByteString => ByteString,
+    finish:  () => ByteString,
+    cleanup: () => Unit               = () => ()): GraphStage[FlowShape[ByteString, ByteString]] = new SimpleLinearGraphStage[ByteString] {
     override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) with InHandler with OutHandler {
       override def onPush(): Unit = {
         val data = f(grab(in))
@@ -47,6 +50,12 @@ private[http] object StreamUtils {
         val data = finish()
         if (data.nonEmpty) emit(out, data)
         completeStage()
+      }
+
+      // ensures cleanup also happens on cancellation/failure, not just normal completion (which calls finish())
+      override def postStop(): Unit = {
+        cleanup()
+        super.postStop()
       }
 
       setHandlers(in, out, this)

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CompressionResourceLeakSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CompressionResourceLeakSpec.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.http.scaladsl.coding
+
+import java.util.zip.{ Deflater, Inflater }
+
+import akka.http.impl.util._
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import akka.testkit._
+import akka.util.ByteString
+import org.scalatest.Inspectors
+import org.scalatest.concurrent.Eventually
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.annotation.nowarn
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
+
+/**
+ * Reproduces a resource leak: java.util.zip.Inflater/Deflater instances used by the gzip/deflate
+ * (de)compression stages wrap native zlib memory that must be released explicitly via `.end()`.
+ * That only happens today on the normal-completion path (upstream finish / encoder finish()).
+ * If the stream is cancelled from downstream (e.g. a client disconnects mid-response) before
+ * that happens, the Inflater/Deflater is never ended.
+ *
+ * These tests drive the stages via TestSource/TestSink so that we can cancel the stream from
+ * downstream *before* upstream ever completes, and then assert that the underlying Inflater/
+ * Deflater was released. A released instance throws IllegalStateException("... has been closed")
+ * from any subsequent call (verified here via `reset()`), so that's used as the release check.
+ */
+@nowarn("msg=deprecated .* is internal API")
+class CompressionResourceLeakSpec extends AnyWordSpec with CodecSpecSupport with Eventually with Inspectors {
+  "GzipDecompressor" should {
+    "end its Inflater when the decode stream is cancelled before upstream finishes" in {
+      var captured: Inflater = null
+      class ProbeGzipDecompressor extends GzipDecompressor() {
+        override protected def newInflater(): Inflater = {
+          val inflater = super.newInflater()
+          captured = inflater
+          inflater
+        }
+      }
+
+      val compressed = new GzipCompressor().compressAndFinish(smallTextBytes)
+
+      val (pub, sub) = TestSource.probe[ByteString]
+        .via(Flow.fromGraph(new ProbeGzipDecompressor))
+        .toMat(TestSink.probe[ByteString])(Keep.both)
+        .run()
+
+      sub.request(1)
+      pub.sendNext(compressed)
+      sub.expectNext(2.seconds.dilated)
+      sub.cancel()
+
+      eventually { captured should not be null }
+      eventually { an[IllegalStateException] should be thrownBy captured.reset() }
+    }
+  }
+
+  "DeflateDecompressor" should {
+    "end its Inflater when the decode stream is cancelled before upstream finishes" in {
+      var captured: Inflater = null
+      class ProbeDeflateDecompressor extends DeflateDecompressor() {
+        override protected def newInflater(wrapped: Boolean): Inflater = {
+          val inflater = super.newInflater(wrapped)
+          captured = inflater
+          inflater
+        }
+      }
+
+      val compressed = new DeflateCompressor().compressAndFinish(smallTextBytes)
+
+      val (pub, sub) = TestSource.probe[ByteString]
+        .via(Flow.fromGraph(new ProbeDeflateDecompressor))
+        .toMat(TestSink.probe[ByteString])(Keep.both)
+        .run()
+
+      sub.request(1)
+      pub.sendNext(compressed)
+      sub.expectNext(2.seconds.dilated)
+      sub.cancel()
+
+      eventually { captured should not be null }
+      eventually { an[IllegalStateException] should be thrownBy captured.reset() }
+    }
+
+    "end every Inflater it creates, not just the last one, when decoding concatenated deflate blocks" in {
+      val captured = ArrayBuffer.empty[Inflater]
+      class ProbeDeflateDecompressor extends DeflateDecompressor() {
+        override protected def newInflater(wrapped: Boolean): Inflater = {
+          val inflater = super.newInflater(wrapped)
+          captured += inflater
+          inflater
+        }
+      }
+
+      // two independently-finished raw deflate blocks concatenated into a single stream: the decompressor
+      // creates a fresh Inflater for each block (see ProbeWrapping), so this must produce (at least) two
+      val concatenated =
+        new DeflateCompressor().compressAndFinish(smallTextBytes) ++
+          new DeflateCompressor().compressAndFinish(largeTextBytes)
+
+      Source.single(concatenated)
+        .via(Flow.fromGraph(new ProbeDeflateDecompressor))
+        .runWith(Sink.ignore)
+        .awaitResult(3.seconds.dilated)
+
+      captured.size should be > 1
+      forAll(captured) { inflater =>
+        an[IllegalStateException] should be thrownBy inflater.reset()
+      }
+    }
+  }
+
+  "the gzip Encoder" should {
+    "end its Deflater when the encode stream is cancelled before upstream finishes" in {
+      class ProbeGzipCompressor extends GzipCompressor {
+        def currentDeflater: Deflater = deflater
+      }
+      var captured: ProbeGzipCompressor = null
+      val probeEncoder = new Gzip(GzipCompressor.DefaultCompressionLevel, Encoder.DefaultFilter) {
+        override def newCompressor: ProbeGzipCompressor = {
+          val c = new ProbeGzipCompressor
+          captured = c
+          c
+        }
+      }
+
+      val (pub, sub) = TestSource.probe[ByteString]
+        .via(probeEncoder.encoderFlow)
+        .toMat(TestSink.probe[ByteString])(Keep.both)
+        .run()
+
+      sub.request(1)
+      pub.sendNext(smallTextBytes)
+      sub.expectNext(2.seconds.dilated)
+      sub.cancel()
+
+      eventually { captured should not be null }
+      eventually { an[IllegalStateException] should be thrownBy captured.currentDeflater.reset() }
+    }
+  }
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CompressionResourceLeakSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/coding/CompressionResourceLeakSpec.scala
@@ -28,11 +28,17 @@ import scala.concurrent.duration._
  *
  * These tests drive the stages via TestSource/TestSink so that we can cancel the stream from
  * downstream *before* upstream ever completes, and then assert that the underlying Inflater/
- * Deflater was released. A released instance throws IllegalStateException("... has been closed")
- * from any subsequent call (verified here via `reset()`), so that's used as the release check.
+ * Deflater was released. A released instance throws from any subsequent call (verified here via
+ * `reset()`) - NullPointerException on JDK 11/17, IllegalStateException on newer JDKs - so
+ * either is accepted as proof of release, see `assertReleased` below.
  */
 @nowarn("msg=deprecated .* is internal API")
 class CompressionResourceLeakSpec extends AnyWordSpec with CodecSpecSupport with Eventually with Inspectors {
+  private def assertReleased(action: => Unit): Unit = {
+    val thrown = the[Throwable] thrownBy action
+    thrown should (be(a[NullPointerException]) or be(a[IllegalStateException]))
+  }
+
   "GzipDecompressor" should {
     "end its Inflater when the decode stream is cancelled before upstream finishes" in {
       var captured: Inflater = null
@@ -57,7 +63,7 @@ class CompressionResourceLeakSpec extends AnyWordSpec with CodecSpecSupport with
       sub.cancel()
 
       eventually { captured should not be null }
-      eventually { an[IllegalStateException] should be thrownBy captured.reset() }
+      eventually { assertReleased(captured.reset()) }
     }
   }
 
@@ -85,7 +91,7 @@ class CompressionResourceLeakSpec extends AnyWordSpec with CodecSpecSupport with
       sub.cancel()
 
       eventually { captured should not be null }
-      eventually { an[IllegalStateException] should be thrownBy captured.reset() }
+      eventually { assertReleased(captured.reset()) }
     }
 
     "end every Inflater it creates, not just the last one, when decoding concatenated deflate blocks" in {
@@ -111,7 +117,7 @@ class CompressionResourceLeakSpec extends AnyWordSpec with CodecSpecSupport with
 
       captured.size should be > 1
       forAll(captured) { inflater =>
-        an[IllegalStateException] should be thrownBy inflater.reset()
+        assertReleased(inflater.reset())
       }
     }
   }
@@ -141,7 +147,7 @@ class CompressionResourceLeakSpec extends AnyWordSpec with CodecSpecSupport with
       sub.cancel()
 
       eventually { captured should not be null }
-      eventually { an[IllegalStateException] should be thrownBy captured.currentDeflater.reset() }
+      eventually { assertReleased(captured.currentDeflater.reset()) }
     }
   }
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/DeflateCompressor.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/DeflateCompressor.scala
@@ -55,6 +55,9 @@ class DeflateCompressor private[coding] (compressionLevel: Int) extends Compress
     res
   }
 
+  /** `Deflater.end()` is safe to call more than once. */
+  override def close(): Unit = deflater.end()
+
   private def newTempBuffer(size: Int = 65536): Array[Byte] = {
     // The default size is somewhat arbitrary, we'd like to guess a better value but Deflater/zlib
     // is buffering in an unpredictable manner.
@@ -92,13 +95,28 @@ private[coding] object DeflateCompressor {
 @InternalApi
 private[coding] class DeflateDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
 
+  /** Overridable for testing purposes */
+  protected def newInflater(wrapped: Boolean): Inflater = new Inflater(!wrapped)
+
   override def createLogic(attr: Attributes) = new ParsingLogic {
+    // the currently active inflater, i.e. the one created by the most recent examineAndBuildInflater call;
+    // ended in postStop so it is released on all termination paths (completion, cancellation, failure)
+    private[this] var currentInflater: Inflater = _
+
+    override def postStop(): Unit = {
+      if (currentInflater ne null) currentInflater.end()
+      super.postStop()
+    }
+
     /** Step that probes if the deflate stream contains a zlib wrapper */
     case object ProbeWrapping extends ParseStep[ByteString] {
       override def onTruncation(): Unit = completeStage()
 
       override def parse(reader: ByteStringParser.ByteReader): ParseResult[ByteString] = {
+        // re-entered as afterInflate once the previous inflater (if any) is finished(), so it's safe to end it here
+        if (currentInflater ne null) currentInflater.end()
         val inflater = examineAndBuildInflater(reader.remainingData)
+        currentInflater = inflater
         ParseResult(None, new Inflate(inflater, noPostProcessing = true, ProbeWrapping))
       }
     }
@@ -119,7 +137,7 @@ private[coding] class DeflateDecompressor(maxBytesPerChunk: Int = Decoder.MaxByt
      */
     private def examineAndBuildInflater(bytes: ByteString): Inflater = {
       val wrapped = (bytes.head & 0x0F) == 0x08
-      new Inflater(!wrapped)
+      newInflater(wrapped)
     }
 
     startWith(ProbeWrapping)

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/Encoder.scala
@@ -57,7 +57,7 @@ trait Encoder {
     def encodeChunk(bytes: ByteString): ByteString = compressor.compressAndFlush(bytes)
     def finish(): ByteString = compressor.finish()
 
-    StreamUtils.byteStringTransformer(encodeChunk, () => finish())
+    StreamUtils.byteStringTransformer(encodeChunk, () => finish(), () => compressor.close())
   }
 }
 
@@ -100,4 +100,11 @@ abstract class Compressor {
   def compressAndFlush(input: ByteString): ByteString
   /** Combines `compress` + `finish` */
   def compressAndFinish(input: ByteString): ByteString
+
+  /**
+   * Releases any native resources held by this Compressor. Called when the encoding stream terminates,
+   * whether by normal completion (in addition to `finish`), cancellation, or failure. Must be safe to call
+   * more than once. Default implementation does nothing.
+   */
+  def close(): Unit = ()
 }

--- a/akka-http/src/main/scala/akka/http/scaladsl/coding/GzipCompressor.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/coding/GzipCompressor.scala
@@ -60,9 +60,18 @@ private[coding] object GzipCompressor {
 /** Internal API */
 @InternalApi
 private[coding] class GzipDecompressor(maxBytesPerChunk: Int = Decoder.MaxBytesPerChunkDefault) extends DeflateDecompressorBase(maxBytesPerChunk) {
+  /** Overridable for testing purposes */
+  protected def newInflater(): Inflater = new Inflater(true)
+
   override def createLogic(attr: Attributes) = new ParsingLogic {
-    private[this] val inflater = new Inflater(true)
+    private[this] val inflater = newInflater()
     private[this] val crc32: CRC32 = new CRC32
+
+    // released on all termination paths (completion, cancellation, failure), not just normal completion
+    override def postStop(): Unit = {
+      inflater.end()
+      super.postStop()
+    }
 
     trait Step extends ParseStep[ByteString] {
       override def onTruncation(): Unit = failStage(new ZipException("Truncated GZIP stream"))


### PR DESCRIPTION
Gzip/deflate (de)compression stages held `java.util.zip.Inflater/Deflater` instances that wrap native zlib memory, but only released them (.end()) on normal stream completion — a client disconnecting mid-response, or any other cancellation/failure, leaked the native memory instead.

Added `postStop()`-based cleanup to the decompression stages (releasing every Inflater created, including for concatenated deflate blocks) and a `Compressor.close()` hook wired into the encoder's stream teardown, so resources are released on every termination path.