### PR TITLE
fix: match Unicode line terminators in SSE field payloads

### DIFF
--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParserSpec.scala
@@ -69,6 +69,14 @@ final class ServerSentEventParserSpec extends AsyncWordSpec with Matchers with B
           )
         )
     }
+    "parse a data field whose payload contains a Unicode line terminator that Java regex `.` doesn't match by default (e.g. U+0085 NEL)" in {
+      val nel = 0x0085.toChar // LineParser only splits on CR/LF, so this is legal mid-line payload content
+      val input = Vector(s"data:foo${nel}bar", "")
+      Source(input)
+        .via(new ServerSentEventParser(1048576, emitEmptyEvents = false))
+        .runWith(Sink.seq)
+        .map(_ shouldBe Vector(ServerSentEvent(s"foo${nel}bar")))
+    }
     "parse ServerSentEvents correctly (and pass empty events)" in {
       val input = """|data: event 1 line 1
                      |data:event 1 line 2

--- a/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParser.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/unmarshalling/sse/ServerSentEventParser.scala
@@ -82,7 +82,8 @@ private object ServerSentEventParser {
 
   private final val Retry = "retry"
 
-  private val Field = """([^:]+): ?(.*)""".r
+  // (?s) so `.` also matches U+0085/U+2028/U+2029, which LineParser doesn't split lines on and so are legal payload
+  private val Field = """(?s)([^:]+): ?(.*)""".r
 }
 
 /** INTERNAL API */


### PR DESCRIPTION
`ServerSentEventParser`'s field regex used `.` for the payload, which Java excludes from matching U+0085/U+2028/U+2029 by default but `LineParser` only splits on CR/LF, so those characters are legal mid-line payload content.

This silently dropped any SSE field (data/event/id/retry) whose value contained one of those characters, since the whole line failed to match and fell through to the ignore case. Adds `(?s)` (DOTALL) to the field regex, plus a regression test reproducing the drop with a U+0085 payload.
