### PR TITLE
build: fix log statup warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -215,6 +215,8 @@ lazy val http2Tests = project("akka-http2-tests")
   .settings(Dependencies.http2Tests)
   .settings {
     lazy val h2specPath = Def.task {
+      val log = streams.value.log
+      val testTarget = (Test / target).value
       // Check for a locally installed h2spec (needed for non-amd64 platforms like Apple Silicon)
       val fromPath: Option[File] = {
         // Check PATH
@@ -233,11 +235,11 @@ lazy val http2Tests = project("akka-http2-tests")
       // Only fall back to the downloaded amd64 binary when on amd64
       val isAmd64 = System.getProperty("os.arch") == "amd64" || System.getProperty("os.arch") == "x86_64"
       fromPath.getOrElse(
-        if (isAmd64) (Test / target).value / h2specName / h2specExe
+        if (isAmd64) testTarget / h2specName / h2specExe
         else {
-          streams.value.log.warn("h2spec not found on PATH and no prebuilt binary available for " + System.getProperty("os.arch") + ". " +
+          log.warn("h2spec not found on PATH and no prebuilt binary available for " + System.getProperty("os.arch") + ". " +
             "Install h2spec locally: go install github.com/summerwind/h2spec/cmd/h2spec@latest")
-          (Test / target).value / "h2spec-not-available"
+          testTarget / "h2spec-not-available"
         }
       )
     }


### PR DESCRIPTION
Before this fix, the following was logged at sbt startup:

```
/Users/sebastian/dev/akka/akka-http/build.sbt:238: warning: value lookup of `streams` inside an `if` expression

problem: `streams.value` is inside an `if` expression of a regular task.
  Regular tasks always evaluate task dependencies (`.value`) regardless of `if` expressions.
solution:
  1. Use a conditional task `Def.taskIf(...)` to evaluate it when the `if` predicate is true or false.
  2. Or turn the task body into a single `if` expression; the task is then auto-converted to a conditional task.
  3. Or make the static evaluation explicit by declaring `streams.value` outside the `if` expression.
  4. If you still want to force the static lookup, you may annotate the task lookup with `@sbtUnchecked`, e.g. `(streams.value: @sbtUnchecked)`.
  5. Add `import sbt.dsl.LinterLevel.Ignore` to your build file to disable all task linting.

          streams.value.log.warn("h2spec not found on PATH and no prebuilt binary available for " + System.getProperty("os.arch") + ". " +
          ^
[info] loading settings for project akka-http-root from build.sbt...
```