### PR TITLE
build: fix race condition in sbt publish

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -4,8 +4,6 @@
 
 package akka
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import scala.language.postfixOps
 
 import sbt.{Def, _}
@@ -33,10 +31,11 @@ object Publish extends AutoPlugin {
 
   lazy val beforePublishTask = taskKey[Unit]("setup before publish")
 
-  lazy val beforePublishDone = new AtomicBoolean(false)
+  private var beforePublishDone = false
 
-  def beforePublish(snapshot: Boolean) = {
-    if (beforePublishDone.compareAndSet(false, true)) {
+  def beforePublish(snapshot: Boolean) = synchronized {
+    if (!beforePublishDone) {
+      beforePublishDone = true
       CiReleasePlugin.setupGpg()
       if (!snapshot)
         cloudsmithCredentials(validate = true)


### PR DESCRIPTION
Publish is failing: https://github.com/akka/akka-http/actions/runs/34347592456 

Problem is a race in `project/Publish.scala` where concurrent `publishSigned` tasks across subprojects could start signing before the one-time GPG key import had finished, since the ´AtomicBoolean` guard deduplicated the import without making other callers wait for it.

Synchronizing beforePublish makes every subproject block until the import completes.