### PR TITLE
chore: consistently use Locale.ROOT for casing

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/settings/ParserSettingsImpl.scala
@@ -98,7 +98,7 @@ object ParserSettingsImpl extends SettingsCompanionImpl[ParserSettingsImpl]("akk
       Uri.ParsingMode(c.getString("uri-parsing-mode")),
       CookieParsingMode(c.getString("cookie-parsing-mode")),
       c.getBoolean("illegal-header-warnings"),
-      c.getStringList("ignore-illegal-header-for").asScala.map(_.toLowerCase).toSet,
+      c.getStringList("ignore-illegal-header-for").asScala.map(_.toRootLowerCase).toSet,
       ErrorLoggingVerbosity(c.getString("error-logging-verbosity")),
       IllegalResponseHeaderNameProcessingMode(c.getString("illegal-response-header-name-processing-mode")),
       IllegalResponseHeaderValueProcessingMode(c.getString("illegal-response-header-value-processing-mode")),

--- a/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedString.scala
+++ b/akka-http-core/src/main/scala/akka/http/impl/util/EnhancedString.scala
@@ -122,4 +122,10 @@ private[http] class EnhancedString(val underlying: String) extends AnyVal {
    * See http://bugs.java.com/view_bug.do?bug_id=6208680
    */
   def toRootLowerCase: String = underlying.toLowerCase(Locale.ROOT)
+
+  /**
+   * Provides a default toUpperCase that doesn't suffer from the dreaded turkish-i problem.
+   * See http://bugs.java.com/view_bug.do?bug_id=6208680
+   */
+  def toRootUpperCase: String = underlying.toUpperCase(Locale.ROOT)
 }

--- a/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/javadsl/settings/ParserSettings.scala
@@ -12,6 +12,7 @@ import akka.http.impl.settings.ParserSettingsImpl
 import java.{ util => ju }
 
 import akka.annotation.DoNotInherit
+import akka.http.impl.util._
 import akka.http.impl.util.JavaMapping.Implicits._
 
 import scala.annotation.varargs
@@ -74,7 +75,7 @@ abstract class ParserSettings private[akka] () extends BodyPartParser.Settings {
   def withIncludeTlsSessionInfoHeader(newValue: Boolean): ParserSettings = self.copy(includeTlsSessionInfoHeader = newValue)
   def withIncludeSslSessionAttribute(newValue: Boolean): ParserSettings = self.copy(includeSslSessionAttribute = newValue)
   def withModeledHeaderParsing(newValue: Boolean): ParserSettings = self.copy(modeledHeaderParsing = newValue)
-  def withIgnoreIllegalHeaderFor(newValue: List[String]): ParserSettings = self.copy(ignoreIllegalHeaderFor = newValue.map(_.toLowerCase).toSet)
+  def withIgnoreIllegalHeaderFor(newValue: List[String]): ParserSettings = self.copy(ignoreIllegalHeaderFor = newValue.map(_.toRootLowerCase).toSet)
 
   // special ---
 

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/ErrorInfo.scala
@@ -6,6 +6,7 @@ package akka.http.scaladsl.model
 
 import StatusCodes.ClientError
 import akka.annotation.InternalApi
+import akka.http.impl.util._
 
 /**
  * Two-level model of error information.
@@ -20,7 +21,7 @@ final class ErrorInfo(
 ) extends scala.Product with scala.Equals with java.io.Serializable {
   def withSummary(newSummary: String) = copy(summary = newSummary)
   def withSummaryPrepended(prefix: String) = withSummary(if (summary.isEmpty) prefix else prefix + ": " + summary)
-  def withErrorHeaderName(headerName: String) = new ErrorInfo(summary, detail, headerName.toLowerCase)
+  def withErrorHeaderName(headerName: String) = new ErrorInfo(summary, detail, headerName.toRootLowerCase)
   def withFallbackSummary(fallbackSummary: String) = if (summary.isEmpty) withSummary(fallbackSummary) else this
   def formatPretty = if (summary.isEmpty) detail else if (detail.isEmpty) summary else summary + ": " + detail
   def format(withDetail: Boolean): String = if (withDetail) formatPretty else summary

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/HttpHeader.scala
@@ -8,7 +8,7 @@ import akka.annotation.InternalApi
 
 import scala.util.{ Failure, Success }
 import akka.parboiled2.ParseError
-import akka.http.impl.util.ToStringRenderable
+import akka.http.impl.util._
 import akka.http.impl.model.parser.{ CharacterClasses, HeaderParser }
 import akka.http.javadsl.model.headers.CustomHeader
 import akka.http.javadsl.{ model => jm }
@@ -80,7 +80,7 @@ object HttpHeader {
       val parser = new HeaderParser(value, settings)
       parser.`header-field-value`.run() match {
         case Success(preProcessedValue) =>
-          HeaderParser.parseFull(name.toLowerCase, preProcessedValue, settings) match {
+          HeaderParser.parseFull(name.toRootLowerCase, preProcessedValue, settings) match {
             case HeaderParser.Success(header) => ParsingResult.Ok(header, Nil)
             case HeaderParser.Failure(info) =>
               val errors = info.withSummaryPrepended(s"Illegal HTTP header '$name'") :: Nil

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/MediaType.scala
@@ -63,7 +63,7 @@ sealed abstract class MediaType(_mainType: String, _subType: String) extends jm.
       case _            => false
     }
 
-  override def hashCode(): Int = value.toLowerCase.hashCode
+  override def hashCode(): Int = value.toRootLowerCase.hashCode
 
   /**
    * JAVA API
@@ -308,12 +308,12 @@ object MediaTypes extends ObjectRegistry[(String, String), MediaType] {
 
   private[this] var extensionMap = Map.empty[String, MediaType]
 
-  def forExtensionOption(ext: String): Option[MediaType] = extensionMap.get(ext.toLowerCase)
-  def forExtension(ext: String): MediaType = extensionMap.getOrElse(ext.toLowerCase, `application/octet-stream`)
+  def forExtensionOption(ext: String): Option[MediaType] = extensionMap.get(ext.toRootLowerCase)
+  def forExtension(ext: String): MediaType = extensionMap.getOrElse(ext.toRootLowerCase, `application/octet-stream`)
 
   private def registerFileExtensions[T <: MediaType](mediaType: T): T = {
     mediaType.fileExtensions.foreach { ext =>
-      val lcExt = ext.toLowerCase
+      val lcExt = ext.toRootLowerCase
       require(!extensionMap.contains(lcExt), s"Extension '$ext' clash: media-types '${extensionMap(lcExt)}' and '$mediaType'")
       extensionMap = extensionMap.updated(lcExt, mediaType)
     }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -845,7 +845,7 @@ object Uri {
         if (allowed(c)) verify(ix + 1, `scheme-char`, allLower && !UPPER_ALPHA(c)) else ix
       } else if (allLower) -1 else -2
     verify() match {
-      case -2 => scheme.toLowerCase
+      case -2 => scheme.toRootLowerCase
       case -1 => scheme
       case ix => fail(s"Invalid URI scheme, unexpected character at pos $ix ('${scheme charAt ix}')")
     }

--- a/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/settings/ParserSettings.scala
@@ -113,7 +113,7 @@ abstract class ParserSettings private[akka] () extends akka.http.javadsl.setting
   override def withIncludeTlsSessionInfoHeader(newValue: Boolean): ParserSettings = self.copy(includeTlsSessionInfoHeader = newValue)
   override def withIncludeSslSessionAttribute(newValue: Boolean): ParserSettings = self.copy(includeSslSessionAttribute = newValue)
   override def withModeledHeaderParsing(newValue: Boolean): ParserSettings = self.copy(modeledHeaderParsing = newValue)
-  override def withIgnoreIllegalHeaderFor(newValue: List[String]): ParserSettings = self.copy(ignoreIllegalHeaderFor = newValue.map(_.toLowerCase).toSet)
+  override def withIgnoreIllegalHeaderFor(newValue: List[String]): ParserSettings = self.copy(ignoreIllegalHeaderFor = newValue.map(_.toRootLowerCase).toSet)
 
   // overloads for idiomatic Scala use
   def withUriParsingMode(newValue: Uri.ParsingMode): ParserSettings = self.copy(uriParsingMode = newValue)

--- a/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
+++ b/akka-http-testkit/src/main/scala/akka/http/scaladsl/testkit/RouteTest.scala
@@ -5,6 +5,7 @@
 package akka.http.scaladsl.testkit
 
 import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
+import akka.http.impl.util._
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
@@ -82,7 +83,7 @@ trait RouteTest extends RequestBuilding with WSTestRequestBuilding with RouteTes
   def charset: HttpCharset = charsetOption getOrElse sys.error("Binary entity does not have charset")
   def headers: immutable.Seq[HttpHeader] = rawResponse.headers
   def header[T >: Null <: HttpHeader: ClassTag]: Option[T] = rawResponse.header[T](implicitly[ClassTag[T]])
-  def header(name: String): Option[HttpHeader] = rawResponse.headers.find(_.is(name.toLowerCase))
+  def header(name: String): Option[HttpHeader] = rawResponse.headers.find(_.is(name.toRootLowerCase))
   def status: StatusCode = rawResponse.status
 
   def closingExtension: String = chunks.lastOption match {

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/HeaderDirectives.scala
@@ -80,7 +80,7 @@ trait HeaderDirectives {
    * @group header
    */
   def headerValueByName(headerName: String): Directive1[String] =
-    headerValue(optionalValue(headerName.toLowerCase)) | reject(MissingHeaderRejection(headerName))
+    headerValue(optionalValue(headerName.toRootLowerCase)) | reject(MissingHeaderRejection(headerName))
 
   /**
    * Extracts the first HTTP request header of the given type.

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/directives/MethodDirectives.scala
@@ -5,6 +5,7 @@
 package akka.http.scaladsl.server
 package directives
 
+import akka.http.impl.util._
 import akka.http.scaladsl.model.{ StatusCodes, HttpMethod }
 import akka.http.scaladsl.model.HttpMethods._
 
@@ -101,7 +102,7 @@ trait MethodDirectives {
   def overrideMethodWithParameter(paramName: String): Directive0 =
     parameter(paramName.optional) flatMap {
       case Some(method) =>
-        getForKey(method.toUpperCase) match {
+        getForKey(method.toRootUpperCase) match {
           case Some(m) => mapRequest(_.withMethod(m))
           case _       => complete(StatusCodes.NotImplemented)
         }


### PR DESCRIPTION
Not a huge thing but we overlooked and used JVM selected locale in a few places, which could mess things up (turkish for example).