### PR TITLE
feat: allow custom ExecutionContext/Materializer when converting Route to handler function

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/RouteHandlerExecutionContextTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/RouteHandlerExecutionContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2026 Lightbend Inc. <https://akka.io>
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://akka.io>
  */
 
 package akka.http.javadsl.server;

--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/RouteHandlerExecutionContextTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/RouteHandlerExecutionContextTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2009-2026 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.http.javadsl.server;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCodes;
+import akka.japi.function.Function;
+import akka.stream.Materializer;
+import akka.stream.SystemMaterializer;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.testkit.javadsl.TestKit;
+import org.junit.Test;
+import scala.concurrent.ExecutionContextExecutor;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class RouteHandlerExecutionContextTest {
+
+  @Test
+  public void usesGivenExecutionContextAndMaterializerInsteadOfSystemDefaults() throws Exception {
+    ActorSystem system = ActorSystem.create("RouteHandlerExecutionContextTest");
+    try {
+      // Route completes asynchronously (via a not-yet-resolved CompletableFuture) so that the
+      // final RouteResult -> HttpResponse mapping is actually scheduled on an ExecutionContext,
+      // rather than run inline as FastFuture does for already-completed Futures.
+      CompletableFuture<String> promise = new CompletableFuture<>();
+      Route route = Directives.onSuccess(promise, Directives::complete);
+
+      AtomicInteger submissionCount = new AtomicInteger(0);
+      ExecutionContextExecutor delegate = system.dispatcher();
+      ExecutionContextExecutor countingEc =
+          new ExecutionContextExecutor() {
+            @Override
+            public void execute(Runnable runnable) {
+              submissionCount.incrementAndGet();
+              delegate.execute(runnable);
+            }
+
+            @Override
+            public void reportFailure(Throwable cause) {
+              delegate.reportFailure(cause);
+            }
+          };
+      Materializer materializer = SystemMaterializer.get(system).materializer();
+
+      Function<HttpRequest, CompletionStage<HttpResponse>> handler =
+          route.handler(system, countingEc, materializer);
+
+      CompletionStage<HttpResponse> responseFuture = handler.apply(HttpRequest.create());
+      promise.complete("ok");
+      HttpResponse response = responseFuture.toCompletableFuture().get();
+
+      assertEquals(StatusCodes.OK, response.status());
+      assertTrue("expected the given ExecutionContext to be used", submissionCount.get() > 0);
+    } finally {
+      TestKit.shutdownActorSystem(system);
+    }
+  }
+
+  @Test
+  public void flowUsesGivenMaterializerInsteadOfSystemDefault() throws Exception {
+    ActorSystem system = ActorSystem.create("RouteHandlerExecutionContextTestFlow");
+    try {
+      Materializer givenMaterializer = Materializer.createMaterializer(system);
+      AtomicReference<Materializer> observedMaterializer = new AtomicReference<>();
+      Route route =
+          Directives.extractMaterializer(
+              mat -> {
+                observedMaterializer.set(mat);
+                return Directives.complete("ok");
+              });
+
+      akka.stream.javadsl.Flow<HttpRequest, HttpResponse, NotUsed> flow =
+          route.flow(system, givenMaterializer);
+
+      HttpResponse response =
+          Source.single(HttpRequest.create())
+              .via(flow)
+              .runWith(Sink.head(), SystemMaterializer.get(system).materializer())
+              .toCompletableFuture()
+              .get();
+
+      assertEquals(StatusCodes.OK, response.status());
+      assertSame(
+          "expected the given Materializer to be used for the route, not the SystemMaterializer",
+          givenMaterializer,
+          observedMaterializer.get());
+    } finally {
+      TestKit.shutdownActorSystem(system);
+    }
+  }
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RouteToFunctionExecutionContextSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RouteToFunctionExecutionContextSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2009-2026 Lightbend Inc. <https://akka.io>
+ */
+
+package akka.http.scaladsl.server
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{ HttpRequest, StatusCodes }
+import akka.http.scaladsl.server.Directives.{ complete, onSuccess }
+import akka.stream.SystemMaterializer
+import akka.testkit.TestKit
+
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContextExecutor, Promise }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class RouteToFunctionExecutionContextSpec extends AnyWordSpec with Matchers {
+  "Route.toFunction" should {
+    "use the default system dispatcher when no ExecutionContext/Materializer are given" in {
+      implicit val system: ActorSystem = ActorSystem("RouteToFunctionExecutionContextSpec1")
+      try {
+        val route: Route = complete(StatusCodes.OK)
+        val handler = Route.toFunction(route)
+        val response = Await.result(handler(HttpRequest()), 5.seconds)
+        response.status shouldBe StatusCodes.OK
+      } finally TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    }
+
+    "use the given ExecutionContext instead of the system dispatcher when one is provided" in {
+      implicit val system: ActorSystem = ActorSystem("RouteToFunctionExecutionContextSpec2")
+      try {
+        // Route completes asynchronously (via a not-yet-resolved Promise) so that the final
+        // RouteResult -> HttpResponse mapping is actually scheduled on an ExecutionContext,
+        // rather than run inline as FastFuture does for already-completed Futures.
+        val promise = Promise[String]()
+        val route: Route = onSuccess(promise.future) { s => complete(s) }
+
+        val submissionCount = new AtomicInteger(0)
+        val countingEc: ExecutionContextExecutor = new ExecutionContextExecutor {
+          private val delegate = system.dispatcher
+          override def execute(runnable: Runnable): Unit = {
+            submissionCount.incrementAndGet()
+            delegate.execute(runnable)
+          }
+          override def reportFailure(cause: Throwable): Unit = delegate.reportFailure(cause)
+        }
+
+        val handler = Route.toFunction(route, countingEc, SystemMaterializer(system).materializer)
+        val responseFuture = handler(HttpRequest())
+        promise.success("ok")
+        val response = Await.result(responseFuture, 5.seconds)
+
+        response.status shouldBe StatusCodes.OK
+        submissionCount.get() should be > 0
+      } finally TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    }
+
+    "fall back to the system dispatcher/SystemMaterializer when null is passed explicitly" in {
+      implicit val system: ActorSystem = ActorSystem("RouteToFunctionExecutionContextSpec3")
+      try {
+        val route: Route = complete(StatusCodes.OK)
+        val handler = Route.toFunction(route, null, null)
+        val response = Await.result(handler(HttpRequest()), 5.seconds)
+        response.status shouldBe StatusCodes.OK
+      } finally TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    }
+  }
+}

--- a/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RouteToFunctionExecutionContextSpec.scala
+++ b/akka-http-tests/src/test/scala/akka/http/scaladsl/server/RouteToFunctionExecutionContextSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2026 Lightbend Inc. <https://akka.io>
+ * Copyright (C) 2009-2025 Lightbend Inc. <https://akka.io>
  */
 
 package akka.http.scaladsl.server

--- a/akka-http/src/main/mima-filters/10.7.6.backwards.excludes/4563-route-handler-custom-ec-mat.excludes
+++ b/akka-http/src/main/mima-filters/10.7.6.backwards.excludes/4563-route-handler-custom-ec-mat.excludes
@@ -1,0 +1,2 @@
+# Added handler overload allowing custom ExecutionContext/Materializer, akka.http.javadsl.server.Route is @DoNotInherit
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.http.javadsl.server.Route.handler")

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Route.scala
@@ -20,6 +20,8 @@ import akka.stream.SystemMaterializer
 import akka.stream.javadsl.Flow
 import akka.japi.function.Function
 
+import scala.concurrent.ExecutionContextExecutor
+
 /**
  * In the Java DSL, a Route can only consist of combinations of the built-in directives. A Route can not be
  * instantiated directly.
@@ -57,6 +59,13 @@ trait Route extends HandlerProvider {
 
   def function(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]] = handler(system)
   def handler(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]]
+
+  /**
+   * Like `handler(system)`, but allows overriding the `ExecutionContext` and `Materializer` used to
+   * complete requests, instead of defaulting to `system.dispatcher()` and the `SystemMaterializer`.
+   * Pass `null` for either parameter to keep its default.
+   */
+  def handler(system: ClassicActorSystemProvider, executionContext: ExecutionContextExecutor, materializer: Materializer): Function[HttpRequest, CompletionStage[HttpResponse]]
 
   /**
    * Seals a route by wrapping it with default exception handling and rejection conversion.

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteAdapter.scala
@@ -23,6 +23,8 @@ import akka.japi.function.Function
 import akka.stream.{ Materializer, javadsl }
 import akka.stream.scaladsl.Flow
 
+import scala.concurrent.ExecutionContextExecutor
+
 /** INTERNAL API */
 @InternalApi
 final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends Route {
@@ -30,17 +32,19 @@ final class RouteAdapter(val delegate: akka.http.scaladsl.server.Route) extends 
   override def flow(system: ActorSystem, materializer: Materializer): javadsl.Flow[HttpRequest, HttpResponse, NotUsed] =
     scalaFlow(system, materializer).asJava
 
-  override def handler(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]] = {
+  override def handler(system: ClassicActorSystemProvider): Function[HttpRequest, CompletionStage[HttpResponse]] =
+    handler(system, null, null)
 
+  override def handler(system: ClassicActorSystemProvider, executionContext: ExecutionContextExecutor, materializer: Materializer): Function[HttpRequest, CompletionStage[HttpResponse]] = {
     import scala.jdk.FutureConverters._
-    import akka.http.impl.util.JavaMapping._
-    val scalaFunction = scaladsl.server.Route.toFunction(delegate)(system)
-    request => scalaFunction(request.asScala).map(_.asJava)(system.classicSystem.dispatcher).asJava
+    val effectiveEc = if (executionContext ne null) executionContext else system.classicSystem.dispatcher
+    val scalaFunction = scaladsl.server.Route.toFunction(delegate, executionContext, materializer)(system)
+    request => scalaFunction(request.asScala).map(_.asJava)(effectiveEc).asJava
   }
 
   private def scalaFlow(system: ActorSystem, materializer: Materializer): Flow[HttpRequest, HttpResponse, NotUsed] = {
     implicit val s: ActorSystem = system
-    Flow[HttpRequest].map(_.asScala).via(delegate).map(_.asJava)
+    Flow[HttpRequest].map(_.asScala).via(scaladsl.server.Route.toFlow(delegate, null, materializer)).map(_.asJava)
   }
 
   override def orElse(alternative: Route): Route =

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Route.scala
@@ -60,6 +60,14 @@ object Route {
     Flow[HttpRequest].mapAsync(1)(toFunction(route))
 
   /**
+   * Turns a `Route` into a server flow, like `toFlow`, but allows overriding the `ExecutionContext` and
+   * `Materializer` used to complete requests. Pass `null` for either parameter to keep its default
+   * (`system.dispatcher` and `SystemMaterializer(system).materializer`, respectively).
+   */
+  def toFlow(route: Route, executionContext: ExecutionContextExecutor, materializer: Materializer)(implicit system: ClassicActorSystemProvider): Flow[HttpRequest, HttpResponse, NotUsed] =
+    Flow[HttpRequest].mapAsync(1)(toFunction(route, executionContext, materializer))
+
+  /**
    * Turns a `Route` into a server flow.
    */
   @deprecated("Replaced by `toFlow` that takes an implicit ActorSystem.", "10.2.0")
@@ -73,7 +81,16 @@ object Route {
                                 exceptionHandler: ExceptionHandler         = null): Flow[HttpRequest, HttpResponse, NotUsed] =
     Flow[HttpRequest].mapAsync(1)(asyncHandler(route))
 
-  def toFunction(route: Route)(implicit system: ClassicActorSystemProvider): HttpRequest => Future[HttpResponse] = {
+  def toFunction(route: Route)(implicit system: ClassicActorSystemProvider): HttpRequest => Future[HttpResponse] =
+    toFunction(route, null, null)
+
+  /**
+   * Turns a `Route` into an async handler function, like `toFunction`, but allows overriding the
+   * `ExecutionContext` and `Materializer` used to complete requests, instead of defaulting to
+   * `system.dispatcher` and `SystemMaterializer(system).materializer`. Pass `null` for either
+   * parameter to keep its default.
+   */
+  def toFunction(route: Route, executionContext: ExecutionContextExecutor, materializer: Materializer)(implicit system: ClassicActorSystemProvider): HttpRequest => Future[HttpResponse] = {
     val routingLog = RoutingLog(system.classicSystem.log)
     val routingSettings = RoutingSettings(system)
     val parserSettings = ParserSettings.forServer
@@ -85,7 +102,9 @@ object Route {
         .tapply(_ => route)
     }
 
-    createAsyncHandler(sealedRoute, routingLog, routingSettings, parserSettings)(system.classicSystem.dispatcher, SystemMaterializer(system).materializer)
+    val effectiveEc = if (executionContext ne null) executionContext else system.classicSystem.dispatcher
+    val effectiveMat = if (materializer ne null) materializer else SystemMaterializer(system).materializer
+    createAsyncHandler(sealedRoute, routingLog, routingSettings, parserSettings)(effectiveEc, effectiveMat)
   }
 
   /**


### PR DESCRIPTION
References #4563

`Route.toFunction`/`toFlow` (Scala) and `Route.handler` (Java) gained overloads that accept an explicit `ExecutionContext`/`Materializer` instead of always defaulting to
`system.dispatcher`/`SystemMaterializer`, restoring the flexibility the deprecated asyncHandler used to offer, so routes served on a custom dispatcher no longer complete on the shared default dispatcher regardless of `ServerBuilder.withMaterializer`.

Also fixes a related bug: `RouteAdapter.flow(system, materializer)` (Java) was silently ignoring the given materializer and always using `SystemMaterializer`.

`ServerBuilder.bind()` itself is unchanged (adding an overload there isn't possible, `ServerBuilder` lives in akka-http-core, which `Route` can't be referenced from, and there'd also be source/bin compat problems with that).

Users needing isolation now call `.bind(Route.toFunction(route, ec, mat))` or `.bind(route.handler(system, ec, mat)::apply)` explicitly.