### PR TITLE
perf: avoid re-parsing and encoding in Uri#withQuery

### DIFF
--- a/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
+++ b/akka-http-core/src/main/scala/akka/http/scaladsl/model/Uri.scala
@@ -118,7 +118,10 @@ sealed abstract case class Uri(scheme: String, authority: Authority, path: Path,
   /**
    * Returns a copy of this Uri with the given query.
    */
-  def withQuery(query: Query): Uri = copy(rawQueryString = if (query.isEmpty) None else Some(query.toString))
+  def withQuery(query: Query): Uri =
+    // Query.toString already renders a valid raw query string (only permitted characters, others
+    // percent-encoded), so we can skip the re-parsing/re-validation that `copy` would otherwise do.
+    Uri.createUnsafe(scheme, authority, path, if (query.isEmpty) None else Some(query.toString), fragment)
 
   /**
    * Returns a copy of this Uri with the given query string.

--- a/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
+++ b/akka-http-core/src/test/scala/akka/http/scaladsl/model/UriSpec.scala
@@ -841,6 +841,11 @@ class UriSpec extends AnyWordSpec with Matchers {
       uri.withRawQueryString("param1=val%22ue1").toString shouldEqual "http://host/path?param1=val%22ue1#fragment"
       uri.withRawQueryString("param1=val\"ue1").toString shouldEqual "http://host/path?param1=val%22ue1#fragment"
       uri.withRawQueryString("param1=val|ue1").toString shouldEqual "http://host/path?param1=val%7Cue1#fragment"
+
+      // characters that must be percent-encoded because they are separators, not just "invalid": & = ; + and space,
+      // plus control chars and non-ASCII, exercised through Query (not a pre-encoded raw string)
+      uri.withQuery(Query("a&b=c;d+e" -> "f ghé")).toString shouldEqual
+        "http://host/path?a%26b%3Dc%3Bd%2Be=f+g%01h%C3%A9#fragment"
     }
 
     "survive parsing a URI with thousands of path segments" in {


### PR DESCRIPTION
`Uri.withQuery` needlessly re-parsed and re-validated the already-correctly-encoded output of `Query.toString`. This builds the Uri directly via `Uri.createUnsafe`, skipping that redundant work. 

Behavior unchanged — verified by existing tests plus a new one covering tricky characters.